### PR TITLE
fix(ci): harden PyPI publish workflow controls

### DIFF
--- a/.github/scripts/publish_plan.py
+++ b/.github/scripts/publish_plan.py
@@ -148,6 +148,35 @@ def topo_sort(selected: set[str], dep_map: dict[str, list[str]]) -> list[str]:
     return order
 
 
+def parse_target_packages(raw: str, available: set[str]) -> list[str]:
+    value = raw.strip()
+    if not value:
+        return []
+
+    names: list[str]
+    if value.startswith("["):
+        parsed = json.loads(value)
+        if not isinstance(parsed, list):
+            raise ValueError("TARGET_PACKAGES JSON must be a list of package names.")
+        names = [str(item).strip() for item in parsed if str(item).strip()]
+    else:
+        names = [part.strip() for part in value.split(",") if part.strip()]
+
+    unknown = sorted(set(names) - available)
+    if unknown:
+        raise ValueError(f"Unknown package(s): {', '.join(unknown)}")
+
+    # Preserve caller order while deduplicating.
+    ordered_unique: list[str] = []
+    seen: set[str] = set()
+    for name in names:
+        if name in seen:
+            continue
+        seen.add(name)
+        ordered_unique.append(name)
+    return ordered_unique
+
+
 def main() -> None:
     root = Path(".")
     package_paths, package_meta = load_packages(root)
@@ -164,8 +193,12 @@ def main() -> None:
 
     root_name = next(name for name, path in package_paths.items() if path == root)
 
+    target_packages_raw = os.environ.get("TARGET_PACKAGES", "")
+    target_packages = parse_target_packages(target_packages_raw, set(package_paths))
     publish_all = os.environ.get("PUBLISH_ALL", "false").strip().lower() == "true"
-    if publish_all:
+    if target_packages:
+        selected = set(target_packages)
+    elif publish_all:
         selected = set(package_paths)
     else:
         selected = select_changed_packages(changed_files, package_paths, root_name, root)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
         description: "Publish all workspace packages (ignore change detection)"
         required: false
         default: "false"
+      packages:
+        description: "Comma-separated package names or JSON list to publish (overrides detection/publish_all)"
+        required: false
+        default: ""
       base_ref:
         description: "Git ref to compare against for change detection (defaults to previous tag)"
         required: false
@@ -40,6 +44,7 @@ jobs:
           BASE_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.base_ref || '' }}
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
           PUBLISH_ALL: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_all || 'false' }}
+          TARGET_PACKAGES: ${{ github.event_name == 'workflow_dispatch' && inputs.packages || '' }}
         run: python .github/scripts/publish_plan.py
 
       - name: Log publish plan


### PR DESCRIPTION
## Summary\n- add publish-all plan support and explicit package batch input\n- add PyPI token fallback path for bootstrap publishing\n- gate auth behavior by env token presence\n- skip existing versions and enable verbose upload logs\n\n## Stack\n- position: 2/6\n- base: stack/01-runtime-foundations
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
