### PR TITLE
Cascade ingestion handling and processing

### DIFF
--- a/src/cascade/defs/resources/iceberg.py
+++ b/src/cascade/defs/resources/iceberg.py
@@ -12,7 +12,7 @@ from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 
 from cascade.config import config
-from cascade.iceberg import append_to_table, ensure_table, get_catalog
+from cascade.iceberg import append_to_table, ensure_table, get_catalog, merge_to_table
 
 
 # --- Resource Classes ---
@@ -53,3 +53,27 @@ class IcebergResource(ConfigurableResource):
     def append_parquet(self, table_name: str, data_path: str) -> None:
         """Append a parquet file or directory to the Iceberg table."""
         append_to_table(table_name=table_name, data_path=data_path, ref=self.ref)
+
+    def merge_parquet(
+        self, table_name: str, data_path: str, unique_key: str
+    ) -> dict[str, int]:
+        """
+        Merge (upsert) a parquet file or directory to the Iceberg table with deduplication.
+
+        This implements idempotent ingestion - safe to run multiple times without
+        creating duplicate records.
+
+        Args:
+            table_name: Fully qualified table name (e.g., "raw.glucose_entries")
+            data_path: Path to parquet file or directory
+            unique_key: Column name to use for deduplication (e.g., "_id")
+
+        Returns:
+            Dictionary with metrics: {"rows_deleted": int, "rows_inserted": int}
+        """
+        return merge_to_table(
+            table_name=table_name,
+            data_path=data_path,
+            unique_key=unique_key,
+            ref=self.ref,
+        )

--- a/src/cascade/iceberg/__init__.py
+++ b/src/cascade/iceberg/__init__.py
@@ -8,7 +8,7 @@ This module provides integration with Apache Iceberg using PyIceberg and Nessie 
 """
 
 from cascade.iceberg.catalog import get_catalog
-from cascade.iceberg.tables import ensure_table, append_to_table
+from cascade.iceberg.tables import ensure_table, append_to_table, merge_to_table
 
 # Public API: Only these functions are exposed when importing the module
-__all__ = ["get_catalog", "ensure_table", "append_to_table"]
+__all__ = ["get_catalog", "ensure_table", "append_to_table", "merge_to_table"]


### PR DESCRIPTION
Implements true idempotent ingestion to prevent duplicate data insertion when the same asset is run multiple times. This addresses the issue where running the DLT nightscout asset twice would insert duplicate records.

## Changes

### Core Merge Functionality
- Add `merge_to_table()` function in `iceberg/tables.py` that implements upsert logic using PyIceberg delete + append pattern
- Add `merge_parquet()` method to IcebergResource for Dagster assets
- Export `merge_to_table` from iceberg module __init__.py

### Schema Enhancements
- Document unique keys for all schemas with inline comments
- Add `get_unique_key()` helper function to programmatically retrieve unique keys per table type
- Mark unique key fields in schema documentation:
  - Nightscout entries: `_id`
  - Nightscout treatments: `_id`
  - GitHub user events: `id`
  - GitHub repo stats: `_dlt_id`

### Asset Updates
- Update `dlt_glucose_entries` asset to use merge instead of append
- Update `dlt_github_user_events` asset to use merge instead of append
- Update `dlt_github_repo_stats` asset to use merge instead of append
- Add merge metrics (rows_deleted, rows_inserted) to asset metadata
- Update asset descriptions to indicate idempotent behavior

## Benefits

1. **Safe Re-runs**: Assets can be run multiple times without creating duplicates
2. **Cost Efficiency**: No storage waste from duplicate data
3. **Data Quality**: Raw layer accurately reflects source system state
4. **DevOps Friendly**: Backfills and retries don't compound data

## Implementation Details

The merge operation works by:
1. Reading new data from staged parquet files
2. Extracting unique key values from new data
3. Deleting existing records with matching unique keys (batched for performance)
4. Appending the new data to the table

This ensures that running an ingestion twice for the same partition results in the same final state - true idempotency.

Fixes issue with duplicate data insertion at raw layer while maintaining the existing deduplication at gold layer for defense in depth.