### PR TITLE
docs: add google-style docstrings for root tests

### DIFF
--- a/tests/test_cli_plugin.py
+++ b/tests/test_cli_plugin.py
@@ -19,44 +19,107 @@ from phlo.plugins.registry_client import RegistryPlugin
 
 
 class DummySource(SourceConnectorPlugin):
+    """Stub source connector for CLI plugin tests."""
+
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Metadata for the dummy source plugin.
+        """
         return PluginMetadata(name="dummy_source", version="1.0.0")
 
     def fetch_data(self, config):
+        """Yield a single dummy record.
+
+        Args:
+            config: Source configuration.
+
+        Yields:
+            dict: Dummy source row.
+        """
         yield {"id": 1}
 
 
 class DummyQuality(QualityCheckPlugin):
+    """Stub quality plugin for CLI plugin tests."""
+
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Metadata for the dummy quality plugin.
+        """
         return PluginMetadata(name="dummy_quality", version="1.0.0")
 
     def create_check(self, **kwargs):
+        """Create a no-op quality check.
+
+        Args:
+            **kwargs: Quality check options.
+
+        Returns:
+            None: No check object for this stub.
+        """
         return None
 
 
 class DummyTransform(TransformationPlugin):
+    """Stub transform plugin for CLI plugin tests."""
+
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Metadata for the dummy transform plugin.
+        """
         return PluginMetadata(name="dummy_transform", version="1.0.0")
 
     def transform(self, df, config):
+        """Return input data unchanged.
+
+        Args:
+            df: Input dataframe-like object.
+            config: Transform configuration.
+
+        Returns:
+            Any: Unmodified input dataframe-like object.
+        """
         return df
 
 
 class DummyService(ServicePlugin):
+    """Stub service plugin for CLI plugin tests."""
+
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Metadata for the dummy service plugin.
+        """
         return PluginMetadata(name="dummy_service", version="1.0.0")
 
     @property
     def service_definition(self) -> dict:
+        """Return a minimal service definition.
+
+        Returns:
+            dict: Service category and compose configuration.
+        """
         return {"category": "core", "compose": {"image": "dummy:latest"}}
 
 
 @pytest.fixture
 def setup_registry():
+    """Provide an isolated plugin registry for each test.
+
+    Yields:
+        PluginRegistry: Cleared global registry with dummy plugins registered.
+    """
     registry = get_global_registry()
     registry.clear()
     registry.register_source_connector(DummySource(), replace=True)
@@ -99,6 +162,14 @@ def test_plugin_list_all_json(setup_registry, monkeypatch):
     ]
 
     def mock_collect_registry_plugins(plugin_type: str) -> list[dict]:
+        """Convert mocked registry plugins to CLI payload dictionaries.
+
+        Args:
+            plugin_type: Requested plugin type.
+
+        Returns:
+            list[dict]: Serialized registry plugins for the CLI response.
+        """
         from phlo.cli.commands.plugin.utils import registry_plugin_to_dict
 
         return [registry_plugin_to_dict(p) for p in registry_plugins]
@@ -213,6 +284,7 @@ def test_plugin_update(monkeypatch):
 
 
 def test_run_pip_uses_python_pip_when_available(monkeypatch):
+    """Use `python -m pip` when pip module is importable."""
     from phlo.cli.commands.plugin.utils import run_pip
 
     calls: list[tuple[list[str], bool, float]] = []
@@ -231,6 +303,7 @@ def test_run_pip_uses_python_pip_when_available(monkeypatch):
 
 
 def test_run_pip_uses_uv_when_pip_module_missing(monkeypatch):
+    """Use `uv pip` when pip module is unavailable but `uv` exists."""
     from phlo.cli.commands.plugin.utils import run_pip
 
     calls: list[tuple[list[str], bool, float]] = []
@@ -248,6 +321,7 @@ def test_run_pip_uses_uv_when_pip_module_missing(monkeypatch):
 
 
 def test_run_pip_errors_when_no_pip_and_no_uv(monkeypatch):
+    """Raise runtime error when neither pip module nor `uv` is available."""
     from phlo.cli.commands.plugin.utils import run_pip
 
     monkeypatch.setattr("phlo.cli.commands.plugin.utils.importlib.util.find_spec", lambda _: None)

--- a/tests/test_cli_services.py
+++ b/tests/test_cli_services.py
@@ -22,6 +22,17 @@ def _service(
     profile: str | None = None,
     category: str = "core",
 ) -> ServiceDefinition:
+    """Build a service definition fixture.
+
+    Args:
+        name: Service name.
+        default: Whether the service is enabled by default.
+        profile: Optional profile name.
+        category: Service category name.
+
+    Returns:
+        ServiceDefinition: Constructed service definition.
+    """
     return ServiceDefinition(
         name=name,
         description=f"{name} service",
@@ -32,6 +43,7 @@ def _service(
 
 
 def test_select_services_to_install_respects_enabled_disabled_and_profiles() -> None:
+    """Verify service selection honors default, enabled, disabled, and profile behavior."""
     postgres = _service("postgres", default=True)
     minio = _service("minio", default=True)
     prometheus = _service("prometheus", profile="observability")
@@ -51,6 +63,11 @@ def test_select_services_to_install_respects_enabled_disabled_and_profiles() -> 
 
 
 def test_find_dagster_container_prefers_configured_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify configured Dagster container name is selected when running.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     # Mock _resolve_container_name to return the configured name
     monkeypatch.setattr(
         "phlo_dagster.containers._resolve_container_name",
@@ -66,6 +83,11 @@ def test_find_dagster_container_prefers_configured_name(monkeypatch: pytest.Monk
 
 
 def test_find_dagster_container_falls_back_to_new_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify fallback to the new Dagster container name.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     # Mock _resolve_container_name to return something that won't match
     monkeypatch.setattr(
         "phlo_dagster.containers._resolve_container_name",
@@ -83,6 +105,11 @@ def test_find_dagster_container_falls_back_to_new_name(monkeypatch: pytest.Monke
 def test_get_profile_service_names_returns_profile_services(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Verify profile expansion returns all services in selected profiles.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     prometheus = _service("prometheus", profile="observability")
     grafana = _service("grafana", profile="observability")
     loki = _service("loki", profile="observability")
@@ -90,7 +117,17 @@ def test_get_profile_service_names_returns_profile_services(
     postgres = _service("postgres", default=True)
 
     class FakeDiscovery:
+        """Test double for service discovery profile lookups."""
+
         def get_services_by_profile(self, profile: str) -> list[ServiceDefinition]:
+            """Return services matching the requested profile.
+
+            Args:
+                profile: Profile name to filter by.
+
+            Returns:
+                list[ServiceDefinition]: Matching services.
+            """
             all_services = [prometheus, grafana, loki, hasura, postgres]
             return [s for s in all_services if s.profile == profile]
 
@@ -117,6 +154,12 @@ def test_detect_phlo_source_path_finds_sibling_phlo_repo(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
+    """Verify sibling phlo repository source path is detected.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory fixture.
+    """
     phlo_repo = tmp_path / "phlo"
     package_dir = phlo_repo / "src" / "phlo"
     package_dir.mkdir(parents=True)
@@ -137,6 +180,12 @@ def test_detect_phlo_source_path_accepts_repo_root_in_env_var(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
+    """Verify PHLO_DEV_SOURCE accepts repository root path input.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory fixture.
+    """
     phlo_repo = tmp_path / "phlo"
     package_dir = phlo_repo / "src" / "phlo"
     package_dir.mkdir(parents=True)
@@ -154,13 +203,37 @@ def test_detect_phlo_source_path_accepts_repo_root_in_env_var(
 
 
 def test_compose_generator_injects_phlo_dev_mounts(tmp_path) -> None:
+    """Verify compose generation injects development mounts for phlo.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+
     class FakeDiscovery:
+        """Test double for compose dependency resolution."""
+
         def resolve_dependencies(
             self, services: list[ServiceDefinition]
         ) -> list[ServiceDefinition]:
+            """Return service list unchanged.
+
+            Args:
+                services: Services to resolve.
+
+            Returns:
+                list[ServiceDefinition]: Input services unchanged.
+            """
             return services
 
         def get_service(self, _name: str) -> None:
+            """Return no service for lookup requests.
+
+            Args:
+                _name: Service name.
+
+            Returns:
+                None: Always none for this test double.
+            """
             return None
 
     service = ServiceDefinition(
@@ -185,13 +258,37 @@ def test_compose_generator_injects_phlo_dev_mounts(tmp_path) -> None:
 
 
 def test_compose_generator_passthrough_compose_keys(tmp_path) -> None:
+    """Verify compose keys pass through to generated service YAML.
+
+    Args:
+        tmp_path: Temporary directory fixture.
+    """
+
     class FakeDiscovery:
+        """Test double for compose dependency resolution."""
+
         def resolve_dependencies(
             self, services: list[ServiceDefinition]
         ) -> list[ServiceDefinition]:
+            """Return service list unchanged.
+
+            Args:
+                services: Services to resolve.
+
+            Returns:
+                list[ServiceDefinition]: Input services unchanged.
+            """
             return services
 
         def get_service(self, _name: str) -> None:
+            """Return no service for lookup requests.
+
+            Args:
+                _name: Service name.
+
+            Returns:
+                None: Always none for this test double.
+            """
             return None
 
     service = ServiceDefinition(
@@ -222,6 +319,12 @@ def test_compose_generator_passthrough_compose_keys(tmp_path) -> None:
 def test_run_service_hooks_uses_sys_executable_when_project_venv_missing(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
+    """Verify hook runner uses current interpreter when project venv is absent.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory fixture.
+    """
     from phlo.cli.commands.services import utils as services_utils
 
     service = ServiceDefinition(
@@ -232,12 +335,31 @@ def test_run_service_hooks_uses_sys_executable_when_project_venv_missing(
     )
 
     class FakeDiscovery:
+        """Test double for service lookup."""
+
         def get_service(self, name: str):
+            """Return service for matching name.
+
+            Args:
+                name: Service name.
+
+            Returns:
+                ServiceDefinition | None: Matching service or none.
+            """
             return service if name == "dagster" else None
 
     calls: list[list[str]] = []
 
     def _fake_run_command(cmd, **_kwargs):
+        """Capture command invocations and return successful process.
+
+        Args:
+            cmd: Command argument sequence.
+            **_kwargs: Unused keyword arguments.
+
+        Returns:
+            CompletedProcess[str]: Successful command result.
+        """
         calls.append(list(cmd))
         return CompletedProcess(cmd, 0, "", "")
 
@@ -259,6 +381,12 @@ def test_run_service_hooks_uses_sys_executable_when_project_venv_missing(
 def test_run_service_hooks_prefers_project_venv_python(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
+    """Verify hook runner prefers project venv python executable.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory fixture.
+    """
     from phlo.cli.commands.services import utils as services_utils
 
     service = ServiceDefinition(
@@ -269,12 +397,31 @@ def test_run_service_hooks_prefers_project_venv_python(
     )
 
     class FakeDiscovery:
+        """Test double for service lookup."""
+
         def get_service(self, name: str):
+            """Return service for matching name.
+
+            Args:
+                name: Service name.
+
+            Returns:
+                ServiceDefinition | None: Matching service or none.
+            """
             return service if name == "dagster" else None
 
     calls: list[list[str]] = []
 
     def _fake_run_command(cmd, **_kwargs):
+        """Capture command invocations and return successful process.
+
+        Args:
+            cmd: Command argument sequence.
+            **_kwargs: Unused keyword arguments.
+
+        Returns:
+            CompletedProcess[str]: Successful command result.
+        """
         calls.append(list(cmd))
         return CompletedProcess(cmd, 0, "", "")
 
@@ -298,6 +445,11 @@ def test_run_service_hooks_prefers_project_venv_python(
 
 
 def test_find_dagster_container_falls_back_to_legacy_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify fallback to legacy Dagster container name.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     monkeypatch.setattr(
         "phlo_dagster.containers._resolve_container_name",
         lambda service, project: "cfg",
@@ -310,6 +462,11 @@ def test_find_dagster_container_falls_back_to_legacy_name(monkeypatch: pytest.Mo
 
 
 def test_find_dagster_container_regex_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify regex-based fallback matches compatible container names.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     monkeypatch.setattr(
         "phlo_dagster.containers._resolve_container_name",
         lambda service, project: "cfg",
@@ -322,6 +479,11 @@ def test_find_dagster_container_regex_fallback(monkeypatch: pytest.MonkeyPatch) 
 
 
 def test_find_dagster_container_regex_excludes_daemon(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify regex fallback excludes daemon container names.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     monkeypatch.setattr(
         "phlo_dagster.containers._resolve_container_name",
         lambda service, project: "cfg",
@@ -335,6 +497,11 @@ def test_find_dagster_container_regex_excludes_daemon(monkeypatch: pytest.Monkey
 
 
 def test_find_dagster_container_raises_when_no_containers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify error is raised when no Dagster containers are running.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
     monkeypatch.setattr(
         "phlo_dagster.containers._resolve_container_name",
         lambda service, project: "cfg",
@@ -348,6 +515,7 @@ def test_find_dagster_container_raises_when_no_containers(monkeypatch: pytest.Mo
 
 
 def test_dagster_container_candidates_structure() -> None:
+    """Verify candidate container names expose configured, new, and legacy values."""
     from phlo_dagster.containers import dagster_container_candidates
 
     candidates = dagster_container_candidates("demo", "demo-dagster-webserver-1")
@@ -357,6 +525,7 @@ def test_dagster_container_candidates_structure() -> None:
 
 
 def test_dagster_container_candidates_no_configured() -> None:
+    """Verify candidate names handle a missing configured container."""
     from phlo_dagster.containers import dagster_container_candidates
 
     candidates = dagster_container_candidates("demo", None)
@@ -365,6 +534,7 @@ def test_dagster_container_candidates_no_configured() -> None:
 
 
 def test_select_first_existing_returns_first_match() -> None:
+    """Verify first existing candidate is selected."""
     from phlo_dagster.containers import select_first_existing
 
     result = select_first_existing(
@@ -375,6 +545,7 @@ def test_select_first_existing_returns_first_match() -> None:
 
 
 def test_select_first_existing_returns_none_when_no_match() -> None:
+    """Verify none is returned when no candidates match existing containers."""
     from phlo_dagster.containers import select_first_existing
 
     result = select_first_existing(["a", "b"], ["x", "y"])
@@ -382,6 +553,7 @@ def test_select_first_existing_returns_none_when_no_match() -> None:
 
 
 def test_select_first_existing_skips_empty_candidates() -> None:
+    """Verify empty candidate names are ignored."""
     from phlo_dagster.containers import select_first_existing
 
     result = select_first_existing(["", "b"], ["b"])
@@ -389,6 +561,7 @@ def test_select_first_existing_skips_empty_candidates() -> None:
 
 
 def test_extract_compose_service_from_label() -> None:
+    """Verify compose service label parsing returns service name."""
     from phlo.cli.commands.services.list import _extract_compose_service
 
     info = {"Labels": "com.docker.compose.project=demo,com.docker.compose.service=postgres,other=x"}
@@ -396,6 +569,7 @@ def test_extract_compose_service_from_label() -> None:
 
 
 def test_extract_compose_service_returns_none_without_label() -> None:
+    """Verify missing compose service labels return none."""
     from phlo.cli.commands.services.list import _extract_compose_service
 
     assert _extract_compose_service({"Labels": "some.other.label=val"}) is None
@@ -405,10 +579,23 @@ def test_extract_compose_service_returns_none_without_label() -> None:
 def test_services_list_handles_malformed_docker_json(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
+    """Verify services list command tolerates malformed docker JSON output.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+        tmp_path: Temporary directory fixture.
+    """
     from phlo.cli.commands.services import list as list_module
 
     class FakeDiscovery:
+        """Test double returning an empty service map."""
+
         def discover(self) -> dict[str, ServiceDefinition]:
+            """Return no services.
+
+            Returns:
+                dict[str, ServiceDefinition]: Empty service mapping.
+            """
             return {}
 
     monkeypatch.setattr(list_module, "ServiceDiscovery", FakeDiscovery)
@@ -426,6 +613,7 @@ def test_services_list_handles_malformed_docker_json(
 
 
 def test_resolve_dependencies_reports_cycle_path() -> None:
+    """Verify dependency cycle errors include the cycle path."""
     discovery = ServiceDiscovery.__new__(ServiceDiscovery)
     discovery.services_dir = None
     discovery._services = {}
@@ -443,6 +631,7 @@ def test_resolve_dependencies_reports_cycle_path() -> None:
 
 
 def test_resolve_dependencies_cycle_path_is_closed() -> None:
+    """Verify reported cycle path is closed and formatted as expected."""
     discovery = ServiceDiscovery.__new__(ServiceDiscovery)
     discovery.services_dir = None
     discovery._services = {}
@@ -465,6 +654,7 @@ def test_resolve_dependencies_cycle_path_is_closed() -> None:
 
 
 def test_find_cycles_returns_closed_paths() -> None:
+    """Verify cycle finder returns closed cycle paths."""
     from phlo.plugins.discovery.services import _find_cycles
 
     graph = {
@@ -479,6 +669,7 @@ def test_find_cycles_returns_closed_paths() -> None:
 
 
 def test_resolve_dependencies_no_cycle() -> None:
+    """Verify dependency resolution order is valid when graph is acyclic."""
     discovery = ServiceDiscovery.__new__(ServiceDiscovery)
     discovery.services_dir = None
     discovery._services = {}

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -8,6 +8,7 @@ from phlo.cli.main import cli
 
 
 def test_workflow_group_help_lists_create() -> None:
+    """Shows the scaffold command in workflow group help output."""
     runner = CliRunner()
     result = runner.invoke(cli, ["workflow", "--help"])
 
@@ -16,6 +17,7 @@ def test_workflow_group_help_lists_create() -> None:
 
 
 def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
+    """Passes CLI options to ingestion scaffold creation."""
     calls = {}
 
     def fake_create_ingestion_workflow(
@@ -27,6 +29,19 @@ def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
         api_base_url: str | None,
         fields: list[str] | None,
     ) -> list[str]:
+        """Captures scaffold arguments and returns mocked output paths.
+
+        Args:
+            domain: Domain passed from CLI option.
+            table_name: Table name passed from CLI option.
+            unique_key: Unique key passed from CLI option.
+            cron: Cron schedule passed from CLI option.
+            api_base_url: Optional API base URL from CLI option.
+            fields: Optional field spec list from CLI option.
+
+        Returns:
+            list[str]: Relative paths representing scaffolded files.
+        """
         calls.update(
             {
                 "domain": domain,
@@ -84,6 +99,11 @@ def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
 
 
 def test_init_with_absolute_path_uses_directory_name_for_project_metadata(tmp_path: Path) -> None:
+    """Uses directory basename, not full absolute path, for project name.
+
+    Args:
+        tmp_path: Temporary filesystem root for the test.
+    """
     project_dir = tmp_path / "my-lakehouse"
 
     runner = CliRunner()

--- a/tests/test_core_service_autoconfig.py
+++ b/tests/test_core_service_autoconfig.py
@@ -18,7 +18,15 @@ PLACEHOLDER_RE = re.compile(r"\$\{([A-Z0-9_]+)(?::-[^}]+)?\}")
 
 
 class ServiceFixture:
+    """Store service name and discovered service definition for assertions."""
+
     def __init__(self, name: str, definition: Mapping[str, Any]):
+        """Initialize the fixture container.
+
+        Args:
+            name: Service identifier.
+            definition: Service definition mapping from the plugin.
+        """
         self.name = name
         self.definition = definition
 
@@ -33,10 +41,26 @@ CORE_SERVICES = {
 
 
 def _extract_placeholders(value: str) -> set[str]:
+    """Extract environment placeholder names from a string.
+
+    Args:
+        value: String that may contain `${VAR}` placeholders.
+
+    Returns:
+        set[str]: Placeholder names without delimiters.
+    """
     return {match.group(1) for match in PLACEHOLDER_RE.finditer(value)}
 
 
 def _collect_placeholders(values: Iterable[object]) -> set[str]:
+    """Collect placeholder names from iterable string values.
+
+    Args:
+        values: Values to scan for placeholders.
+
+    Returns:
+        set[str]: Union of extracted placeholder names.
+    """
     placeholders: set[str] = set()
     for item in values:
         if isinstance(item, str):
@@ -45,6 +69,14 @@ def _collect_placeholders(values: Iterable[object]) -> set[str]:
 
 
 def _collect_service_placeholders(definition: Mapping[str, Any]) -> set[str]:
+    """Collect placeholders referenced by a service definition.
+
+    Args:
+        definition: Service definition mapping.
+
+    Returns:
+        set[str]: Placeholder names referenced in image, build args, and compose data.
+    """
     placeholders: set[str] = set()
 
     image = definition.get("image")
@@ -70,6 +102,7 @@ def _collect_service_placeholders(definition: Mapping[str, Any]) -> set[str]:
 
 
 def test_core_service_dependencies_are_declared() -> None:
+    """Verify core service dependency declarations match expected topology."""
     expected = {
         "dagster": {"postgres", "minio", "nessie", "trino"},
         "nessie": {"postgres", "minio"},
@@ -87,6 +120,7 @@ def test_core_service_dependencies_are_declared() -> None:
 
 
 def test_core_service_hooks_configured_for_auto_setup() -> None:
+    """Verify required post-start hooks are configured for auto-setup."""
     dagster_hooks = CORE_SERVICES["dagster"].definition.get("hooks", {})
     assert isinstance(dagster_hooks, dict)
     post_start = dagster_hooks.get("post_start", [])
@@ -105,6 +139,7 @@ def test_core_service_hooks_configured_for_auto_setup() -> None:
 
 
 def test_core_service_placeholders_defined_in_env_vars() -> None:
+    """Verify referenced placeholders are defined in service env var maps."""
     available_env = set()
     placeholders: set[str] = set()
     for fixture in CORE_SERVICES.values():

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -13,6 +13,8 @@ pytestmark = pytest.mark.integration
 
 @dataclass
 class _Settings:
+    """Minimal settings stub used to control executor selection in tests."""
+
     phlo_force_in_process_executor: bool = False
     phlo_force_multiprocess_executor: bool = False
     phlo_host_platform: str | None = None
@@ -20,6 +22,7 @@ class _Settings:
 
 
 def test_default_executor_honors_platform() -> None:
+    """Selects executor type from detected platform when no force flags are set."""
     with patch("phlo_dagster.framework.definitions.get_settings", return_value=_Settings()):
         with patch("platform.system", return_value="Darwin"):
             from phlo_dagster.framework.definitions import _default_executor
@@ -37,6 +40,7 @@ def test_default_executor_honors_platform() -> None:
 
 
 def test_default_executor_honors_force_flags() -> None:
+    """Prefers explicit force flags over platform-derived defaults."""
     settings = _Settings(phlo_force_in_process_executor=True)
     with patch("phlo_dagster.framework.definitions.get_settings", return_value=settings):
         from phlo_dagster.framework.definitions import _default_executor
@@ -55,6 +59,7 @@ def test_default_executor_honors_force_flags() -> None:
 
 
 def test_build_definitions_merges_user_defs() -> None:
+    """Builds Dagster definitions when workflow discovery returns user definitions."""
     empty_defs = dg.Definitions()
     with patch("phlo_dagster.framework.definitions.get_settings", return_value=_Settings()):
         with patch(

--- a/tests/test_golden_path_utils.py
+++ b/tests/test_golden_path_utils.py
@@ -29,10 +29,22 @@ write_file = _mod.write_file
 
 
 class TestForceRemoveDirectory:
+    """Tests for `force_remove_directory`."""
+
     def test_returns_true_for_nonexistent(self, tmp_path: Path) -> None:
+        """Verify missing directories are treated as successfully removed.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         assert force_remove_directory(tmp_path / "nope") is True
 
     def test_removes_existing_directory(self, tmp_path: Path) -> None:
+        """Verify existing directories are deleted.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         target = tmp_path / "subdir"
         target.mkdir()
         (target / "file.txt").write_text("data")
@@ -41,49 +53,81 @@ class TestForceRemoveDirectory:
 
 
 class TestFindAvailablePort:
+    """Tests for `find_available_port`."""
+
     def test_returns_port_when_available(self) -> None:
+        """Verify an available port is returned within the search window."""
         port = find_available_port(49200, max_tries=5)
         assert port is not None
         assert 49200 <= port < 49205
 
     def test_returns_none_when_exhausted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Verify `None` is returned when all probed ports are unavailable.
+
+        Args:
+            monkeypatch: Pytest monkeypatch fixture.
+        """
         monkeypatch.setattr(_mod, "check_port_in_use", lambda _port: True)
         assert find_available_port(9000, max_tries=3) is None
 
 
 class TestExtractOpenmetadataToken:
+    """Tests for `extract_openmetadata_token`."""
+
     def test_extracts_access_token(self) -> None:
+        """Verify direct `accessToken` values are extracted."""
         assert extract_openmetadata_token({"accessToken": "abc123"}) == "abc123"
 
     def test_extracts_jwt_token(self) -> None:
+        """Verify direct `jwtToken` values are extracted."""
         assert extract_openmetadata_token({"jwtToken": "jwt-val"}) == "jwt-val"
 
     def test_extracts_nested_token(self) -> None:
+        """Verify tokens nested inside dictionaries are extracted."""
         payload = {"data": {"accessToken": "nested-tok"}}
         assert extract_openmetadata_token(payload) == "nested-tok"
 
     def test_returns_none_for_empty(self) -> None:
+        """Verify empty payloads return `None`."""
         assert extract_openmetadata_token({}) is None
         assert extract_openmetadata_token([]) is None
 
     def test_extracts_from_list(self) -> None:
+        """Verify token extraction works for list payloads."""
         assert extract_openmetadata_token([{"token": "list-tok"}]) == "list-tok"
 
 
 class TestReadEnvFile:
+    """Tests for `read_env_file`."""
+
     def test_parses_key_value_pairs(self, tmp_path: Path) -> None:
+        """Verify key-value pairs are parsed from env files.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         env_file = tmp_path / ".env"
         env_file.write_text("FOO=bar\nBAZ=qux\n")
         result = read_env_file(env_file)
         assert result == {"FOO": "bar", "BAZ": "qux"}
 
     def test_ignores_comments_and_blanks(self, tmp_path: Path) -> None:
+        """Verify comments and blank lines are ignored.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         env_file = tmp_path / ".env"
         env_file.write_text("# comment\n\nKEY=val\n")
         result = read_env_file(env_file)
         assert result == {"KEY": "val"}
 
     def test_handles_equals_in_value(self, tmp_path: Path) -> None:
+        """Verify values can include `=` characters.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         env_file = tmp_path / ".env"
         env_file.write_text("DSN=postgres://u:p@host/db?opt=1\n")
         result = read_env_file(env_file)
@@ -91,13 +135,25 @@ class TestReadEnvFile:
 
 
 class TestUpsertEnvFile:
+    """Tests for `upsert_env_file`."""
+
     def test_creates_new_file(self, tmp_path: Path) -> None:
+        """Verify upsert creates files when absent.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         env_file = tmp_path / ".env"
         upsert_env_file(env_file, {"A": "1", "B": "2"})
         result = read_env_file(env_file)
         assert result == {"A": "1", "B": "2"}
 
     def test_updates_existing_key(self, tmp_path: Path) -> None:
+        """Verify existing keys are updated in-place.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         env_file = tmp_path / ".env"
         env_file.write_text("X=old\nY=keep\n")
         upsert_env_file(env_file, {"X": "new"})
@@ -105,6 +161,11 @@ class TestUpsertEnvFile:
         assert result == {"X": "new", "Y": "keep"}
 
     def test_appends_new_key(self, tmp_path: Path) -> None:
+        """Verify new keys are appended when missing.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         env_file = tmp_path / ".env"
         env_file.write_text("X=1\n")
         upsert_env_file(env_file, {"Z": "3"})
@@ -112,6 +173,11 @@ class TestUpsertEnvFile:
         assert result == {"X": "1", "Z": "3"}
 
     def test_preserves_comments(self, tmp_path: Path) -> None:
+        """Verify existing comments remain after updates.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         env_file = tmp_path / ".env"
         env_file.write_text("# header\nA=1\n")
         upsert_env_file(env_file, {"A": "2"})
@@ -120,7 +186,14 @@ class TestUpsertEnvFile:
 
 
 class TestWriteFile:
+    """Tests for `write_file`."""
+
     def test_creates_file_and_parents(self, tmp_path: Path) -> None:
+        """Verify file writes create parent directories as needed.
+
+        Args:
+            tmp_path: Temporary path fixture.
+        """
         target = tmp_path / "deep" / "nested" / "file.txt"
         write_file(target, "hello")
         assert target.read_text() == "hello"

--- a/tests/test_hook_bus.py
+++ b/tests/test_hook_bus.py
@@ -8,13 +8,16 @@ from phlo.plugins.hooks import FailurePolicy, HookFilter, HookRegistration
 
 
 def test_hook_bus_filters_and_ordering() -> None:
+    """Verify hook execution order honors filters and priority."""
     bus = MockHookBus()
     calls: list[str] = []
 
     def handler_a(_event) -> None:
+        """Record invocation of the lower-priority handler."""
         calls.append("a")
 
     def handler_b(_event) -> None:
+        """Record invocation of the higher-priority handler."""
         calls.append("b")
 
     bus.register(
@@ -47,9 +50,11 @@ def test_hook_bus_filters_and_ordering() -> None:
 
 
 def test_hook_bus_failure_policy_raise() -> None:
+    """Verify exceptions propagate when failure policy is set to raise."""
     bus = MockHookBus()
 
     def handler(_event) -> None:
+        """Raise a fixed error to validate failure propagation behavior."""
         raise RuntimeError("boom")
 
     bus.register(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -11,6 +11,7 @@ from phlo.logging import LoggingSettings, _render_log_file_path, get_logger, set
 
 
 def test_render_log_file_path_resolves_template(tmp_path: Path) -> None:
+    """Resolves ``{YMD}`` placeholders into a concrete log path."""
     template = str(tmp_path / "{YMD}.log")
     path = _render_log_file_path(template)
 
@@ -23,6 +24,12 @@ def test_render_log_file_path_resolves_template(tmp_path: Path) -> None:
 def test_render_log_file_path_respects_project_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Resolves relative templates under ``PHLO_PROJECT_PATH`` when set.
+
+    Args:
+        tmp_path: Temporary filesystem root for the test.
+        monkeypatch: Pytest fixture for environment mutation.
+    """
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     template = ".phlo/logs/{YMD}.log"
 
@@ -36,6 +43,12 @@ def test_render_log_file_path_respects_project_path(
 def test_render_log_file_path_warns_on_unknown_placeholder(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
+    """Logs a warning and returns ``None`` for unknown placeholders.
+
+    Args:
+        tmp_path: Temporary filesystem root for the test.
+        caplog: Pytest fixture for capturing log output.
+    """
     template = str(tmp_path / "{NOPE}.log")
 
     with caplog.at_level(logging.WARNING, logger="phlo.logging"):
@@ -46,6 +59,11 @@ def test_render_log_file_path_warns_on_unknown_placeholder(
 
 
 def test_setup_logging_writes_to_file(tmp_path: Path) -> None:
+    """Configures file logging and verifies emitted content is persisted.
+
+    Args:
+        tmp_path: Temporary filesystem root for the test.
+    """
     template = str(tmp_path / "phlo-{YMD}.log")
     settings = LoggingSettings(
         level="INFO",

--- a/tests/test_native_process_manager.py
+++ b/tests/test_native_process_manager.py
@@ -13,6 +13,16 @@ from phlo.plugins.discovery import ServiceDefinition
 
 
 def _svc(name: str, dev: dict | None = None, **kwargs) -> ServiceDefinition:
+    """Build a service definition fixture for tests.
+
+    Args:
+        name: Service name.
+        dev: Optional development configuration.
+        **kwargs: Additional `ServiceDefinition` fields.
+
+    Returns:
+        Service definition object.
+    """
     return ServiceDefinition(
         name=name,
         description=f"{name} service",
@@ -23,24 +33,32 @@ def _svc(name: str, dev: dict | None = None, **kwargs) -> ServiceDefinition:
 
 
 class TestCanRunDev:
+    """Tests for `NativeProcessManager.can_run_dev`."""
+
     def test_returns_true_when_dev_has_command(self) -> None:
+        """Verify services with a dev command are runnable."""
         mgr = NativeProcessManager(Path("/tmp"))
         svc = _svc("api", dev={"command": ["npm", "start"]})
         assert mgr.can_run_dev(svc) is True
 
     def test_returns_false_when_no_dev(self) -> None:
+        """Verify services without dev config are not runnable."""
         mgr = NativeProcessManager(Path("/tmp"))
         svc = _svc("postgres")
         assert mgr.can_run_dev(svc) is False
 
     def test_returns_false_when_dev_has_no_command(self) -> None:
+        """Verify missing dev command marks service as non-runnable."""
         mgr = NativeProcessManager(Path("/tmp"))
         svc = _svc("api", dev={"environment": {"PORT": "3000"}})
         assert mgr.can_run_dev(svc) is False
 
 
 class TestExpandEnvVars:
+    """Tests for `NativeProcessManager._expand_env_vars`."""
+
     def test_expands_simple_var(self) -> None:
+        """Verify simple placeholder expansion."""
         mgr = NativeProcessManager(Path("/tmp"))
         result = mgr._expand_env_vars(
             "http://${HOST}:${PORT}", {"HOST": "localhost", "PORT": "3000"}
@@ -48,39 +66,48 @@ class TestExpandEnvVars:
         assert result == "http://localhost:3000"
 
     def test_uses_default_when_var_missing(self) -> None:
+        """Verify default values are used for missing variables."""
         mgr = NativeProcessManager(Path("/tmp"))
         result = mgr._expand_env_vars("${HOST:-0.0.0.0}", {})
         assert result == "0.0.0.0"
 
     def test_prefers_env_value_over_default(self) -> None:
+        """Verify explicit values override defaults."""
         mgr = NativeProcessManager(Path("/tmp"))
         result = mgr._expand_env_vars("${HOST:-0.0.0.0}", {"HOST": "myhost"})
         assert result == "myhost"
 
     def test_raises_key_error_for_missing_var_without_default(self) -> None:
+        """Verify missing required placeholders raise `KeyError`."""
         mgr = NativeProcessManager(Path("/tmp"))
         with pytest.raises(KeyError, match="MISSING"):
             mgr._expand_env_vars("${MISSING}/path", {})
 
     def test_no_substitution_when_no_vars(self) -> None:
+        """Verify plain strings are returned unchanged."""
         mgr = NativeProcessManager(Path("/tmp"))
         assert mgr._expand_env_vars("plain-string", {}) == "plain-string"
 
 
 class TestResolvePath:
+    """Tests for `NativeProcessManager._resolve_path`."""
+
     def test_replaces_project_root(self) -> None:
+        """Verify `{project_root}` placeholders are resolved."""
         mgr = NativeProcessManager(Path("/my/project"))
         svc = _svc("api")
         result = mgr._resolve_path("{project_root}/dist", svc)
         assert result == Path("/my/project/dist")
 
     def test_replaces_source_path(self) -> None:
+        """Verify `{source_path}` placeholders are resolved."""
         mgr = NativeProcessManager(Path("/my/project"))
         svc = _svc("api", source_path=Path("/pkg/src"))
         result = mgr._resolve_path("{source_path}/build", svc)
         assert result == Path("/pkg/src/build")
 
     def test_returns_plain_path_when_no_placeholders(self) -> None:
+        """Verify plain path inputs are converted directly."""
         mgr = NativeProcessManager(Path("/my/project"))
         svc = _svc("api")
         result = mgr._resolve_path("./dist", svc)
@@ -88,20 +115,26 @@ class TestResolvePath:
 
 
 class TestProcessTracking:
+    """Tests for process tracking helpers."""
+
     def test_get_running_services_empty(self) -> None:
+        """Verify no processes yields an empty running-service list."""
         mgr = NativeProcessManager(Path("/tmp"))
         assert mgr.get_running_services() == []
 
     def test_get_process_returns_none_for_unknown(self) -> None:
+        """Verify unknown process names return `None`."""
         mgr = NativeProcessManager(Path("/tmp"))
         assert mgr.get_process("nonexistent") is None
 
     def test_stop_unknown_service_returns_false(self) -> None:
+        """Verify stopping unknown services returns `False`."""
         mgr = NativeProcessManager(Path("/tmp"))
         result = asyncio.run(mgr.stop_service("nonexistent"))
         assert result is False
 
     def test_get_running_services_filters_by_poll(self) -> None:
+        """Verify running list excludes exited processes by polling state."""
         mgr = NativeProcessManager(Path("/tmp"))
         running = MagicMock()
         running.poll.return_value = None  # still running
@@ -114,6 +147,7 @@ class TestProcessTracking:
         assert mgr.get_running_services() == ["alive"]
 
     def test_get_process_returns_process(self) -> None:
+        """Verify stored process objects are returned by name."""
         mgr = NativeProcessManager(Path("/tmp"))
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -23,6 +23,8 @@ def test_fetch_registry_uses_local_cache(monkeypatch):
     }
 
     class DummySettings:
+        """Settings stub for exercising local-registry fallback path."""
+
         plugin_registry_url = ""
         plugin_registry_cache_ttl_seconds = 3600
         plugin_registry_timeout_seconds = 1
@@ -63,6 +65,8 @@ def test_search_plugins_filters(monkeypatch):
     }
 
     class DummySettings:
+        """Settings stub for exercising cached registry search behavior."""
+
         plugin_registry_url = ""
         plugin_registry_cache_ttl_seconds = 3600
         plugin_registry_timeout_seconds = 1

--- a/tests/test_plugin_system.py
+++ b/tests/test_plugin_system.py
@@ -34,6 +34,11 @@ class DummySourcePlugin(SourceConnectorPlugin):
 
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Metadata for the dummy source plugin.
+        """
         return PluginMetadata(
             name="test_source",
             version="1.0.0",
@@ -51,6 +56,11 @@ class DummyQualityPlugin(QualityCheckPlugin):
 
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Metadata for the dummy quality plugin.
+        """
         return PluginMetadata(
             name="test_quality",
             version="1.0.0",
@@ -67,6 +77,11 @@ class DummyTransformPlugin(TransformationPlugin):
 
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Metadata for the dummy transform plugin.
+        """
         return PluginMetadata(
             name="test_transform",
             version="1.0.0",
@@ -83,6 +98,11 @@ class DummyServicePlugin(ServicePlugin):
 
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Metadata for the dummy service plugin.
+        """
         return PluginMetadata(
             name="test_service",
             version="1.0.0",
@@ -91,6 +111,11 @@ class DummyServicePlugin(ServicePlugin):
 
     @property
     def service_definition(self) -> dict:
+        """Return a minimal service definition for tests.
+
+        Returns:
+            dict: Service category and compose image config.
+        """
         return {
             "category": "core",
             "compose": {"image": "test-service:latest"},
@@ -210,6 +235,8 @@ class TestPluginValidation:
         """Test validation fails for missing metadata."""
 
         class BadPlugin:
+            """Plugin-like object missing required metadata and methods."""
+
             pass
 
         assert clean_registry.validate_plugin(BadPlugin()) is False
@@ -220,11 +247,26 @@ class TestPluginValidation:
         # so we test with a mock that has the structure but missing callable
 
         class BrokenSource(SourceConnectorPlugin):
+            """Source plugin with fetch method intentionally overridden in test."""
+
             @property
             def metadata(self):
+                """Return placeholder metadata for the broken source.
+
+                Returns:
+                    PluginMetadata: Minimal metadata for validation tests.
+                """
                 return PluginMetadata(name="broken", version="1.0.0")
 
             def fetch_data(self, config):
+                """Return a non-generator payload used in validation tests.
+
+                Args:
+                    config: Source configuration.
+
+                Returns:
+                    list: Placeholder rows.
+                """
                 return []
 
         plugin = BrokenSource()
@@ -246,8 +288,15 @@ class TestPluginListing:
         plugin1 = DummySourcePlugin()
 
         class AnotherSourcePlugin(SourceConnectorPlugin):
+            """Additional source connector used to test listing behavior."""
+
             @property
             def metadata(self) -> PluginMetadata:
+                """Return plugin metadata.
+
+                Returns:
+                    PluginMetadata: Metadata for the second source plugin.
+                """
                 return PluginMetadata(
                     name="test_source2",
                     version="1.0.0",
@@ -255,6 +304,14 @@ class TestPluginListing:
                 )
 
             def fetch_data(self, config):
+                """Yield one row for list tests.
+
+                Args:
+                    config: Source configuration.
+
+                Yields:
+                    dict: Dummy source row.
+                """
                 yield {"id": 2, "value": "test2"}
 
         plugin2 = AnotherSourcePlugin()

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -7,6 +7,7 @@ from phlo_dlt.scaffold import create_ingestion_workflow, parse_field_specs
 
 
 def test_parse_field_specs_validates_and_dedupes() -> None:
+    """Normalizes field specs and keeps first occurrence for duplicate names."""
     specs = parse_field_specs(["User ID:str!", "created_at:datetime", "user_id:int"])
     assert [s.name for s in specs] == ["user_id", "created_at"]
     assert specs[0].nullable is False
@@ -15,6 +16,12 @@ def test_parse_field_specs_validates_and_dedupes() -> None:
 def test_scaffold_generates_no_todos_and_is_syntax_valid(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Generates scaffold files without placeholders and with valid Python syntax.
+
+    Args:
+        tmp_path: Temporary filesystem root for generated files.
+        monkeypatch: Pytest fixture for changing current working directory.
+    """
     monkeypatch.chdir(tmp_path)
     (tmp_path / "workflows" / "schemas").mkdir(parents=True)
     (tmp_path / "workflows" / "ingestion").mkdir(parents=True)

--- a/tests/test_services_discovery.py
+++ b/tests/test_services_discovery.py
@@ -9,12 +9,24 @@ from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery, get_glob
 
 
 class DummyServicePlugin(ServicePlugin):
+    """Provide a minimal service plugin for discovery tests."""
+
     @property
     def metadata(self) -> PluginMetadata:
+        """Return plugin metadata.
+
+        Returns:
+            PluginMetadata: Static metadata for the dummy plugin.
+        """
         return PluginMetadata(name="dummy_service", version="1.0.0")
 
     @property
     def service_definition(self) -> dict:
+        """Return the service definition used in tests.
+
+        Returns:
+            dict: Service configuration for discovery assertions.
+        """
         return {
             "name": "dummy_service",
             "description": "Dummy service",
@@ -26,6 +38,7 @@ class DummyServicePlugin(ServicePlugin):
 
 @pytest.fixture
 def clean_registry():
+    """Clear the global registry before and after each test."""
     registry = get_global_registry()
     registry.clear()
     yield registry
@@ -37,6 +50,7 @@ def test_service_discovery_includes_plugins(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """Ensure discovered services include registered service plugins."""
     registry = get_global_registry()
     registry.register_service(DummyServicePlugin(), replace=True)
 


### PR DESCRIPTION
## Summary
- add Google-style docstrings across root-level test modules in `tests/`
- focus on helper functions, nested handlers, and test fixtures without behavior changes
- keep scope to root `tests/` coverage follow-up

## Validation
- `make check`
- root tests AST scan: zero missing docstrings in `tests/`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
