### PR TITLE
fix(observatory): add QueryClientProvider for SSR

### DIFF
--- a/services/observatory/src/routes/__root.tsx
+++ b/services/observatory/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { TanStackDevtools } from '@tanstack/react-devtools'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   HeadContent,
   Link,
@@ -30,6 +31,16 @@ import {
 import { cn } from '@/lib/utils'
 import { getSearchIndex } from '@/server/search.server'
 
+// Create a stable QueryClient for React Query
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60, // 1 minute
+      retry: 1,
+    },
+  },
+})
+
 export const Route = createRootRoute({
   head: () => ({
     meta: [
@@ -55,9 +66,11 @@ const THEME_STORAGE_KEY = 'phlo-observatory-theme'
 
 function RootLayout() {
   return (
-    <ObservatorySettingsProvider>
-      <RootLayoutInner />
-    </ObservatorySettingsProvider>
+    <QueryClientProvider client={queryClient}>
+      <ObservatorySettingsProvider>
+        <RootLayoutInner />
+      </ObservatorySettingsProvider>
+    </QueryClientProvider>
   )
 }
 


### PR DESCRIPTION
## Summary
The useRealtimePolling hook uses @tanstack/react-query's useQuery, which requires a QueryClientProvider during SSR. This was causing a 'No QueryClient set' error on the homepage.

## Changes
- Added QueryClient with sensible defaults (1 min stale time, 1 retry)
- Wrapped the app with QueryClientProvider in __root.tsx

## Testing
- Verified homepage loads without errors
- All checks pass