### PR TITLE
feat(security): add enterprise security configuration options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ POSTGRES_USER=lake
 POSTGRES_PASSWORD=lakepass
 POSTGRES_DB=lakehouse
 POSTGRES_PORT=10000
+# Postgres SSL (optional)
+# POSTGRES_SSL_MODE=require
+# POSTGRES_SSL_CERT_FILE=/path/to/cert.pem
+# POSTGRES_SSL_KEY_FILE=/path/to/key.pem
+# POSTGRES_SSL_CA_FILE=/path/to/ca.pem
 
 # MinIO
 MINIO_HOST=minio
@@ -10,14 +15,54 @@ MINIO_ROOT_USER=minio
 MINIO_ROOT_PASSWORD=minio999
 MINIO_CONSOLE_PORT=10002
 MINIO_API_PORT=10001
+# MinIO TLS (optional - set server URL to enable)
+# MINIO_SERVER_URL=https://minio.example.com
+# MinIO OIDC Authentication (optional)
+# MINIO_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
+# MINIO_OIDC_CLIENT_ID=minio
+# MINIO_OIDC_CLIENT_SECRET=your-client-secret
+# MinIO LDAP Authentication (optional)
+# MINIO_LDAP_SERVER=ldap.example.com:636
+# MINIO_LDAP_BIND_DN=cn=admin,dc=example,dc=com
+# MINIO_LDAP_BIND_PASSWORD=ldap-password
+# MINIO_LDAP_USER_BASE_DN=ou=users,dc=example,dc=com
+# MINIO_LDAP_USER_FILTER=(uid=%s)
+# MinIO Encryption (optional)
+# MINIO_AUTO_ENCRYPTION=on
+# MinIO Audit Logging (optional)
+# MINIO_AUDIT_ENABLED=on
+# MINIO_AUDIT_ENDPOINT=http://audit-service:8080/logs
 
 # Nessie (Git-like data catalog)
 NESSIE_VERSION=0.105.5
 NESSIE_PORT=10003
+# Nessie OIDC Authentication (optional)
+# NESSIE_OIDC_ENABLED=true
+# NESSIE_OIDC_SERVER_URL=https://auth.example.com/realms/phlo
+# NESSIE_OIDC_CLIENT_ID=nessie
+# NESSIE_OIDC_CLIENT_SECRET=your-client-secret
+# Nessie Authorization (optional)
+# NESSIE_AUTHZ_ENABLED=true
 
 # Trino (Query Engine)
 TRINO_VERSION=477
 TRINO_PORT=10005
+# Trino Authentication (optional - choose one)
+# TRINO_AUTH_TYPE=PASSWORD
+# TRINO_LDAP_URL=ldaps://ldap.example.com:636
+# TRINO_LDAP_USER_BIND_PATTERN=${USER}@example.com
+# -- or --
+# TRINO_AUTH_TYPE=OAUTH2
+# TRINO_OAUTH2_ISSUER=https://auth.example.com
+# TRINO_OAUTH2_CLIENT_ID=trino
+# TRINO_OAUTH2_CLIENT_SECRET=your-client-secret
+# Trino HTTPS (optional)
+# TRINO_HTTPS_ENABLED=true
+# TRINO_HTTPS_KEYSTORE_PATH=/etc/trino/keystore.jks
+# TRINO_HTTPS_KEYSTORE_PASSWORD=keystore-password
+# Trino Access Control (optional)
+# TRINO_ACCESS_CONTROL_TYPE=file
+# TRINO_ACCESS_CONTROL_CONFIG_FILE=/etc/trino/access-control.json
 
 # Iceberg
 ICEBERG_WAREHOUSE_PATH=s3://lake/warehouse

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -309,6 +309,87 @@ SMTP_FROM=alerts@yourdomain.com
 SMTP_TO=team@yourdomain.com
 ```
 
+### Security Configuration
+
+See [Security Setup Guide](../setup/security.md) for detailed setup instructions.
+
+#### Trino Authentication
+
+```bash
+# Authentication type (PASSWORD, OAUTH2, JWT, CERTIFICATE, KERBEROS, or empty)
+TRINO_AUTH_TYPE=
+
+# LDAP Authentication (when TRINO_AUTH_TYPE=PASSWORD)
+TRINO_LDAP_URL=ldaps://ldap.example.com:636
+TRINO_LDAP_USER_BIND_PATTERN=${USER}@example.com
+
+# OAuth2/OIDC Authentication (when TRINO_AUTH_TYPE=OAUTH2)
+TRINO_OAUTH2_ISSUER=https://auth.example.com
+TRINO_OAUTH2_CLIENT_ID=trino
+TRINO_OAUTH2_CLIENT_SECRET=your-client-secret
+
+# HTTPS/TLS
+TRINO_HTTPS_ENABLED=false
+TRINO_HTTPS_KEYSTORE_PATH=/etc/trino/keystore.jks
+TRINO_HTTPS_KEYSTORE_PASSWORD=keystore-password
+
+# Access Control
+TRINO_ACCESS_CONTROL_TYPE=file
+TRINO_ACCESS_CONTROL_CONFIG_FILE=/etc/trino/access-control.json
+```
+
+#### Nessie Authentication
+
+```bash
+# OIDC/OAuth2 Authentication
+NESSIE_OIDC_ENABLED=false
+NESSIE_OIDC_SERVER_URL=https://auth.example.com/realms/phlo
+NESSIE_OIDC_CLIENT_ID=nessie
+NESSIE_OIDC_CLIENT_SECRET=your-client-secret
+NESSIE_OIDC_ISSUER=https://auth.example.com
+
+# Authorization
+NESSIE_AUTHZ_ENABLED=false
+```
+
+#### MinIO Security
+
+```bash
+# TLS (set server URL to enable HTTPS)
+MINIO_SERVER_URL=https://minio.example.com
+
+# OIDC Authentication
+MINIO_OIDC_CONFIG_URL=https://auth.example.com/.well-known/openid-configuration
+MINIO_OIDC_CLIENT_ID=minio
+MINIO_OIDC_CLIENT_SECRET=your-client-secret
+MINIO_OIDC_CLAIM_NAME=policy
+MINIO_OIDC_SCOPES=openid
+
+# LDAP Authentication
+MINIO_LDAP_SERVER=ldap.example.com:636
+MINIO_LDAP_BIND_DN=cn=admin,dc=example,dc=com
+MINIO_LDAP_BIND_PASSWORD=ldap-password
+MINIO_LDAP_USER_BASE_DN=ou=users,dc=example,dc=com
+MINIO_LDAP_USER_FILTER=(uid=%s)
+
+# Encryption at Rest
+MINIO_AUTO_ENCRYPTION=off
+
+# Audit Logging
+MINIO_AUDIT_ENABLED=off
+MINIO_AUDIT_ENDPOINT=http://audit-service:8080/logs
+```
+
+#### PostgreSQL SSL
+
+```bash
+# SSL Mode (disable, allow, prefer, require, verify-ca, verify-full)
+POSTGRES_SSL_MODE=prefer
+POSTGRES_SSL_CERT_FILE=/path/to/cert.pem
+POSTGRES_SSL_KEY_FILE=/path/to/key.pem
+POSTGRES_SSL_CA_FILE=/path/to/ca.pem
+```
+
 ### dbt Configuration
 
 ```bash

--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -1,0 +1,424 @@
+# Security Setup Guide
+
+This guide covers enterprise security configuration for Phlo, including authentication, authorization, encryption, and audit logging.
+
+## Overview
+
+Phlo's underlying services (Trino, Nessie, MinIO, PostgreSQL) support enterprise security features. This guide explains how to enable and configure them.
+
+| Feature | Trino | Nessie | MinIO | PostgreSQL |
+|---------|-------|--------|-------|------------|
+| LDAP Auth | Yes | No | Yes | No |
+| OAuth2/OIDC | Yes | Yes | Yes | No |
+| TLS/HTTPS | Yes | Yes | Yes | Yes |
+| Access Control | Yes | Yes | Yes (IAM) | Yes (RLS) |
+| Audit Logging | Yes | Yes | Yes | Yes |
+
+## Quick Start
+
+For a minimal secure setup, configure these environment variables in your `.env`:
+
+```bash
+# Strong passwords (required)
+POSTGRES_PASSWORD=<generate-strong-password>
+MINIO_ROOT_PASSWORD=<generate-strong-password>
+JWT_SECRET=<generate-strong-password>
+
+# Enable TLS (recommended for production)
+POSTGRES_SSL_MODE=require
+MINIO_SERVER_URL=https://minio.example.com
+
+# Enable authentication (choose based on your IdP)
+NESSIE_OIDC_ENABLED=true
+NESSIE_OIDC_SERVER_URL=https://auth.example.com/realms/phlo
+```
+
+Generate strong passwords:
+
+```bash
+openssl rand -base64 32
+```
+
+## Authentication
+
+### Option 1: LDAP Authentication
+
+LDAP works with Trino and MinIO. Configure your LDAP server details:
+
+#### Trino LDAP
+
+```bash
+# .env
+TRINO_AUTH_TYPE=PASSWORD
+TRINO_LDAP_URL=ldaps://ldap.example.com:636
+TRINO_LDAP_USER_BIND_PATTERN=${USER}@example.com
+```
+
+Users authenticate with their LDAP credentials when connecting to Trino.
+
+#### MinIO LDAP
+
+```bash
+# .env
+MINIO_LDAP_SERVER=ldap.example.com:636
+MINIO_LDAP_BIND_DN=cn=admin,dc=example,dc=com
+MINIO_LDAP_BIND_PASSWORD=ldap-admin-password
+MINIO_LDAP_USER_BASE_DN=ou=users,dc=example,dc=com
+MINIO_LDAP_USER_FILTER=(uid=%s)
+```
+
+### Option 2: OAuth2/OIDC Authentication
+
+OIDC works with all services and is recommended for unified SSO.
+
+#### Prerequisites
+
+1. An OIDC provider (Keycloak, Auth0, Okta, Azure AD, etc.)
+2. Create clients for each service:
+   - `nessie` - for Nessie catalog
+   - `minio` - for MinIO storage
+   - `trino` - for Trino query engine
+
+#### Nessie OIDC
+
+```bash
+# .env
+NESSIE_OIDC_ENABLED=true
+NESSIE_OIDC_SERVER_URL=https://auth.example.com/realms/phlo
+NESSIE_OIDC_CLIENT_ID=nessie
+NESSIE_OIDC_CLIENT_SECRET=your-client-secret
+```
+
+#### MinIO OIDC
+
+```bash
+# .env
+MINIO_OIDC_CONFIG_URL=https://auth.example.com/realms/phlo/.well-known/openid-configuration
+MINIO_OIDC_CLIENT_ID=minio
+MINIO_OIDC_CLIENT_SECRET=your-client-secret
+MINIO_OIDC_CLAIM_NAME=policy
+```
+
+The `policy` claim in the JWT should contain the MinIO policy name(s) to assign.
+
+#### Trino OAuth2
+
+```bash
+# .env
+TRINO_AUTH_TYPE=OAUTH2
+TRINO_OAUTH2_ISSUER=https://auth.example.com/realms/phlo
+TRINO_OAUTH2_CLIENT_ID=trino
+TRINO_OAUTH2_CLIENT_SECRET=your-client-secret
+```
+
+### Keycloak Example Setup
+
+If using Keycloak as your identity provider:
+
+1. Create a realm called `phlo`
+2. Create clients:
+
+```json
+{
+  "clientId": "nessie",
+  "protocol": "openid-connect",
+  "publicClient": false,
+  "standardFlowEnabled": true,
+  "serviceAccountsEnabled": true
+}
+```
+
+3. Create users and assign roles
+4. Map roles to policies in MinIO
+
+## Authorization
+
+### Trino Access Control
+
+Create an access control rules file:
+
+```json
+{
+  "catalogs": [
+    {
+      "catalog": "iceberg",
+      "allow": "all"
+    }
+  ],
+  "schemas": [
+    {
+      "catalog": "iceberg",
+      "schema": "raw",
+      "owner": false
+    }
+  ],
+  "tables": [
+    {
+      "catalog": "iceberg",
+      "schema": ".*",
+      "table": ".*",
+      "privileges": ["SELECT"],
+      "filter": "department = current_user_department()"
+    }
+  ]
+}
+```
+
+Enable in `.env`:
+
+```bash
+TRINO_ACCESS_CONTROL_TYPE=file
+TRINO_ACCESS_CONTROL_CONFIG_FILE=/etc/trino/access-control.json
+```
+
+Mount the rules file in your service configuration.
+
+### Nessie Authorization
+
+Enable authorization:
+
+```bash
+NESSIE_AUTHZ_ENABLED=true
+```
+
+Nessie authorization rules are configured through the Nessie server. See [Nessie Authorization](https://projectnessie.org/features/authz/) for details.
+
+### MinIO IAM Policies
+
+Create IAM policies for fine-grained access:
+
+```bash
+# Create a read-only policy
+mc admin policy create local readonly-lake - <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::lake/*", "arn:aws:s3:::lake"]
+    }
+  ]
+}
+EOF
+
+# Attach to user
+mc admin policy attach local readonly-lake --user analyst
+```
+
+### PostgreSQL Row-Level Security
+
+Phlo includes a pre-built RLS framework in PostgREST. Enable it:
+
+```sql
+-- Enable RLS on a table
+ALTER TABLE marts.customers ENABLE ROW LEVEL SECURITY;
+
+-- Create policy for analysts (see only their region)
+CREATE POLICY analyst_region ON marts.customers
+  FOR SELECT
+  TO analyst
+  USING (region = current_setting('app.user_region'));
+
+-- Create policy for admins (see everything)
+CREATE POLICY admin_all ON marts.customers
+  FOR ALL
+  TO admin
+  USING (true);
+```
+
+The JWT token should include claims that set the user's role and context.
+
+## Encryption
+
+### TLS/HTTPS
+
+#### PostgreSQL SSL
+
+```bash
+# .env
+POSTGRES_SSL_MODE=require
+```
+
+For certificate verification:
+
+```bash
+POSTGRES_SSL_MODE=verify-full
+POSTGRES_SSL_CA_FILE=/path/to/ca.pem
+```
+
+#### MinIO TLS
+
+1. Place certificates in `./volumes/minio-certs/`:
+   - `public.crt` - Server certificate
+   - `private.key` - Private key
+   - `CAs/` - CA certificates (optional)
+
+2. Enable TLS:
+
+```bash
+MINIO_SERVER_URL=https://minio.example.com:9000
+```
+
+#### Trino HTTPS
+
+1. Create a Java keystore:
+
+```bash
+keytool -genkeypair -alias trino -keyalg RSA -keysize 2048 \
+  -keystore keystore.jks -validity 365 \
+  -dname "CN=trino.example.com"
+```
+
+2. Enable HTTPS:
+
+```bash
+TRINO_HTTPS_ENABLED=true
+TRINO_HTTPS_KEYSTORE_PATH=/etc/trino/keystore.jks
+TRINO_HTTPS_KEYSTORE_PASSWORD=your-keystore-password
+```
+
+### Encryption at Rest
+
+#### MinIO Server-Side Encryption
+
+```bash
+MINIO_AUTO_ENCRYPTION=on
+```
+
+This encrypts all objects automatically using MinIO's built-in encryption.
+
+For KMS-based encryption, configure a KMS provider:
+
+```bash
+MINIO_KMS_KES_ENDPOINT=https://kes.example.com:7373
+MINIO_KMS_KES_KEY_FILE=/path/to/kes-key.key
+MINIO_KMS_KES_CERT_FILE=/path/to/kes-cert.crt
+MINIO_KMS_KES_KEY_NAME=my-key
+```
+
+## Audit Logging
+
+### MinIO Audit Logs
+
+Send audit logs to a webhook:
+
+```bash
+MINIO_AUDIT_ENABLED=on
+MINIO_AUDIT_ENDPOINT=http://loki:3100/loki/api/v1/push
+```
+
+Or configure for Kafka:
+
+```bash
+MINIO_AUDIT_KAFKA_ENABLE=on
+MINIO_AUDIT_KAFKA_BROKERS=kafka:9092
+MINIO_AUDIT_KAFKA_TOPIC=minio-audit
+```
+
+### PostgreSQL Audit Logging
+
+Enable pgaudit extension:
+
+```sql
+-- In PostgreSQL
+CREATE EXTENSION IF NOT EXISTS pgaudit;
+ALTER SYSTEM SET pgaudit.log = 'all';
+SELECT pg_reload_conf();
+```
+
+### Trino Query Logging
+
+Trino logs all queries by default. Configure log retention:
+
+```properties
+# coordinator config
+query.max-history=10000
+```
+
+## Existing Security Features
+
+Phlo already includes these security features that you can use:
+
+### PostgREST JWT Authentication
+
+Located in `packages/phlo-postgrest/src/phlo_postgrest/sql/`:
+
+- `003_jwt_functions.sql` - JWT signing and verification
+- `004_roles.sql` - Role-based access control
+
+Usage:
+
+```bash
+# Get a JWT token
+curl -X POST http://localhost:10018/rpc/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "admin", "password": "admin123"}'
+
+# Use token for authenticated requests
+curl http://localhost:10018/customers \
+  -H "Authorization: Bearer <token>"
+```
+
+### Hasura Permissions
+
+Located in `packages/phlo-hasura/src/phlo_hasura/permissions.py`:
+
+- Full RBAC with row and column-level permissions
+- Configure via Hasura console or API
+
+### Observatory Token Auth
+
+Enable UI authentication:
+
+```bash
+OBSERVATORY_AUTH_ENABLED=true
+OBSERVATORY_AUTH_TOKEN=your-secure-token
+```
+
+## Production Checklist
+
+Before going to production, ensure:
+
+- [ ] All default passwords changed
+- [ ] TLS enabled for all services
+- [ ] Authentication configured (LDAP or OIDC)
+- [ ] Access control rules defined
+- [ ] Audit logging enabled
+- [ ] Secrets stored securely (not in git)
+- [ ] Network segmentation (services not exposed publicly)
+- [ ] Regular credential rotation policy
+
+## Troubleshooting
+
+### OIDC Token Issues
+
+```bash
+# Decode JWT to inspect claims
+echo "<token>" | cut -d. -f2 | base64 -d | jq
+```
+
+### LDAP Connection Issues
+
+```bash
+# Test LDAP connection
+ldapsearch -x -H ldaps://ldap.example.com:636 \
+  -D "cn=admin,dc=example,dc=com" \
+  -W -b "dc=example,dc=com" "(uid=testuser)"
+```
+
+### Certificate Issues
+
+```bash
+# Verify certificate
+openssl s_client -connect minio.example.com:9000 -showcerts
+
+# Check certificate dates
+openssl x509 -in cert.pem -noout -dates
+```
+
+## Next Steps
+
+- [Configuration Reference](../reference/configuration-reference.md) - All security variables
+- [Production Deployment](../blog/12-production-deployment.md) - Deployment guide
+- [Observability Setup](observability.md) - Monitoring and logging

--- a/packages/phlo-minio/src/phlo_minio/service.yaml
+++ b/packages/phlo-minio/src/phlo_minio/service.yaml
@@ -10,12 +10,32 @@ compose:
   environment:
     MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minio}
     MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minio123}
+    # TLS
+    MINIO_SERVER_URL: ${MINIO_SERVER_URL:-}
+    # Identity Provider (OIDC)
+    MINIO_IDENTITY_OPENID_CONFIG_URL: ${MINIO_OIDC_CONFIG_URL:-}
+    MINIO_IDENTITY_OPENID_CLIENT_ID: ${MINIO_OIDC_CLIENT_ID:-}
+    MINIO_IDENTITY_OPENID_CLIENT_SECRET: ${MINIO_OIDC_CLIENT_SECRET:-}
+    MINIO_IDENTITY_OPENID_CLAIM_NAME: ${MINIO_OIDC_CLAIM_NAME:-policy}
+    MINIO_IDENTITY_OPENID_SCOPES: ${MINIO_OIDC_SCOPES:-openid}
+    # LDAP
+    MINIO_IDENTITY_LDAP_SERVER_ADDR: ${MINIO_LDAP_SERVER:-}
+    MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN: ${MINIO_LDAP_BIND_DN:-}
+    MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD: ${MINIO_LDAP_BIND_PASSWORD:-}
+    MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN: ${MINIO_LDAP_USER_BASE_DN:-}
+    MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER: ${MINIO_LDAP_USER_FILTER:-}
+    # Encryption
+    MINIO_KMS_AUTO_ENCRYPTION: ${MINIO_AUTO_ENCRYPTION:-off}
+    # Audit logging
+    MINIO_AUDIT_WEBHOOK_ENABLE: ${MINIO_AUDIT_ENABLED:-off}
+    MINIO_AUDIT_WEBHOOK_ENDPOINT: ${MINIO_AUDIT_ENDPOINT:-}
   command: ["server", "/data", "--console-address", ":9001"]
   ports:
     - "${MINIO_API_PORT:-9000}:9000"
     - "${MINIO_CONSOLE_PORT:-9001}:9001"
   volumes:
     - ./volumes/minio:/data
+    - ./volumes/minio-certs:/root/.minio/certs:ro
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
     interval: 10s
@@ -36,3 +56,52 @@ env_vars:
   MINIO_CONSOLE_PORT:
     default: 9001
     description: MinIO console port
+  # TLS
+  MINIO_SERVER_URL:
+    default: ""
+    description: "Public URL for MinIO (e.g., https://minio.example.com). Enables TLS if https://"
+  # OIDC Authentication
+  MINIO_OIDC_CONFIG_URL:
+    default: ""
+    description: "OIDC discovery URL (e.g., https://auth.example.com/.well-known/openid-configuration)"
+  MINIO_OIDC_CLIENT_ID:
+    default: ""
+    description: "OIDC client ID"
+  MINIO_OIDC_CLIENT_SECRET:
+    default: ""
+    description: "OIDC client secret"
+    secret: true
+  MINIO_OIDC_CLAIM_NAME:
+    default: "policy"
+    description: "JWT claim name containing MinIO policy"
+  MINIO_OIDC_SCOPES:
+    default: "openid"
+    description: "OIDC scopes to request"
+  # LDAP Authentication
+  MINIO_LDAP_SERVER:
+    default: ""
+    description: "LDAP server address (e.g., ldap.example.com:636)"
+  MINIO_LDAP_BIND_DN:
+    default: ""
+    description: "LDAP bind DN for lookups"
+  MINIO_LDAP_BIND_PASSWORD:
+    default: ""
+    description: "LDAP bind password"
+    secret: true
+  MINIO_LDAP_USER_BASE_DN:
+    default: ""
+    description: "LDAP user search base DN"
+  MINIO_LDAP_USER_FILTER:
+    default: ""
+    description: "LDAP user search filter (e.g., (uid=%s))"
+  # Encryption
+  MINIO_AUTO_ENCRYPTION:
+    default: "off"
+    description: "Enable automatic server-side encryption (on/off)"
+  # Audit Logging
+  MINIO_AUDIT_ENABLED:
+    default: "off"
+    description: "Enable audit logging via webhook (on/off)"
+  MINIO_AUDIT_ENDPOINT:
+    default: ""
+    description: "Webhook endpoint for audit logs"

--- a/packages/phlo-nessie/src/phlo_nessie/service.yaml
+++ b/packages/phlo-nessie/src/phlo_nessie/service.yaml
@@ -24,6 +24,14 @@ compose:
     nessie.catalog.service.s3.default-options.access-key: urn:nessie-secret:quarkus:nessie.catalog.secrets.access-key
     nessie.catalog.secrets.access-key.name: ${MINIO_ROOT_USER:-minio}
     nessie.catalog.secrets.access-key.secret: ${MINIO_ROOT_PASSWORD:-minio123}
+    # OIDC Authentication (Quarkus)
+    QUARKUS_OIDC_ENABLED: ${NESSIE_OIDC_ENABLED:-false}
+    QUARKUS_OIDC_AUTH_SERVER_URL: ${NESSIE_OIDC_SERVER_URL:-}
+    QUARKUS_OIDC_CLIENT_ID: ${NESSIE_OIDC_CLIENT_ID:-}
+    QUARKUS_OIDC_CREDENTIALS_SECRET: ${NESSIE_OIDC_CLIENT_SECRET:-}
+    QUARKUS_OIDC_TOKEN_ISSUER: ${NESSIE_OIDC_ISSUER:-}
+    # Authorization
+    NESSIE_SERVER_AUTHORIZATION_ENABLED: ${NESSIE_AUTHZ_ENABLED:-false}
   ports:
     - "${NESSIE_PORT:-19120}:19120"
   healthcheck:
@@ -40,6 +48,27 @@ env_vars:
   NESSIE_PORT:
     default: 19120
     description: Nessie API port
+  # OIDC Authentication
+  NESSIE_OIDC_ENABLED:
+    default: "false"
+    description: "Enable OIDC/OAuth2 authentication"
+  NESSIE_OIDC_SERVER_URL:
+    default: ""
+    description: "OIDC server URL (e.g., https://auth.example.com/realms/phlo)"
+  NESSIE_OIDC_CLIENT_ID:
+    default: ""
+    description: "OIDC client ID"
+  NESSIE_OIDC_CLIENT_SECRET:
+    default: ""
+    description: "OIDC client secret"
+    secret: true
+  NESSIE_OIDC_ISSUER:
+    default: ""
+    description: "OIDC token issuer URL (if different from server URL)"
+  # Authorization
+  NESSIE_AUTHZ_ENABLED:
+    default: "false"
+    description: "Enable Nessie authorization rules"
 
 hooks:
   post_start:

--- a/packages/phlo-postgres/src/phlo_postgres/service.yaml
+++ b/packages/phlo-postgres/src/phlo_postgres/service.yaml
@@ -11,10 +11,13 @@ compose:
     POSTGRES_USER: ${POSTGRES_USER:-phlo}
     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-phlo}
     POSTGRES_DB: ${POSTGRES_DB:-phlo}
+    # SSL/TLS
+    POSTGRES_SSL_MODE: ${POSTGRES_SSL_MODE:-prefer}
   ports:
     - "${POSTGRES_PORT:-5432}:5432"
   volumes:
     - ./volumes/postgres:/var/lib/postgresql/data
+    - ./volumes/postgres-certs:/var/lib/postgresql/certs:ro
   healthcheck:
     test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-phlo}"]
     interval: 10s
@@ -35,3 +38,16 @@ env_vars:
   POSTGRES_PORT:
     default: 5432
     description: PostgreSQL host port
+  # SSL/TLS
+  POSTGRES_SSL_MODE:
+    default: "prefer"
+    description: "SSL mode: disable, allow, prefer, require, verify-ca, verify-full"
+  POSTGRES_SSL_CERT_FILE:
+    default: ""
+    description: "Path to SSL certificate file"
+  POSTGRES_SSL_KEY_FILE:
+    default: ""
+    description: "Path to SSL private key file"
+  POSTGRES_SSL_CA_FILE:
+    default: ""
+    description: "Path to SSL CA certificate file"

--- a/packages/phlo-trino/src/phlo_trino/service.yaml
+++ b/packages/phlo-trino/src/phlo_trino/service.yaml
@@ -21,6 +21,7 @@ compose:
     - "${TRINO_PORT:-8080}:8080"
   volumes:
     - ./trino/catalog:/etc/trino/catalog:ro
+    - ./trino/etc:/etc/trino/etc:ro
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:8080/v1/info"]
     interval: 10s
@@ -35,6 +36,44 @@ env_vars:
   TRINO_PORT:
     default: 8080
     description: Trino HTTP port
+  # Authentication
+  TRINO_AUTH_TYPE:
+    default: ""
+    description: "Authentication type: PASSWORD, OAUTH2, JWT, CERTIFICATE, KERBEROS, or empty for none"
+  TRINO_LDAP_URL:
+    default: ""
+    description: "LDAP server URL for PASSWORD auth (e.g., ldaps://ldap.example.com:636)"
+  TRINO_LDAP_USER_BIND_PATTERN:
+    default: ""
+    description: "LDAP user bind pattern (e.g., ${USER}@example.com)"
+  TRINO_OAUTH2_ISSUER:
+    default: ""
+    description: "OAuth2/OIDC issuer URL"
+  TRINO_OAUTH2_CLIENT_ID:
+    default: ""
+    description: "OAuth2 client ID"
+  TRINO_OAUTH2_CLIENT_SECRET:
+    default: ""
+    description: "OAuth2 client secret"
+    secret: true
+  # TLS/HTTPS
+  TRINO_HTTPS_ENABLED:
+    default: "false"
+    description: "Enable HTTPS for Trino coordinator"
+  TRINO_HTTPS_KEYSTORE_PATH:
+    default: ""
+    description: "Path to Java keystore for HTTPS"
+  TRINO_HTTPS_KEYSTORE_PASSWORD:
+    default: ""
+    description: "Keystore password"
+    secret: true
+  # Access Control
+  TRINO_ACCESS_CONTROL_TYPE:
+    default: ""
+    description: "Access control type: file, read-only, allow-all, or empty for default"
+  TRINO_ACCESS_CONTROL_CONFIG_FILE:
+    default: ""
+    description: "Path to access control rules JSON file"
 
 files:
   - source: catalog/iceberg.properties


### PR DESCRIPTION
## Summary

- Add environment variables for authentication, authorization, encryption, and audit logging across all core services
- Create comprehensive security setup guide with examples for LDAP, OAuth2/OIDC, TLS, and access control
- Document existing security features (PostgREST JWT, Hasura permissions)

### Services Updated

| Service | Features Added |
|---------|----------------|
| **Trino** | LDAP auth, OAuth2/OIDC, HTTPS, file-based access control |
| **Nessie** | OIDC authentication, authorization rules |
| **MinIO** | OIDC, LDAP, TLS, server-side encryption, audit webhooks |
| **PostgreSQL** | SSL/TLS configuration |

### Files Changed

- `packages/phlo-trino/src/phlo_trino/service.yaml` - Auth and access control env vars
- `packages/phlo-nessie/src/phlo_nessie/service.yaml` - OIDC env vars
- `packages/phlo-minio/src/phlo_minio/service.yaml` - OIDC, LDAP, encryption env vars
- `packages/phlo-postgres/src/phlo_postgres/service.yaml` - SSL env vars
- `.env.example` - Commented examples for all security options
- `docs/reference/configuration-reference.md` - Security configuration section
- `docs/setup/security.md` - **NEW** Comprehensive security setup guide

## Test plan

- [ ] Verify services start with default (no auth) configuration
- [ ] Test OIDC configuration with a test Keycloak instance
- [ ] Verify TLS certificate mounting works
- [ ] Review documentation for accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Security Setup Guide with authentication, authorization, encryption, and audit logging details
  * Updated configuration reference with security configuration examples

* **New Features**
  * Added enterprise security capabilities: OIDC and LDAP authentication, TLS/SSL encryption, and audit logging across MinIO, PostgreSQL, Trino, and Nessie

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->