### PR TITLE
Add Pydantic validation for asset outputs

### DIFF
--- a/lakehousekit/defs/ingestion/raw.py
+++ b/lakehousekit/defs/ingestion/raw.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Dict
-
 from dagster import AssetExecutionContext, asset
 
 from lakehousekit.config import config
+from lakehousekit.schemas import RawDataOutput
 
 RAW_BIOREACTOR_PATH = config.raw_bioreactor_path_obj
 
@@ -13,21 +12,21 @@ RAW_BIOREACTOR_PATH = config.raw_bioreactor_path_obj
     group_name="raw_ingestion",
     description="Raw bioreactor parquet files from Airbyte ingestion",
 )
-def raw_bioreactor_data(context: AssetExecutionContext) -> Dict[str, Any]:
+def raw_bioreactor_data(context: AssetExecutionContext) -> RawDataOutput:
     """Materialised bioreactor parquet files placed in the raw lake."""
 
     raw_path = RAW_BIOREACTOR_PATH
 
     if not raw_path.exists():
         context.log.warning("Raw data path does not exist: %s", raw_path)
-        return {"status": "no_data", "path": str(raw_path)}
+        return RawDataOutput(status="no_data", path=str(raw_path))
 
     files = sorted(file.name for file in raw_path.glob("*.parquet"))
     context.log.info("Found %d parquet files", len(files))
 
-    return {
-        "status": "available",
-        "path": str(raw_path),
-        "file_count": len(files),
-        "files": files[:10],
-    }
+    return RawDataOutput(
+        status="available",
+        path=str(raw_path),
+        file_count=len(files),
+        files=files[:10],
+    )

--- a/lakehousekit/schemas/__init__.py
+++ b/lakehousekit/schemas/__init__.py
@@ -1,5 +1,17 @@
 from __future__ import annotations
 
+from lakehousekit.schemas.asset_outputs import (
+    DatahubIngestionOutput,
+    PublishPostgresOutput,
+    RawDataOutput,
+    TablePublishStats,
+)
 from lakehousekit.schemas.glucose import FactGlucoseReadings
 
-__all__ = ["FactGlucoseReadings"]
+__all__ = [
+    "DatahubIngestionOutput",
+    "FactGlucoseReadings",
+    "PublishPostgresOutput",
+    "RawDataOutput",
+    "TablePublishStats",
+]

--- a/lakehousekit/schemas/asset_outputs.py
+++ b/lakehousekit/schemas/asset_outputs.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class RawDataOutput(BaseModel):
+    """Output model for raw data ingestion assets."""
+
+    status: str = Field(
+        ...,
+        description="Status of the raw data: 'available' or 'no_data'",
+    )
+    path: str = Field(
+        ...,
+        description="Path to the raw data directory",
+    )
+    file_count: int = Field(
+        default=0,
+        ge=0,
+        description="Total number of parquet files found",
+    )
+    files: list[str] = Field(
+        default_factory=list,
+        description="List of file names (up to 10 for display)",
+        max_length=10,
+    )
+
+
+class TablePublishStats(BaseModel):
+    """Statistics for a published table."""
+
+    row_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of rows in the published table",
+    )
+    column_count: int = Field(
+        ...,
+        ge=0,
+        description="Number of columns in the published table",
+    )
+
+
+class PublishPostgresOutput(BaseModel):
+    """Output model for DuckDB to Postgres publishing assets."""
+
+    tables: dict[str, TablePublishStats] = Field(
+        ...,
+        description="Publishing statistics for each table",
+    )
+
+
+class DatahubIngestionOutput(BaseModel):
+    """Output model for DataHub metadata ingestion assets."""
+
+    status: str = Field(
+        ...,
+        description="Status message from DataHub ingestion",
+    )
+    tables_processed: int = Field(
+        ...,
+        ge=0,
+        description="Number of tables processed in the ingestion",
+    )


### PR DESCRIPTION
## Summary

Assets now return validated Pydantic models instead of untyped dictionaries, preventing schema changes from breaking downstream assets silently.

## Changes

- Created `lakehousekit/schemas/asset_outputs.py` with validation models:
  - `RawDataOutput`: validates raw ingestion asset outputs
  - `TablePublishStats`: validates per-table publishing statistics  
  - `PublishPostgresOutput`: validates postgres publishing outputs
  - `DatahubIngestionOutput`: validates datahub ingestion results

- Updated `raw_bioreactor_data` to return `RawDataOutput`
- Updated `publish_glucose_marts_to_postgres` to return `PublishPostgresOutput`
- Updated `ingest_dbt_to_datahub` input/output to use validated models

## Benefits

- Runtime validation catches schema issues early
- Type safety with IDE support and autocomplete
- Clear field descriptions and constraints (e.g., non-negative counts)
- Protection against silent downstream failures

## Test plan

- [ ] Verify all assets load successfully in Dagster UI
- [ ] Run the full pipeline and confirm asset outputs are validated
- [ ] Check that invalid outputs trigger Pydantic validation errors
- [ ] Confirm type hints work correctly in IDE

Addresses AUDIT.md task 14