### PR TITLE
test: harden integration signal and marker discipline

### DIFF
--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -485,6 +485,9 @@ pytest tests/ -m integration -v
 # Run only unit tests (exclude integration)
 pytest tests/ -m "not integration" -v
 
+# Run only explicit unit marker tests
+pytest tests/ -m unit -v
+
 # Run with verbose output
 pytest tests/ -v -s
 ```
@@ -580,6 +583,10 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "integration: mark test as integration test (requires Docker)"
+    )
+    config.addinivalue_line(
+        "markers",
+        "unit: mark test as unit test (no external services)"
     )
 
 

--- a/docs/packages/phlo-testing.md
+++ b/docs/packages/phlo-testing.md
@@ -104,10 +104,15 @@ result = MockTrinoResult(
 )
 ```
 
-### Integration Test Markers
+### Test Marker Rules
 
 ```python
 import pytest
+
+@pytest.mark.unit
+def test_pure_transform_logic():
+    """No network, Docker, or filesystem side effects."""
+    pass
 
 @pytest.mark.integration
 def test_full_pipeline():
@@ -120,9 +125,14 @@ def test_large_dataset():
     pass
 
 # Run specific markers
+# pytest -m unit
 # pytest -m integration
 # pytest -m "not slow"
 ```
+
+Use `unit` for import-only tests, pure functions, and tests that run without external services.
+Use `integration` only for tests that require service discovery, Docker containers, dbt artifacts,
+or other cross-package runtime wiring.
 
 ## Common Test Patterns
 

--- a/packages/phlo-api/tests/test_integration_api.py
+++ b/packages/phlo-api/tests/test_integration_api.py
@@ -133,8 +133,8 @@ class TestPluginsEndpoints:
         client = TestClient(app)
         response = client.get("/api/plugins/services")
 
-        # Should return 200 (list) or 404 (unknown type)
-        assert response.status_code in (200, 404)
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
 
     def test_plugins_unknown_type_returns_404(self):
         """Test unknown plugin type returns 404."""
@@ -144,8 +144,8 @@ class TestPluginsEndpoints:
         client = TestClient(app)
         response = client.get("/api/plugins/unknown_type_that_does_not_exist")
 
-        # Should return 404 for unknown plugin type
-        assert response.status_code in (200, 404)
+        assert response.status_code == 404
+        assert "Unknown plugin type" in response.json()["detail"]
 
 
 # =============================================================================
@@ -192,8 +192,8 @@ class TestServicesEndpoints:
         # Try to get a service that likely exists or doesn't
         response = client.get("/api/services/trino")
 
-        # Should return 200 or 404 depending on whether service exists
-        assert response.status_code in (200, 404, 500)  # 500 if discovery fails
+        # trino may or may not exist in local service manifests.
+        assert response.status_code in (200, 404)
 
     def test_service_not_found_returns_404(self):
         """Test unknown service returns 404."""
@@ -203,8 +203,8 @@ class TestServicesEndpoints:
         client = TestClient(app)
         response = client.get("/api/services/nonexistent_service_xyz")
 
-        # Should return 404 for unknown service
-        assert response.status_code in (404, 500)  # 500 if discovery not available
+        assert response.status_code == 404
+        assert "Service not found" in response.json()["detail"]
 
 
 # =============================================================================

--- a/packages/phlo-observatory/tests/test_integration_observatory.py
+++ b/packages/phlo-observatory/tests/test_integration_observatory.py
@@ -1,8 +1,10 @@
-"""Integration tests for phlo-observatory."""
+"""Unit tests for phlo-observatory import surface."""
+
+import importlib
 
 import pytest
 
-pytestmark = pytest.mark.integration
+pytestmark = pytest.mark.unit
 
 
 def test_observatory_importable():
@@ -12,13 +14,13 @@ def test_observatory_importable():
     assert phlo_observatory is not None
 
 
-def test_observatory_app_exists():
-    """Test that observatory app or main module exists."""
-    try:
-        import importlib
+def test_observatory_plugin_module_importable():
+    """Test that the service plugin module is importable."""
+    plugin_module = importlib.import_module("phlo_observatory.plugin")
+    assert plugin_module is not None
 
-        app_module = importlib.import_module("phlo_observatory.app")
-        assert app_module is not None
-    except Exception:
-        # May have different structure
-        pass
+
+def test_observatory_app_module_absent():
+    """Test that legacy app module is not exposed by this package."""
+    with pytest.raises(ModuleNotFoundError, match="phlo_observatory.app"):
+        importlib.import_module("phlo_observatory.app")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ norecursedirs = ["src", ".venv"]
 addopts = "--ignore=src --continue-on-collection-errors -m 'not integration'"
 markers = [
     "integration: marks tests as requiring external services or dbt manifest (run with '-m integration')",
+    "unit: marks fast tests that do not require external services (run with '-m unit')",
 ]
 filterwarnings = [
     # pyiceberg emits Pydantic v2.12 deprecations from @model_validator usage.


### PR DESCRIPTION
## Root cause
Permissive test assertions and broad exception handling allowed ambiguous green results and blurred unit/integration boundaries.

## What changed
- Tightened API integration assertions (removed implicit `500` acceptance unless intentional).
- Replaced broad `except Exception` with explicit exception expectations.
- Reclassified lightweight observatory import-smoke tests to unit.
- Documented marker rules for `integration` vs unit tests.

## Verification
- `uv run pytest -q` passed in worker branch.
- `uv run pytest -m integration -q` failed only on known Iceberg DNS drift (addressed in dedicated Iceberg PR).
- `make check` was blocked in worker env by missing TS tooling (`eslint`/`prettier`/`tsc`).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/191" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
