### PR TITLE
chore(release): use prerelease versioning strategy

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,3 +21,4 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
+          versioning-strategy: prerelease


### PR DESCRIPTION
## Summary
- force prerelease versioning in release-please action

## Notes
- keeps alpha bumps as patch increments