### PR TITLE
fix(services): clear disabled state when re-adding service

### DIFF
--- a/src/phlo/cli/commands/services/add.py
+++ b/src/phlo/cli/commands/services/add.py
@@ -81,19 +81,31 @@ def add_cmd(service_name: str, no_start: bool):
     service = all_services[service_name]
 
     # Update config
-    if "services" not in config:
+    if not isinstance(config.get("services"), dict):
         config["services"] = {}
-    if "enabled" not in config["services"]:
+    if not isinstance(config["services"].get("enabled"), list):
         config["services"]["enabled"] = []
+    if not isinstance(config["services"].get("disabled"), list):
+        config["services"]["disabled"] = []
 
     enabled = config["services"]["enabled"]
-    if service_name in enabled:
+    disabled = config["services"]["disabled"]
+
+    is_enabled = service_name in enabled
+    is_disabled = service_name in disabled
+
+    if is_enabled and not is_disabled:
         logger.info("services_add_already_enabled", service_name=service_name)
         click.echo(f"Service '{service_name}' is already enabled.")
         return
 
-    enabled.append(service_name)
+    if not is_enabled:
+        enabled.append(service_name)
+    if is_disabled:
+        disabled = [name for name in disabled if name != service_name]
+
     config["services"]["enabled"] = sorted(set(enabled))
+    config["services"]["disabled"] = sorted(set(disabled))
 
     # Write updated config
     with open(config_file, "w") as f:

--- a/tests/test_cli_services_add.py
+++ b/tests/test_cli_services_add.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from phlo.cli.infrastructure.selection import select_services_to_install
+from phlo.plugins.discovery import ServiceDefinition
+
+
+def _service(name: str, *, default: bool = False) -> ServiceDefinition:
+    """Build a minimal service definition test fixture."""
+    return ServiceDefinition(
+        name=name,
+        description=f"{name} service",
+        default=default,
+    )
+
+
+def test_services_add_clears_disabled_after_remove_and_reenables_install_selection(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Verify remove+add clears disabled state and re-selects the service for install."""
+    postgres = _service("postgres", default=True)
+    prometheus = _service("prometheus")
+    services = {postgres.name: postgres, prometheus.name: prometheus}
+    selected_names: list[str] = []
+
+    class FakeDiscovery:
+        """Minimal service discovery stub for add/remove command tests."""
+
+        def discover(self) -> dict[str, ServiceDefinition]:
+            return services
+
+        def get_default_services(self, disabled_services=None) -> list[ServiceDefinition]:
+            return [postgres]
+
+    def fake_regenerate_compose(discovery, config: dict, _phlo_dir) -> None:
+        selected = select_services_to_install(
+            all_services=discovery.discover(),
+            default_services=discovery.get_default_services(),
+            enabled_names=config.get("services", {}).get("enabled", []),
+            disabled_names=config.get("services", {}).get("disabled", []),
+        )
+        selected_names[:] = [service.name for service in selected]
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".phlo").mkdir()
+    config_file = tmp_path / "phlo.yaml"
+    config_file.write_text(
+        yaml.dump(
+            {
+                "services": {
+                    "enabled": ["prometheus"],
+                    "disabled": [],
+                }
+            },
+            sort_keys=False,
+        )
+    )
+
+    from phlo.cli.commands.services import add as add_module
+    from phlo.cli.commands.services import remove as remove_module
+
+    monkeypatch.setattr(add_module, "ServiceDiscovery", FakeDiscovery)
+    monkeypatch.setattr(remove_module, "ServiceDiscovery", FakeDiscovery)
+    monkeypatch.setattr(remove_module, "_regenerate_compose", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(add_module, "_regenerate_compose", fake_regenerate_compose)
+
+    runner = CliRunner()
+    remove_result = runner.invoke(remove_module.remove_cmd, ["prometheus", "--keep-running"])
+    assert remove_result.exit_code == 0
+
+    after_remove = yaml.safe_load(config_file.read_text())
+    assert after_remove["services"]["enabled"] == []
+    assert after_remove["services"]["disabled"] == ["prometheus"]
+
+    add_result = runner.invoke(add_module.add_cmd, ["prometheus", "--no-start"])
+    assert add_result.exit_code == 0
+
+    after_add = yaml.safe_load(config_file.read_text())
+    assert after_add["services"]["enabled"] == ["prometheus"]
+    assert after_add["services"]["disabled"] == []
+    assert "prometheus" in selected_names


### PR DESCRIPTION
## Summary
- clear services.disabled entry when phlo services add re-enables a service
- normalize services config containers in add flow before mutation
- add regression test for remove->add flow to prove service is selected for install again

Closes #205