### PR TITLE
fix: suppress pyiceberg Pydantic v2.12 deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,8 +136,9 @@ markers = [
     "integration: marks tests as requiring external services or dbt manifest (run with '-m integration')",
 ]
 filterwarnings = [
-    # pyiceberg still emits Pydantic v2.12 deprecations; filter until upstream cleanup.
-    "ignore:.*PydanticDeprecatedSince212.*:DeprecationWarning:pyiceberg.*",
+    # pyiceberg emits Pydantic v2.12 deprecations from @model_validator usage.
+    # Suppress until upstream fixes: https://github.com/apache/iceberg-python/issues
+    "ignore:Using `@model_validator` with mode='after' on a classmethod is deprecated:DeprecationWarning",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary

Updates pytest filterwarnings pattern to properly suppress pyiceberg's Pydantic v2.12 deprecation warnings.

## Changes

- Fixed the warning filter pattern in `pyproject.toml`
- The previous pattern used a module filter (`pyiceberg.*`) that didn't match the actual import paths
- New pattern matches the specific deprecation message about `@model_validator`

## Testing

```
71 passed, 1 skipped, 6 deselected in 3.25s
```

No warnings in test output.

## Related

Part of alpha.3 release plan (item 2.1): [0001-alpha3-release-plan.md](docs/architecture/specs/0001-alpha3-release-plan.md)