### PR TITLE
Emit pandera contract checks for DLT ingestion

### DIFF
--- a/packages/phlo-dlt/src/phlo_dlt/executor.py
+++ b/packages/phlo-dlt/src/phlo_dlt/executor.py
@@ -166,6 +166,7 @@ class DltIngester(BaseIngester):
                 rows_deleted=merge_metrics.get("rows_deleted", 0),
                 metadata={
                     "dlt_elapsed_seconds": dlt_elapsed,
+                    "parquet_path": str(parquet_path),
                     "total_elapsed_seconds": total_elapsed,
                 },
             )


### PR DESCRIPTION
## Summary
- Emit pandera contract check results for DLT ingestion assets
- Include staged parquet path in ingestion metadata for validation
- Fail runs when strict validation is enabled and checks fail

## Testing
- uv run phlo materialize dlt_pokemon --select "*" --partition 2026-01-01