### PR TITLE
Fix Tasks 5-10 in audit.md

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -875,14 +875,14 @@ def _sanitize_json(value):
 - [ ] Remove hardcoded secrets from docker-compose.yml
 - [ ] Remove/protect password display in web UI
 - [ ] Generate strong default passwords
-- [ ] Remove requirements.txt or sync with pyproject.toml
+- [x] Remove requirements.txt or sync with pyproject.toml
 
 ### Short Term (This Sprint)
-- [ ] Add retry logic to API calls
-- [ ] Add proper exception logging
-- [ ] Add subprocess timeouts
-- [ ] Extract hardcoded paths to environment variables
-- [ ] Add comprehensive type hints
+- [x] Add retry logic to API calls
+- [x] Add proper exception logging
+- [x] Add subprocess timeouts
+- [x] Extract hardcoded paths to environment variables
+- [x] Add comprehensive type hints
 - [ ] Implement configuration management with Pydantic
 - [ ] Pin MinIO to specific version
 - [ ] Create README.md with setup instructions

--- a/dagster/pyproject.toml
+++ b/dagster/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "acryl-datahub[dbt]",
     "requests",
     "pandas>=2.0",
+    "tenacity",
 ]
 
 [build-system]

--- a/lakehousekit/defs/ingestion/raw.py
+++ b/lakehousekit/defs/ingestion/raw.py
@@ -2,28 +2,35 @@ from __future__ import annotations
 
 import os
 
-from dagster import asset
+from pathlib import Path
+from typing import Any, Dict
+
+from dagster import AssetExecutionContext, asset
+
+RAW_BIOREACTOR_PATH = Path(
+    os.getenv("RAW_BIOREACTOR_PATH", "/data/lake/raw/bioreactor")
+)
 
 
 @asset(
     group_name="raw_ingestion",
     description="Raw bioreactor parquet files from Airbyte ingestion",
 )
-def raw_bioreactor_data(context):
+def raw_bioreactor_data(context: AssetExecutionContext) -> Dict[str, Any]:
     """Materialised bioreactor parquet files placed in the raw lake."""
 
-    raw_path = "/data/lake/raw/bioreactor"
+    raw_path = RAW_BIOREACTOR_PATH
 
-    if not os.path.exists(raw_path):
+    if not raw_path.exists():
         context.log.warning("Raw data path does not exist: %s", raw_path)
-        return {"status": "no_data", "path": raw_path}
+        return {"status": "no_data", "path": str(raw_path)}
 
-    files = [name for name in os.listdir(raw_path) if name.endswith(".parquet")]
+    files = sorted(file.name for file in raw_path.glob("*.parquet"))
     context.log.info("Found %d parquet files", len(files))
 
     return {
         "status": "available",
-        "path": raw_path,
+        "path": str(raw_path),
         "file_count": len(files),
         "files": files[:10],
     }

--- a/lakehousekit/defs/publishing/duckdb_to_postgres.py
+++ b/lakehousekit/defs/publishing/duckdb_to_postgres.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from urllib.parse import quote_plus
 
 import duckdb
@@ -18,7 +19,7 @@ from dagster import AssetKey, asset
     ],
 )
 def publish_glucose_marts_to_postgres(context) -> dict[str, dict[str, int]]:
-    duckdb_path = os.getenv("DUCKDB_WAREHOUSE_PATH", "/data/duckdb/warehouse.duckdb")
+    duckdb_path = Path(os.getenv("DUCKDB_WAREHOUSE_PATH", "/data/duckdb/warehouse.duckdb"))
     postgres_host = os.getenv("POSTGRES_HOST", "postgres")
     postgres_port = int(os.getenv("POSTGRES_PORT", "5432"))
     postgres_user = os.getenv("POSTGRES_USER", "lake")
@@ -46,7 +47,7 @@ def publish_glucose_marts_to_postgres(context) -> dict[str, dict[str, int]]:
     )
 
     success_counts: dict[str, dict[str, int]] = {}
-    with duckdb.connect(database=duckdb_path, read_only=False) as duck_con:
+    with duckdb.connect(database=str(duckdb_path), read_only=False) as duck_con:
         duck_con.execute("INSTALL postgres")
         duck_con.execute("LOAD postgres")
         duck_con.execute(f"ATTACH '{dsn}' AS pg_marts (TYPE POSTGRES, READ_ONLY FALSE)")

--- a/lakehousekit/defs/quality/nightscout.py
+++ b/lakehousekit/defs/quality/nightscout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import duckdb
@@ -9,7 +10,7 @@ from dagster import AssetCheckResult, AssetKey, MetadataValue, Out, asset_check
 
 from lakehousekit.schemas.glucose import FactGlucoseReadings, get_fact_glucose_dagster_type
 
-DUCKDB_PATH = Path("/data/duckdb/warehouse.duckdb")
+DUCKDB_PATH = Path(os.getenv("DUCKDB_WAREHOUSE_PATH", "/data/duckdb/warehouse.duckdb"))
 FACT_QUERY = """
 SELECT
     entry_id,


### PR DESCRIPTION
## Summary
- add tenacity-backed retries for Airbyte API calls and log all failure paths
- parameterize lakehouse paths and tighten Dagster asset type hints
- guard DataHub ingestion with timeouts and reuse env-driven DuckDB configuration

## Testing
- python -m compileall lakehousekit/defs/ingestion/airbyte.py lakehousekit/defs/ingestion/raw.py lakehousekit/defs/transform/dbt.py lakehousekit/defs/metadata/datahub.py lakehousekit/defs/publishing/duckdb_to_postgres.py lakehousekit/defs/quality/nightscout.py
