### PR TITLE
refactor(api): split trino SQL helpers for maintainability

### DIFF
--- a/packages/phlo-api/src/phlo_api/observatory_api/trino.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/trino.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import os
-import re
-from math import isfinite
 from time import monotonic
 from typing import Any
 
@@ -18,6 +16,13 @@ from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
 from phlo.logging import get_logger
+from phlo_api.observatory_api.trino_sql import (
+    is_probably_qualified_table,
+    qualify_table_name,
+    quote_identifier,
+    sql_literal,
+    validate_read_only_query,
+)
 
 logger = get_logger(__name__)
 
@@ -180,26 +185,6 @@ async def execute_trino_query(
     except Exception as e:
         logger.exception("Trino query failed")
         return QueryExecutionError(error=str(e), kind="trino")
-
-
-def quote_identifier(identifier: str) -> str:
-    """Quote an SQL identifier."""
-    if not identifier:
-        raise ValueError("Identifier cannot be empty")
-    if "\x00" in identifier:
-        raise ValueError("Identifier cannot contain NUL bytes")
-    escaped = identifier.replace('"', '""')
-    return f'"{escaped}"'
-
-
-def qualify_table_name(catalog: str, schema: str, table: str) -> str:
-    """Build a fully qualified table name."""
-    return f"{quote_identifier(catalog)}.{quote_identifier(schema)}.{quote_identifier(table)}"
-
-
-def is_probably_qualified_table(table: str) -> bool:
-    """Check if a table name appears to be fully qualified."""
-    return table.count(".") >= 2 or table.startswith('"')
 
 
 # --- API Endpoints ---
@@ -414,23 +399,6 @@ class QueryWithFiltersRequest(BaseModel):
     timeout_ms: int = 30000
 
 
-def _sql_literal(value: object) -> str:
-    if value is None:
-        raise ValueError("Use IS NULL for null filters")
-    if isinstance(value, bool):
-        return "TRUE" if value else "FALSE"
-    if isinstance(value, int):
-        return str(value)
-    if isinstance(value, float):
-        if not isfinite(value):
-            raise ValueError("Non-finite float values are not supported")
-        return str(value)
-    if isinstance(value, str):
-        escaped = value.replace("'", "''")
-        return f"'{escaped}'"
-    raise ValueError(f"Unsupported filter value type: {type(value).__name__}")
-
-
 @router.post("/query-with-filters", response_model=DataPreviewResult | dict)
 async def query_with_filters(
     request: QueryWithFiltersRequest,
@@ -452,7 +420,7 @@ async def query_with_filters(
             if value is None:
                 where_parts.append(f"{quoted_column} IS NULL")
             else:
-                where_parts.append(f"{quoted_column} = {_sql_literal(value)}")
+                where_parts.append(f"{quoted_column} = {sql_literal(value)}")
 
         where_clause = " AND ".join(where_parts)
         limit = int(request.limit)
@@ -479,125 +447,6 @@ async def query_with_filters(
         )
     except ValueError as e:
         return {"error": str(e)}
-
-
-def strip_sql_literals_and_comments(query: str) -> str:
-    """Return query with string literals, identifiers, and comments removed."""
-    out: list[str] = []
-    i = 0
-    in_single = False
-    in_double = False
-    in_line_comment = False
-    in_block_comment = False
-    length = len(query)
-
-    while i < length:
-        ch = query[i]
-        nxt = query[i + 1] if i + 1 < length else ""
-
-        if in_line_comment:
-            if ch in "\r\n":
-                in_line_comment = False
-                out.append(ch)
-            else:
-                out.append(" ")
-            i += 1
-            continue
-
-        if in_block_comment:
-            if ch == "*" and nxt == "/":
-                out.extend([" ", " "])
-                i += 2
-                in_block_comment = False
-                continue
-            out.append(" ")
-            i += 1
-            continue
-
-        if in_single:
-            if ch == "'":
-                if nxt == "'":
-                    out.extend([" ", " "])
-                    i += 2
-                    continue
-                in_single = False
-            out.append(" ")
-            i += 1
-            continue
-
-        if in_double:
-            if ch == '"':
-                if nxt == '"':
-                    out.extend([" ", " "])
-                    i += 2
-                    continue
-                in_double = False
-            out.append(" ")
-            i += 1
-            continue
-
-        if ch == "-" and nxt == "-":
-            in_line_comment = True
-            out.extend([" ", " "])
-            i += 2
-            continue
-
-        if ch == "/" and nxt == "*":
-            in_block_comment = True
-            out.extend([" ", " "])
-            i += 2
-            continue
-
-        if ch == "'":
-            in_single = True
-            out.append(" ")
-            i += 1
-            continue
-
-        if ch == '"':
-            in_double = True
-            out.append(" ")
-            i += 1
-            continue
-
-        out.append(ch)
-        i += 1
-
-    return "".join(out)
-
-
-def validate_read_only_query(query: str) -> str | None:
-    """Validate a query is read-only and a single statement."""
-    cleaned = strip_sql_literals_and_comments(query)
-    trimmed = cleaned.strip()
-    if not trimmed:
-        return "Query cannot be empty"
-
-    while trimmed.endswith(";"):
-        trimmed = trimmed[:-1].rstrip()
-    if ";" in trimmed:
-        return "Multiple statements are not allowed in read-only mode"
-
-    cleaned_upper = trimmed.upper()
-    forbidden = [
-        "INSERT",
-        "UPDATE",
-        "DELETE",
-        "DROP",
-        "CREATE",
-        "ALTER",
-        "TRUNCATE",
-        "MERGE",
-        "CALL",
-        "GRANT",
-        "REVOKE",
-    ]
-    pattern = re.compile(rf"\b({'|'.join(forbidden)})\b")
-    match = pattern.search(cleaned_upper)
-    if match:
-        return f"{match.group(1)} statements are not allowed in read-only mode"
-
-    return None
 
 
 @router.get("/row/{table:path}/{row_id}", response_model=DataPreviewResult | dict)

--- a/packages/phlo-api/src/phlo_api/observatory_api/trino_sql.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/trino_sql.py
@@ -1,0 +1,163 @@
+"""SQL helper utilities for Trino API query construction and validation."""
+
+from __future__ import annotations
+
+import re
+from math import isfinite
+
+_FORBIDDEN_READ_ONLY_KEYWORDS = (
+    "INSERT",
+    "UPDATE",
+    "DELETE",
+    "DROP",
+    "CREATE",
+    "ALTER",
+    "TRUNCATE",
+    "MERGE",
+    "CALL",
+    "GRANT",
+    "REVOKE",
+)
+_FORBIDDEN_READ_ONLY_PATTERN = re.compile(rf"\b({'|'.join(_FORBIDDEN_READ_ONLY_KEYWORDS)})\b")
+
+
+def quote_identifier(identifier: str) -> str:
+    """Quote an SQL identifier."""
+    if not identifier:
+        raise ValueError("Identifier cannot be empty")
+    if "\x00" in identifier:
+        raise ValueError("Identifier cannot contain NUL bytes")
+    escaped = identifier.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def qualify_table_name(catalog: str, schema: str, table: str) -> str:
+    """Build a fully qualified table name."""
+    return f"{quote_identifier(catalog)}.{quote_identifier(schema)}.{quote_identifier(table)}"
+
+
+def is_probably_qualified_table(table: str) -> bool:
+    """Check if a table name appears to be fully qualified."""
+    return table.count(".") >= 2 or table.startswith('"')
+
+
+def sql_literal(value: object) -> str:
+    """Convert a Python value to a safe SQL literal."""
+    if value is None:
+        raise ValueError("Use IS NULL for null filters")
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        if not isfinite(value):
+            raise ValueError("Non-finite float values are not supported")
+        return str(value)
+    if isinstance(value, str):
+        escaped = value.replace("'", "''")
+        return f"'{escaped}'"
+    raise ValueError(f"Unsupported filter value type: {type(value).__name__}")
+
+
+def strip_sql_literals_and_comments(query: str) -> str:
+    """Return query with string literals, identifiers, and comments removed."""
+    out: list[str] = []
+    i = 0
+    in_single = False
+    in_double = False
+    in_line_comment = False
+    in_block_comment = False
+    length = len(query)
+
+    while i < length:
+        ch = query[i]
+        nxt = query[i + 1] if i + 1 < length else ""
+
+        if in_line_comment:
+            if ch in "\r\n":
+                in_line_comment = False
+                out.append(ch)
+            else:
+                out.append(" ")
+            i += 1
+            continue
+
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                out.extend([" ", " "])
+                i += 2
+                in_block_comment = False
+                continue
+            out.append(" ")
+            i += 1
+            continue
+
+        if in_single:
+            if ch == "'":
+                if nxt == "'":
+                    out.extend([" ", " "])
+                    i += 2
+                    continue
+                in_single = False
+            out.append(" ")
+            i += 1
+            continue
+
+        if in_double:
+            if ch == '"':
+                if nxt == '"':
+                    out.extend([" ", " "])
+                    i += 2
+                    continue
+                in_double = False
+            out.append(" ")
+            i += 1
+            continue
+
+        if ch == "-" and nxt == "-":
+            in_line_comment = True
+            out.extend([" ", " "])
+            i += 2
+            continue
+
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            out.extend([" ", " "])
+            i += 2
+            continue
+
+        if ch == "'":
+            in_single = True
+            out.append(" ")
+            i += 1
+            continue
+
+        if ch == '"':
+            in_double = True
+            out.append(" ")
+            i += 1
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def validate_read_only_query(query: str) -> str | None:
+    """Validate a query is read-only and a single statement."""
+    cleaned = strip_sql_literals_and_comments(query)
+    trimmed = cleaned.strip()
+    if not trimmed:
+        return "Query cannot be empty"
+
+    while trimmed.endswith(";"):
+        trimmed = trimmed[:-1].rstrip()
+    if ";" in trimmed:
+        return "Multiple statements are not allowed in read-only mode"
+
+    match = _FORBIDDEN_READ_ONLY_PATTERN.search(trimmed.upper())
+    if match:
+        return f"{match.group(1)} statements are not allowed in read-only mode"
+
+    return None

--- a/packages/phlo-api/tests/test_trino_sql.py
+++ b/packages/phlo-api/tests/test_trino_sql.py
@@ -1,0 +1,86 @@
+"""Unit tests for Trino SQL helper utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from phlo_api.observatory_api.trino_sql import (
+    is_probably_qualified_table,
+    qualify_table_name,
+    quote_identifier,
+    sql_literal,
+    strip_sql_literals_and_comments,
+    validate_read_only_query,
+)
+
+
+def test_quote_identifier_escapes_double_quotes() -> None:
+    assert quote_identifier('col"umn') == '"col""umn"'
+
+
+@pytest.mark.parametrize("identifier", ["", "abc\x00def"])
+def test_quote_identifier_rejects_invalid_identifiers(identifier: str) -> None:
+    with pytest.raises(ValueError):
+        quote_identifier(identifier)
+
+
+def test_qualify_table_name_quotes_all_parts() -> None:
+    assert qualify_table_name("iceberg", "main", "events") == '"iceberg"."main"."events"'
+
+
+@pytest.mark.parametrize(
+    ("table_name", "expected"),
+    [("iceberg.main.events", True), ('"iceberg"."main"."events"', True), ("events", False)],
+)
+def test_is_probably_qualified_table(table_name: str, expected: bool) -> None:
+    assert is_probably_qualified_table(table_name) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, "TRUE"),
+        (False, "FALSE"),
+        (12, "12"),
+        (2.5, "2.5"),
+        ("O'Hare", "'O''Hare'"),
+    ],
+)
+def test_sql_literal_supported_types(value: object, expected: str) -> None:
+    assert sql_literal(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, float("inf"), float("-inf"), float("nan"), {"k": "v"}])
+def test_sql_literal_rejects_unsafe_values(value: object) -> None:
+    with pytest.raises(ValueError):
+        sql_literal(value)
+
+
+def test_strip_sql_literals_and_comments_removes_forbidden_tokens() -> None:
+    query = """
+    SELECT '-- INSERT in string' AS text_col, "DROP" AS identifier
+    FROM events
+    -- DELETE from comment
+    WHERE note = 'UPDATE here' /* CREATE block */
+    """
+    stripped = strip_sql_literals_and_comments(query)
+    assert "INSERT" not in stripped
+    assert "DELETE" not in stripped
+    assert "UPDATE" not in stripped
+    assert "CREATE" not in stripped
+    assert "SELECT" in stripped
+    assert "FROM events" in stripped
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_error"),
+    [
+        ("", "Query cannot be empty"),
+        ("SELECT 1; SELECT 2", "Multiple statements are not allowed in read-only mode"),
+        ("DELETE FROM events", "DELETE statements are not allowed in read-only mode"),
+        ("SELECT 'DROP TABLE users' AS text", None),
+        ("SELECT 1;", None),
+    ],
+)
+def test_validate_read_only_query(query: str, expected_error: str | None) -> None:
+    assert validate_read_only_query(query) == expected_error


### PR DESCRIPTION
## Root cause
`packages/phlo-api/src/phlo_api/observatory_api/trino.py` exceeded module-size guideline and mixed concerns, reducing maintainability/testability.

## What changed
- Extracted SQL helper concern into `trino_sql.py`.
- Kept endpoint behavior/contracts unchanged.
- Added focused regression tests for extracted SQL helpers.

## Verification
- Focused `phlo-api` tests passed in worker branch.
- `make check` passed in worker branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
