### PR TITLE
fix(services): fail fast on invalid --profile in start

### DIFF
--- a/src/phlo/cli/commands/services/start.py
+++ b/src/phlo/cli/commands/services/start.py
@@ -30,7 +30,9 @@ logger = get_logger(__name__)
 
 def _validate_requested_profiles(profile_names: tuple[str, ...]) -> tuple[str, ...]:
     """Normalize and validate requested profile names."""
-    requested_profiles = tuple(dict.fromkeys(name.strip() for name in profile_names if name.strip()))
+    requested_profiles = tuple(
+        dict.fromkeys(name.strip() for name in profile_names if name.strip())
+    )
     if not requested_profiles:
         return ()
 

--- a/tests/test_cli_services.py
+++ b/tests/test_cli_services.py
@@ -859,7 +859,9 @@ def test_services_start_uses_profile_targets_without_default_fallback(
     monkeypatch.setattr(start_module, "compose_base_cmd", lambda **_kwargs: ["docker", "compose"])
     monkeypatch.setattr(start_module, "run_command", _fake_run_command)
     monkeypatch.setattr(start_module, "require_docker", lambda: None)
-    monkeypatch.setattr(start_module, "_emit_service_lifecycle_events", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        start_module, "_emit_service_lifecycle_events", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(start_module, "_run_service_hooks", lambda *args, **kwargs: None)
 
     result = CliRunner().invoke(start_module.start_cmd, ["--profile", "observability"])


### PR DESCRIPTION
## Summary
- validate `phlo services start --profile` values against discovered profiles
- raise a friendly ClickException listing valid profile options for invalid input
- add regression tests for both invalid and valid profile behavior

## Testing
- uv run ruff check src/phlo/cli/commands/services/start.py tests/test_cli_services.py
- uv run pytest tests/test_cli_services.py -k "services_start_rejects_unknown_profile or services_start_uses_profile_targets_without_default_fallback"

Closes #209
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
