### PR TITLE
feat: register phlo-api service plugin

### DIFF
--- a/packages/phlo-observatory/src/phlo_observatory/src/server/services.server.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/server/services.server.ts
@@ -86,10 +86,10 @@ const serviceMetadata: Record<
     description: 'GraphQL API for PostgreSQL',
     default: false,
   },
-  fastapi: {
+  'phlo-api': {
     category: 'api',
-    description: 'Custom FastAPI service layer',
-    default: false,
+    description: 'Backend API for Observatory and Phlo internals',
+    default: true,
   },
   prometheus: {
     category: 'observability',

--- a/registry/plugins.json
+++ b/registry/plugins.json
@@ -165,6 +165,16 @@
       "tags": ["api", "graphql"],
       "verified": true
     },
+    "phlo-api": {
+      "type": "service",
+      "package": "phlo-api",
+      "version": "0.1.0",
+      "description": "Backend API exposing Phlo internals to Observatory",
+      "author": "Phlo Team",
+      "homepage": "https://github.com/iamgp/phlo/tree/main/packages/phlo-api",
+      "tags": ["api", "observability"],
+      "verified": true
+    },
     "postgrest": {
       "type": "service",
       "package": "phlo-postgrest",

--- a/src/phlo/plugins/registry_data.json
+++ b/src/phlo/plugins/registry_data.json
@@ -195,6 +195,16 @@
       "tags": ["api", "graphql"],
       "verified": true
     },
+    "phlo-api": {
+      "type": "service",
+      "package": "phlo-api",
+      "version": "0.1.0",
+      "description": "Backend API exposing Phlo internals to Observatory",
+      "author": "Phlo Team",
+      "homepage": "https://github.com/iamgp/phlo/tree/main/packages/phlo-api",
+      "tags": ["api", "observability"],
+      "verified": true
+    },
     "postgrest": {
       "type": "service",
       "package": "phlo-postgrest",


### PR DESCRIPTION
## Summary
- add phlo-api to the plugin registry data and published registry
- align Observatory service metadata with the phlo-api service name

## Testing
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check src/phlo
- uv run pytest -m "not integration" --tb=short --ignore=tests/test_definitions.py --ignore=tests/test_system_e2e.py --ignore=tests/test_transform.py --ignore=tests/test_resources.py --ignore=tests/test_quality.py --ignore=tests/scripts/test_duckdb_iceberg.py
- uv run sqlfluff lint examples/glucose-platform/transforms/dbt/models --ignore parsing (skipped: examples moved to phlo-examples)
- npm ci
- npx eslint src --ext .ts,.tsx
- npx tsc --noEmit
- npx prettier --check .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched phlo-api v0.1.0, a new backend API service providing secure access to Phlo internals and Observatory platform integration with comprehensive observability features. Enables detailed system performance tracking and real-time health monitoring capabilities across your infrastructure. The service is now fully registered, verified, and ready for immediate production deployment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->