### PR TITLE
feat: add more pandera tests

### DIFF
--- a/src/cascade/defs/quality/github.py
+++ b/src/cascade/defs/quality/github.py
@@ -10,6 +10,8 @@ from dagster import AssetCheckResult, AssetKey, MetadataValue, asset_check
 
 from cascade.defs.resources.trino import TrinoResource
 from cascade.schemas.github import (
+    FactGitHubRepoStats,
+    FactGitHubUserEvents,
     GitHubRepoStats,
     GitHubUserEvents,
     VALID_EVENT_TYPES,
@@ -345,6 +347,284 @@ def github_repo_stats_quality_check(context, trino: TrinoResource) -> AssetCheck
         )
 
     except Exception as exc:  # pragma: no cover - defensive logging
+        context.log.exception(f"Unexpected error during validation: {exc}")
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "reason": MetadataValue.text("unexpected_error"),
+                "error": MetadataValue.text(str(exc)),
+            },
+        )
+
+
+# --- Fact Table Asset Checks (Enriched Data) ---
+# Asset checks for validating enriched fact tables with calculated fields
+
+FACT_USER_EVENTS_QUERY = """
+SELECT
+    event_id,
+    event_type,
+    event_category,
+    actor_login,
+    actor_id,
+    repo_name,
+    repo_full_name,
+    public,
+    is_repo_public,
+    involves_organization,
+    created_at,
+    event_date,
+    hour_of_day,
+    day_of_week,
+    day_name
+FROM iceberg_dev.silver.fct_github_user_events
+"""
+
+FACT_REPO_STATS_QUERY = """
+SELECT
+    repo_name,
+    repo_full_name,
+    repo_id,
+    repo_owner,
+    repo_short_name,
+    collection_date,
+    contributor_count,
+    total_commits_last_52_weeks,
+    weeks_with_activity,
+    activity_score,
+    contribution_level,
+    activity_level,
+    repository_health,
+    avg_commits_per_week
+FROM iceberg_dev.silver.fct_github_repo_stats
+"""
+
+
+@asset_check(
+    name="fact_github_user_events_quality",
+    asset=AssetKey(["fct_github_user_events"]),
+    blocking=False,
+    description="Validate enriched GitHub user events fact table using Pandera schema validation.",
+)
+def fact_github_user_events_quality_check(context, trino: TrinoResource) -> AssetCheckResult:
+    """
+    Quality check for enriched GitHub user events fact table.
+
+    Validates enriched user events with calculated fields against the FactGitHubUserEvents schema,
+    checking data types, categorization, extracted JSON fields, and time dimensions.
+    """
+    query = FACT_USER_EVENTS_QUERY
+    partition_key = getattr(context, "partition_key", None)
+    if partition_key is None:
+        partition_key = getattr(context, "asset_partition_key", None)
+
+    if partition_key:
+        partition_date = partition_key
+        query = f"{FACT_USER_EVENTS_QUERY}\nWHERE DATE(created_at) = DATE '{partition_date}'"
+        context.log.info(f"Validating partition: {partition_date}")
+
+    try:
+        with trino.cursor(schema="silver") as cursor:
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            if not cursor.description:
+                return AssetCheckResult(
+                    passed=False,
+                    metadata={
+                        "reason": MetadataValue.text("missing_column_metadata"),
+                        "query": MetadataValue.text(query),
+                    },
+                )
+            columns = [desc[0] for desc in cursor.description]
+
+        events_df = pd.DataFrame(rows, columns=columns)
+
+        # Type conversions
+        if "hour_of_day" in events_df.columns:
+            events_df["hour_of_day"] = events_df["hour_of_day"].astype("int64")
+        if "day_of_week" in events_df.columns:
+            events_df["day_of_week"] = events_df["day_of_week"].astype("int64")
+        if "public" in events_df.columns:
+            events_df["public"] = events_df["public"].astype("bool")
+        if "is_repo_public" in events_df.columns:
+            events_df["is_repo_public"] = events_df["is_repo_public"].astype("bool")
+        if "involves_organization" in events_df.columns:
+            events_df["involves_organization"] = events_df["involves_organization"].astype("bool")
+        if "created_at" in events_df.columns:
+            events_df["created_at"] = pd.to_datetime(events_df["created_at"])
+        if "event_date" in events_df.columns:
+            events_df["event_date"] = pd.to_datetime(events_df["event_date"])
+
+        context.log.info(f"Loaded {len(events_df)} rows from fact table")
+    except Exception as exc:
+        context.log.error(f"Failed to load data from Trino: {exc}")
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "reason": MetadataValue.text("trino_query_failed"),
+                "error": MetadataValue.text(str(exc)),
+                "query": MetadataValue.text(query),
+            },
+        )
+
+    if events_df.empty:
+        return AssetCheckResult(
+            passed=True,
+            metadata={
+                "rows_validated": MetadataValue.int(0),
+                "note": MetadataValue.text("No data available for selected partition"),
+            },
+        )
+
+    # Validate using Pandera schema
+    context.log.info("Validating enriched fact data with Pandera schema...")
+    try:
+        FactGitHubUserEvents.validate(events_df, lazy=True)
+        context.log.info("All validation checks passed!")
+
+        return AssetCheckResult(
+            passed=True,
+            metadata={
+                "rows_validated": MetadataValue.int(len(events_df)),
+                "columns_validated": MetadataValue.int(len(events_df.columns)),
+                "schema_version": MetadataValue.text("1.0.0"),
+            },
+        )
+
+    except pandera.errors.SchemaErrors as err:
+        failure_cases = err.failure_cases
+        context.log.warning(f"Schema validation failed with {len(failure_cases)} check failures")
+
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "rows_evaluated": MetadataValue.int(len(events_df)),
+                "failed_checks": MetadataValue.int(len(failure_cases)),
+                "failures_by_column": MetadataValue.json(
+                    failure_cases.groupby("column").size().to_dict()
+                ),
+                "sample_failures": MetadataValue.json(
+                    failure_cases.head(20)[
+                        ["schema_context", "column", "check", "failure_case"]
+                    ].to_dict(orient="records")
+                ),
+                "error_summary": MetadataValue.text(str(err)),
+            },
+        )
+
+    except Exception as exc:
+        context.log.exception(f"Unexpected error during validation: {exc}")
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "reason": MetadataValue.text("unexpected_error"),
+                "error": MetadataValue.text(str(exc)),
+            },
+        )
+
+
+@asset_check(
+    name="fact_github_repo_stats_quality",
+    asset=AssetKey(["fct_github_repo_stats"]),
+    blocking=False,
+    description="Validate enriched GitHub repo stats fact table using Pandera schema validation.",
+)
+def fact_github_repo_stats_quality_check(context, trino: TrinoResource) -> AssetCheckResult:
+    """
+    Quality check for enriched GitHub repo stats fact table.
+
+    Validates enriched repo stats with calculated metrics against the FactGitHubRepoStats schema,
+    checking contributor counts, activity scores, and classification fields.
+    """
+    query = FACT_REPO_STATS_QUERY
+    partition_key = getattr(context, "partition_key", None)
+    if partition_key is None:
+        partition_key = getattr(context, "asset_partition_key", None)
+
+    if partition_key:
+        partition_date = partition_key
+        query = f"{FACT_REPO_STATS_QUERY}\nWHERE collection_date = '{partition_date}'"
+        context.log.info(f"Validating partition: {partition_date}")
+
+    try:
+        with trino.cursor(schema="silver") as cursor:
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            if not cursor.description:
+                return AssetCheckResult(
+                    passed=False,
+                    metadata={
+                        "reason": MetadataValue.text("missing_column_metadata"),
+                        "query": MetadataValue.text(query),
+                    },
+                )
+            columns = [desc[0] for desc in cursor.description]
+
+        stats_df = pd.DataFrame(rows, columns=columns)
+
+        # Type conversions
+        for col in ["repo_id", "contributor_count", "total_commits_last_52_weeks", "weeks_with_activity"]:
+            if col in stats_df.columns:
+                stats_df[col] = stats_df[col].astype("int64")
+
+        context.log.info(f"Loaded {len(stats_df)} rows from fact table")
+    except Exception as exc:
+        context.log.error(f"Failed to load data from Trino: {exc}")
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "reason": MetadataValue.text("trino_query_failed"),
+                "error": MetadataValue.text(str(exc)),
+                "query": MetadataValue.text(query),
+            },
+        )
+
+    if stats_df.empty:
+        return AssetCheckResult(
+            passed=True,
+            metadata={
+                "rows_validated": MetadataValue.int(0),
+                "note": MetadataValue.text("No data available for selected partition"),
+            },
+        )
+
+    # Validate using Pandera schema
+    context.log.info("Validating enriched fact data with Pandera schema...")
+    try:
+        FactGitHubRepoStats.validate(stats_df, lazy=True)
+        context.log.info("All validation checks passed!")
+
+        return AssetCheckResult(
+            passed=True,
+            metadata={
+                "rows_validated": MetadataValue.int(len(stats_df)),
+                "columns_validated": MetadataValue.int(len(stats_df.columns)),
+                "schema_version": MetadataValue.text("1.0.0"),
+            },
+        )
+
+    except pandera.errors.SchemaErrors as err:
+        failure_cases = err.failure_cases
+        context.log.warning(f"Schema validation failed with {len(failure_cases)} check failures")
+
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "rows_evaluated": MetadataValue.int(len(stats_df)),
+                "failed_checks": MetadataValue.int(len(failure_cases)),
+                "failures_by_column": MetadataValue.json(
+                    failure_cases.groupby("column").size().to_dict()
+                ),
+                "sample_failures": MetadataValue.json(
+                    failure_cases.head(20)[
+                        ["schema_context", "column", "check", "failure_case"]
+                    ].to_dict(orient="records")
+                ),
+                "error_summary": MetadataValue.text(str(err)),
+            },
+        )
+
+    except Exception as exc:
         context.log.exception(f"Unexpected error during validation: {exc}")
         return AssetCheckResult(
             passed=False,

--- a/src/cascade/defs/quality/nightscout.py
+++ b/src/cascade/defs/quality/nightscout.py
@@ -10,8 +10,9 @@ from dagster import AssetCheckResult, AssetKey, MetadataValue, asset_check
 
 from cascade.defs.resources.trino import TrinoResource
 from cascade.schemas.glucose import (
-FactGlucoseReadings,
-get_fact_glucose_dagster_type,
+    FactDailyGlucoseMetrics,
+    FactGlucoseReadings,
+    get_fact_glucose_dagster_type,
 )
 
 # --- Query Templates ---
@@ -185,6 +186,167 @@ def nightscout_glucose_quality_check(context, trino: TrinoResource) -> AssetChec
         )
 
     except Exception as exc:  # pragma: no cover - defensive logging
+        context.log.exception(f"Unexpected error during validation: {exc}")
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "reason": MetadataValue.text("unexpected_error"),
+                "error": MetadataValue.text(str(exc)),
+            },
+        )
+
+
+# --- Gold Layer Asset Checks ---
+# Asset checks for validating gold layer aggregated data
+
+DAILY_METRICS_QUERY = """
+SELECT
+    reading_date,
+    day_name,
+    day_of_week,
+    week_of_year,
+    month,
+    year,
+    reading_count,
+    avg_glucose_mg_dl,
+    min_glucose_mg_dl,
+    max_glucose_mg_dl,
+    stddev_glucose_mg_dl,
+    time_in_range_pct,
+    time_below_range_pct,
+    time_above_range_pct,
+    estimated_a1c_pct
+FROM iceberg_dev.gold.fct_daily_glucose_metrics
+"""
+
+
+@asset_check(
+    name="daily_glucose_metrics_quality",
+    asset=AssetKey(["fct_daily_glucose_metrics"]),
+    blocking=False,
+    description="Validate daily glucose metrics using Pandera schema validation.",
+)
+def daily_glucose_metrics_quality_check(context, trino: TrinoResource) -> AssetCheckResult:
+    """
+    Quality check for daily glucose metrics fact table.
+
+    Validates aggregated daily glucose metrics against the FactDailyGlucoseMetrics schema,
+    checking daily statistics, time in range percentages, and estimated A1C.
+    """
+    query = DAILY_METRICS_QUERY
+    partition_key = getattr(context, "partition_key", None)
+    if partition_key is None:
+        partition_key = getattr(context, "asset_partition_key", None)
+
+    if partition_key:
+        partition_date = partition_key
+        query = f"{DAILY_METRICS_QUERY}\nWHERE reading_date = DATE '{partition_date}'"
+        context.log.info(f"Validating partition: {partition_date}")
+
+    try:
+        with trino.cursor(schema="gold") as cursor:
+            cursor.execute(query)
+            rows = cursor.fetchall()
+
+            if not cursor.description:
+                context.log.warning(
+                    "Trino did not return column metadata for query, aborting check."
+                )
+                return AssetCheckResult(
+                    passed=False,
+                    metadata={
+                        "reason": MetadataValue.text("missing_column_metadata"),
+                        "query": MetadataValue.text(query),
+                    },
+                )
+
+            columns = [desc[0] for desc in cursor.description]
+
+        metrics_df = pd.DataFrame(rows, columns=columns)
+
+        # Explicitly cast columns to correct types
+        type_conversions = {
+            "day_of_week": "int64",
+            "week_of_year": "int64",
+            "month": "int64",
+            "year": "int64",
+            "reading_count": "int64",
+        }
+        for col, dtype in type_conversions.items():
+            if col in metrics_df.columns:
+                metrics_df[col] = metrics_df[col].astype(dtype)
+
+        # Convert timestamp fields
+        if "reading_date" in metrics_df.columns:
+            metrics_df["reading_date"] = pd.to_datetime(metrics_df["reading_date"])
+
+        context.log.info(
+            f"Loaded {len(metrics_df)} rows from iceberg_dev.gold.fct_daily_glucose_metrics"
+        )
+    except Exception as exc:
+        context.log.error(f"Failed to load data from Trino: {exc}")
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "reason": MetadataValue.text("trino_query_failed"),
+                "error": MetadataValue.text(str(exc)),
+                "query": MetadataValue.text(query),
+            },
+        )
+
+    if metrics_df.empty:
+        context.log.warning("No rows returned for validation; marking check as skipped.")
+        return AssetCheckResult(
+            passed=True,
+            metadata={
+                "rows_validated": MetadataValue.int(0),
+                "note": MetadataValue.text("No data available for selected partition"),
+            },
+        )
+
+    # Validate using Pandera schema
+    context.log.info("Validating daily metrics with Pandera schema...")
+    try:
+        # Use lazy validation to collect all errors
+        FactDailyGlucoseMetrics.validate(metrics_df, lazy=True)
+
+        context.log.info("All validation checks passed!")
+
+        return AssetCheckResult(
+            passed=True,
+            metadata={
+                "rows_validated": MetadataValue.int(len(metrics_df)),
+                "columns_validated": MetadataValue.int(len(metrics_df.columns)),
+                "schema_version": MetadataValue.text("1.0.0"),
+            },
+        )
+
+    except pandera.errors.SchemaErrors as err:
+        failure_cases = err.failure_cases
+        context.log.warning(
+            f"Schema validation failed with {len(failure_cases)} check failures"
+        )
+
+        failures_by_column = failure_cases.groupby("column").size().to_dict()
+        failures_by_check = failure_cases.groupby("check").size().to_dict()
+
+        sample_failures = failure_cases.head(20)[
+            ["schema_context", "column", "check", "check_number", "failure_case"]
+        ].to_dict(orient="records")
+
+        return AssetCheckResult(
+            passed=False,
+            metadata={
+                "rows_evaluated": MetadataValue.int(len(metrics_df)),
+                "failed_checks": MetadataValue.int(len(failure_cases)),
+                "failures_by_column": MetadataValue.json(failures_by_column),
+                "failures_by_check": MetadataValue.json(failures_by_check),
+                "sample_failures": MetadataValue.json(sample_failures),
+                "error_summary": MetadataValue.text(str(err)),
+            },
+        )
+
+    except Exception as exc:
         context.log.exception(f"Unexpected error during validation: {exc}")
         return AssetCheckResult(
             passed=False,

--- a/src/cascade/schemas/github.py
+++ b/src/cascade/schemas/github.py
@@ -33,6 +33,130 @@ VALID_EVENT_TYPES = [
 
 # --- Pandera Schemas ---
 # DataFrame schemas for validating structured data in the pipeline
+
+class RawGitHubUserEvents(DataFrameModel):
+    """
+    Schema for raw GitHub user events from the API.
+
+    Validates raw GitHub user events at ingestion time before dbt transformation:
+    - Valid event types
+    - Required fields (id, type, actor, repo, payload)
+    - Proper timestamp formatting
+    - Unique event IDs
+    """
+
+    id: str = Field(
+        nullable=False,
+        unique=True,
+        description="Unique identifier for the GitHub event",
+    )
+
+    type: str = Field(
+        isin=VALID_EVENT_TYPES,
+        nullable=False,
+        description="Type of GitHub event (e.g., 'PushEvent', 'IssuesEvent')",
+    )
+
+    actor: str = Field(
+        nullable=False,
+        description="JSON string containing actor information",
+    )
+
+    repo: str = Field(
+        nullable=False,
+        description="JSON string containing repository information",
+    )
+
+    payload: str = Field(
+        nullable=False,
+        description="JSON string containing event payload data",
+    )
+
+    public: bool = Field(
+        nullable=False,
+        description="Whether the event is public or private",
+    )
+
+    created_at: datetime = Field(
+        nullable=False,
+        description="Timestamp when the event was created",
+    )
+
+    org: str | None = Field(
+        nullable=True,
+        description="JSON string containing organization information (nullable)",
+    )
+
+    _cascade_ingested_at: datetime = Field(
+        nullable=False,
+        description="Timestamp when data was ingested by Cascade",
+    )
+
+    class Config:
+        strict = False  # Allow DLT metadata fields
+        coerce = True
+
+
+class RawGitHubRepoStats(DataFrameModel):
+    """
+    Schema for raw GitHub repository statistics from the API.
+
+    Validates raw repository statistics at ingestion time before dbt transformation:
+    - Repository identification fields
+    - Collection date validation
+    - JSON structure for statistics data
+    """
+
+    repo_name: str = Field(
+        nullable=False,
+        description="Name of the repository",
+    )
+
+    repo_full_name: str = Field(
+        nullable=False,
+        description="Full name of the repository (owner/repo)",
+    )
+
+    repo_id: int = Field(
+        nullable=False,
+        description="GitHub repository ID",
+    )
+
+    collection_date: str = Field(
+        nullable=False,
+        description="Date when statistics were collected (YYYY-MM-DD)",
+    )
+
+    contributors_data: str | None = Field(
+        nullable=True,
+        description="JSON string containing contributors statistics",
+    )
+
+    commit_activity_data: str | None = Field(
+        nullable=True,
+        description="JSON string containing commit activity statistics",
+    )
+
+    code_frequency_data: str | None = Field(
+        nullable=True,
+        description="JSON string containing code frequency statistics",
+    )
+
+    participation_data: str | None = Field(
+        nullable=True,
+        description="JSON string containing participation statistics",
+    )
+
+    _cascade_ingested_at: datetime = Field(
+        nullable=False,
+        description="Timestamp when data was ingested by Cascade",
+    )
+
+    class Config:
+        strict = False  # Allow DLT metadata fields
+        coerce = True
+
+
 class GitHubUserEvents(DataFrameModel):
     """
     Schema for the user_events table.
@@ -144,6 +268,211 @@ class GitHubRepoStats(DataFrameModel):
     class Config:
         strict = True  # No additional columns allowed
         coerce = True  # Auto type coercion where possible
+
+
+class FactGitHubUserEvents(DataFrameModel):
+    """
+    Schema for the fct_github_user_events fact table (silver layer).
+
+    Validates enriched GitHub user events with calculated metrics:
+    - Event categorization
+    - Extracted JSON fields (actor_login, repo_name, etc.)
+    - Time dimensions (hour_of_day, day_of_week)
+    - Boolean flags (is_repo_public, involves_organization)
+    """
+
+    event_id: str = Field(
+        nullable=False,
+        unique=True,
+        description="Unique identifier for the GitHub event",
+    )
+
+    event_type: str = Field(
+        isin=VALID_EVENT_TYPES,
+        nullable=False,
+        description="Type of GitHub event",
+    )
+
+    event_category: str = Field(
+        isin=[
+            "code_contribution",
+            "issue_management",
+            "pull_request",
+            "repository_management",
+            "social",
+            "collaboration",
+            "release_management",
+            "documentation",
+            "visibility",
+            "other",
+        ],
+        nullable=False,
+        description="Categorized event type for analytics",
+    )
+
+    actor_login: str = Field(
+        nullable=False,
+        description="GitHub username of the actor (extracted from JSON)",
+    )
+
+    actor_id: str = Field(
+        nullable=False,
+        description="GitHub actor ID (extracted from JSON)",
+    )
+
+    repo_name: str = Field(
+        nullable=False,
+        description="Repository name (extracted from JSON)",
+    )
+
+    repo_full_name: str = Field(
+        nullable=False,
+        description="Full repository name owner/repo (extracted from JSON)",
+    )
+
+    public: bool = Field(
+        nullable=False,
+        description="Whether the event is public",
+    )
+
+    is_repo_public: bool = Field(
+        nullable=False,
+        description="Whether the repository is public",
+    )
+
+    involves_organization: bool = Field(
+        nullable=False,
+        description="Whether the event involves an organization",
+    )
+
+    created_at: datetime = Field(
+        nullable=False,
+        description="Event creation timestamp",
+    )
+
+    event_date: datetime = Field(
+        nullable=False,
+        description="Date of the event (truncated to day)",
+    )
+
+    hour_of_day: int = Field(
+        ge=0,
+        le=23,
+        nullable=False,
+        description="Hour when event occurred (0-23)",
+    )
+
+    day_of_week: int = Field(
+        ge=1,
+        le=7,
+        nullable=False,
+        description="Day of week (1=Monday, 7=Sunday)",
+    )
+
+    day_name: str = Field(
+        nullable=False,
+        description="Name of the day (e.g., 'Monday', 'Tuesday')",
+    )
+
+    class Config:
+        strict = True  # No additional columns allowed
+        coerce = True
+
+
+class FactGitHubRepoStats(DataFrameModel):
+    """
+    Schema for the fct_github_repo_stats fact table (silver layer).
+
+    Validates enriched GitHub repository statistics with calculated metrics:
+    - Contributor counts
+    - Commit activity summaries
+    - Activity scores
+    - Classification fields (contribution_level, activity_level, repository_health)
+    """
+
+    repo_name: str = Field(
+        nullable=False,
+        description="Name of the repository",
+    )
+
+    repo_full_name: str = Field(
+        nullable=False,
+        unique=True,
+        description="Full name of the repository (owner/repo)",
+    )
+
+    repo_id: int = Field(
+        nullable=False,
+        unique=True,
+        description="GitHub repository ID",
+    )
+
+    repo_owner: str = Field(
+        nullable=False,
+        description="Repository owner (extracted from full_name)",
+    )
+
+    repo_short_name: str = Field(
+        nullable=False,
+        description="Repository short name (extracted from full_name)",
+    )
+
+    collection_date: str = Field(
+        nullable=False,
+        description="Date when statistics were collected (YYYY-MM-DD)",
+    )
+
+    contributor_count: int = Field(
+        ge=0,
+        nullable=False,
+        description="Number of contributors",
+    )
+
+    total_commits_last_52_weeks: int = Field(
+        ge=0,
+        nullable=False,
+        description="Total commits in last 52 weeks",
+    )
+
+    weeks_with_activity: int = Field(
+        ge=0,
+        nullable=False,
+        description="Number of weeks with activity",
+    )
+
+    activity_score: int | float = Field(
+        ge=0,
+        nullable=False,
+        description="Calculated activity score",
+    )
+
+    contribution_level: str = Field(
+        isin=["high_contribution", "medium_contribution", "low_contribution", "no_contribution"],
+        nullable=False,
+        description="Contribution level classification",
+    )
+
+    activity_level: str = Field(
+        isin=["very_active", "active", "moderate", "inactive"],
+        nullable=False,
+        description="Activity level classification",
+    )
+
+    repository_health: str = Field(
+        isin=["healthy", "stable", "developing", "dormant"],
+        nullable=False,
+        description="Repository health status",
+    )
+
+    avg_commits_per_week: float | None = Field(
+        ge=0,
+        nullable=True,
+        description="Average commits per week",
+    )
+
+    class Config:
+        strict = True  # No additional columns allowed
+        coerce = True
 
 
 # --- Dagster Type Conversion ---

--- a/src/cascade/schemas/glucose.py
+++ b/src/cascade/schemas/glucose.py
@@ -29,6 +29,67 @@ VALID_DIRECTIONS = [
 
 # --- Pandera Schemas ---
 # DataFrame schemas for validating structured data in the pipeline
+
+class RawGlucoseEntries(DataFrameModel):
+    """
+    Schema for raw Nightscout glucose entries from the API.
+
+    Validates raw glucose data at ingestion time before dbt transformation:
+    - Valid glucose ranges (1-1000 mg/dL for raw data, wider than fact table)
+    - Proper field types and nullability
+    - Required metadata fields
+    - Unique entry IDs
+    """
+
+    _id: str = Field(
+        nullable=False,
+        unique=True,
+        description="Nightscout entry ID (unique identifier)",
+    )
+
+    sgv: int = Field(
+        ge=1,
+        le=1000,
+        nullable=False,
+        description="Sensor glucose value in mg/dL (1-1000 for raw data)",
+    )
+
+    date: int = Field(
+        nullable=False,
+        description="Unix timestamp in milliseconds",
+    )
+
+    date_string: datetime = Field(
+        nullable=False,
+        description="ISO 8601 timestamp",
+    )
+
+    direction: str | None = Field(
+        isin=VALID_DIRECTIONS,
+        nullable=True,
+        description="Trend direction (e.g., 'SingleUp', 'Flat')",
+    )
+
+    device: str | None = Field(
+        nullable=True,
+        description="Device name that recorded the entry",
+    )
+
+    type: str | None = Field(
+        nullable=True,
+        description="Entry type (e.g., 'sgv')",
+    )
+
+    _cascade_ingested_at: datetime = Field(
+        nullable=False,
+        description="Timestamp when data was ingested by Cascade",
+    )
+
+    class Config:
+        strict = False  # Allow DLT metadata fields
+        coerce = True
+
+
 class FactGlucoseReadings(DataFrameModel):
     """
     Schema for the fact_glucose_readings table.
@@ -91,6 +152,123 @@ class FactGlucoseReadings(DataFrameModel):
         isin=[0, 1],
         nullable=False,
         description="Whether glucose level is within target range (0=no, 1=yes)",
+    )
+
+    class Config:
+        strict = True  # No additional columns allowed
+        coerce = True  # Auto type coercion where possible
+
+
+class FactDailyGlucoseMetrics(DataFrameModel):
+    """
+    Schema for the fct_daily_glucose_metrics table.
+
+    Validates daily aggregated glucose metrics:
+    - Daily statistics (avg, min, max, stddev)
+    - Time in range percentages
+    - Estimated A1C
+    - Time dimensions
+    """
+
+    reading_date: datetime = Field(
+        nullable=False,
+        unique=True,
+        description="Date of glucose readings (unique per day)",
+    )
+
+    day_name: str = Field(
+        nullable=False,
+        isin=["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+        description="Name of the day",
+    )
+
+    day_of_week: int = Field(
+        ge=1,
+        le=7,
+        nullable=False,
+        description="Day of week (1=Monday, 7=Sunday)",
+    )
+
+    week_of_year: int = Field(
+        ge=1,
+        le=53,
+        nullable=False,
+        description="Week of the year (1-53)",
+    )
+
+    month: int = Field(
+        ge=1,
+        le=12,
+        nullable=False,
+        description="Month number (1-12)",
+    )
+
+    year: int = Field(
+        ge=2000,
+        le=2100,
+        nullable=False,
+        description="Year (2000-2100 reasonable range)",
+    )
+
+    reading_count: int = Field(
+        ge=0,
+        nullable=False,
+        description="Number of readings for the day",
+    )
+
+    avg_glucose_mg_dl: float | None = Field(
+        ge=0,
+        le=1000,
+        nullable=True,
+        description="Average glucose level for the day",
+    )
+
+    min_glucose_mg_dl: int | None = Field(
+        ge=0,
+        le=1000,
+        nullable=True,
+        description="Minimum glucose level for the day",
+    )
+
+    max_glucose_mg_dl: int | None = Field(
+        ge=0,
+        le=1000,
+        nullable=True,
+        description="Maximum glucose level for the day",
+    )
+
+    stddev_glucose_mg_dl: float | None = Field(
+        ge=0,
+        nullable=True,
+        description="Standard deviation of glucose levels",
+    )
+
+    time_in_range_pct: float | None = Field(
+        ge=0,
+        le=100,
+        nullable=True,
+        description="Percentage of time in target range (70-180 mg/dL)",
+    )
+
+    time_below_range_pct: float | None = Field(
+        ge=0,
+        le=100,
+        nullable=True,
+        description="Percentage of time below range (<70 mg/dL)",
+    )
+
+    time_above_range_pct: float | None = Field(
+        ge=0,
+        le=100,
+        nullable=True,
+        description="Percentage of time above range (>180 mg/dL)",
+    )
+
+    estimated_a1c_pct: float | None = Field(
+        ge=0,
+        le=20,
+        nullable=True,
+        description="Estimated A1C percentage (GMI approximation)",
     )
 
     class Config:


### PR DESCRIPTION
Add comprehensive Pandera schema validation at both ingestion and transformation layers to strengthen data quality assurance beyond dbt tests.

Ingestion layer: validate raw API data (glucose, GitHub events, repo stats)
Fact tables: validate enriched data with calculated fields and categorizations
Benefits: early issue detection, type safety, detailed error reporting