### PR TITLE
Release: keep 0.x minor bumps

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -2,6 +2,7 @@
   "packages": {
     ".": {
       "release-type": "python",
+      "bump-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true
     }


### PR DESCRIPTION
- add bump-minor-pre-major so breaking changes bump minor (0.x) instead of 1.0.0