### PR TITLE
fix(plugins): invoke plugin lifecycle hooks in discovery replacement

### DIFF
--- a/src/phlo/plugins/discovery/plugins.py
+++ b/src/phlo/plugins/discovery/plugins.py
@@ -71,6 +71,19 @@ _PLUGIN_GETTER_METHODS = {
     "orchestrators": "get_orchestrator",
 }
 
+_PLUGIN_EXPECTED_TYPES = {
+    "source_connectors": SourceConnectorPlugin,
+    "quality_checks": QualityCheckPlugin,
+    "transformations": TransformationPlugin,
+    "services": ServicePlugin,
+    "cli_commands": CliCommandPlugin,
+    "hooks": HookPlugin,
+    "catalogs": CatalogPlugin,
+    "asset_providers": AssetProviderPlugin,
+    "resource_providers": ResourceProviderPlugin,
+    "orchestrators": OrchestratorAdapterPlugin,
+}
+
 
 def _is_plugin_allowed(plugin_name: str) -> bool:
     """
@@ -95,6 +108,67 @@ def _is_plugin_allowed(plugin_name: str) -> bool:
         return False
 
     return True
+
+
+def _register_plugin_with_lifecycle(plugin_type: str, plugin: Plugin, replace: bool = True) -> None:
+    """Register plugin with initialize/cleanup lifecycle hooks and rollback safeguards."""
+    registry = get_global_registry()
+    register_method_name = _PLUGIN_REGISTER_METHODS.get(plugin_type)
+    getter_method_name = _PLUGIN_GETTER_METHODS.get(plugin_type)
+
+    if not register_method_name or not getter_method_name:
+        raise ValueError(f"Unknown plugin type: {plugin_type}")
+
+    register_method = getattr(registry, register_method_name)
+    existing_plugin = getattr(registry, getter_method_name)(plugin.metadata.name)
+
+    # Let registry raise duplicate registration errors without initializing a plugin that
+    # cannot be registered.
+    if existing_plugin and not replace:
+        register_method(plugin, replace=False)
+        return
+
+    try:
+        plugin.initialize({})
+    except Exception:
+        try:
+            plugin.cleanup()
+        except Exception:
+            logger.warning(
+                "plugin_cleanup_after_initialize_failed",
+                plugin_type=plugin_type,
+                plugin_name=plugin.metadata.name,
+                exc_info=True,
+            )
+        raise
+
+    existing_cleaned = False
+    try:
+        if existing_plugin and replace:
+            existing_plugin.cleanup()
+            existing_cleaned = True
+        register_method(plugin, replace=replace)
+    except Exception:
+        if existing_cleaned:
+            try:
+                existing_plugin.initialize({})
+            except Exception:
+                logger.error(
+                    "plugin_recovery_initialize_failed",
+                    plugin_type=plugin_type,
+                    plugin_name=plugin.metadata.name,
+                    exc_info=True,
+                )
+        try:
+            plugin.cleanup()
+        except Exception:
+            logger.warning(
+                "plugin_cleanup_after_registration_failed",
+                plugin_type=plugin_type,
+                plugin_name=plugin.metadata.name,
+                exc_info=True,
+            )
+        raise
 
 
 def discover_plugins(
@@ -193,18 +267,7 @@ def discover_plugins(
                         continue
 
                     # Validate specific plugin type
-                    expected_type = {
-                        "source_connectors": SourceConnectorPlugin,
-                        "quality_checks": QualityCheckPlugin,
-                        "transformations": TransformationPlugin,
-                        "services": ServicePlugin,
-                        "cli_commands": CliCommandPlugin,
-                        "hooks": HookPlugin,
-                        "catalogs": CatalogPlugin,
-                        "asset_providers": AssetProviderPlugin,
-                        "resource_providers": ResourceProviderPlugin,
-                        "orchestrators": OrchestratorAdapterPlugin,
-                    }[ptype]
+                    expected_type = _PLUGIN_EXPECTED_TYPES[ptype]
 
                     if not isinstance(plugin, expected_type):
                         logger.error(
@@ -215,6 +278,9 @@ def discover_plugins(
                         )
                         continue
 
+                    if auto_register:
+                        _register_plugin_with_lifecycle(ptype, plugin, replace=True)
+
                     # Add to discovered plugins
                     discovered[ptype].append(plugin)
 
@@ -224,12 +290,6 @@ def discover_plugins(
                         plugin_version=plugin.metadata.version,
                         plugin_type=ptype,
                     )
-
-                    if auto_register:
-                        registry = get_global_registry()
-                        register_method = _PLUGIN_REGISTER_METHODS.get(ptype)
-                        if register_method:
-                            getattr(registry, register_method)(plugin, replace=True)
 
                 except Exception:
                     logger.error(

--- a/tests/test_plugin_discovery_lifecycle.py
+++ b/tests/test_plugin_discovery_lifecycle.py
@@ -1,0 +1,159 @@
+"""Regression tests for plugin lifecycle hooks during discovery registration."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from phlo.plugins import PluginMetadata, SourceConnectorPlugin, discover_plugins
+from phlo.plugins.discovery import get_global_registry
+
+
+class _SettingsStub:
+    """Test settings stub for plugin discovery."""
+
+    plugins_enabled = True
+    plugins_whitelist: list[str] = []
+    plugins_blacklist: list[str] = []
+
+
+class _EntryPointStub:
+    """Simple entry point stub for discovery tests."""
+
+    def __init__(self, name: str, plugin: SourceConnectorPlugin) -> None:
+        self.name = name
+        self.value = f"tests:{name}"
+        self._plugin = plugin
+
+    def load(self) -> SourceConnectorPlugin:
+        """Return plugin instance for entry point loading."""
+        return self._plugin
+
+
+class _LifecycleSourcePlugin(SourceConnectorPlugin):
+    """Source plugin with observable initialize/cleanup lifecycle events."""
+
+    def __init__(
+        self,
+        marker: str,
+        events: list[str],
+        *,
+        fail_initialize: bool = False,
+        fail_cleanup: bool = False,
+    ) -> None:
+        self.marker = marker
+        self._events = events
+        self._fail_initialize = fail_initialize
+        self._fail_cleanup = fail_cleanup
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        """Return metadata with a stable plugin name for replacement tests."""
+        return PluginMetadata(name="lifecycle_source", version=f"1.0.0-{self.marker}")
+
+    def initialize(self, config: dict[str, object]) -> None:
+        """Track plugin initialization and optionally fail."""
+        self._events.append(f"initialize:{self.marker}")
+        if self._fail_initialize:
+            raise RuntimeError(f"initialize failed for {self.marker}")
+
+    def cleanup(self) -> None:
+        """Track plugin cleanup and optionally fail."""
+        self._events.append(f"cleanup:{self.marker}")
+        if self._fail_cleanup:
+            raise RuntimeError(f"cleanup failed for {self.marker}")
+
+    def fetch_data(self, config: dict[str, object]) -> Iterator[dict[str, int]]:
+        """Yield one row to satisfy source plugin interface."""
+        yield {"id": 1}
+
+
+@pytest.fixture
+def clean_registry() -> Iterator:
+    """Reset global plugin registry around each lifecycle regression test."""
+    registry = get_global_registry()
+    registry.clear()
+    yield registry
+    registry.clear()
+
+
+def _patch_source_entry_points(
+    monkeypatch: pytest.MonkeyPatch, entry_points: list[_EntryPointStub]
+) -> None:
+    """Patch settings and entry point discovery for source connector tests."""
+
+    monkeypatch.setattr("phlo.plugins.discovery.plugins.get_settings", lambda: _SettingsStub())
+
+    def _fake_entry_points(*_args, **kwargs):
+        group = kwargs.get("group")
+        if group == "phlo.plugins.sources":
+            return entry_points
+        return []
+
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.plugins.importlib.metadata.entry_points",
+        _fake_entry_points,
+    )
+
+
+def test_discover_plugins_calls_initialize_before_registration(
+    clean_registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Initialize is called when discovered plugin registration succeeds."""
+    events: list[str] = []
+    plugin = _LifecycleSourcePlugin(marker="new", events=events)
+    _patch_source_entry_points(
+        monkeypatch, [_EntryPointStub(name="lifecycle_source", plugin=plugin)]
+    )
+
+    discover_plugins(plugin_type="source_connectors", auto_register=True)
+
+    assert clean_registry.get_source_connector("lifecycle_source") is plugin
+    assert events == ["initialize:new"]
+
+
+def test_discover_plugins_cleans_existing_plugin_before_replacement_registration(
+    clean_registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Replacement flow cleans existing plugin before new registration."""
+    events: list[str] = []
+    existing = _LifecycleSourcePlugin(marker="old", events=events)
+    clean_registry.register_source_connector(existing)
+
+    incoming = _LifecycleSourcePlugin(marker="new", events=events)
+    _patch_source_entry_points(
+        monkeypatch, [_EntryPointStub(name="lifecycle_source", plugin=incoming)]
+    )
+
+    register_source_connector = clean_registry.register_source_connector
+
+    def _track_register(plugin: SourceConnectorPlugin, replace: bool = False) -> None:
+        events.append(f"register:{plugin.marker}")
+        register_source_connector(plugin, replace=replace)
+
+    monkeypatch.setattr(clean_registry, "register_source_connector", _track_register)
+
+    discover_plugins(plugin_type="source_connectors", auto_register=True)
+
+    assert clean_registry.get_source_connector("lifecycle_source") is incoming
+    assert events == ["initialize:new", "cleanup:old", "register:new"]
+
+
+def test_discover_plugins_keeps_existing_plugin_when_cleanup_fails(
+    clean_registry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleanup failure during replacement preserves prior registry plugin."""
+    events: list[str] = []
+    existing = _LifecycleSourcePlugin(marker="old", events=events, fail_cleanup=True)
+    clean_registry.register_source_connector(existing)
+
+    incoming = _LifecycleSourcePlugin(marker="new", events=events)
+    _patch_source_entry_points(
+        monkeypatch, [_EntryPointStub(name="lifecycle_source", plugin=incoming)]
+    )
+
+    discover_plugins(plugin_type="source_connectors", auto_register=True)
+
+    assert clean_registry.get_source_connector("lifecycle_source") is existing
+    assert events == ["initialize:new", "cleanup:old", "cleanup:new"]


### PR DESCRIPTION
## Summary
- run plugin `initialize({})` before successful discovery registration
- run existing plugin `cleanup()` before replacement registration and clean up incoming plugin on failure
- add rollback safeguards so replacement failures do not swap out registry entries
- add lifecycle regression tests for initialize, replace+cleanup ordering, and cleanup-failure preservation

## Testing
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run ruff check src/phlo/plugins/discovery/plugins.py tests/test_plugin_discovery_lifecycle.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest tests/test_plugin_discovery_lifecycle.py`
- `UV_PROJECT_ENVIRONMENT=.venv-codex uv run pytest tests/test_plugin_system.py -k 'discover or duplicate_registration_with_replace'`

Closes #206

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
