### PR TITLE
docs(adr): add retrospective decisions

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/architecture/decisions

--- a/docs/architecture/decisions/0001-quality-check-contract.md
+++ b/docs/architecture/decisions/0001-quality-check-contract.md
@@ -1,0 +1,43 @@
+# 1. Standardize quality check naming and metadata contract
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Phlo produces quality signals from multiple sources (Pandera validation, dbt tests, and custom checks).
+Observability surfaces (Dagster UI, GraphQL consumers, and Observatory) need a consistent way to:
+
+- Identify checks across runs and assets.
+- Render results without source-specific branching.
+- Provide enough debugging context (partition, counts, repro SQL, sample).
+
+Without a contract, each producer would emit bespoke metadata keys and naming, forcing consumers to
+special-case every check source and making new check sources expensive to add.
+
+## Decision
+
+Adopt a small, shared contract for all asset checks:
+
+- **Naming**
+  - Pandera contract check name is `pandera_contract`.
+  - dbt checks are named deterministically as `dbt__<test_type>__<target>` (sanitized for Dagster).
+- **Required metadata keys**
+  - `source` (`pandera|dbt|phlo`)
+  - `partition_key` (when applicable)
+  - `failed_count`
+  - `total_count` (when available)
+  - `query_or_sql` (when applicable)
+  - `sample` (<= 20 items, when available)
+  - Optional: `repro_sql` (safe SQL snippet for investigation)
+
+## Consequences
+
+- Consumers can render quality results consistently and add features (filtering, drilldown) without
+  needing per-source logic.
+- Check producers must follow the contract; deviations are treated as bugs.
+- Some metadata is necessarily best-effort (e.g., `total_count` or `repro_sql`) depending on source.
+

--- a/docs/architecture/decisions/0002-pandas-datetime-coercion-scope.md
+++ b/docs/architecture/decisions/0002-pandas-datetime-coercion-scope.md
@@ -1,0 +1,37 @@
+# 2. Limit datetime coercion during Pandera validation
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Ingestion validation uses Pandera schemas with `coerce=True` defaults.
+Naively coercing many columns to datetime can:
+
+- Mask upstream data issues by converting broad inputs unexpectedly.
+- Add unnecessary CPU overhead on large datasets.
+- Create surprising behavior when non-datetime columns are coerced (or attempted).
+
+We need validation to be strict enough to catch real schema issues while remaining performant and
+predictable.
+
+## Decision
+
+When validating with Pandera, only attempt datetime coercion for columns that are:
+
+- Declared as datetime in the Pandera schema, and
+- Present in the incoming dataframe, and
+- Currently stored as object/string types that Pandas can reasonably parse.
+
+All other columns are left untouched and Pandera validation remains the source of truth.
+
+## Consequences
+
+- Validation is more predictable and less “magical”.
+- Performance improves on wide tables where only a small number of datetime columns exist.
+- Some dirty-but-coercible values may still pass; this remains a schema design choice (strictness
+  should live in the schema, not hidden coercion logic).
+

--- a/docs/architecture/decisions/0003-quality-severity-policy.md
+++ b/docs/architecture/decisions/0003-quality-severity-policy.md
@@ -1,0 +1,35 @@
+# 3. Define a severity policy for quality checks (blocking vs warn)
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Not all quality failures should have the same impact:
+
+- Contract/schema violations are typically correctness failures and should block downstream work.
+- Some tests (e.g., anomaly/drift) are informative and should be warn-only.
+
+We need a uniform policy so check producers and consumers agree on semantics, and so automation can
+rely on consistent status meaning.
+
+## Decision
+
+Adopt a shared severity mapping:
+
+- Pandera contract failures are **ERROR** (blocking).
+- dbt tests are **ERROR** for `not_null`, `unique`, and `relationships`; other test types default to
+  **WARN**.
+- dbt tags can override:
+  - `tag:blocking` forces **ERROR**
+  - `tag:warn` or `tag:anomaly` forces **WARN**
+
+## Consequences
+
+- Users get sensible defaults without needing to annotate every test.
+- Teams can still override per-test behavior via tags.
+- Consumers (Observatory, sensors) can treat WARN and ERROR differently without custom heuristics.
+

--- a/docs/architecture/decisions/0004-partition-scoped-checks-and-samples.md
+++ b/docs/architecture/decisions/0004-partition-scoped-checks-and-samples.md
@@ -1,0 +1,35 @@
+# 4. Make checks partition-aware and include failure sampling
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Running checks against full tables can be:
+
+- Expensive (especially on Iceberg tables).
+- Misleading for partitioned pipelines (where correctness is evaluated per partition/run).
+
+When checks fail, users also need actionable debugging context: a small sample and a query/SQL link
+to reproduce the failure in Trino.
+
+## Decision
+
+Standardize two behaviors across check sources:
+
+1. **Partition scoping**
+   - If the run has a partition key, checks should scope to that partition by default.
+   - When unpartitioned, checks may use a rolling window (configurable) unless explicitly full-table.
+   - Default partition column is `_phlo_partition_date` unless overridden.
+2. **Actionable failure output**
+   - Include a small failure sample (<= 20 items) and a reproducible SQL snippet when possible.
+
+## Consequences
+
+- Checks become safe-by-default for partitioned assets (no accidental full-table scans).
+- Observatory can show consistent failure drilldowns across check sources.
+- Some sources (e.g., dbt) may not always provide row-level samples; the contract allows best-effort.
+

--- a/docs/architecture/decisions/0005-dbt-translator-metadata.md
+++ b/docs/architecture/decisions/0005-dbt-translator-metadata.md
@@ -1,0 +1,33 @@
+# 5. Store dbt compiled SQL in Dagster asset metadata (not descriptions)
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Dagster asset descriptions are intended to be human-facing summaries, but compiled SQL can be large.
+Embedding compiled SQL in descriptions:
+
+- Bloats UI payloads and makes descriptions noisy.
+- Increases risk of exceeding size limits or reducing readability.
+- Makes it harder for consumers to selectively fetch/use the SQL.
+
+We still want compiled SQL available for tooling (lineage, debugging, “open in SQL” workflows).
+
+## Decision
+
+Use a custom `DagsterDbtTranslator` to:
+
+- Improve group naming heuristics for dbt models.
+- Attach compiled SQL to asset **metadata** (e.g., `phlo/compiled_sql` and related fields), with
+  truncation controls and source tracking.
+
+## Consequences
+
+- UIs and consumers can access compiled SQL when needed without polluting descriptions.
+- Metadata size is still bounded; truncation is explicit and discoverable.
+- Translator becomes the central place to evolve dbt→Dagster mapping semantics.
+

--- a/docs/architecture/decisions/0006-public-api-and-structured-logging.md
+++ b/docs/architecture/decisions/0006-public-api-and-structured-logging.md
@@ -1,0 +1,31 @@
+# 6. Maintain explicit public exports and avoid print() in library code
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Phlo is a library + CLI. For good developer ergonomics and type checking:
+
+- The public API should be explicit (`__all__`) and stable.
+- Import-time side effects should be minimized (lazy imports where appropriate).
+
+Separately, `print()` in library modules creates noisy output and is hard to route/structure compared
+to standard logging.
+
+## Decision
+
+- Use explicit `__all__` exports for public modules and resources, with typed/lazy imports where
+  necessary.
+- Replace non-CLI `print()` usage with structured logging (`logging.getLogger(__name__)` and
+  Dagster context logs where applicable).
+
+## Consequences
+
+- basedpyright has a clearer view of the public surface area.
+- Users get consistent logs that can be routed/filtered across environments.
+- Some internal refactors are required to avoid import cycles while keeping exports explicit.
+

--- a/docs/architecture/decisions/0007-cli-services-architecture.md
+++ b/docs/architecture/decisions/0007-cli-services-architecture.md
@@ -1,0 +1,28 @@
+# 7. Refactor `phlo services` into testable, composable units
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+The `phlo services` CLI interacts with Docker Compose and local project state.
+A monolithic implementation makes it hard to:
+
+- Test behavior without invoking Docker.
+- Provide consistent error handling and argument validation.
+- Extend commands safely as the service catalog grows.
+
+## Decision
+
+Refactor services CLI logic into focused modules (command building, container selection, service
+selection, command runner), and keep the Click/Typer command layer thin.
+
+## Consequences
+
+- Core logic becomes unit-testable and easier to reason about.
+- Error messages are more consistent and actionable.
+- Some internal module boundaries are introduced and must be maintained to avoid regressions.
+

--- a/docs/architecture/decisions/0008-scaffolds-without-placeholders.md
+++ b/docs/architecture/decisions/0008-scaffolds-without-placeholders.md
@@ -1,0 +1,31 @@
+# 8. Scaffold generators must emit working code (no TODO placeholders by default)
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Early development can tolerate breaking changes, but generated scaffolds should still be immediately
+actionable. Emitting TODO-heavy templates:
+
+- Produces “slop” that users must manually clean up.
+- Leads to inconsistent patterns across projects.
+- Makes it harder to scale beyond a single developer.
+
+## Decision
+
+All `phlo` scaffolding commands should:
+
+- Require explicit inputs for values that cannot be reasonably inferred.
+- Generate minimal working code/config without TODO placeholders.
+- Provide flags (e.g., `--field name:type`) to ensure generated artifacts are valid and typed.
+
+## Consequences
+
+- Scaffolds are more reliable and reduce follow-up manual work.
+- Users may need to supply more inputs up front (a deliberate tradeoff).
+- Template logic must remain strict to prevent regressions into placeholder output.
+

--- a/docs/architecture/decisions/0009-publishing-yaml-scaffold.md
+++ b/docs/architecture/decisions/0009-publishing-yaml-scaffold.md
@@ -1,0 +1,33 @@
+# 9. Scaffold `publishing.yaml` from dbt manifest with an idempotent merge strategy
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Publishing configuration should reflect project reality (dbt models, dependencies, and metadata),
+but it is also hand-edited.
+We need a CLI that can:
+
+- Bootstrap a valid `publishing.yaml`.
+- Update it as the project evolves without clobbering manual edits.
+- Restrict scope (e.g., only marts models) and support dry runs.
+
+## Decision
+
+Implement `phlo publishing scaffold` that:
+
+- Reads dbt `manifest.json` directly for accurate model metadata.
+- Generates/updates `publishing.yaml` using an idempotent merge strategy that preserves existing
+  fields and only adds missing stanzas/values.
+- Supports `--select`, `--dry-run`, and output path controls.
+
+## Consequences
+
+- Publishing config stays in sync with dbt with low manual effort.
+- The scaffold must be careful about merge semantics; “preserve edits” becomes a contract.
+- The CLI depends on dbt artifacts being present (manifest generation becomes part of workflow).
+

--- a/docs/architecture/decisions/0010-emit-dagster-asset-checks.md
+++ b/docs/architecture/decisions/0010-emit-dagster-asset-checks.md
@@ -1,0 +1,30 @@
+# 10. Emit Pandera and dbt results as Dagster asset checks
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Dagster asset checks are the canonical mechanism to surface data quality in the platform.
+We want Pandera and dbt results to be visible as asset checks so that:
+
+- Dagster UI, sensors, and GraphQL can treat quality signals uniformly.
+- Observatory can build a Quality Center on top of Dagster checks, not bespoke sources.
+
+## Decision
+
+- In ingestion, emit a partition-scoped `pandera_contract` asset check based on the Pandera schema
+  and staged parquet data; fail the run by default on contract failures.
+- In dbt transforms, parse `run_results.json` + `manifest.json` after dbt execution and emit one
+  Dagster asset check per dbt test, attached to the tested asset key, following the shared naming,
+  metadata, and severity policies.
+
+## Consequences
+
+- Quality becomes first-class in Dagster across ingestion and transform layers.
+- Check emission adds overhead (artifact parsing, metadata shaping) but remains bounded and testable.
+- Check producers must maintain correct asset key mapping; the dbt translator becomes critical.
+

--- a/docs/architecture/decisions/0011-observatory-quality-from-dagster.md
+++ b/docs/architecture/decisions/0011-observatory-quality-from-dagster.md
@@ -1,0 +1,35 @@
+# 11. Observatory Quality Center sources from Dagster GraphQL with caching and drilldown
+
+Date: 2025-12-14
+
+## Status
+
+Accepted
+
+## Context
+
+Observatory needs a unified view of quality across assets with:
+
+- A dashboard summary (counts, recent activity).
+- Filtering (by layer/status/type).
+- Drilldown (metadata, sample, history) and links to investigate in SQL.
+
+Dagster is the source of truth for asset checks, but GraphQL queries can be expensive if repeatedly
+issued from the UI.
+
+## Decision
+
+- Implement server-side aggregation of Dagster asset checks via Dagster GraphQL:
+  - Fetch check definitions per asset.
+  - Fetch recent check executions per asset and compute “latest status” per check.
+  - Provide a consolidated API for overview, failing checks, recent executions, and per-check history.
+- Use a short-lived in-memory cache to avoid hammering Dagster on rapid UI refresh.
+- Provide “Open in SQL” deep links by reusing check metadata (`repro_sql` / `query_or_sql`) and by
+  enabling `?sql=` and `?tab=` URL parameters in the Data Explorer.
+
+## Consequences
+
+- Observatory stays Dagster-check-native and does not need to understand Pandera/dbt internals.
+- Caching improves perceived performance but introduces brief staleness (acceptable for monitoring).
+- Deep linking depends on stable URL and query-handling semantics in the Data Explorer.
+


### PR DESCRIPTION
Retrospective ADRs for decisions implemented since 3af8e8f0.

Adds ADRs in `docs/architecture/decisions/` using the Michael Nygard template.
