### PR TITLE
docs: add missing documentation for undocumented subsystems

### DIFF
--- a/docs/errors/PHLO-004.md
+++ b/docs/errors/PHLO-004.md
@@ -1,0 +1,222 @@
+# PHLO-004: Validation Failed
+
+**Error Type:** Discovery and Configuration Error
+**Severity:** High
+**Exception Class:** `PhloValidationError`
+
+## Description
+
+This error occurs when data validation fails against a Pandera schema. Phlo validates ingested data before writing to Iceberg tables, ensuring data quality constraints are met. When incoming data violates schema constraints, this error is raised with details about which fields failed validation.
+
+## Common Causes
+
+1. **Data doesn't match constraints**
+   - Values violate `Check` constraints (e.g., `Check.greater_than(0)`)
+   - String values don't match expected patterns
+   - Enum values outside allowed set
+
+2. **Type mismatches**
+   - Column contains strings where integers are expected
+   - Date fields in wrong format
+   - Mixed types in a single column
+
+3. **Nulls in non-nullable fields**
+   - Source data contains `None`/`NaN` in required columns
+   - Missing fields in source records
+
+4. **Values out of range**
+   - Numeric values outside min/max bounds
+   - String lengths exceeding limits
+   - Dates outside valid ranges
+
+## Solutions
+
+### Solution 1: Inspect the validation failure details
+
+The error message includes which columns and checks failed:
+
+```python
+from phlo.exceptions import PhloValidationError
+
+try:
+    # Asset execution triggers validation
+    pass
+except PhloValidationError as e:
+    print(e)  # Shows column, check, and failing values
+```
+
+### Solution 2: Fix schema constraints
+
+Adjust your Pandera schema to match actual data:
+
+```python
+import pandera as pa
+
+# ❌ Schema too strict
+class WeatherObservations(pa.DataFrameModel):
+    temperature: float = pa.Field(ge=-50, le=50)  # Rejects 51°C
+    humidity: float = pa.Field(ge=0, le=100)
+
+# ✅ Schema with realistic ranges
+class WeatherObservations(pa.DataFrameModel):
+    temperature: float = pa.Field(ge=-90, le=60)  # Expanded range
+    humidity: float = pa.Field(ge=0, le=100)
+```
+
+### Solution 3: Handle nullable fields
+
+Mark fields as nullable when source data may contain nulls:
+
+```python
+import pandera as pa
+from typing import Optional
+
+# ❌ All fields required
+class WeatherObservations(pa.DataFrameModel):
+    station_id: str
+    temperature: float
+    wind_speed: float  # Fails if source omits wind_speed
+
+# ✅ Optional fields marked nullable
+class WeatherObservations(pa.DataFrameModel):
+    station_id: str
+    temperature: float
+    wind_speed: Optional[float] = pa.Field(nullable=True)
+```
+
+### Solution 4: Clean data before validation
+
+Pre-process data to fix known issues:
+
+```python
+@phlo_ingestion(
+    unique_key="observation_id",
+    validation_schema=WeatherObservations,
+)
+def weather_observations(partition: str):
+    data = fetch_raw_data(partition)
+
+    # Clean known issues before Phlo validates
+    for record in data:
+        if record.get("temperature") == "N/A":
+            record["temperature"] = None
+        if isinstance(record.get("wind_speed"), str):
+            record["wind_speed"] = float(record["wind_speed"])
+
+    return data
+```
+
+## Examples
+
+### ❌ Incorrect: Schema doesn't account for source data quirks
+
+```python
+class SensorReadings(pa.DataFrameModel):
+    sensor_id: str
+    value: float  # Source sometimes sends "ERROR" as value
+    timestamp: str
+```
+
+### ✅ Correct: Schema handles expected variations
+
+```python
+class SensorReadings(pa.DataFrameModel):
+    sensor_id: str
+    value: Optional[float] = pa.Field(nullable=True)
+    timestamp: str = pa.Field(str_matches=r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}")
+```
+
+## Debugging Steps
+
+1. **Check which columns failed**
+
+   ```bash
+   docker logs dagster-webserver 2>&1 | grep "PhloValidationError"
+   ```
+
+2. **Validate data manually**
+
+   ```python
+   import pandera as pa
+   from workflows.schemas.weather import WeatherObservations
+
+   df = fetch_raw_data_as_dataframe("2024-01-15")
+
+   try:
+       WeatherObservations.validate(df)
+       print("✅ Validation passed")
+   except pa.errors.SchemaError as e:
+       print(f"❌ Validation failed:\n{e}")
+       print(f"Failure cases:\n{e.failure_cases}")
+   ```
+
+3. **Profile the data**
+
+   ```python
+   df = fetch_raw_data_as_dataframe("2024-01-15")
+   print(df.dtypes)
+   print(df.describe())
+   print(df.isnull().sum())
+   ```
+
+4. **Test with a single record**
+
+   ```python
+   import pandas as pd
+   from workflows.schemas.weather import WeatherObservations
+
+   sample = pd.DataFrame([{"station_id": "KSFO", "temperature": 18.5}])
+   WeatherObservations.validate(sample)
+   ```
+
+## Related Errors
+
+- [PHLO-005: Missing Schema](./PHLO-005.md) - Schema not provided to decorator
+- [PHLO-002: Schema Mismatch](./PHLO-002.md) - unique_key not found in schema
+- [PHLO-200: Schema Conversion Error](./PHLO-200.md) - Schema cannot convert to Iceberg
+
+## Prevention
+
+1. **Add schema tests**
+
+   ```python
+   # tests/test_schemas.py
+   import pandas as pd
+   from workflows.schemas.weather import WeatherObservations
+
+   def test_schema_validates_sample_data():
+       df = pd.DataFrame([
+           {"station_id": "KSFO", "temperature": 18.5, "wind_speed": 5.2},
+       ])
+       WeatherObservations.validate(df)
+   ```
+
+2. **Use `allow_threshold` for gradual enforcement**
+
+   ```python
+   @phlo_quality(
+       validation_schema=WeatherObservations,
+       allow_threshold=0.95,  # Allow up to 5% failures
+   )
+   ```
+
+3. **Document expected data ranges**
+
+   ```python
+   class WeatherObservations(pa.DataFrameModel):
+       """Weather station observation data.
+
+       Temperature: -90°C to 60°C (world record extremes)
+       Humidity: 0-100%
+       Wind speed: 0-120 m/s (nullable for indoor stations)
+       """
+       temperature: float = pa.Field(ge=-90, le=60)
+       humidity: float = pa.Field(ge=0, le=100)
+       wind_speed: Optional[float] = pa.Field(nullable=True, ge=0, le=120)
+   ```
+
+## Additional Resources
+
+- [Pandera Documentation](https://pandera.readthedocs.io/)
+- [Pandera DataFrameModel](https://pandera.readthedocs.io/en/stable/dataframe_models.html)
+- [Phlo Quality Guide](../guides/quality.md)

--- a/docs/errors/PHLO-005.md
+++ b/docs/errors/PHLO-005.md
@@ -1,0 +1,202 @@
+# PHLO-005: Missing Schema
+
+**Error Type:** Discovery and Configuration Error
+**Severity:** High
+**Exception Class:** `PhloConfigError`
+
+## Description
+
+This error occurs when the `validation_schema` parameter is not provided to the `@phlo_ingestion` or `@phlo_quality` decorator. Phlo requires a Pandera schema to validate data and derive Iceberg table schemas.
+
+## Common Causes
+
+1. **Missing `validation_schema` parameter**
+   - Decorator called without `validation_schema` argument
+   - Parameter name misspelled
+
+2. **Schema class not imported**
+   - Schema defined in another module but not imported
+   - Import statement removed or commented out
+
+3. **Typo in schema class name**
+   - Class name misspelled in decorator call
+   - Using wrong schema class
+
+4. **Schema module has import errors**
+   - Schema file has syntax errors
+   - Schema depends on unavailable library
+
+## Solutions
+
+### Solution 1: Add the validation_schema parameter
+
+```python
+from phlo_dlt.decorator import phlo_ingestion
+from workflows.schemas.weather import WeatherObservations
+
+# ❌ Missing validation_schema
+@phlo_ingestion(
+    unique_key="observation_id",
+)
+def weather_observations(partition: str):
+    pass
+
+# ✅ Schema provided
+@phlo_ingestion(
+    unique_key="observation_id",
+    validation_schema=WeatherObservations,
+)
+def weather_observations(partition: str):
+    pass
+```
+
+### Solution 2: Create the schema class
+
+If no schema exists yet, create one in `workflows/schemas/`:
+
+```python
+# workflows/schemas/weather.py
+import pandera as pa
+from typing import Optional
+
+class WeatherObservations(pa.DataFrameModel):
+    observation_id: str = pa.Field(unique=True)
+    station_id: str
+    temperature: float = pa.Field(ge=-90, le=60)
+    humidity: Optional[float] = pa.Field(nullable=True, ge=0, le=100)
+    timestamp: str
+
+    class Config:
+        strict = True
+```
+
+### Solution 3: Fix the import
+
+Ensure the schema module is importable:
+
+```bash
+python -c "from workflows.schemas.weather import WeatherObservations; print('✅ Import OK')"
+```
+
+If the import fails, check:
+
+```python
+# ❌ Wrong import path
+from schemas.weather import WeatherObservations
+
+# ✅ Correct import path
+from workflows.schemas.weather import WeatherObservations
+```
+
+## Examples
+
+### ❌ Incorrect: No schema
+
+```python
+@phlo_ingestion(
+    unique_key="observation_id",
+)
+def weather_observations(partition: str):
+    return fetch_weather_data(partition)
+```
+
+### ❌ Incorrect: Typo in parameter name
+
+```python
+@phlo_ingestion(
+    unique_key="observation_id",
+    schema=WeatherObservations,  # ❌ Wrong parameter name
+)
+def weather_observations(partition: str):
+    return fetch_weather_data(partition)
+```
+
+### ✅ Correct: Schema provided
+
+```python
+@phlo_ingestion(
+    unique_key="observation_id",
+    validation_schema=WeatherObservations,
+)
+def weather_observations(partition: str):
+    return fetch_weather_data(partition)
+```
+
+## Debugging Steps
+
+1. **Check decorator parameters**
+
+   ```bash
+   grep -n "phlo_ingestion\|phlo_quality" workflows/ingestion/weather/observations.py
+   ```
+
+2. **Verify schema import**
+
+   ```python
+   from workflows.schemas.weather import WeatherObservations
+   print(f"Schema fields: {list(WeatherObservations.to_schema().columns.keys())}")
+   ```
+
+3. **List available schemas**
+
+   ```bash
+   find workflows/schemas -name "*.py" -not -name "__init__.py"
+   ```
+
+4. **Check for import errors**
+
+   ```bash
+   python -c "import workflows.schemas.weather" 2>&1
+   ```
+
+## Related Errors
+
+- [PHLO-001: Asset Not Discovered](./PHLO-001.md) - Asset not found by Dagster
+- [PHLO-002: Schema Mismatch](./PHLO-002.md) - unique_key not in schema
+- [PHLO-004: Validation Failed](./PHLO-004.md) - Data fails schema validation
+
+## Prevention
+
+1. **Use IDE auto-complete**
+   - Modern editors will suggest `validation_schema=` when typing decorator parameters
+
+2. **Add a schema for every ingestion**
+
+   ```
+   workflows/
+   ├── ingestion/
+   │   └── weather/
+   │       └── observations.py
+   └── schemas/
+       └── weather.py          # Schema for weather domain
+   ```
+
+3. **Test schema availability in CI**
+
+   ```python
+   # tests/test_schemas.py
+   def test_all_ingestions_have_schemas():
+       from phlo_dagster.framework.definitions import defs
+       for asset in defs.assets:
+           assert hasattr(asset, "validation_schema"), (
+               f"Asset {asset.key} missing validation_schema"
+           )
+   ```
+
+4. **Use a schema template**
+
+   ```python
+   # workflows/schemas/_template.py
+   import pandera as pa
+
+   class MySchema(pa.DataFrameModel):
+       id: str = pa.Field(unique=True)
+
+       class Config:
+           strict = True
+   ```
+
+## Additional Resources
+
+- [Pandera DataFrameModel](https://pandera.readthedocs.io/en/stable/dataframe_models.html)
+- [Phlo Asset Creation Guide](../TESTING_GUIDE.md#creating-assets)

--- a/docs/errors/PHLO-007.md
+++ b/docs/errors/PHLO-007.md
@@ -1,0 +1,186 @@
+# PHLO-007: Table Not Found
+
+**Error Type:** Runtime and Integration Error
+**Severity:** High
+**Exception Class:** `PhloTableError`
+
+## Description
+
+This error occurs when an Iceberg table cannot be found in the catalog. Phlo uses Nessie as the Iceberg catalog and stores tables in S3-compatible storage (MinIO). When a referenced table doesn't exist in the catalog, this error is raised.
+
+## Common Causes
+
+1. **Table not yet created**
+   - Ingestion asset hasn't run yet
+   - Table creation failed silently on first run
+
+2. **Wrong table name**
+   - Typo in table reference
+   - Asset name doesn't match expected table name
+   - Snake_case vs other naming mismatch
+
+3. **Wrong namespace**
+   - Table exists in a different Nessie namespace/branch
+   - Referencing wrong catalog database
+
+4. **Catalog permissions**
+   - Nessie user lacks read access
+   - S3/MinIO credentials missing or expired
+
+## Solutions
+
+### Solution 1: Verify the table exists in the catalog
+
+```python
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog("default")
+
+# List all tables
+for namespace in catalog.list_namespaces():
+    for table in catalog.list_tables(namespace):
+        print(f"{namespace}.{table}")
+```
+
+### Solution 2: Run the ingestion asset first
+
+If the table hasn't been created yet, materialize the ingestion asset:
+
+```bash
+# Via Dagster UI or CLI
+dagster asset materialize --select weather_observations
+```
+
+Or trigger via Phlo:
+
+```bash
+phlo services start
+# Then materialize through the Dagster UI at http://localhost:3000
+```
+
+### Solution 3: Check table naming
+
+Phlo uses snake_case for table names derived from asset names:
+
+```python
+# Asset name -> Table name
+# weather_observations -> dlt_weather_observations (ingestion tables)
+
+# ❌ Wrong table reference
+catalog.load_table("default.WeatherObservations")
+
+# ✅ Correct table reference
+catalog.load_table("default.dlt_weather_observations")
+```
+
+### Solution 4: Verify catalog connection
+
+```python
+from pyiceberg.catalog import load_catalog
+
+try:
+    catalog = load_catalog("default")
+    namespaces = catalog.list_namespaces()
+    print(f"✅ Catalog connected. Namespaces: {namespaces}")
+except Exception as e:
+    print(f"❌ Catalog connection failed: {e}")
+```
+
+## Examples
+
+### ❌ Incorrect: Wrong namespace
+
+```python
+# Table is in "bronze" namespace, not "default"
+table = catalog.load_table("default.weather_observations")
+```
+
+### ✅ Correct: Right namespace
+
+```python
+table = catalog.load_table("bronze.dlt_weather_observations")
+```
+
+### ❌ Incorrect: CamelCase table name
+
+```python
+table = catalog.load_table("default.WeatherObservations")
+```
+
+### ✅ Correct: snake_case table name
+
+```python
+table = catalog.load_table("default.dlt_weather_observations")
+```
+
+## Debugging Steps
+
+1. **List all tables in catalog**
+
+   ```bash
+   docker exec dagster-webserver python -c "
+   from pyiceberg.catalog import load_catalog
+   catalog = load_catalog('default')
+   for ns in catalog.list_namespaces():
+       for tbl in catalog.list_tables(ns):
+           print(f'{ns}.{tbl}')
+   "
+   ```
+
+2. **Check Nessie API**
+
+   ```bash
+   curl http://localhost:19120/api/v2/trees/main
+   ```
+
+3. **Verify services are running**
+
+   ```bash
+   phlo services list --json
+   ```
+
+4. **Check S3/MinIO storage**
+
+   ```bash
+   # List buckets
+   docker exec minio mc ls local/
+   ```
+
+## Related Errors
+
+- [PHLO-008: Infrastructure Error](./PHLO-008.md) - Catalog service unavailable
+- [PHLO-400: Iceberg Catalog Error](./PHLO-400.md) - Catalog operations failed
+- [PHLO-401: Iceberg Table Error](./PHLO-401.md) - Table operations failed
+- [PHLO-006: Ingestion Failed](./PHLO-006.md) - Ingestion that creates tables failed
+
+## Prevention
+
+1. **Use Phlo asset dependencies**
+   - Ensure downstream assets declare dependencies on ingestion assets
+   - Dagster will enforce execution order
+
+2. **Add table existence checks**
+
+   ```python
+   from pyiceberg.catalog import load_catalog
+   from pyiceberg.exceptions import NoSuchTableError
+
+   def table_exists(table_name: str) -> bool:
+       catalog = load_catalog("default")
+       try:
+           catalog.load_table(table_name)
+           return True
+       except NoSuchTableError:
+           return False
+   ```
+
+3. **Follow naming conventions**
+   - Asset names in snake_case
+   - Ingestion assets use `dlt_<table_name>` prefix
+   - Database objects in lowercase
+
+## Additional Resources
+
+- [PyIceberg Documentation](https://py.iceberg.apache.org/)
+- [Nessie REST API](https://projectnessie.org/nessie-latest/api/)
+- [Phlo Storage Architecture](../reference/architecture.md)

--- a/docs/errors/PHLO-008.md
+++ b/docs/errors/PHLO-008.md
@@ -1,0 +1,234 @@
+# PHLO-008: Infrastructure Error
+
+**Error Type:** Runtime and Integration Error
+**Severity:** Critical
+**Exception Class:** `PhloInfrastructureError`
+
+## Description
+
+This error occurs when infrastructure services required by Phlo are unavailable or not responding. Phlo depends on several services (Dagster, Nessie, MinIO, Trino, Postgres) and this error is raised when connections to these services fail.
+
+## Common Causes
+
+1. **Services not running**
+   - `phlo services start` not executed
+   - Docker containers crashed or stopped
+   - Docker daemon not running
+
+2. **Connection refused**
+   - Service is starting up (not ready yet)
+   - Port conflict with another application
+   - Service bound to wrong interface
+
+3. **Authentication failed**
+   - Credentials in `.phlo/.env` incorrect
+   - Credentials rotated but not updated
+   - Environment variables not loaded
+
+4. **Resource exhaustion**
+   - Docker out of disk space
+   - Insufficient memory for containers
+   - Too many open connections
+
+## Solutions
+
+### Solution 1: Start Phlo services
+
+```bash
+# Start all services
+phlo services start
+
+# Verify services are running
+phlo services list --json
+```
+
+### Solution 2: Check Docker status
+
+```bash
+# Check Docker is running
+docker info
+
+# Check container status
+docker ps -a --filter "label=phlo"
+
+# Restart crashed containers
+phlo services restart
+```
+
+### Solution 3: Check service logs
+
+```bash
+# View logs for a specific service
+phlo services logs -f dagster-webserver
+
+# Check all services
+docker compose -f .phlo/docker-compose.yml logs --tail=50
+```
+
+### Solution 4: Verify connection settings
+
+Check `.phlo/.env` has correct connection details:
+
+```bash
+# .phlo/.env
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+NESSIE_URI=http://localhost:19120/api/v2
+MINIO_ENDPOINT=http://localhost:9000
+TRINO_HOST=localhost
+TRINO_PORT=8080
+```
+
+Test connectivity:
+
+```bash
+# Postgres
+pg_isready -h localhost -p 5432
+
+# Nessie
+curl -s http://localhost:19120/api/v2/config | head -1
+
+# MinIO
+curl -s http://localhost:9000/minio/health/live
+
+# Trino
+curl -s http://localhost:8080/v1/info
+```
+
+## Examples
+
+### ❌ Incorrect: Assuming services are running
+
+```python
+from pyiceberg.catalog import load_catalog
+
+# ❌ No check — will fail if Nessie is down
+catalog = load_catalog("default")
+tables = catalog.list_tables("bronze")
+```
+
+### ✅ Correct: Check service availability
+
+```python
+from phlo.exceptions import PhloInfrastructureError
+from pyiceberg.catalog import load_catalog
+
+try:
+    catalog = load_catalog("default")
+    tables = catalog.list_tables("bronze")
+except Exception as e:
+    raise PhloInfrastructureError(
+        message="Cannot connect to Iceberg catalog (Nessie)",
+        suggestions=[
+            "Run 'phlo services start' to start infrastructure",
+            "Check Nessie is running: curl http://localhost:19120/api/v2/config",
+            "Review logs: phlo services logs -f nessie",
+        ],
+        cause=e,
+    )
+```
+
+## Debugging Steps
+
+1. **Check all service health**
+
+   ```bash
+   phlo services list --json
+   ```
+
+2. **View container status**
+
+   ```bash
+   docker ps -a --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+   ```
+
+3. **Check resource usage**
+
+   ```bash
+   docker stats --no-stream
+   ```
+
+4. **Review service logs for errors**
+
+   ```bash
+   phlo services logs -f dagster-webserver
+   phlo services logs -f nessie
+   phlo services logs -f minio
+   phlo services logs -f trino
+   phlo services logs -f postgres
+   ```
+
+5. **Check Docker disk usage**
+
+   ```bash
+   docker system df
+   ```
+
+6. **Reset services**
+
+   ```bash
+   phlo services stop
+   phlo services reset
+   phlo services start
+   ```
+
+## Service Port Reference
+
+| Service           | Default Port | Health Check URL                          |
+| ----------------- | ------------ | ----------------------------------------- |
+| Dagster Webserver | 3000         | `http://localhost:3000`                    |
+| Nessie            | 19120        | `http://localhost:19120/api/v2/config`     |
+| MinIO API         | 9000         | `http://localhost:9000/minio/health/live`  |
+| MinIO Console     | 9001         | `http://localhost:9001`                    |
+| Trino             | 8080         | `http://localhost:8080/v1/info`            |
+| Postgres          | 5432         | `pg_isready -h localhost -p 5432`         |
+
+## Related Errors
+
+- [PHLO-006: Ingestion Failed](./PHLO-006.md) - Ingestion fails due to infra issues
+- [PHLO-007: Table Not Found](./PHLO-007.md) - Table missing (catalog may be down)
+- [PHLO-400: Iceberg Catalog Error](./PHLO-400.md) - Catalog-specific infra failures
+
+## Prevention
+
+1. **Start services before development**
+
+   ```bash
+   phlo services start
+   phlo services list --json  # Verify all healthy
+   ```
+
+2. **Add health checks to workflows**
+
+   ```python
+   import requests
+
+   def check_infrastructure():
+       services = {
+           "Nessie": "http://localhost:19120/api/v2/config",
+           "MinIO": "http://localhost:9000/minio/health/live",
+           "Trino": "http://localhost:8080/v1/info",
+       }
+       for name, url in services.items():
+           try:
+               requests.get(url, timeout=5).raise_for_status()
+           except Exception:
+               raise PhloInfrastructureError(
+                   message=f"{name} is not available at {url}",
+                   suggestions=[
+                       f"Check {name} container: docker logs {name.lower()}",
+                       "Run 'phlo services restart' to restart all services",
+                   ],
+               )
+   ```
+
+3. **Monitor with Docker health checks**
+   - Phlo services include Docker health checks
+   - Use `docker ps` to see health status
+   - Set up alerting on container restarts
+
+## Additional Resources
+
+- [Docker Documentation](https://docs.docker.com/)
+- [Phlo Services Guide](../guides/services.md)
+- [Troubleshooting Guide](../operations/troubleshooting.md)

--- a/docs/errors/PHLO-200.md
+++ b/docs/errors/PHLO-200.md
@@ -1,0 +1,190 @@
+# PHLO-200: Schema Conversion Error
+
+**Error Type:** Schema and Type Error
+**Severity:** High
+**Exception Class:** `SchemaConversionError`
+
+## Description
+
+This error occurs when a Pandera schema cannot be converted to a PyIceberg schema. Phlo automatically converts Pandera `DataFrameModel` schemas to Iceberg table schemas for table creation and validation. When the conversion encounters unsupported types or structures, this error is raised.
+
+## Common Causes
+
+1. **Unsupported Pandera types**
+   - Custom Pandera types without Iceberg equivalents
+   - Complex Python types (e.g., `dict`, `set`, `tuple`)
+   - Generic types that can't be mapped
+
+2. **Complex nested schemas**
+   - Deeply nested struct types
+   - Recursive schema definitions
+   - Variable-structure JSON columns
+
+3. **Custom Pandera types**
+   - User-defined `DataType` subclasses
+   - Extension types from third-party libraries
+
+4. **Ambiguous type annotations**
+   - `Any` type annotations
+   - Union types with incompatible members
+   - Missing type annotations
+
+## Solutions
+
+### Solution 1: Use supported types
+
+Stick to types that have direct Iceberg mappings:
+
+```python
+import pandera as pa
+from typing import Optional
+
+# ✅ All types have Iceberg equivalents
+class WeatherObservations(pa.DataFrameModel):
+    observation_id: str          # -> Iceberg StringType
+    temperature: float           # -> Iceberg DoubleType
+    pressure: int                # -> Iceberg LongType
+    is_valid: bool               # -> Iceberg BooleanType
+    timestamp: str               # -> Iceberg StringType
+    reading: Optional[float] = pa.Field(nullable=True)  # -> Iceberg DoubleType (optional)
+```
+
+### Solution 2: Simplify complex types
+
+Replace complex types with simple, serializable alternatives:
+
+```python
+import pandera as pa
+
+# ❌ Complex nested type
+class EventData(pa.DataFrameModel):
+    metadata: dict  # Can't convert dict to Iceberg
+
+# ✅ Flatten or serialize complex types
+class EventData(pa.DataFrameModel):
+    metadata_json: str  # Store as JSON string
+    metadata_source: str
+    metadata_version: int
+```
+
+### Solution 3: Override type mapping
+
+If you need a specific Iceberg type, annotate the field:
+
+```python
+import pandera as pa
+
+class SensorReadings(pa.DataFrameModel):
+    sensor_id: str
+    reading: float = pa.Field(ge=0)  # Maps to DoubleType
+    precision_reading: pa.Float32 = pa.Field()  # Maps to FloatType
+```
+
+## Examples
+
+### ❌ Incorrect: Unsupported type
+
+```python
+class EventLog(pa.DataFrameModel):
+    event_id: str
+    payload: dict           # ❌ dict has no Iceberg equivalent
+    tags: list              # ❌ untyped list is ambiguous
+```
+
+### ✅ Correct: Supported types only
+
+```python
+class EventLog(pa.DataFrameModel):
+    event_id: str
+    payload_json: str       # ✅ Serialize to JSON string
+    tags_csv: str           # ✅ Comma-separated string
+```
+
+## Debugging Steps
+
+1. **Inspect schema fields and types**
+
+   ```python
+   from workflows.schemas.weather import WeatherObservations
+
+   schema = WeatherObservations.to_schema()
+   for col_name, col in schema.columns.items():
+       print(f"{col_name}: {col.dtype}")
+   ```
+
+2. **Test conversion manually**
+
+   ```python
+   from phlo_quality.iceberg import pandera_to_iceberg_schema
+   from workflows.schemas.weather import WeatherObservations
+
+   try:
+       iceberg_schema = pandera_to_iceberg_schema(WeatherObservations)
+       print(f"✅ Conversion OK: {iceberg_schema}")
+   except SchemaConversionError as e:
+       print(f"❌ Conversion failed: {e}")
+   ```
+
+3. **Check Pandera type resolution**
+
+   ```python
+   import pandera as pa
+
+   schema = WeatherObservations.to_schema()
+   for name, col in schema.columns.items():
+       print(f"{name}: pandera_type={col.dtype}, python_type={col.dtype.type}")
+   ```
+
+## Type Mapping Reference
+
+| Pandera / Python Type | Iceberg Type    |
+| --------------------- | --------------- |
+| `str`                 | `StringType`    |
+| `int`                 | `LongType`      |
+| `float`               | `DoubleType`    |
+| `bool`                | `BooleanType`   |
+| `pa.Float32`          | `FloatType`     |
+| `pa.Float64`          | `DoubleType`    |
+| `pa.Int32`            | `IntegerType`   |
+| `pa.Int64`            | `LongType`      |
+| `bytes`               | `BinaryType`    |
+| `datetime`            | `TimestampType` |
+| `date`                | `DateType`      |
+
+## Related Errors
+
+- [PHLO-201: Type Conversion Error](./PHLO-201.md) - Individual field type conversion failed
+- [PHLO-004: Validation Failed](./PHLO-004.md) - Data validation against schema failed
+- [PHLO-002: Schema Mismatch](./PHLO-002.md) - Schema configuration mismatch
+
+## Prevention
+
+1. **Use only supported types in schemas**
+
+   ```python
+   # Supported: str, int, float, bool, Optional[T], datetime, date, bytes
+   # Avoid: dict, list, set, tuple, Any, complex Union types
+   ```
+
+2. **Test schema conversion in CI**
+
+   ```python
+   # tests/test_schema_conversion.py
+   from phlo_quality.iceberg import pandera_to_iceberg_schema
+   from workflows.schemas.weather import WeatherObservations
+
+   def test_schema_converts_to_iceberg():
+       iceberg_schema = pandera_to_iceberg_schema(WeatherObservations)
+       assert len(iceberg_schema.fields) > 0
+   ```
+
+3. **Serialize complex data**
+   - Store JSON blobs as `str` columns
+   - Flatten nested structures into top-level columns
+   - Use separate tables for one-to-many relationships
+
+## Additional Resources
+
+- [PyIceberg Schema Documentation](https://py.iceberg.apache.org/)
+- [Pandera Data Types](https://pandera.readthedocs.io/en/stable/dtypes.html)
+- [Apache Iceberg Type System](https://iceberg.apache.org/spec/#schemas-and-data-types)

--- a/docs/errors/PHLO-201.md
+++ b/docs/errors/PHLO-201.md
@@ -1,0 +1,161 @@
+# PHLO-201: Type Conversion Error
+
+**Error Type:** Schema and Type Error
+**Severity:** Medium
+**Exception Class:** `PhloError` (code `PHLO-201`)
+
+## Description
+
+This error occurs when an individual field type cannot be mapped between Pandera and Iceberg type systems. Unlike [PHLO-200](./PHLO-200.md), which covers whole-schema conversion failures, this error is specific to a single field whose type has no known Iceberg equivalent.
+
+## Common Causes
+
+1. **Unsupported Python type annotation**
+   - Using `Any`, `object`, or untyped generics
+   - Custom classes as type annotations
+
+2. **Ambiguous numeric types**
+   - `Decimal` without precision/scale specification
+   - NumPy-specific types not recognized by the converter
+
+3. **Complex collection types**
+   - `List[dict]` or `Dict[str, Any]`
+   - Nested optional collections
+
+4. **Third-party type extensions**
+   - Pandas `CategoricalDtype`
+   - Custom Pandera `DataType` subclasses
+
+## Solutions
+
+### Solution 1: Replace with a supported type
+
+```python
+import pandera as pa
+
+# ❌ Unsupported type
+class SensorData(pa.DataFrameModel):
+    reading: object  # No Iceberg mapping for 'object'
+
+# ✅ Use explicit type
+class SensorData(pa.DataFrameModel):
+    reading: float
+```
+
+### Solution 2: Serialize complex fields
+
+```python
+import pandera as pa
+
+# ❌ Complex nested type
+class EventData(pa.DataFrameModel):
+    labels: list  # Can't map untyped list
+
+# ✅ Serialize to string
+class EventData(pa.DataFrameModel):
+    labels_json: str  # Store as JSON string
+```
+
+### Solution 3: Use Pandera typed fields
+
+```python
+import pandera as pa
+
+# ❌ Ambiguous
+class Measurements(pa.DataFrameModel):
+    value: object
+
+# ✅ Explicit Pandera type
+class Measurements(pa.DataFrameModel):
+    value: pa.Float64 = pa.Field(ge=0)
+```
+
+## Examples
+
+### ❌ Incorrect: Unmappable types
+
+```python
+from decimal import Decimal
+
+class FinancialData(pa.DataFrameModel):
+    amount: Decimal      # ❌ Decimal without precision
+    metadata: dict       # ❌ dict type
+    tags: list           # ❌ untyped list
+```
+
+### ✅ Correct: Explicit mappable types
+
+```python
+class FinancialData(pa.DataFrameModel):
+    amount: float        # ✅ Maps to DoubleType
+    metadata_json: str   # ✅ Serialized dict
+    tags_csv: str        # ✅ Serialized list
+```
+
+## Debugging Steps
+
+1. **Identify the failing field**
+
+   ```python
+   # The error message includes the field name and type
+   # Example: "Cannot convert type 'object' for field 'metadata'"
+   ```
+
+2. **Check field type resolution**
+
+   ```python
+   from workflows.schemas.events import EventData
+
+   schema = EventData.to_schema()
+   for name, col in schema.columns.items():
+       print(f"{name}: dtype={col.dtype}, python_type={col.dtype.type}")
+   ```
+
+3. **Test individual field conversion**
+
+   ```python
+   from phlo_quality.iceberg import pandera_type_to_iceberg
+
+   try:
+       iceberg_type = pandera_type_to_iceberg("float")
+       print(f"✅ Mapped to: {iceberg_type}")
+   except Exception as e:
+       print(f"❌ Cannot map: {e}")
+   ```
+
+## Related Errors
+
+- [PHLO-200: Schema Conversion Error](./PHLO-200.md) - Whole schema conversion failed
+- [PHLO-004: Validation Failed](./PHLO-004.md) - Data validation failed
+- [PHLO-002: Schema Mismatch](./PHLO-002.md) - Schema configuration issue
+
+## Prevention
+
+1. **Reference the type mapping table**
+   - See [PHLO-200 Type Mapping Reference](./PHLO-200.md#type-mapping-reference) for supported types
+
+2. **Annotate all fields explicitly**
+
+   ```python
+   class MySchema(pa.DataFrameModel):
+       # Always use explicit types, never 'object' or 'Any'
+       id: str
+       value: float
+       count: int
+       active: bool
+   ```
+
+3. **Test conversion for new schemas**
+
+   ```python
+   def test_new_schema_converts():
+       from phlo_quality.iceberg import pandera_to_iceberg_schema
+       iceberg_schema = pandera_to_iceberg_schema(MyNewSchema)
+       assert len(iceberg_schema.fields) == len(MyNewSchema.to_schema().columns)
+   ```
+
+## Additional Resources
+
+- [PyIceberg Type System](https://py.iceberg.apache.org/)
+- [Pandera Data Types](https://pandera.readthedocs.io/en/stable/dtypes.html)
+- [PHLO-200: Schema Conversion Error](./PHLO-200.md)

--- a/docs/errors/PHLO-300.md
+++ b/docs/errors/PHLO-300.md
@@ -1,0 +1,230 @@
+# PHLO-300: DLT Pipeline Failed
+
+**Error Type:** DLT Error
+**Severity:** High
+**Exception Class:** `DLTPipelineError`
+
+## Description
+
+This error occurs when a DLT (Data Load Tool) pipeline execution fails. Phlo uses DLT via the `@phlo_ingestion` decorator for data ingestion, and this error wraps DLT-specific failures including source errors, destination write failures, and schema evolution conflicts.
+
+## Common Causes
+
+1. **Source errors**
+   - API endpoint returns errors
+   - Source credentials invalid or expired
+   - Source rate limiting
+
+2. **Destination errors**
+   - Cannot write to Iceberg/S3 destination
+   - Destination storage full
+   - Destination permissions denied
+
+3. **Schema evolution conflicts**
+   - Source schema changed incompatibly
+   - New columns conflict with existing types
+   - Required columns removed from source
+
+4. **Pipeline configuration errors**
+   - Invalid pipeline name
+   - Incorrect dataset name
+   - Missing DLT secrets
+
+## Solutions
+
+### Solution 1: Check the DLT pipeline trace
+
+DLT stores pipeline traces for debugging:
+
+```python
+import dlt
+
+pipeline = dlt.pipeline(
+    pipeline_name="weather_pipeline",
+    destination="filesystem",
+)
+
+# Check last load info
+info = pipeline.last_trace
+print(info)
+```
+
+### Solution 2: Verify source connectivity
+
+Test the data source independently:
+
+```python
+# Test source function outside of DLT
+from workflows.ingestion.weather.observations import fetch_weather_data
+
+try:
+    data = list(fetch_weather_data("2024-01-15"))
+    print(f"✅ Source returned {len(data)} records")
+except Exception as e:
+    print(f"❌ Source error: {e}")
+```
+
+### Solution 3: Reset pipeline state
+
+If the pipeline is in a broken state, reset it:
+
+```python
+import dlt
+
+pipeline = dlt.pipeline(
+    pipeline_name="weather_pipeline",
+    destination="filesystem",
+)
+
+# Drop pipeline state and start fresh
+pipeline.drop()
+```
+
+### Solution 4: Check DLT secrets
+
+Ensure DLT can access required credentials:
+
+```python
+# .phlo/.env.local
+WEATHER_API_KEY=your-api-key
+
+# Or via DLT secrets
+# .dlt/secrets.toml
+# [sources.weather]
+# api_key = "your-api-key"
+```
+
+## Examples
+
+### ❌ Incorrect: No error context in ingestion
+
+```python
+@phlo_ingestion(
+    unique_key="observation_id",
+    validation_schema=WeatherObservations,
+)
+def weather_observations(partition: str):
+    # ❌ DLT errors will be opaque
+    return requests.get(f"https://api.weather.com/{partition}").json()
+```
+
+### ✅ Correct: Source with error handling
+
+```python
+@phlo_ingestion(
+    unique_key="observation_id",
+    validation_schema=WeatherObservations,
+)
+def weather_observations(partition: str):
+    response = requests.get(
+        f"https://api.weather.com/{partition}",
+        timeout=30,
+    )
+
+    if response.status_code == 429:
+        raise DLTPipelineError(
+            message="Weather API rate limit exceeded",
+            suggestions=[
+                "Reduce ingestion frequency in cron schedule",
+                "Implement backoff between partition fetches",
+                "Check API plan rate limits",
+            ],
+        )
+
+    response.raise_for_status()
+    return response.json()
+```
+
+## Debugging Steps
+
+1. **Check DLT pipeline logs**
+
+   ```bash
+   docker logs dagster-webserver 2>&1 | grep -i "dlt\|pipeline"
+   ```
+
+2. **List DLT pipelines**
+
+   ```python
+   import dlt
+   pipelines = dlt.pipeline().list_pipelines()
+   for p in pipelines:
+       print(f"{p.pipeline_name}: {p.state}")
+   ```
+
+3. **Check source data**
+
+   ```python
+   # Test source independently
+   source_data = list(your_source_function("2024-01-15"))
+   print(f"Records: {len(source_data)}")
+   print(f"Sample: {source_data[0] if source_data else 'empty'}")
+   ```
+
+4. **Verify destination access**
+
+   ```bash
+   # Check MinIO/S3 access
+   curl -s http://localhost:9000/minio/health/live
+   ```
+
+5. **Review Dagster run logs**
+
+   ```bash
+   # In Dagster UI: Runs > Select failed run > View logs
+   phlo services logs -f dagster-webserver
+   ```
+
+## Related Errors
+
+- [PHLO-301: DLT Source Error](./PHLO-301.md) - Source-specific DLT failures
+- [PHLO-006: Ingestion Failed](./PHLO-006.md) - General ingestion failures
+- [PHLO-008: Infrastructure Error](./PHLO-008.md) - Infrastructure services down
+- [PHLO-400: Iceberg Catalog Error](./PHLO-400.md) - Destination catalog issues
+
+## Prevention
+
+1. **Test sources independently**
+
+   ```python
+   # tests/test_sources.py
+   def test_weather_source_returns_data():
+       data = list(fetch_weather_data("2024-01-15"))
+       assert len(data) > 0
+       assert "observation_id" in data[0]
+   ```
+
+2. **Use DLT retry configuration**
+
+   ```python
+   @phlo_ingestion(
+       unique_key="observation_id",
+       validation_schema=WeatherObservations,
+   )
+   def weather_observations(partition: str):
+       return dlt.resource(
+           fetch_weather_data,
+           max_table_nesting=1,
+       )(partition)
+   ```
+
+3. **Monitor pipeline health**
+   - Check Dagster UI for failed materializations
+   - Set up alerts on repeated failures
+   - Review DLT traces after failures
+
+4. **Pin source schemas**
+
+   ```python
+   # Prevent unexpected schema evolution
+   @phlo_ingestion(
+       unique_key="observation_id",
+       validation_schema=WeatherObservations,  # Schema acts as a contract
+   )
+   ```
+
+## Additional Resources
+
+- [DLT Documentation](https://dlthub.com/docs/)
+- [DLT Pipeline Traces](https://dlthub.com/docs/running-in-production/running#inspect-save-and-alert-on-load-info)
+- [Phlo Ingestion Guide](../guides/ingestion.md)

--- a/docs/errors/PHLO-301.md
+++ b/docs/errors/PHLO-301.md
@@ -1,0 +1,247 @@
+# PHLO-301: DLT Source Error
+
+**Error Type:** DLT Error
+**Severity:** High
+**Exception Class:** `PhloError` (code `PHLO-301`)
+
+## Description
+
+This error occurs when a DLT source cannot produce data. The source function — the data-fetching logic inside a `@phlo_ingestion` asset — fails before data reaches the DLT pipeline. This is distinct from [PHLO-300](./PHLO-300.md), which covers pipeline-level failures; PHLO-301 is specific to the data source itself.
+
+## Common Causes
+
+1. **Source not accessible**
+   - API endpoint down or unreachable
+   - Database connection refused
+   - File path doesn't exist
+
+2. **Invalid credentials**
+   - API key expired or revoked
+   - Database password changed
+   - OAuth token not refreshed
+
+3. **Rate limiting**
+   - API rate limit exceeded
+   - Too many concurrent requests
+   - Burst limit hit
+
+4. **Unexpected data format**
+   - API response format changed
+   - CSV delimiter changed
+   - JSON structure differs from expected
+
+## Solutions
+
+### Solution 1: Verify source accessibility
+
+```python
+import requests
+
+# Test API endpoint directly
+try:
+    response = requests.get("https://api.weather.com/status", timeout=10)
+    response.raise_for_status()
+    print(f"✅ Source accessible: {response.status_code}")
+except requests.RequestException as e:
+    print(f"❌ Source not accessible: {e}")
+```
+
+### Solution 2: Check and refresh credentials
+
+```bash
+# Verify environment variables are set
+echo $WEATHER_API_KEY
+
+# Test credentials
+curl -H "Authorization: Bearer $WEATHER_API_KEY" \
+     https://api.weather.com/v1/test
+```
+
+```python
+import os
+
+api_key = os.getenv("WEATHER_API_KEY")
+if not api_key:
+    print("❌ WEATHER_API_KEY not set")
+    print("Add to .phlo/.env.local: WEATHER_API_KEY=your-key")
+```
+
+### Solution 3: Handle rate limiting
+
+```python
+import time
+import requests
+
+@phlo_ingestion(
+    unique_key="observation_id",
+    validation_schema=WeatherObservations,
+)
+def weather_observations(partition: str):
+    response = requests.get(
+        f"https://api.weather.com/observations/{partition}",
+        headers={"Authorization": f"Bearer {os.getenv('WEATHER_API_KEY')}"},
+    )
+
+    if response.status_code == 429:
+        retry_after = int(response.headers.get("Retry-After", 60))
+        time.sleep(retry_after)
+        response = requests.get(
+            f"https://api.weather.com/observations/{partition}",
+            headers={"Authorization": f"Bearer {os.getenv('WEATHER_API_KEY')}"},
+        )
+
+    response.raise_for_status()
+    return response.json()
+```
+
+### Solution 4: Validate response format
+
+```python
+@phlo_ingestion(
+    unique_key="observation_id",
+    validation_schema=WeatherObservations,
+)
+def weather_observations(partition: str):
+    response = requests.get(f"https://api.weather.com/observations/{partition}")
+    response.raise_for_status()
+
+    data = response.json()
+
+    # Validate expected format
+    if not isinstance(data, list):
+        raise ValueError(
+            f"Expected list of records, got {type(data).__name__}. "
+            "API response format may have changed."
+        )
+
+    if data and "observation_id" not in data[0]:
+        raise ValueError(
+            f"Expected 'observation_id' field. Got keys: {list(data[0].keys())}"
+        )
+
+    return data
+```
+
+## Examples
+
+### ❌ Incorrect: No source validation
+
+```python
+@phlo_ingestion(...)
+def weather_observations(partition: str):
+    return requests.get(f"https://api.weather.com/{partition}").json()
+```
+
+### ✅ Correct: Source with validation and error handling
+
+```python
+@phlo_ingestion(...)
+def weather_observations(partition: str, context):
+    context.log.info(f"Fetching from weather API for {partition}")
+
+    response = requests.get(
+        f"https://api.weather.com/observations/{partition}",
+        headers={"Authorization": f"Bearer {os.getenv('WEATHER_API_KEY')}"},
+        timeout=30,
+    )
+
+    response.raise_for_status()
+    data = response.json()
+
+    if not data:
+        context.log.warning(f"No data returned for partition {partition}")
+        return []
+
+    context.log.info(f"✅ Fetched {len(data)} records")
+    return data
+```
+
+## Debugging Steps
+
+1. **Test source function directly**
+
+   ```python
+   from workflows.ingestion.weather.observations import fetch_weather_data
+
+   data = list(fetch_weather_data("2024-01-15"))
+   print(f"Records: {len(data)}")
+   ```
+
+2. **Check credentials**
+
+   ```bash
+   # List relevant env vars
+   env | grep -i "api_key\|secret\|token" | grep -i weather
+   ```
+
+3. **Test API with curl**
+
+   ```bash
+   curl -v -H "Authorization: Bearer $WEATHER_API_KEY" \
+        "https://api.weather.com/observations/2024-01-15"
+   ```
+
+4. **Check rate limit headers**
+
+   ```python
+   response = requests.get(url, headers=headers)
+   print(f"Rate-Limit-Remaining: {response.headers.get('X-RateLimit-Remaining')}")
+   print(f"Rate-Limit-Reset: {response.headers.get('X-RateLimit-Reset')}")
+   ```
+
+## Related Errors
+
+- [PHLO-300: DLT Pipeline Failed](./PHLO-300.md) - Pipeline-level DLT failures
+- [PHLO-006: Ingestion Failed](./PHLO-006.md) - General ingestion failures
+- [PHLO-008: Infrastructure Error](./PHLO-008.md) - Infrastructure services unavailable
+
+## Prevention
+
+1. **Add source health checks**
+
+   ```python
+   def check_weather_api():
+       response = requests.get(
+           "https://api.weather.com/health",
+           timeout=5,
+       )
+       return response.status_code == 200
+   ```
+
+2. **Store credentials securely**
+   - Use `.phlo/.env.local` for local credentials (git-ignored)
+   - Use secrets management in production
+   - Rotate credentials on a schedule
+
+3. **Test sources in CI**
+
+   ```python
+   # tests/test_sources.py
+   from unittest.mock import patch
+
+   def test_weather_source_handles_errors():
+       with patch("requests.get") as mock_get:
+           mock_get.return_value.status_code = 500
+           mock_get.return_value.raise_for_status.side_effect = (
+               requests.HTTPError("500 Server Error")
+           )
+           with pytest.raises(requests.HTTPError):
+               fetch_weather_data("2024-01-15")
+   ```
+
+4. **Implement retries with backoff**
+
+   ```python
+   from requests.adapters import HTTPAdapter
+   from urllib3.util.retry import Retry
+
+   session = requests.Session()
+   retry = Retry(total=3, backoff_factor=1, status_forcelist=[429, 500, 502, 503])
+   session.mount("https://", HTTPAdapter(max_retries=retry))
+   ```
+
+## Additional Resources
+
+- [DLT Sources Documentation](https://dlthub.com/docs/general-usage/source)
+- [Requests Library](https://docs.python-requests.org/)
+- [Phlo Ingestion Guide](../guides/ingestion.md)

--- a/docs/errors/PHLO-400.md
+++ b/docs/errors/PHLO-400.md
@@ -1,0 +1,216 @@
+# PHLO-400: Iceberg Catalog Error
+
+**Error Type:** Iceberg Error
+**Severity:** Critical
+**Exception Class:** `IcebergCatalogError`
+
+## Description
+
+This error occurs when Iceberg catalog operations fail. Phlo uses Nessie as the Iceberg catalog for managing table metadata, namespaces, and branching. When the catalog is unavailable, misconfigured, or rejects operations, this error is raised.
+
+## Common Causes
+
+1. **Catalog not initialized**
+   - Nessie service not started
+   - Catalog configuration missing from environment
+   - First-time setup not completed
+
+2. **Connection failed**
+   - Nessie endpoint unreachable
+   - Network timeout
+   - DNS resolution failure
+
+3. **Permissions denied**
+   - Catalog user lacks required permissions
+   - Authentication token expired
+   - Namespace access restricted
+
+4. **S3/MinIO unavailable**
+   - MinIO service not running
+   - S3 bucket doesn't exist
+   - S3 credentials invalid
+
+## Solutions
+
+### Solution 1: Start catalog services
+
+```bash
+# Start all Phlo services (includes Nessie + MinIO)
+phlo services start
+
+# Verify Nessie is running
+curl -s http://localhost:19120/api/v2/config | python -m json.tool
+```
+
+### Solution 2: Verify catalog configuration
+
+Check that catalog settings are correct in `.phlo/.env`:
+
+```bash
+# .phlo/.env
+NESSIE_URI=http://localhost:19120/api/v2
+MINIO_ENDPOINT=http://localhost:9000
+MINIO_ACCESS_KEY=admin
+MINIO_SECRET_KEY=password
+```
+
+### Solution 3: Test catalog connection
+
+```python
+from pyiceberg.catalog import load_catalog
+
+try:
+    catalog = load_catalog("default")
+    namespaces = catalog.list_namespaces()
+    print(f"✅ Catalog connected. Namespaces: {namespaces}")
+except Exception as e:
+    print(f"❌ Catalog error: {e}")
+```
+
+### Solution 4: Create missing namespace
+
+```python
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog("default")
+
+# Create namespace if it doesn't exist
+existing = [ns[0] for ns in catalog.list_namespaces()]
+if "bronze" not in existing:
+    catalog.create_namespace("bronze")
+    print("✅ Created 'bronze' namespace")
+```
+
+## Examples
+
+### ❌ Incorrect: No catalog error handling
+
+```python
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog("default")
+table = catalog.load_table("bronze.observations")  # Fails silently if catalog down
+```
+
+### ✅ Correct: Handle catalog errors
+
+```python
+from pyiceberg.catalog import load_catalog
+from phlo.exceptions import IcebergCatalogError
+
+try:
+    catalog = load_catalog("default")
+    table = catalog.load_table("bronze.observations")
+except Exception as e:
+    raise IcebergCatalogError(
+        message="Failed to connect to Iceberg catalog",
+        suggestions=[
+            "Run 'phlo services start' to start infrastructure",
+            "Check Nessie: curl http://localhost:19120/api/v2/config",
+            "Verify NESSIE_URI in .phlo/.env",
+        ],
+        cause=e,
+    )
+```
+
+## Debugging Steps
+
+1. **Check Nessie health**
+
+   ```bash
+   curl -s http://localhost:19120/api/v2/config
+   ```
+
+2. **List catalog contents**
+
+   ```bash
+   curl -s http://localhost:19120/api/v2/trees/main | python -m json.tool
+   ```
+
+3. **Check Nessie container**
+
+   ```bash
+   docker ps -a --filter "name=nessie"
+   docker logs nessie --tail=50
+   ```
+
+4. **Check MinIO health**
+
+   ```bash
+   curl -s http://localhost:9000/minio/health/live
+   ```
+
+5. **Verify S3 buckets exist**
+
+   ```bash
+   docker exec minio mc ls local/
+   ```
+
+6. **Test PyIceberg connection**
+
+   ```python
+   from pyiceberg.catalog import load_catalog
+
+   catalog = load_catalog("default")
+   print("Namespaces:", catalog.list_namespaces())
+   for ns in catalog.list_namespaces():
+       print(f"  Tables in {ns}:", catalog.list_tables(ns))
+   ```
+
+## Related Errors
+
+- [PHLO-401: Iceberg Table Error](./PHLO-401.md) - Table-level operations failed
+- [PHLO-402: Iceberg Write Error](./PHLO-402.md) - Write operations failed
+- [PHLO-007: Table Not Found](./PHLO-007.md) - Specific table not in catalog
+- [PHLO-008: Infrastructure Error](./PHLO-008.md) - General infrastructure failures
+
+## Prevention
+
+1. **Start services before development**
+
+   ```bash
+   phlo services start
+   phlo services list --json
+   ```
+
+2. **Add catalog connectivity tests**
+
+   ```python
+   # tests/test_infrastructure.py
+   from pyiceberg.catalog import load_catalog
+
+   def test_catalog_connected():
+       catalog = load_catalog("default")
+       namespaces = catalog.list_namespaces()
+       assert len(namespaces) > 0, "No namespaces found in catalog"
+   ```
+
+3. **Use health checks in CI/CD**
+
+   ```bash
+   #!/bin/bash
+   # scripts/wait-for-services.sh
+   echo "Waiting for Nessie..."
+   until curl -sf http://localhost:19120/api/v2/config > /dev/null; do
+       sleep 2
+   done
+   echo "✅ Nessie ready"
+   ```
+
+4. **Configure connection timeouts**
+
+   ```python
+   from pyiceberg.catalog import load_catalog
+
+   catalog = load_catalog(
+       "default",
+       **{"uri": "http://localhost:19120/api/v2", "timeout": 10},
+   )
+   ```
+
+## Additional Resources
+
+- [Nessie Documentation](https://projectnessie.org/)
+- [Nessie REST API](https://projectnessie.org/nessie-latest/api/)
+- [PyIceberg Catalog Configuration](https://py.iceberg.apache.org/)
+- [Phlo Services Guide](../guides/services.md)

--- a/docs/errors/PHLO-401.md
+++ b/docs/errors/PHLO-401.md
@@ -1,0 +1,210 @@
+# PHLO-401: Iceberg Table Error
+
+**Error Type:** Iceberg Error
+**Severity:** High
+**Exception Class:** `PhloError` (code `PHLO-401`)
+
+## Description
+
+This error occurs when Iceberg table operations fail. This covers operations like loading table metadata, reading table data, updating table properties, or managing table snapshots. It is distinct from [PHLO-007](./PHLO-007.md) (table not found) and [PHLO-402](./PHLO-402.md) (write failures).
+
+## Common Causes
+
+1. **Table not found**
+   - Table doesn't exist in the namespace
+   - Wrong table name or namespace
+   - Table was dropped
+
+2. **Schema mismatch**
+   - Table schema evolved incompatibly
+   - Attempting to read with wrong schema version
+   - Column types changed
+
+3. **Concurrent modification**
+   - Two processes modifying the same table
+   - Optimistic concurrency conflict
+   - Stale metadata reference
+
+4. **Permissions**
+   - Insufficient permissions to read/modify table
+   - S3 bucket policy denying access
+   - Nessie branch protection
+
+## Solutions
+
+### Solution 1: Verify table exists
+
+```python
+from pyiceberg.catalog import load_catalog
+from pyiceberg.exceptions import NoSuchTableError
+
+catalog = load_catalog("default")
+
+try:
+    table = catalog.load_table("bronze.dlt_weather_observations")
+    print(f"✅ Table found: {table.metadata.schema()}")
+except NoSuchTableError:
+    print("❌ Table does not exist")
+    print("Available tables:")
+    for tbl in catalog.list_tables("bronze"):
+        print(f"  - {tbl}")
+```
+
+### Solution 2: Check table schema
+
+```python
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog("default")
+table = catalog.load_table("bronze.dlt_weather_observations")
+
+# Inspect current schema
+schema = table.schema()
+print("Current schema:")
+for field in schema.fields:
+    print(f"  {field.name}: {field.field_type} (optional={field.optional})")
+```
+
+### Solution 3: Handle concurrent modifications
+
+```python
+from pyiceberg.catalog import load_catalog
+from pyiceberg.exceptions import CommitFailedException
+
+catalog = load_catalog("default")
+table = catalog.load_table("bronze.dlt_weather_observations")
+
+try:
+    # Perform table operation
+    with table.update_schema() as update:
+        update.add_column("new_field", "string")
+except CommitFailedException:
+    # Refresh metadata and retry
+    table = catalog.load_table("bronze.dlt_weather_observations")
+    with table.update_schema() as update:
+        update.add_column("new_field", "string")
+```
+
+### Solution 4: Refresh stale table reference
+
+```python
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog("default")
+
+# Always load fresh table reference before operations
+table = catalog.load_table("bronze.dlt_weather_observations")
+scan = table.scan()
+df = scan.to_pandas()
+print(f"✅ Read {len(df)} rows")
+```
+
+## Examples
+
+### ❌ Incorrect: Reusing stale table reference
+
+```python
+table = catalog.load_table("bronze.observations")
+# ... long-running process ...
+# ❌ Table metadata may be stale
+df = table.scan().to_pandas()
+```
+
+### ✅ Correct: Reload before operations
+
+```python
+# ✅ Fresh reference before read
+table = catalog.load_table("bronze.observations")
+df = table.scan().to_pandas()
+```
+
+## Debugging Steps
+
+1. **List tables in namespace**
+
+   ```python
+   from pyiceberg.catalog import load_catalog
+
+   catalog = load_catalog("default")
+   for ns in catalog.list_namespaces():
+       tables = catalog.list_tables(ns)
+       print(f"{ns}: {tables}")
+   ```
+
+2. **Inspect table metadata**
+
+   ```python
+   table = catalog.load_table("bronze.dlt_weather_observations")
+   print(f"Schema: {table.schema()}")
+   print(f"Snapshots: {table.metadata.snapshots}")
+   print(f"Properties: {table.properties}")
+   ```
+
+3. **Check Nessie branch**
+
+   ```bash
+   curl -s http://localhost:19120/api/v2/trees/main | python -m json.tool
+   ```
+
+4. **Verify S3 data files**
+
+   ```bash
+   docker exec minio mc ls local/warehouse/bronze/dlt_weather_observations/
+   ```
+
+## Related Errors
+
+- [PHLO-007: Table Not Found](./PHLO-007.md) - Table doesn't exist
+- [PHLO-400: Iceberg Catalog Error](./PHLO-400.md) - Catalog-level failures
+- [PHLO-402: Iceberg Write Error](./PHLO-402.md) - Write-specific failures
+- [PHLO-200: Schema Conversion Error](./PHLO-200.md) - Schema conversion issues
+
+## Prevention
+
+1. **Use fresh table references**
+   - Always call `catalog.load_table()` before critical operations
+   - Don't cache table objects across long-running processes
+
+2. **Handle concurrency**
+
+   ```python
+   from pyiceberg.exceptions import CommitFailedException
+
+   MAX_RETRIES = 3
+   for attempt in range(MAX_RETRIES):
+       try:
+           table = catalog.load_table(table_name)
+           # ... perform operation ...
+           break
+       except CommitFailedException:
+           if attempt == MAX_RETRIES - 1:
+               raise
+   ```
+
+3. **Monitor table health**
+
+   ```python
+   def check_table_health(table_name: str):
+       catalog = load_catalog("default")
+       table = catalog.load_table(table_name)
+       snapshots = table.metadata.snapshots
+       print(f"Table: {table_name}")
+       print(f"  Schema fields: {len(table.schema().fields)}")
+       print(f"  Snapshots: {len(snapshots)}")
+   ```
+
+4. **Test table operations in CI**
+
+   ```python
+   def test_table_readable():
+       catalog = load_catalog("default")
+       table = catalog.load_table("bronze.dlt_weather_observations")
+       df = table.scan(limit=1).to_pandas()
+       assert len(df) >= 0
+   ```
+
+## Additional Resources
+
+- [PyIceberg Table API](https://py.iceberg.apache.org/)
+- [Apache Iceberg Spec — Table Metadata](https://iceberg.apache.org/spec/#table-metadata)
+- [Nessie Branching](https://projectnessie.org/features/transactions/)

--- a/docs/errors/PHLO-402.md
+++ b/docs/errors/PHLO-402.md
@@ -1,0 +1,263 @@
+# PHLO-402: Iceberg Write Error
+
+**Error Type:** Iceberg Error
+**Severity:** High
+**Exception Class:** `PhloError` (code `PHLO-402`)
+
+## Description
+
+This error occurs when data cannot be written to an Iceberg table. Write operations include appending new data, overwriting partitions, and upserts. Failures can stem from schema mismatches between the data and table, invalid partition specifications, S3 storage issues, or insufficient permissions.
+
+## Common Causes
+
+1. **Schema mismatch**
+   - DataFrame columns don't match table schema
+   - Column types differ (e.g., writing string to int column)
+   - Missing required columns
+
+2. **Partition spec invalid**
+   - Partition column doesn't exist in data
+   - Partition values contain invalid characters
+   - Partition field type mismatch
+
+3. **S3 write failed**
+   - MinIO/S3 storage full
+   - S3 endpoint unreachable
+   - Write timeout on large files
+
+4. **Insufficient permissions**
+   - S3 bucket policy denies write access
+   - MinIO credentials invalid
+   - Read-only access configured
+
+## Solutions
+
+### Solution 1: Align data schema with table schema
+
+```python
+from pyiceberg.catalog import load_catalog
+import pandas as pd
+
+catalog = load_catalog("default")
+table = catalog.load_table("bronze.dlt_weather_observations")
+
+# Check expected schema
+print("Table schema:")
+for field in table.schema().fields:
+    print(f"  {field.name}: {field.field_type}")
+
+# Ensure DataFrame matches
+df = pd.DataFrame([{
+    "observation_id": "obs-001",
+    "station_id": "KSFO",
+    "temperature": 18.5,
+    "timestamp": "2024-01-15T12:00:00",
+}])
+
+# ✅ Verify columns match
+table_columns = {f.name for f in table.schema().fields}
+df_columns = set(df.columns)
+missing = table_columns - df_columns
+extra = df_columns - table_columns
+
+if missing:
+    print(f"❌ Missing columns: {missing}")
+if extra:
+    print(f"⚠️ Extra columns (will be ignored): {extra}")
+```
+
+### Solution 2: Fix column types
+
+```python
+import pandas as pd
+
+# ❌ Wrong types
+df = pd.DataFrame([{
+    "temperature": "18.5",     # String, should be float
+    "station_id": 12345,       # Int, should be string
+}])
+
+# ✅ Correct types
+df = pd.DataFrame([{
+    "temperature": 18.5,       # Float
+    "station_id": "KSFO",     # String
+}])
+
+# Or cast explicitly
+df["temperature"] = df["temperature"].astype(float)
+df["station_id"] = df["station_id"].astype(str)
+```
+
+### Solution 3: Check S3/MinIO access
+
+```bash
+# Verify MinIO is running
+curl -s http://localhost:9000/minio/health/live
+
+# Check bucket exists
+docker exec minio mc ls local/warehouse/
+
+# Check disk space
+docker exec minio mc admin info local/
+```
+
+### Solution 4: Verify write permissions
+
+```python
+from pyiceberg.catalog import load_catalog
+import pyarrow as pa
+
+catalog = load_catalog("default")
+table = catalog.load_table("bronze.dlt_weather_observations")
+
+# Test write with minimal data
+test_table = pa.table({
+    "observation_id": ["test-001"],
+    "station_id": ["TEST"],
+    "temperature": [0.0],
+    "timestamp": ["2024-01-01T00:00:00"],
+})
+
+try:
+    table.append(test_table)
+    print("✅ Write succeeded")
+except Exception as e:
+    print(f"❌ Write failed: {e}")
+```
+
+## Examples
+
+### ❌ Incorrect: Schema mismatch
+
+```python
+import pandas as pd
+
+# DataFrame has wrong column names
+df = pd.DataFrame([{
+    "temp": 18.5,              # ❌ Should be "temperature"
+    "station": "KSFO",         # ❌ Should be "station_id"
+}])
+
+table.append(df)  # Fails with schema mismatch
+```
+
+### ✅ Correct: Matching schema
+
+```python
+import pandas as pd
+
+df = pd.DataFrame([{
+    "observation_id": "obs-001",
+    "station_id": "KSFO",
+    "temperature": 18.5,
+    "timestamp": "2024-01-15T12:00:00",
+}])
+
+table.append(df)  # ✅ Columns match table schema
+```
+
+## Debugging Steps
+
+1. **Compare data and table schemas**
+
+   ```python
+   from pyiceberg.catalog import load_catalog
+
+   catalog = load_catalog("default")
+   table = catalog.load_table("bronze.dlt_weather_observations")
+
+   print("Table schema:")
+   for field in table.schema().fields:
+       print(f"  {field.name}: {field.field_type} (optional={field.optional})")
+
+   print("\nDataFrame schema:")
+   print(df.dtypes)
+   ```
+
+2. **Check S3 storage health**
+
+   ```bash
+   # MinIO health
+   curl -s http://localhost:9000/minio/health/live
+
+   # List warehouse contents
+   docker exec minio mc ls local/warehouse/ --recursive | head -20
+
+   # Check disk usage
+   docker exec minio mc admin info local/
+   ```
+
+3. **Review write error details**
+
+   ```bash
+   docker logs dagster-webserver 2>&1 | grep -i "write\|append\|iceberg" | tail -20
+   ```
+
+4. **Test with PyArrow directly**
+
+   ```python
+   import pyarrow as pa
+
+   # Convert to PyArrow and check types
+   arrow_table = pa.Table.from_pandas(df)
+   print(arrow_table.schema)
+   ```
+
+## Related Errors
+
+- [PHLO-400: Iceberg Catalog Error](./PHLO-400.md) - Catalog connection failures
+- [PHLO-401: Iceberg Table Error](./PHLO-401.md) - Table operation failures
+- [PHLO-007: Table Not Found](./PHLO-007.md) - Table doesn't exist
+- [PHLO-008: Infrastructure Error](./PHLO-008.md) - MinIO/S3 unavailable
+- [PHLO-200: Schema Conversion Error](./PHLO-200.md) - Schema type mapping issues
+
+## Prevention
+
+1. **Validate data before writing**
+
+   ```python
+   from workflows.schemas.weather import WeatherObservations
+
+   # Pandera validation catches issues before Iceberg write
+   WeatherObservations.validate(df)
+   ```
+
+2. **Use Phlo decorators**
+   - `@phlo_ingestion` handles schema alignment and writes automatically
+   - Validation runs before writes, catching mismatches early
+
+3. **Monitor storage capacity**
+
+   ```bash
+   # Add to monitoring/alerting
+   docker exec minio mc admin info local/ --json | python -c "
+   import sys, json
+   info = json.load(sys.stdin)
+   print(f'Used: {info.get(\"used\", \"unknown\")}')
+   "
+   ```
+
+4. **Test writes in CI**
+
+   ```python
+   def test_write_to_iceberg():
+       catalog = load_catalog("default")
+       table = catalog.load_table("bronze.dlt_weather_observations")
+
+       test_data = pa.table({
+           "observation_id": ["ci-test-001"],
+           "station_id": ["TEST"],
+           "temperature": [0.0],
+           "timestamp": ["2024-01-01T00:00:00"],
+       })
+
+       table.append(test_data)
+       # Clean up test data
+   ```
+
+## Additional Resources
+
+- [PyIceberg Write API](https://py.iceberg.apache.org/)
+- [Apache Iceberg Spec — Data Files](https://iceberg.apache.org/spec/#data-files)
+- [MinIO Documentation](https://min.io/docs/)
+- [PyArrow Documentation](https://arrow.apache.org/docs/python/)

--- a/docs/guides/compose-generation.md
+++ b/docs/guides/compose-generation.md
@@ -1,0 +1,168 @@
+# Compose Generation
+
+`phlo services init` generates Docker Compose files, environment files, and supporting
+configuration from installed service plugins. This guide covers the three modules that
+power this process: `env.py`, `generator.py`, and `native.py`.
+
+## Module roles
+
+```text
+phlo services init
+    │
+    ├── generator.py   → docker-compose.yml
+    ├── env.py         → .phlo/.env, .phlo/.env.local
+    └── native.py      → subprocess services (--native mode)
+```
+
+### env.py — environment variable materialization
+
+Renders `.env` (non-secret defaults) and `.env.local` (secrets and local overrides) from
+discovered `ServiceDefinition` objects.
+
+Key functions:
+
+| Function             | Output          | Description                                      |
+|----------------------|-----------------|--------------------------------------------------|
+| `generate_env`       | `.phlo/.env`    | Non-secret defaults; grouped by service category |
+| `generate_env_local` | `.phlo/.env.local` | Secrets only; preserves existing local values |
+| `render_env`         | (internal)      | Shared renderer with `include_secrets` / `include_non_secrets` flags |
+
+Variables are grouped by category (`core`, `orchestration`, `bi`, `admin`, `api`,
+`observability`) with section headers. Overrides from `phlo.yaml` (`env:` section)
+take precedence over package defaults. Existing `.env.local` values are preserved
+on regeneration.
+
+### generator.py — compose YAML generation
+
+`ComposeGenerator` builds `docker-compose.yml` from service definitions.
+
+```python
+class ComposeGenerator:
+    def __init__(self, discovery: ServiceDiscovery): ...
+
+    def generate_compose(
+        self,
+        services: list[ServiceDefinition],
+        output_dir: Path,
+        dev_mode: bool = False,
+        phlo_src_path: str | None = None,
+        user_overrides: dict[str, Any] | None = None,
+    ) -> str: ...
+```
+
+The generator:
+
+1. Sorts services by dependency order via `discovery.resolve_dependencies()`.
+2. Builds per-service configs — image/build, ports, volumes, healthchecks, env_file.
+3. Resolves `depends_on` conditions (`service_healthy`, `service_started`,
+   `service_completed_successfully` for setup containers).
+4. Applies dev mode overrides (source mounts, `PHLO_DEV_MODE=true`).
+5. Applies user overrides from `phlo.yaml` (last, highest precedence).
+6. Emits YAML with a header comment.
+
+Additional methods:
+
+- `generate_env` / `generate_env_local` — delegate to `env.py`.
+- `copy_service_files` — copies extra files required by services to `.phlo/`.
+- `generate_gitignore` — generates `.phlo/.gitignore` (env files, volumes, service data).
+
+### native.py — native subprocess services
+
+`NativeProcessManager` runs services as local subprocesses instead of Docker containers.
+
+```python
+class NativeProcessManager:
+    def __init__(self, project_root: Path, log_dir: Path | None = None): ...
+
+    async def start_service(self, service, env_overrides=None) -> NativeProcess | None: ...
+    async def stop_service(self, name, timeout=10) -> bool: ...
+    async def stop_all(self, timeout=10) -> None: ...
+```
+
+Features:
+
+- Expands `${VAR}` and `${VAR:-default}` placeholders in commands and environment.
+- Runs optional build steps (`requires_build`, `build_command`, `build_if_missing`).
+- Starts processes in new sessions for clean signal handling.
+- Logs output to per-service files in `log_dir`.
+- Polls health check URLs with `httpx` (30s timeout).
+- Graceful shutdown via `SIGTERM` → `SIGKILL` fallback.
+
+## Service plugin contributions
+
+Each service package includes a `service.yaml` that declares:
+
+- Docker image or build context
+- Environment variables (with defaults, secrets, descriptions)
+- Compose config (ports, volumes, healthcheck, command)
+- Dependencies on other services
+- Dev mode overrides
+- Additional files to copy
+
+The `ServiceDiscovery` system collects these into `ServiceDefinition` objects that
+`ComposeGenerator` and `NativeProcessManager` consume.
+
+## Environment file generation
+
+Generated files in `.phlo/`:
+
+| File         | Contents                                    | Git-tracked |
+|--------------|---------------------------------------------|-------------|
+| `.env`       | Non-secret defaults from all services       | No          |
+| `.env.local` | Secrets and local overrides (preserved)     | No          |
+
+Override precedence (highest to lowest):
+
+1. Existing `.env.local` values (secrets preserved on regeneration)
+2. `phlo.yaml` `env:` section overrides
+3. Package `service.yaml` defaults
+
+## Native mode
+
+Use `--native` flag for services that support subprocess execution (e.g., phlo-api,
+Observatory). A service supports native mode when its `service.yaml` includes a `dev`
+section with a `command` list.
+
+```bash
+phlo services start --native
+```
+
+Native and Docker services can run side by side — Docker handles infrastructure
+(Postgres, MinIO) while native mode runs application services for faster iteration.
+
+## Customization via phlo.yaml
+
+Service overrides in `phlo.yaml` use the `ServiceOverride` model:
+
+```yaml
+services:
+  observatory:
+    enabled: true
+    ports:
+      - "8080:3000"
+    environment:
+      DEBUG: "true"
+  superset:
+    enabled: false
+```
+
+Override behavior:
+
+| Field         | Behavior                              |
+|---------------|---------------------------------------|
+| `enabled`     | Include/exclude service entirely      |
+| `ports`       | Replaces package defaults             |
+| `environment` | Merges with package defaults          |
+| `volumes`     | Appends to package defaults           |
+| `depends_on`  | Replaces package defaults             |
+| `command`     | Replaces package default              |
+| `healthcheck` | Replaces package default              |
+
+Inline custom services (`type: inline`) can define `image`, `build`, and `healthcheck`
+directly in `phlo.yaml` without a service package.
+
+## See also
+
+- [Service Packages](service-packages.md) — writing `service.yaml`
+- [Plugin Development](plugin-development.md) — service plugin lifecycle
+- [Configuration Reference](../reference/configuration-reference.md) — phlo.yaml schema

--- a/docs/guides/hook-event-bus.md
+++ b/docs/guides/hook-event-bus.md
@@ -1,0 +1,447 @@
+# Hook Event Bus Guide
+
+Event-driven extension system for Phlo plugins.
+
+## Overview
+
+The hook event bus lets plugins subscribe to lifecycle events — ingestion runs, transform
+completions, quality check results, and more — without direct coupling between components.
+Plugins register handlers that the bus dispatches in priority order whenever an event is
+emitted.
+
+## Architecture
+
+```
+Producer (emitter)
+   │
+   ▼
+┌────────────────────────────┐
+│  HookBus (singleton)       │
+│  ─ lazy plugin discovery   │
+│  ─ priority-ordered dispatch│
+│  ─ filter matching          │
+│  ─ failure policy handling  │
+└────────────────────────────┘
+   │
+   ▼
+Registered handlers (sorted by priority → plugin name → hook name)
+```
+
+Key behaviours:
+
+- **Lazy discovery** — `HookBus` discovers and registers `HookProvider` plugins on first
+  `emit()`, so there is no upfront cost if no events are fired.
+- **Priority ordering** — handlers are dispatched in ascending `priority` order (lower
+  numbers run first). Default priority is `100`.
+- **Filter matching** — handlers can declare filters on `event_types`, `asset_keys`, and
+  `tags`; unmatched events are skipped.
+
+## Event Types
+
+All events inherit from `HookEvent` and share these base fields:
+
+| Field        | Type              | Default          |
+| ------------ | ----------------- | ---------------- |
+| `event_type` | `str`             | *(required)*     |
+| `version`    | `str`             | `"1.0"`          |
+| `timestamp`  | `datetime`        | UTC now          |
+| `tags`       | `dict[str, str]`  | `{}`             |
+
+### ServiceLifecycleEvent
+
+Emitted around service start/stop phases.
+
+| Field            | Type                  |
+| ---------------- | --------------------- |
+| `service_name`   | `str`                 |
+| `project_name`   | `str \| None`         |
+| `project_root`   | `str \| None`         |
+| `container_name` | `str \| None`         |
+| `phase`          | `str \| None`         |
+| `status`         | `str \| None`         |
+| `metadata`       | `dict[str, Any]`      |
+
+### IngestionEvent
+
+Emitted for ingestion lifecycle stages.
+
+| Field           | Type                  |
+| --------------- | --------------------- |
+| `asset_key`     | `str`                 |
+| `table_name`    | `str`                 |
+| `group_name`    | `str`                 |
+| `partition_key` | `str \| None`         |
+| `run_id`        | `str \| None`         |
+| `branch_name`   | `str \| None`         |
+| `status`        | `str \| None`         |
+| `metrics`       | `dict[str, Any]`      |
+| `error`         | `str \| None`         |
+
+### TransformEvent
+
+Emitted for transformation lifecycle stages.
+
+| Field           | Type                  |
+| --------------- | --------------------- |
+| `tool`          | `str`                 |
+| `project_dir`   | `str \| None`         |
+| `target`        | `str \| None`         |
+| `partition_key` | `str \| None`         |
+| `asset_key`     | `str \| None`         |
+| `model_names`   | `list[str]`           |
+| `status`        | `str \| None`         |
+| `metrics`       | `dict[str, Any]`      |
+| `error`         | `str \| None`         |
+
+### PublishEvent
+
+Emitted when publishing data to downstream targets.
+
+| Field           | Type                  |
+| --------------- | --------------------- |
+| `asset_key`     | `str \| None`         |
+| `target_system` | `str \| None`         |
+| `tables`        | `dict[str, str]`      |
+| `status`        | `str \| None`         |
+| `metrics`       | `dict[str, Any]`      |
+| `error`         | `str \| None`         |
+
+### QualityResultEvent
+
+Emitted with quality check outcomes.
+
+| Field           | Type                  |
+| --------------- | --------------------- |
+| `asset_key`     | `str`                 |
+| `check_name`    | `str`                 |
+| `passed`        | `bool`                |
+| `severity`      | `str \| None`         |
+| `check_type`    | `str \| None`         |
+| `partition_key` | `str \| None`         |
+| `metadata`      | `dict[str, Any]`      |
+
+### LineageEvent
+
+Emitted for lineage edges between assets.
+
+| Field        | Type                      |
+| ------------ | ------------------------- |
+| `edges`      | `list[tuple[str, str]]`   |
+| `asset_keys` | `list[str]`               |
+| `metadata`   | `dict[str, Any]`          |
+
+### TelemetryEvent
+
+Emitted for telemetry metrics and logs.
+
+| Field     | Type                  |
+| --------- | --------------------- |
+| `name`    | `str`                 |
+| `value`   | `Any \| None`         |
+| `level`   | `str \| None`         |
+| `unit`    | `str \| None`         |
+| `payload` | `dict[str, Any]`      |
+
+### LogEvent
+
+Emitted for structured log records (see [Logging Guide](logging.md)).
+
+| Field           | Type                  |
+| --------------- | --------------------- |
+| `logger`        | `str`                 |
+| `level`         | `str`                 |
+| `message`       | `str`                 |
+| `service`       | `str \| None`         |
+| `run_id`        | `str \| None`         |
+| `asset_key`     | `str \| None`         |
+| `job_name`      | `str \| None`         |
+| `partition_key` | `str \| None`         |
+| `check_name`    | `str \| None`         |
+| `metadata`      | `dict[str, Any]`      |
+
+## Emitter Helpers
+
+Each domain provides an emitter class paired with a frozen context dataclass. The emitter
+wraps `HookBus.emit()` and fills in shared fields from the context.
+
+### IngestionEventEmitter
+
+```python
+from phlo.hooks.emitters import IngestionEventEmitter, IngestionEventContext
+
+ctx = IngestionEventContext(
+    asset_key="dlt_orders",
+    table_name="orders",
+    group_name="sales",
+    run_id="abc-123",
+)
+emitter = IngestionEventEmitter(ctx)
+
+emitter.emit_start()
+# ... perform ingestion ...
+emitter.emit_end(status="completed", metrics={"rows": 1500})
+```
+
+### TransformEventEmitter
+
+```python
+from phlo.hooks.emitters import TransformEventEmitter, TransformEventContext
+
+ctx = TransformEventContext(tool="dbt", project_dir="workflows/transforms/dbt")
+emitter = TransformEventEmitter(ctx)
+
+emitter.emit_start()
+emitter.emit_end(status="completed", metrics={"models": 5})
+```
+
+### PublishEventEmitter
+
+```python
+from phlo.hooks.emitters import PublishEventEmitter, PublishEventContext
+
+ctx = PublishEventContext(asset_key="orders_gold", target_system="trino")
+emitter = PublishEventEmitter(ctx)
+
+emitter.emit_start()
+emitter.emit_end(status="completed")
+```
+
+### QualityResultEventEmitter
+
+```python
+from phlo.hooks.emitters import QualityResultEventEmitter, QualityResultEventContext
+
+ctx = QualityResultEventContext(asset_key="dlt_orders")
+emitter = QualityResultEventEmitter(ctx)
+
+emitter.emit_result(check_name="row_count", passed=True, check_type="metric")
+emitter.emit_result(check_name="schema_valid", passed=False, severity="error")
+```
+
+### LineageEventEmitter
+
+```python
+from phlo.hooks.emitters import LineageEventEmitter, LineageEventContext
+
+ctx = LineageEventContext()
+emitter = LineageEventEmitter(ctx)
+
+emitter.emit_edges(
+    edges=[("raw_orders", "stg_orders"), ("stg_orders", "orders_gold")],
+    asset_keys=["raw_orders", "stg_orders", "orders_gold"],
+)
+```
+
+### TelemetryEventEmitter
+
+```python
+from phlo.hooks.emitters import TelemetryEventEmitter, TelemetryEventContext
+
+ctx = TelemetryEventContext()
+emitter = TelemetryEventEmitter(ctx)
+
+emitter.emit_metric(name="ingestion.duration_ms", value=1234, unit="ms")
+emitter.emit_log(name="checkpoint", level="info", value="snapshot saved")
+```
+
+### ServiceLifecycleEventEmitter
+
+```python
+from phlo.hooks.emitters import ServiceLifecycleEventEmitter, ServiceLifecycleEventContext
+
+ctx = ServiceLifecycleEventContext(service_name="trino", project_name="my_project")
+emitter = ServiceLifecycleEventEmitter(ctx)
+
+emitter.emit(phase="start", status="running")
+emitter.emit(phase="stop", status="stopped")
+```
+
+## Subscribing to Events
+
+### HookProvider Protocol
+
+Any object that implements `get_hooks() -> Iterable[HookRegistration]` satisfies the
+`HookProvider` protocol and can be registered with the bus:
+
+```python
+from phlo.hooks.events import HookEvent
+from phlo.plugins.hooks import HookProvider, HookRegistration
+
+class MyProvider:
+    def get_hooks(self) -> list[HookRegistration]:
+        return [
+            HookRegistration(
+                hook_name="on_ingestion",
+                handler=self._handle_ingestion,
+                priority=50,
+            ),
+        ]
+
+    def _handle_ingestion(self, event: HookEvent) -> None:
+        print(f"Ingestion event: {event.event_type}")
+```
+
+### HookPlugin Base Class
+
+For convenience, `HookPlugin` extends `Plugin` and `HookProvider`. Override `get_hooks()`
+to provide registrations:
+
+```python
+from phlo.plugins.hooks import HookPlugin, HookRegistration
+
+class NotificationPlugin(HookPlugin):
+    def get_hooks(self) -> list[HookRegistration]:
+        return [
+            HookRegistration(hook_name="notify", handler=self._notify),
+        ]
+
+    def _notify(self, event):
+        ...
+```
+
+Register the plugin via the `phlo.plugins.hooks` entry point group in `pyproject.toml`:
+
+```toml
+[project.entry-points."phlo.plugins.hooks"]
+my-notification = "my_package.plugin:NotificationPlugin"
+```
+
+### HookHandler Protocol
+
+Alternatively, implement the `HookHandler` protocol (a class with a `handle_event` method):
+
+```python
+from phlo.hooks.events import HookEvent
+from phlo.plugins.hooks import HookHandler
+
+class MyHandler:
+    def handle_event(self, event: HookEvent) -> None:
+        ...
+```
+
+Pass a `HookHandler` instance as the `handler` in a `HookRegistration`.
+
+### HookFilter
+
+Narrow which events reach a handler:
+
+```python
+from phlo.plugins.hooks import HookFilter, HookRegistration
+
+HookRegistration(
+    hook_name="ingestion_only",
+    handler=my_handler,
+    filters=HookFilter(
+        event_types={"ingestion.start", "ingestion.end"},
+        asset_keys={"dlt_orders", "dlt_customers"},
+        tags={"env": "production"},
+    ),
+)
+```
+
+| Field         | Type                   | Behaviour                                    |
+| ------------- | ---------------------- | -------------------------------------------- |
+| `event_types` | `set[str] \| None`     | Match events whose `event_type` is in the set |
+| `asset_keys`  | `set[str] \| None`     | Match events containing any listed asset key  |
+| `tags`        | `dict[str, str] \| None` | All specified tags must match exactly       |
+
+All filter fields default to `None` (no filtering).
+
+### FailurePolicy
+
+Control what happens when a handler raises:
+
+| Policy   | Behaviour                                    |
+| -------- | -------------------------------------------- |
+| `IGNORE` | Silently skip the failed handler             |
+| `LOG`    | Log the exception and continue *(default)*   |
+| `RAISE`  | Re-raise the exception, halting dispatch     |
+
+```python
+from phlo.plugins.hooks import FailurePolicy, HookRegistration
+
+HookRegistration(
+    hook_name="critical_handler",
+    handler=my_handler,
+    failure_policy=FailurePolicy.RAISE,
+)
+```
+
+### Priority Ordering
+
+Handlers are dispatched in ascending order of `(priority, plugin_name, hook_name)`.
+Lower priority values run first. The default priority is `100`.
+
+## Direct Bus Usage
+
+For ad-hoc usage outside of the plugin system:
+
+```python
+from phlo.hooks.bus import get_hook_bus
+from phlo.hooks.events import TelemetryEvent
+
+bus = get_hook_bus()
+
+# Emit an event directly
+bus.emit(TelemetryEvent(event_type="telemetry.metric", name="custom.counter", value=1))
+
+# Register a one-off handler
+from phlo.plugins.hooks import HookRegistration
+
+bus.register(
+    HookRegistration(hook_name="inline", handler=lambda e: print(e)),
+    plugin_name="ad-hoc",
+)
+
+# Register a full provider
+bus.register_provider(my_provider, plugin_name="my-provider")
+```
+
+## Example: Ingestion Notification Plugin
+
+A minimal plugin that sends a notification whenever an ingestion run completes:
+
+```python
+from phlo.hooks.events import HookEvent, IngestionEvent
+from phlo.plugins.hooks import (
+    FailurePolicy,
+    HookFilter,
+    HookPlugin,
+    HookRegistration,
+)
+
+
+class IngestionNotifier(HookPlugin):
+    """Send a notification when ingestion completes."""
+
+    def get_hooks(self) -> list[HookRegistration]:
+        return [
+            HookRegistration(
+                hook_name="ingestion_complete",
+                handler=self._on_complete,
+                priority=200,
+                filters=HookFilter(event_types={"ingestion.end"}),
+                failure_policy=FailurePolicy.LOG,
+            ),
+        ]
+
+    def _on_complete(self, event: HookEvent) -> None:
+        assert isinstance(event, IngestionEvent)
+        status = event.status or "unknown"
+        msg = f"Ingestion {event.asset_key} finished: {status}"
+        if event.error:
+            msg += f" (error: {event.error})"
+        _send_notification(msg)
+
+
+def _send_notification(message: str) -> None:
+    # Replace with your notification backend (Slack, email, webhook, etc.)
+    print(message)
+```
+
+Register it in `pyproject.toml`:
+
+```toml
+[project.entry-points."phlo.plugins.hooks"]
+ingestion-notifier = "my_package.notifier:IngestionNotifier"
+```

--- a/docs/guides/logging.md
+++ b/docs/guides/logging.md
@@ -1,0 +1,153 @@
+# Logging Guide
+
+Structured logging for Phlo, powered by structlog with automatic hook-bus routing.
+
+## Overview
+
+Phlo wraps [structlog](https://www.structlog.org/) over Python's standard `logging` module
+to produce structured, context-rich log output. Every log record can optionally be routed to
+the [hook event bus](hook-event-bus.md) as a `LogEvent`, enabling plugins to react to log
+activity without coupling to the logging implementation.
+
+## Quick Start
+
+```python
+from phlo.logging import get_logger
+
+logger = get_logger(__name__)
+
+logger.info("pipeline started", asset_key="orders", run_id="abc-123")
+logger.warning("row count low", count=12)
+```
+
+`get_logger()` calls `setup_logging()` automatically the first time it is used, so no
+explicit setup is needed in most application code.
+
+## Log Formats
+
+The output format is controlled by `PHLO_LOG_FORMAT`:
+
+| Value     | Behaviour                                                        |
+| --------- | ---------------------------------------------------------------- |
+| `auto`    | Console (coloured, human-friendly) when stdout is a TTY; JSON otherwise |
+| `json`    | Always JSON                                                      |
+| `console` | Always console                                                   |
+
+File output (when enabled) is always JSON regardless of the stream format.
+
+## Configuration
+
+All settings are read from environment variables (or `.phlo/.env` / `.phlo/.env.local`).
+
+| Variable                   | Default              | Description                                     |
+| -------------------------- | -------------------- | ----------------------------------------------- |
+| `PHLO_LOG_LEVEL`           | `INFO`               | Minimum log level (`DEBUG`, `INFO`, `WARNING`, …) |
+| `PHLO_LOG_FORMAT`          | `auto`               | Output format: `auto`, `json`, or `console`     |
+| `PHLO_LOG_ROUTER_ENABLED`  | `true`               | Emit log records to the hook bus as `LogEvent`s  |
+| `PHLO_LOG_SERVICE_NAME`    | `phlo`               | Default `service` field on every log record      |
+| `PHLO_LOG_FILE_TEMPLATE`   | `.phlo/logs/{YMD}.log` | File path template (empty string to disable)   |
+
+## Context Binding
+
+Attach correlation fields to all subsequent log records in the current async/thread context:
+
+```python
+from phlo.logging import bind_context, clear_context
+
+bind_context(run_id="abc-123", asset_key="orders")
+logger.info("processing")          # includes run_id and asset_key
+clear_context()                    # resets all bound fields
+```
+
+### Correlation Fields
+
+The following fields are recognised by the log router and forwarded to `LogEvent`:
+
+- `run_id`
+- `asset_key`
+- `job_name`
+- `partition_key`
+- `check_name`
+
+Any other bound fields are included in the `LogEvent.metadata` dict.
+
+## Hook Bus Routing
+
+When `PHLO_LOG_ROUTER_ENABLED` is `true`, a `LogRouterHandler` is attached to the root
+logger. It converts every log record into a `LogEvent` and emits it via `get_hook_bus().emit()`.
+
+The handler uses a re-entrancy guard (`suppress_log_routing()`) to prevent infinite loops
+when hook handlers themselves produce log output.
+
+### Suppressing Routing
+
+Use the context manager to temporarily disable routing (for example inside a hook handler):
+
+```python
+from phlo.logging import suppress_log_routing
+
+with suppress_log_routing():
+    logger.info("this message will NOT be sent to the hook bus")
+```
+
+## Service-Scoped Loggers
+
+Override the default service name on a per-logger basis:
+
+```python
+logger = get_logger("my_module", service="my-service")
+logger.info("hello")  # service="my-service" instead of the global default
+```
+
+## File Logging
+
+When `PHLO_LOG_FILE_TEMPLATE` is set (non-empty), a `FileHandler` writes JSON-formatted
+logs to the rendered path. Parent directories are created automatically.
+
+### Template Placeholders
+
+Use Python `str.format()` syntax in the template:
+
+| Placeholder   | Example        | Description                    |
+| ------------- | -------------- | ------------------------------ |
+| `{YMD}`       | `20260217`     | Year + month + day             |
+| `{YM}`        | `202602`       | Year + month                   |
+| `{Y}` / `{YYYY}` | `2026`     | Four-digit year                |
+| `{M}` / `{MM}`   | `02`       | Zero-padded month              |
+| `{D}` / `{DD}`   | `17`       | Zero-padded day                |
+| `{H}`         | `14`           | Zero-padded hour (UTC)         |
+| `{HM}`        | `1430`         | Hour + minute                  |
+| `{HMS}`       | `143022`       | Hour + minute + second         |
+| `{DATE}`      | `2026-02-17`   | ISO date                       |
+| `{TIMESTAMP}` | `20260217143022` | Full timestamp               |
+
+### Path Resolution
+
+- Absolute paths are used as-is.
+- Relative paths are resolved against `PHLO_PROJECT_PATH` (env var) if set, otherwise the
+  current working directory.
+
+```bash
+# Write daily logs under the project .phlo directory
+PHLO_LOG_FILE_TEMPLATE=".phlo/logs/{YMD}.log"
+
+# Write hourly logs with an absolute path
+PHLO_LOG_FILE_TEMPLATE="/var/log/phlo/{DATE}/{H}.log"
+```
+
+## Setup
+
+`setup_logging()` is called automatically by the CLI and by `get_logger()` on first use.
+To reconfigure logging (for example in tests or custom entry points), pass `force=True`:
+
+```python
+from phlo.logging import setup_logging, LoggingSettings
+
+setup_logging(
+    LoggingSettings(level="DEBUG", log_format="json", router_enabled=False),
+    force=True,
+)
+```
+
+`LoggingSettings.from_settings()` reads values from the global `phlo.config.settings`
+configuration, so environment variables and `.phlo/.env` files are respected automatically.

--- a/docs/guides/operations-contracts.md
+++ b/docs/guides/operations-contracts.md
@@ -1,0 +1,158 @@
+# Operations Contracts
+
+Phlo defines abstract contracts for ingestion and transformation engines. Orchestrator
+adapters consume these contracts, allowing different backends (DLT, Airbyte, dbt, custom)
+to plug in without coupling to a specific orchestrator.
+
+## Architecture
+
+```text
+┌─────────────────────┐     ┌──────────────────────┐
+│ BaseIngester (ABC)  │     │ BaseTransformer (ABC) │
+└─────────┬───────────┘     └──────────┬───────────┘
+          │ implements                  │ implements
+          ▼                            ▼
+┌─────────────────────┐     ┌──────────────────────┐
+│ phlo-dlt ingester   │     │ phlo-dbt transformer │
+└─────────┬───────────┘     └──────────┬───────────┘
+          │ returns                     │ returns
+          ▼                            ▼
+┌─────────────────────┐     ┌──────────────────────┐
+│ IngestionResult     │     │ TransformationResult │
+└─────────────────────┘     └──────────────────────┘
+```
+
+## BaseIngester
+
+**Module:** `phlo.operations.ingestion`
+
+Abstract base class for ingestion engines.
+
+### Constructor
+
+```python
+class BaseIngester(ABC):
+    def __init__(self, context: Any, logger: Any):
+```
+
+| Parameter | Type  | Description                              |
+|-----------|-------|------------------------------------------|
+| `context` | `Any` | Orchestrator-provided execution context  |
+| `logger`  | `Any` | Logger for ingestion diagnostics         |
+
+Both are stored as instance attributes (`self.context`, `self.logger`).
+
+### run_ingestion
+
+```python
+@abstractmethod
+def run_ingestion(
+    self,
+    partition_key: str | None,
+    parameters: Dict[str, Any],
+) -> IngestionResult:
+```
+
+Execute ingestion logic for a partition. `partition_key` is `None` for unpartitioned runs.
+`parameters` carries backend-specific configuration (source credentials, table filters, etc.).
+
+## IngestionResult
+
+Dataclass returned by `run_ingestion`.
+
+```python
+@dataclass
+class IngestionResult:
+    status: str              # "success", "partial", "failed"
+    rows_inserted: int       # rows written to destination
+    rows_deleted: int        # rows removed (e.g. replace loads)
+    metadata: Dict[str, Any] # arbitrary backend-specific details
+```
+
+## BaseTransformer
+
+**Module:** `phlo.operations.transformation`
+
+Generic ABC parameterized on context type.
+
+### Constructor
+
+```python
+class BaseTransformer(Generic[ContextT], ABC):
+    def __init__(self, context: ContextT, logger: Logger):
+```
+
+| Parameter | Type       | Description                          |
+|-----------|------------|--------------------------------------|
+| `context` | `ContextT` | Engine-specific execution context    |
+| `logger`  | `Logger`   | Logger conforming to `Logger` protocol |
+
+The `Logger` protocol requires `info()`, `warning()`, and `error()` methods.
+
+### run_transform
+
+```python
+@abstractmethod
+def run_transform(
+    self,
+    partition_key: str | None = None,
+    parameters: dict[str, Any] | None = None,
+) -> TransformationResult:
+```
+
+Run transformations for an optional partition. Both arguments default to `None` for
+full, unparameterized runs.
+
+## TransformationResult
+
+Dataclass returned by `run_transform`.
+
+```python
+@dataclass
+class TransformationResult:
+    status: str                            # "success", "partial", "failed"
+    models_built: int                      # models successfully materialized
+    models_failed: int                     # models that errored
+    tests_passed: int                      # passing test assertions
+    tests_failed: int                      # failing test assertions
+    metadata: dict[str, Any] = field(...)  # backend-specific details
+    error: str | None = None               # error message on failure
+```
+
+## Example: custom ingester
+
+```python
+from phlo.operations.ingestion import BaseIngester, IngestionResult
+
+class CsvIngester(BaseIngester):
+    def run_ingestion(self, partition_key, parameters):
+        path = parameters["path"]
+        self.logger.info("Loading CSV from %s", path)
+        # ... read CSV and write to destination ...
+        return IngestionResult(
+            status="success",
+            rows_inserted=1000,
+            rows_deleted=0,
+            metadata={"source": path},
+        )
+```
+
+## Package implementations
+
+### phlo-dlt
+
+The `phlo-dlt` package provides a DLT-based ingester that wraps DLT pipelines behind
+`BaseIngester`. The `@phlo_ingestion` decorator constructs a `BaseIngester` subclass
+and wires it to the orchestrator via capability specs.
+
+### phlo-dbt
+
+The `phlo-dbt` package provides a dbt-based transformer that subclasses
+`BaseTransformer`. It invokes `dbt run` and `dbt test`, then maps CLI output into
+a `TransformationResult` with model/test counts and error details.
+
+## See also
+
+- [Capability Primitives](capability-primitives.md) — orchestrator-agnostic specs
+- [Orchestrator Adapters](orchestrator-adapters.md) — how adapters consume these contracts
+- [Plugin Development](plugin-development.md) — writing packages that implement contracts

--- a/docs/guides/orchestrator-adapters.md
+++ b/docs/guides/orchestrator-adapters.md
@@ -1,0 +1,227 @@
+# Orchestrator Adapters
+
+Phlo is orchestrator-agnostic. Packages publish capability specs — `AssetSpec`,
+`AssetCheckSpec`, `ResourceSpec` — and an orchestrator adapter translates those into
+runtime definitions. This guide covers selection, the adapter interface, capability specs,
+runtime context, the registry, and discovery.
+
+## Design overview
+
+```text
+Packages → Capability Specs → CapabilityRegistry → Orchestrator Adapter → Runtime
+                                                          ▲
+                                              get_active_orchestrator()
+                                              reads PHLO_ORCHESTRATOR
+```
+
+Packages never import orchestrator libraries. They declare specs; the active adapter
+consumes them.
+
+## Selecting the active orchestrator
+
+**Module:** `phlo.orchestrators.selection`
+
+```python
+def get_active_orchestrator(name: str | None = None) -> OrchestratorAdapterPlugin:
+```
+
+Resolution order:
+
+1. Explicit `name` argument (if provided).
+2. `PHLO_ORCHESTRATOR` setting (alias `PHLO_ORCHESTRATOR_NAME`).
+3. Default: `"dagster"`.
+
+The function discovers orchestrator plugins via entry points, looks up the adapter by
+name in the global plugin registry, and raises `PhloConfigError` if not found.
+
+## OrchestratorAdapterPlugin interface
+
+**Module:** `phlo.plugins.base.orchestrator`
+
+```python
+class OrchestratorAdapterPlugin(Plugin, ABC):
+    @abstractmethod
+    def build_definitions(
+        self,
+        *,
+        assets: Iterable[AssetSpec],
+        checks: Iterable[AssetCheckSpec],
+        resources: Iterable[ResourceSpec],
+    ) -> Any:
+        """Build orchestrator-native definitions from capability specs."""
+```
+
+An adapter receives the full set of registered specs and returns whatever the orchestrator
+runtime expects (e.g., a Dagster `Definitions` object).
+
+## Capability specs
+
+**Module:** `phlo.capabilities.specs`
+
+All specs are frozen, slotted dataclasses.
+
+### AssetSpec
+
+| Field        | Type                    | Description                            |
+|--------------|-------------------------|----------------------------------------|
+| `key`        | `str`                   | Unique asset identifier                |
+| `group`      | `str \| None`           | Logical grouping                       |
+| `description`| `str \| None`           | Human-readable description             |
+| `kinds`      | `set[str]`              | Asset kinds (e.g. `{"dlt", "iceberg"}`) |
+| `tags`       | `dict[str, str]`        | Arbitrary tags                         |
+| `metadata`   | `dict[str, Any]`        | Arbitrary metadata                     |
+| `partitions` | `PartitionSpec \| None` | Partitioning config                    |
+| `deps`       | `list[str]`             | Upstream asset keys                    |
+| `resources`  | `set[str]`              | Required resource names                |
+| `run`        | `RunSpec \| None`       | Execution function and schedule        |
+| `checks`     | `list[AssetCheckSpec]`  | Inline check specs                     |
+
+### PartitionSpec
+
+| Field        | Type            | Description                  |
+|--------------|-----------------|------------------------------|
+| `kind`       | `str`           | Partition kind (e.g. `daily`) |
+| `start_date` | `date \| None`  | Partition start date         |
+| `timezone`   | `str \| None`   | Partition timezone           |
+
+### RunSpec
+
+| Field                  | Type                                              | Description                    |
+|------------------------|----------------------------------------------------|--------------------------------|
+| `fn`                   | `Callable[[RuntimeContext], Iterable[RunResult]]` | Execution function             |
+| `max_runtime_seconds`  | `int \| None`                                     | Timeout                        |
+| `max_retries`          | `int \| None`                                     | Retry count                    |
+| `retry_delay_seconds`  | `int \| None`                                     | Delay between retries          |
+| `cron`                 | `str \| None`                                     | Schedule expression            |
+| `freshness_hours`      | `tuple[int, int] \| None`                         | (warn, error) freshness bounds |
+
+### AssetCheckSpec
+
+| Field         | Type                                              | Description              |
+|---------------|----------------------------------------------------|--------------------------|
+| `name`        | `str`                                              | Check name               |
+| `asset_key`   | `str`                                              | Asset this check targets |
+| `fn`          | `Callable[[RuntimeContext], CheckResult] \| None` | Check function           |
+| `blocking`    | `bool`                                             | Blocks downstream assets |
+| `description` | `str \| None`                                      | Human-readable text      |
+| `severity`    | `str \| None`                                      | Severity level           |
+| `tags`        | `dict[str, str]`                                   | Arbitrary tags           |
+
+### ResourceSpec
+
+| Field      | Type  | Description          |
+|------------|-------|----------------------|
+| `name`     | `str` | Resource identifier  |
+| `resource` | `Any` | Resource object      |
+
+### MaterializeResult
+
+| Field      | Type              | Description           |
+|------------|-------------------|-----------------------|
+| `metadata` | `dict[str, Any]`  | Result metadata       |
+| `status`   | `str \| None`     | Materialization status|
+
+### CheckResult
+
+| Field        | Type             | Description          |
+|--------------|------------------|----------------------|
+| `check_name` | `str`            | Check name           |
+| `asset_key`  | `str`            | Checked asset key    |
+| `passed`     | `bool`           | Whether check passed |
+| `severity`   | `str \| None`    | Severity level       |
+| `metadata`   | `dict[str, Any]` | Result metadata      |
+
+`RunResult` is the union `MaterializeResult | CheckResult`.
+
+## RuntimeContext protocol
+
+**Module:** `phlo.capabilities.runtime`
+
+```python
+class RuntimeContext(Protocol):
+    run_id: str | None
+    partition_key: str | None
+    tags: dict[str, str]
+
+    @property
+    def logger(self) -> Any: ...
+
+    @property
+    def resources(self) -> dict[str, Any]: ...
+
+    def get_resource(self, name: str) -> Any: ...
+```
+
+Orchestrator adapters provide an implementation of this protocol. The `RunSpec.fn` callback
+receives it at execution time, giving asset code access to the run ID, partition, tags,
+logger, and resources without importing orchestrator-specific APIs.
+
+## CapabilityRegistry
+
+**Module:** `phlo.capabilities.registry`
+
+Thread-safe in-memory store for capability specs. All mutations are guarded by a lock.
+
+| Method              | Description                                   |
+|---------------------|-----------------------------------------------|
+| `register_asset`    | Store/replace an `AssetSpec` by key            |
+| `register_check`    | Store/replace an `AssetCheckSpec` by (asset, name) |
+| `register_resource` | Store/replace a `ResourceSpec` by name         |
+| `list_assets`       | Snapshot list of all registered assets         |
+| `list_checks`       | Snapshot list of all registered checks         |
+| `list_resources`    | Snapshot list of all registered resources      |
+| `clear`             | Remove all entries                             |
+| `clear_checks`      | Remove only checks                             |
+
+Module-level helpers (`register_asset`, `register_check`, `register_resource`,
+`clear_capabilities`) operate on the process-global registry returned by
+`get_capability_registry()`.
+
+## Discovery flow
+
+**Module:** `phlo.capabilities.discovery`
+
+```python
+def discover_capabilities() -> None:
+```
+
+1. Calls `discover_plugins(plugin_type="asset_providers")` and
+   `discover_plugins(plugin_type="resource_providers")` to find providers via entry points.
+2. Iterates discovered asset providers, calling `get_assets()` and `get_checks()`.
+3. Iterates discovered resource providers, calling `get_resources()`.
+4. Registers all returned specs in the global `CapabilityRegistry`.
+5. Logs warnings for any provider that fails to load.
+
+## Writing a custom adapter
+
+1. Subclass `OrchestratorAdapterPlugin`.
+2. Implement `build_definitions` — translate specs into your orchestrator's native API.
+3. Register via entry point group `phlo.plugins.orchestrators`.
+
+```python
+from phlo.plugins.base import OrchestratorAdapterPlugin
+from phlo.capabilities.specs import AssetSpec, AssetCheckSpec, ResourceSpec
+
+class AirflowAdapter(OrchestratorAdapterPlugin):
+    name = "airflow"
+
+    def build_definitions(self, *, assets, checks, resources):
+        # Convert specs into Airflow DAGs / tasks
+        dags = []
+        for asset in assets:
+            dag = self._build_dag(asset)
+            dags.append(dag)
+        return dags
+```
+
+Set the orchestrator in `.phlo/.env`:
+
+```env
+PHLO_ORCHESTRATOR=airflow
+```
+
+## See also
+
+- [Capability Primitives](capability-primitives.md) — detailed spec walkthrough
+- [Operations Contracts](operations-contracts.md) — ingestion/transformation ABCs
+- [Plugin Development](plugin-development.md) — entry point registration

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -1,0 +1,156 @@
+# Plugin Registry
+
+The plugin registry is a centralized catalog of available Phlo plugins. It provides
+search, caching, and offline fallback so CLI commands like `phlo plugin search` work
+without network access.
+
+## Registry data format
+
+The canonical registry lives at `registry/plugins.json`. Top-level structure:
+
+```json
+{
+  "$schema": "https://registry.phlohouse.com/schema/v1.json",
+  "version": "1.0.0",
+  "updated_at": "2025-12-22T00:00:00Z",
+  "plugins": {
+    "dagster": { ... },
+    "postgres": { ... }
+  }
+}
+```
+
+Each plugin entry:
+
+```json
+{
+  "type": "service",
+  "package": "phlo-dagster",
+  "version": "0.1.0",
+  "description": "Data orchestration platform",
+  "author": "Phlo Team",
+  "homepage": "https://github.com/...",
+  "tags": ["orchestration", "core"],
+  "verified": true,
+  "core": true
+}
+```
+
+## RegistryPlugin dataclass
+
+**Module:** `phlo.plugins.registry_client`
+
+```python
+@dataclass(frozen=True)
+class RegistryPlugin:
+    name: str          # plugin identifier (registry key)
+    type: str          # source | quality | transform | service | hooks | ...
+    package: str       # pip-installable package name
+    version: str       # latest published version
+    description: str   # human-readable summary
+    author: str        # maintainer
+    homepage: str | None  # project URL
+    tags: list[str]    # search/filter tags
+    verified: bool     # verified by Phlo team
+    core: bool         # ships with core install
+```
+
+## API
+
+### fetch_registry
+
+```python
+def fetch_registry(force_refresh: bool = False) -> dict[str, Any]:
+```
+
+Returns the raw registry payload with caching. Pass `force_refresh=True` to bypass
+the cache TTL.
+
+### list_registry_plugins
+
+```python
+def list_registry_plugins() -> list[RegistryPlugin]:
+```
+
+Returns all plugins as normalized `RegistryPlugin` entries.
+
+### search_plugins
+
+```python
+def search_plugins(
+    query: str | None = None,
+    plugin_type: str | None = None,
+    tags: list[str] | None = None,
+) -> list[RegistryPlugin]:
+```
+
+Filter plugins by:
+
+- `query` — substring match against name, description, package, and tags.
+- `plugin_type` — exact match on `type` field (`"service"`, `"source"`, etc.).
+- `tags` — all provided tags must be present (case-insensitive subset match).
+
+Filters are applied in order: type → tags → query.
+
+### get_plugin
+
+```python
+def get_plugin(name: str) -> RegistryPlugin | None:
+```
+
+Returns a single plugin by registry key, or `None`.
+
+## Caching
+
+The registry client caches the fetched payload in-memory. The cache is valid for
+`plugin_registry_cache_ttl_seconds` (default: 3600s / 1 hour).
+
+```python
+def clear_registry_cache() -> None:
+```
+
+Resets the cache — useful in tests or after manual registry updates.
+
+## Fallback chain
+
+When `fetch_registry()` is called:
+
+1. **Remote URL** — fetches from `plugin_registry_url` with `plugin_registry_timeout_seconds`
+   timeout. Validates the payload contains a `plugins` section.
+2. **Bundled package data** — loads `phlo/plugins/registry_data.json` from the installed
+   package via `importlib.resources`.
+3. **Repo file** — walks parent directories to find `registry/plugins.json`.
+
+If step 1 fails (network error, timeout, invalid payload), falls back to step 2.
+If step 2 fails (file not found in package), falls back to step 3.
+Raises `FileNotFoundError` if all sources are exhausted.
+
+## Configuration
+
+Settings in `phlo.config.settings`:
+
+| Setting                             | Default                                          | Description              |
+|-------------------------------------|--------------------------------------------------|--------------------------|
+| `plugin_registry_url`               | `https://registry.phlohouse.com/plugins.json`    | Remote registry URL      |
+| `plugin_registry_cache_ttl_seconds` | `3600`                                           | Cache lifetime (seconds) |
+| `plugin_registry_timeout_seconds`   | `10`                                             | HTTP fetch timeout       |
+
+Override via `.phlo/.env` or environment variables.
+
+## Registry schema
+
+The registry is validated against a JSON Schema at `registry/schema/v1.json`.
+
+Required top-level fields: `$schema`, `version`, `updated_at`, `plugins`.
+
+Each plugin entry requires: `type`, `package`, `version`, `description`, `author`,
+`tags`, `verified`. The `type` field is constrained to:
+`source`, `quality`, `transform`, `service`, `hooks`, `assets`, `resources`,
+`orchestrators`, `catalogs`.
+
+Optional fields: `homepage`, `core`.
+
+## See also
+
+- [Plugin Development](plugin-development.md) — creating and publishing plugins
+- [Configuration Reference](../reference/configuration-reference.md) — all settings

--- a/docs/guides/semantic-layer.md
+++ b/docs/guides/semantic-layer.md
@@ -1,0 +1,75 @@
+# Semantic Layer
+
+Phlo provides a thin semantic layer abstraction that lets downstream consumers (BI tools,
+APIs, notebooks) discover and query named models without coupling to a specific
+transformation engine.
+
+## SemanticModel
+
+**Module:** `phlo.plugins.semantic`
+
+Frozen dataclass representing a single semantic model.
+
+```python
+@dataclass(frozen=True)
+class SemanticModel:
+    name: str                              # unique model identifier
+    description: str | None = None         # human-readable description
+    sql: str | None = None                 # SQL definition or reference
+    metadata: dict[str, Any] = field(...)  # arbitrary extra attributes
+```
+
+`metadata` can carry engine-specific details — column definitions, freshness policies,
+access controls, etc.
+
+## SemanticLayerProvider
+
+ABC that exposes semantic models from a backend.
+
+```python
+class SemanticLayerProvider(ABC):
+    @abstractmethod
+    def list_models(self) -> Iterable[SemanticModel]:
+        """Return all semantic models."""
+
+    @abstractmethod
+    def get_model(self, name: str) -> SemanticModel | None:
+        """Return a model by name, or None."""
+```
+
+## Example: implementing a provider
+
+```python
+from phlo.plugins.semantic import SemanticLayerProvider, SemanticModel
+
+class TrinoSemanticProvider(SemanticLayerProvider):
+    def __init__(self, catalog: str, schema: str):
+        self.catalog = catalog
+        self.schema = schema
+        self._models: dict[str, SemanticModel] = {}
+
+    def list_models(self):
+        return list(self._models.values())
+
+    def get_model(self, name):
+        return self._models.get(name)
+
+    def register(self, model: SemanticModel):
+        self._models[model.name] = model
+```
+
+## Plugin system integration
+
+Semantic layer providers are discovered through the standard Phlo plugin entry point
+system. A package registers its provider under the appropriate entry point group and
+the provider is loaded at runtime alongside other plugins.
+
+Providers can be combined — for example, a dbt package can publish `SemanticModel`
+entries from its manifest while a Trino package exposes live views. Consumers call
+`list_models()` on whichever provider is active without knowing the underlying engine.
+
+## See also
+
+- [Plugin Development](plugin-development.md) — entry point registration
+- [Capability Primitives](capability-primitives.md) — asset and resource specs
+- [Data Modeling](data-modeling.md) — dbt-based transformation models

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1573,6 +1573,6 @@ phlo materialize failed_asset
 
 ## Next Steps
 
-- [Configuration Reference](configuration.md) - Detailed configuration options
+- [Configuration Reference](configuration-reference.md) - Detailed configuration options
 - [Developer Guide](../guides/developer-guide.md) - Building workflows
 - [Troubleshooting](../operations/troubleshooting.md) - Common issues

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -18,6 +18,36 @@ Environment variables are materialized into `.phlo/.env` (generated, non-secret 
 and `.phlo/.env.local` (local secrets). Edit `phlo.yaml` for committed defaults and
 `.phlo/.env.local` for secrets.
 
+### Orchestrator Configuration
+
+```bash
+# Active orchestrator adapter (default: dagster)
+PHLO_ORCHESTRATOR=dagster
+# Alias
+PHLO_ORCHESTRATOR_NAME=dagster
+```
+
+### Logging Configuration
+
+```bash
+# Log level (default: INFO)
+PHLO_LOG_LEVEL=INFO
+
+# Log output format: auto (tty=console, else JSON), json, console
+PHLO_LOG_FORMAT=auto
+
+# Emit structured log events to the hook bus (default: true)
+PHLO_LOG_ROUTER_ENABLED=true
+
+# Default service name attached to log records (default: phlo)
+PHLO_LOG_SERVICE_NAME=phlo
+
+# Log file path template with date placeholders (default: .phlo/logs/{YMD}.log)
+# Available placeholders: {YMD}, {YM}, {Y}, {YYYY}, {M}, {MM}, {D}, {DD}, {H}, {HM}, {HMS}, {DATE}, {TIMESTAMP}
+# Set empty to disable file logging
+PHLO_LOG_FILE_TEMPLATE=.phlo/logs/{YMD}.log
+```
+
 ### Database Configuration
 
 PostgreSQL database settings:
@@ -76,7 +106,7 @@ Nessie Git-like catalog:
 ```bash
 # Version and connectivity
 NESSIE_VERSION=0.106.0
-NESSIE_PORT=19120
+NESSIE_PORT=10003
 NESSIE_HOST=nessie
 NESSIE_API_VERSION=v1
 ```

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -1,0 +1,502 @@
+# Plugin API Reference
+
+Comprehensive API reference for all Phlo plugin base classes.
+
+## Overview
+
+Phlo's plugin system uses abstract base classes to define contracts for each extension point. All plugin types inherit from [`Plugin`](#plugin) and must provide [`PluginMetadata`](#pluginmetadata).
+
+```
+Plugin (ABC)
+├── ServicePlugin
+├── CliCommandPlugin
+├── SourceConnectorPlugin
+├── QualityCheckPlugin[T]
+├── TransformationPlugin
+├── CatalogPlugin
+├── AssetProviderPlugin
+├── ResourceProviderPlugin
+└── OrchestratorAdapterPlugin
+```
+
+**Import path** — all base classes are re-exported from a single module:
+
+```python
+from phlo.plugins.base import (
+    Plugin,
+    PluginMetadata,
+    ServicePlugin,
+    CliCommandPlugin,
+    SourceConnectorPlugin,
+    QualityCheckPlugin,
+    TransformationPlugin,
+    CatalogPlugin,
+    AssetProviderPlugin,
+    ResourceProviderPlugin,
+    OrchestratorAdapterPlugin,
+)
+```
+
+---
+
+## Plugin
+
+`phlo.plugins.base.plugin.Plugin`
+
+Abstract base class for all Phlo plugins.
+
+### Abstract properties
+
+| Property | Return type | Description |
+|----------|-------------|-------------|
+| `metadata` | `PluginMetadata` | Plugin identity and metadata. |
+
+### Concrete methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `initialize` | `(config: dict[str, Any]) -> None` | Called once when the plugin is loaded. Override to validate config, set up connections, or load resources. |
+| `cleanup` | `() -> None` | Called when the plugin is unloaded. Override to close connections, release resources, or save state. |
+
+---
+
+## PluginMetadata
+
+`phlo.plugins.base.plugin.PluginMetadata`
+
+Dataclass describing a plugin's identity.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | *(required)* | Unique name within plugin type. |
+| `version` | `str` | *(required)* | Semver version string. |
+| `description` | `str` | `""` | Human-readable description. |
+| `author` | `str` | `""` | Author name or organization. |
+| `license` | `str` | `""` | License identifier (e.g., `MIT`, `Apache-2.0`). |
+| `homepage` | `str` | `""` | Homepage or repository URL. |
+| `tags` | `list[str]` | `[]` | Tags for categorization and search. |
+| `dependencies` | `list[str]` | `[]` | Python package dependencies required by the plugin. |
+
+```python
+from phlo.plugins.base import PluginMetadata
+
+meta = PluginMetadata(
+    name="my-plugin",
+    version="0.1.0",
+    description="Example plugin",
+    author="Acme Corp",
+    tags=["example"],
+)
+```
+
+---
+
+## ServicePlugin
+
+`phlo.plugins.base.service.ServicePlugin`
+
+**Inherits:** `Plugin`, `ABC`
+
+Provides Docker-based infrastructure components that compose into a Phlo stack. The `service_definition` property returns a dict equivalent to a `service.yaml` file.
+
+### Abstract properties
+
+| Property | Return type | Description |
+|----------|-------------|-------------|
+| `service_definition` | `dict[str, Any]` | Full service definition (equivalent to `service.yaml`). |
+
+### Concrete properties
+
+| Property | Return type | Description |
+|----------|-------------|-------------|
+| `category` | `str` | Service category (`core`, `api`, `bi`, `observability`, etc.). Defaults to `"custom"`. |
+| `is_default` | `bool` | Whether the service is installed by default. |
+| `profile` | `str \| None` | Optional profile this service belongs to. |
+
+### Concrete methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_compose_fragment` | `() -> dict[str, Any]` | Docker Compose service configuration from definition. |
+| `get_files` | `() -> list[dict[str, str]]` | Files to copy during initialization. |
+| `get_dependencies` | `() -> list[str]` | Service names this service depends on. |
+
+### Example
+
+```python
+from phlo.plugins.base import ServicePlugin, PluginMetadata
+
+class RedisService(ServicePlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(name="redis", version="1.0.0", description="Redis cache")
+
+    @property
+    def service_definition(self) -> dict:
+        return {
+            "category": "core",
+            "default": False,
+            "compose": {
+                "image": "redis:7-alpine",
+                "ports": ["6379:6379"],
+            },
+        }
+```
+
+---
+
+## CliCommandPlugin
+
+`phlo.plugins.base.cli.CliCommandPlugin`
+
+**Inherits:** `Plugin`, `ABC`
+
+Contributes [Click](https://click.palletsprojects.com/) commands or groups to the `phlo` CLI at runtime. Keeps the core CLI lightweight while capability packages provide their own CLI surface.
+
+### Abstract methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_cli_commands` | `() -> list[click.Command]` | Return Click commands/groups to register on the root CLI. |
+
+### Example
+
+```python
+import click
+from phlo.plugins.base import CliCommandPlugin, PluginMetadata
+
+class MyCliPlugin(CliCommandPlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(name="hello", version="1.0.0")
+
+    def get_cli_commands(self) -> list[click.Command]:
+        @click.command()
+        def hello():
+            """Say hello from a plugin."""
+            click.echo("Hello from plugin!")
+
+        return [hello]
+```
+
+---
+
+## SourceConnectorPlugin
+
+`phlo.plugins.base.source.SourceConnectorPlugin`
+
+**Inherits:** `Plugin`, `ABC`
+
+Enables ingesting data from external sources (APIs, databases, file systems, etc.).
+
+### Abstract methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `fetch_data` | `(config: dict[str, Any]) -> Iterator[dict[str, Any]]` | Yield dictionaries representing individual records from the source. `config` contains connection parameters, query/filter settings, pagination, and credentials. |
+
+### Concrete methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_schema` | `(config: dict[str, Any]) -> dict[str, str] \| None` | Return a column-name-to-type mapping (e.g., `{"id": "string"}`). Returns `None` if schema is dynamic. |
+| `test_connection` | `(config: dict[str, Any]) -> bool` | Test reachability of the source. Default implementation calls `fetch_data` and tries to read one record. |
+
+### Example
+
+```python
+from collections.abc import Iterator
+from phlo.plugins.base import SourceConnectorPlugin, PluginMetadata
+
+class GitHubConnector(SourceConnectorPlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="github", version="1.0.0", description="Fetch data from GitHub API"
+        )
+
+    def fetch_data(self, config: dict) -> Iterator[dict]:
+        for event in fetch_github_events(config["api_token"], config["repo"]):
+            yield event
+
+    def get_schema(self, config: dict) -> dict:
+        return {"id": "string", "type": "string", "created_at": "timestamp"}
+```
+
+---
+
+## QualityCheckPlugin
+
+`phlo.plugins.base.quality.QualityCheckPlugin`
+
+**Inherits:** `Plugin`, `ABC`, `Generic[TQualityCheck]`
+
+Factory for custom data quality checks that integrate with the `@phlo_quality` decorator.
+
+### Abstract methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `create_check` | `(**kwargs) -> TQualityCheck` | Create and return a quality check instance configured with the provided parameters. |
+
+### Example
+
+```python
+from phlo.plugins.base import QualityCheckPlugin, PluginMetadata
+from phlo_quality.checks import QualityCheck, QualityCheckResult
+
+class BusinessRuleCheck(QualityCheckPlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="business_rule", version="1.0.0", description="Validate business rules"
+        )
+
+    def create_check(self, **kwargs) -> QualityCheck:
+        return BusinessRuleQualityCheck(rule=kwargs["rule"])
+```
+
+---
+
+## TransformationPlugin
+
+`phlo.plugins.base.transform.TransformationPlugin`
+
+**Inherits:** `Plugin`, `ABC`
+
+Custom data processing steps that compose into data pipelines.
+
+### Abstract methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `transform` | `(df: pd.DataFrame, config: dict[str, Any]) -> pd.DataFrame` | Transform a DataFrame and return the result. |
+
+### Concrete methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_output_schema` | `(input_schema: dict[str, str], config: dict[str, Any]) -> dict[str, str] \| None` | Return the schema of the transformed data. Returns `None` if unknown. |
+| `validate_config` | `(config: dict[str, Any]) -> bool` | Validate transformation configuration. Returns `True` by default. |
+
+### Example
+
+```python
+import pandas as pd
+from phlo.plugins.base import TransformationPlugin, PluginMetadata
+
+class PivotTransform(TransformationPlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(name="pivot", version="1.0.0", description="Pivot table")
+
+    def transform(self, df: pd.DataFrame, config: dict) -> pd.DataFrame:
+        return df.pivot_table(
+            index=config["index"],
+            columns=config["columns"],
+            values=config["values"],
+            aggfunc=config.get("aggfunc", "mean"),
+        )
+```
+
+---
+
+## CatalogPlugin
+
+`phlo.plugins.base.catalog.CatalogPlugin`
+
+**Inherits:** `Plugin`, `ABC`
+
+Engine-agnostic catalog configuration. Engine adapters serialize catalog properties into their native formats.
+
+### Abstract properties
+
+| Property | Return type | Description |
+|----------|-------------|-------------|
+| `targets` | `list[str]` | Engine identifiers that can consume this catalog (e.g., `["trino"]`, `["trino", "spark"]`). |
+| `catalog_name` | `str` | Catalog identifier used by the engine. |
+
+### Abstract methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_properties` | `() -> dict[str, Any]` | Return catalog configuration as key-value pairs. |
+
+### Concrete methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `supports_target` | `(target: str) -> bool` | Returns `True` if the catalog supports the given engine target. |
+
+### Example
+
+```python
+from phlo.plugins.base import CatalogPlugin, PluginMetadata
+
+class IcebergNessieCatalog(CatalogPlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(name="iceberg-nessie", version="1.0.0")
+
+    @property
+    def targets(self) -> list[str]:
+        return ["trino"]
+
+    @property
+    def catalog_name(self) -> str:
+        return "iceberg"
+
+    def get_properties(self) -> dict:
+        return {
+            "connector.name": "iceberg",
+            "iceberg.catalog.type": "nessie",
+            "iceberg.catalog.uri": "http://nessie:19120/api/v2",
+        }
+```
+
+---
+
+## AssetProviderPlugin
+
+`phlo.plugins.base.providers.AssetProviderPlugin`
+
+**Inherits:** `Plugin`, `ABC`
+
+Provides orchestrator-agnostic asset and asset-check specifications.
+
+### Abstract methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_assets` | `() -> Iterable[AssetSpec]` | Return asset specifications exposed by this plugin. |
+
+### Concrete methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_checks` | `() -> Iterable[AssetCheckSpec]` | Return asset check specifications. Returns `[]` by default. |
+
+`AssetSpec` and `AssetCheckSpec` are defined in `phlo.capabilities.specs`.
+
+### Example
+
+```python
+from phlo.capabilities.specs import AssetSpec
+from phlo.plugins.base import AssetProviderPlugin, PluginMetadata
+
+class MyAssetProvider(AssetProviderPlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(name="my-assets", version="1.0.0")
+
+    def get_assets(self):
+        yield AssetSpec(key="my_table", group="bronze", description="Raw data")
+```
+
+---
+
+## ResourceProviderPlugin
+
+`phlo.plugins.base.providers.ResourceProviderPlugin`
+
+**Inherits:** `Plugin`, `ABC`
+
+Provides resource specifications that assets and checks can depend on.
+
+### Abstract methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `get_resources` | `() -> Iterable[ResourceSpec]` | Return resource specifications exposed by this plugin. |
+
+`ResourceSpec` is defined in `phlo.capabilities.specs`.
+
+### Example
+
+```python
+from phlo.capabilities.specs import ResourceSpec
+from phlo.plugins.base import ResourceProviderPlugin, PluginMetadata
+
+class MyResourceProvider(ResourceProviderPlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(name="my-resources", version="1.0.0")
+
+    def get_resources(self):
+        yield ResourceSpec(name="my_db", resource=create_db_resource())
+```
+
+---
+
+## OrchestratorAdapterPlugin
+
+`phlo.plugins.base.orchestrator.OrchestratorAdapterPlugin`
+
+**Inherits:** `Plugin`, `ABC`
+
+Translates normalized capability specs into orchestrator-native definitions (e.g., Dagster).
+
+### Abstract methods
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `build_definitions` | `(*, assets: Iterable[AssetSpec], checks: Iterable[AssetCheckSpec], resources: Iterable[ResourceSpec]) -> Any` | Build orchestrator-native definitions from capability specs. |
+
+All spec types are from `phlo.capabilities.specs`.
+
+### Example
+
+```python
+from phlo.plugins.base import OrchestratorAdapterPlugin, PluginMetadata
+
+class CustomOrchestratorAdapter(OrchestratorAdapterPlugin):
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(name="custom-orchestrator", version="1.0.0")
+
+    def build_definitions(self, *, assets, checks, resources):
+        # Convert specs to orchestrator-native definitions
+        return build_native_defs(assets, checks, resources)
+```
+
+---
+
+## Entry Point Registration
+
+Plugins are discovered at runtime via Python [entry points](https://packaging.python.org/en/latest/specifications/entry-points/). Declare them in your package's `pyproject.toml`:
+
+| Plugin type | Entry point group |
+|-------------|-------------------|
+| Source connectors | `phlo.plugins.sources` |
+| Quality checks | `phlo.plugins.quality` |
+| Transformations | `phlo.plugins.transforms` |
+| Services | `phlo.plugins.services` |
+| CLI commands | `phlo.plugins.cli` |
+| Hooks | `phlo.plugins.hooks` |
+| Catalogs | `phlo.plugins.catalogs` |
+| Asset providers | `phlo.plugins.assets` |
+| Resource providers | `phlo.plugins.resources` |
+| Orchestrators | `phlo.plugins.orchestrators` |
+
+### pyproject.toml example
+
+```toml
+[project.entry-points."phlo.plugins.sources"]
+my_source = "my_package.source:MySourceConnector"
+
+[project.entry-points."phlo.plugins.services"]
+redis = "my_package.services:RedisService"
+
+[project.entry-points."phlo.plugins.cli"]
+hello = "my_package.cli:MyCliPlugin"
+```
+
+The entry point **name** becomes the plugin identifier. The **value** points to the plugin class (which is instantiated automatically during discovery).
+
+### Discovery behavior
+
+- Plugins are auto-discovered on import unless `PHLO_NO_AUTO_DISCOVER=1` is set.
+- Plugins can be filtered via `plugins_whitelist` / `plugins_blacklist` in settings.
+- Discovery validates that each plugin is an instance of the expected base class for its entry point group.
+
+See also: [Configuration Reference](configuration-reference.md) for plugin settings.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,15 @@ nav:
       - dbt Development: guides/dbt-development.md
       - Data Modeling: guides/data-modeling.md
       - Dagster Assets: guides/dagster-assets.md
+      - Capability Primitives: guides/capability-primitives.md
+      - Orchestrator Adapters: guides/orchestrator-adapters.md
+      - Operations Contracts: guides/operations-contracts.md
+      - Logging: guides/logging.md
+      - Hook Event Bus: guides/hook-event-bus.md
+      - Semantic Layer: guides/semantic-layer.md
       - Plugin Development: guides/plugin-development.md
+      - Plugin Registry: guides/plugin-registry.md
+      - Compose Generation: guides/compose-generation.md
       - Service Packages: guides/service-packages.md
       - Testing Strategy: guides/testing-strategy.md
   - Setup:
@@ -107,8 +115,29 @@ nav:
       - API Reference: reference/phlo-api.md
       - CLI Reference: reference/cli-reference.md
       - Configuration: reference/configuration-reference.md
+      - Plugin API: reference/plugin-api.md
+      - Quality Checks Catalog: reference/quality-checks-catalog.md
       - DuckDB Queries: reference/duckdb-queries.md
       - Common Errors: reference/common-errors.md
+  - Errors:
+      - Error Index: errors/README.md
+      - PHLO-001 Asset Not Discovered: errors/PHLO-001.md
+      - PHLO-002 Schema Mismatch: errors/PHLO-002.md
+      - PHLO-003 Invalid Cron: errors/PHLO-003.md
+      - PHLO-004 Validation Failed: errors/PHLO-004.md
+      - PHLO-005 Missing Schema: errors/PHLO-005.md
+      - PHLO-006 Ingestion Failed: errors/PHLO-006.md
+      - PHLO-007 Table Not Found: errors/PHLO-007.md
+      - PHLO-008 Infrastructure Error: errors/PHLO-008.md
+      - PHLO-200 Schema Conversion: errors/PHLO-200.md
+      - PHLO-201 Type Conversion: errors/PHLO-201.md
+      - PHLO-300 DLT Pipeline Failed: errors/PHLO-300.md
+      - PHLO-301 DLT Source Error: errors/PHLO-301.md
+      - PHLO-400 Iceberg Catalog: errors/PHLO-400.md
+      - PHLO-401 Iceberg Table: errors/PHLO-401.md
+      - PHLO-402 Iceberg Write: errors/PHLO-402.md
+  - Observatory:
+      - Extensions: observatory/extensions.md
   - Operations:
       - Operations Guide: operations/operations-guide.md
       - Best Practices: operations/best-practices.md


### PR DESCRIPTION
## Summary

Audit of docs vs. codebase identified significant documentation gaps. This PR closes them.

### New error detail pages (11)
PHLO-004, PHLO-005, PHLO-007, PHLO-008, PHLO-200, PHLO-201, PHLO-300, PHLO-301, PHLO-400, PHLO-401, PHLO-402 — all referenced from `docs/errors/README.md` but previously missing.

### New guides (7)
- **Logging** — structlog setup, formats, file logging, hook-bus routing, context binding
- **Hook Event Bus** — 9 event types, emitters, filters, failure policies, HookPlugin base
- **Operations Contracts** — BaseIngester/BaseTransformer ABCs and result dataclasses
- **Orchestrator Adapters** — selection flow, capability specs, RuntimeContext, CapabilityRegistry
- **Semantic Layer** — SemanticModel/SemanticLayerProvider interfaces
- **Plugin Registry** — registry client, caching, fallback chain, search API
- **Compose Generation** — Docker Compose generation, env materialization, native mode

### New reference doc
- **Plugin API Reference** — all 9 plugin base classes with signatures and examples

### Updated existing docs
- **configuration-reference.md** — added orchestrator, logging, and plugin system settings; fixed Nessie port inconsistency (19120 → 10003)
- **cli-reference.md** — fixed broken configuration link
- **mkdocs.yml** — added all new + previously unlisted pages to nav (capability-primitives, quality-checks-catalog, observatory extensions, errors section)

### Out of scope
Architecture ADRs and blog posts nav entries — tracked separately.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
