### PR TITLE
test: add registry client cache fallback tests

### DIFF
--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -2,6 +2,9 @@
 
 import time
 
+import pytest
+import requests
+
 from phlo.plugins import registry_client
 
 
@@ -87,3 +90,131 @@ def test_search_plugins_filters(monkeypatch):
     results = registry_client.search_plugins(tags=["api"])
     assert len(results) == 1
     assert results[0].name == "alpha"
+
+
+def test_fetch_registry_remote_exception_falls_back_to_local(monkeypatch):
+    """Remote fetch failures should fall back to local registry data."""
+    sample_registry = {
+        "version": "1.0.0",
+        "plugins": {
+            "fallback": {
+                "type": "source",
+                "package": "phlo-plugin-fallback",
+                "version": "1.0.0",
+                "description": "Fallback plugin",
+                "author": "Phlo Team",
+                "tags": ["fallback"],
+                "verified": True,
+            }
+        },
+    }
+
+    class DummySettings:
+        plugin_registry_url = "https://example.com/registry.json"
+        plugin_registry_cache_ttl_seconds = 3600
+        plugin_registry_timeout_seconds = 2
+
+    local_calls = {"count": 0}
+
+    def fake_load_local():
+        local_calls["count"] += 1
+        return sample_registry
+
+    def fake_get(*_args, **_kwargs):
+        raise requests.exceptions.Timeout("network timeout")
+
+    registry_client.clear_registry_cache()
+    monkeypatch.setattr(registry_client, "get_settings", lambda: DummySettings())
+    monkeypatch.setattr(registry_client, "_load_registry_from_local", fake_load_local)
+    monkeypatch.setattr(registry_client.requests, "get", fake_get)
+
+    registry = registry_client.fetch_registry(force_refresh=True)
+
+    assert registry["plugins"]["fallback"]["package"] == "phlo-plugin-fallback"
+    assert local_calls["count"] == 1
+
+
+def test_fetch_registry_invalid_payload_raises_explicit_error(monkeypatch):
+    """Invalid payload should raise a clear validation error."""
+
+    class DummySettings:
+        plugin_registry_url = ""
+        plugin_registry_cache_ttl_seconds = 3600
+        plugin_registry_timeout_seconds = 1
+
+    registry_client.clear_registry_cache()
+    monkeypatch.setattr(registry_client, "get_settings", lambda: DummySettings())
+    monkeypatch.setattr(registry_client, "_load_registry_from_local", lambda: {"version": "1.0.0"})
+
+    with pytest.raises(ValueError, match="Registry payload missing plugins section\\."):
+        registry_client.fetch_registry(force_refresh=True)
+
+
+def test_fetch_registry_respects_cache_ttl_and_avoids_extra_http(monkeypatch):
+    """Cached registry should skip HTTP until TTL expires."""
+    first_registry = {
+        "version": "1.0.0",
+        "plugins": {
+            "alpha": {
+                "type": "source",
+                "package": "phlo-plugin-alpha",
+                "version": "1.0.0",
+                "description": "Alpha plugin",
+                "author": "Phlo Team",
+                "tags": ["alpha"],
+                "verified": True,
+            }
+        },
+    }
+    second_registry = {
+        "version": "1.1.0",
+        "plugins": {
+            "alpha": {
+                "type": "source",
+                "package": "phlo-plugin-alpha",
+                "version": "2.0.0",
+                "description": "Alpha plugin",
+                "author": "Phlo Team",
+                "tags": ["alpha"],
+                "verified": True,
+            }
+        },
+    }
+
+    class DummySettings:
+        plugin_registry_url = "https://example.com/registry.json"
+        plugin_registry_cache_ttl_seconds = 60
+        plugin_registry_timeout_seconds = 2
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    http_calls = []
+
+    def fake_get(url, timeout):
+        http_calls.append((url, timeout))
+        payload = first_registry if len(http_calls) == 1 else second_registry
+        return FakeResponse(payload)
+
+    timestamps = iter([100.0, 120.0, 200.0])
+
+    registry_client.clear_registry_cache()
+    monkeypatch.setattr(registry_client, "get_settings", lambda: DummySettings())
+    monkeypatch.setattr(registry_client.time, "time", lambda: next(timestamps))
+    monkeypatch.setattr(registry_client.requests, "get", fake_get)
+
+    first_fetch = registry_client.fetch_registry()
+    second_fetch = registry_client.fetch_registry()
+    third_fetch = registry_client.fetch_registry()
+
+    assert len(http_calls) == 2
+    assert first_fetch["plugins"]["alpha"]["version"] == "1.0.0"
+    assert second_fetch["plugins"]["alpha"]["version"] == "1.0.0"
+    assert third_fetch["plugins"]["alpha"]["version"] == "2.0.0"


### PR DESCRIPTION
## Summary
- add test coverage for remote fetch exception fallback to local registry
- add invalid payload validation test with explicit ValueError assertion
- add TTL cache behavior test to ensure no extra HTTP within TTL and refresh after expiry

## Testing
- uv run ruff check tests/test_plugin_registry.py
- uv run pytest tests/test_plugin_registry.py

Closes #213
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
