### PR TITLE
test(logging): add logging core regression tests

### DIFF
--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,10 +4,40 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from phlo.logging import LoggingSettings, _render_log_file_path, get_logger, setup_logging
+from phlo.logging import (
+    LoggingSettings,
+    LogRouterHandler,
+    _record_to_event,
+    _render_log_file_path,
+    get_logger,
+    log_event,
+    setup_logging,
+    suppress_log_routing,
+)
+
+
+def _make_record(
+    *,
+    msg: Any,
+    level: int = logging.INFO,
+    name: str = "phlo.tests.logging",
+    lineno: int = 7,
+) -> logging.LogRecord:
+    """Create a deterministic `LogRecord` for routing tests."""
+    return logging.LogRecord(
+        name=name,
+        level=level,
+        pathname=__file__,
+        lineno=lineno,
+        msg=msg,
+        args=(),
+        exc_info=None,
+        func="test_func",
+    )
 
 
 def test_render_log_file_path_resolves_template(tmp_path: Path) -> None:
@@ -115,3 +145,118 @@ def test_setup_logging_redacts_sensitive_fields(tmp_path: Path) -> None:
     assert "<redacted>" in contents
     assert "abc123" not in contents
     assert "p@ss" not in contents
+
+
+def test_record_to_event_extracts_tags_and_metadata() -> None:
+    """Builds event fields from record extras and strips consumed keys."""
+    record = _make_record(
+        msg={
+            "event": "asset materialized",
+            "service": "ingestion-worker",
+            "run_id": 42,
+            "asset_key": "raw.orders",
+            "tags": {"team": "analytics", "attempt": 2},
+            "custom_field": "ok",
+            "api_token": "secret-value",
+        }
+    )
+
+    event = _record_to_event(record, "phlo-default")
+
+    assert event is not None
+    assert event.service == "ingestion-worker"
+    assert event.message == "asset materialized"
+    assert event.run_id == "42"
+    assert event.asset_key == "raw.orders"
+    assert event.tags == {
+        "team": "analytics",
+        "attempt": "2",
+        "service": "ingestion-worker",
+    }
+    assert event.metadata["custom_field"] == "ok"
+    assert event.metadata["api_token"] == "<redacted>"
+    assert "service" not in event.metadata
+    assert "run_id" not in event.metadata
+    assert "asset_key" not in event.metadata
+    assert "tags" not in event.metadata
+
+
+def test_log_router_handler_emit_routes_and_reports_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Routes converted events and reports failures through `handleError`."""
+
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+            self.should_fail = False
+
+        def emit(self, event: Any) -> None:
+            if self.should_fail:
+                raise RuntimeError("emit failed")
+            self.events.append(event)
+
+    bus = RecordingBus()
+    monkeypatch.setattr("phlo.hooks.bus.get_hook_bus", lambda: bus)
+    handler = LogRouterHandler(service_name="router-service")
+
+    routed = _make_record(msg={"event": "routed", "tags": {"source": "test"}})
+    handler.emit(routed)
+
+    assert len(bus.events) == 1
+    assert bus.events[0].message == "routed"
+    assert bus.events[0].tags["source"] == "test"
+
+    errors: list[logging.LogRecord] = []
+    monkeypatch.setattr(handler, "handleError", lambda failed: errors.append(failed))
+    bus.should_fail = True
+    failing = _make_record(msg="will fail")
+
+    handler.emit(failing)
+
+    assert errors == [failing]
+
+
+def test_suppress_log_routing_blocks_emit_then_restores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Prevents routing while active and restores routing afterward."""
+
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    monkeypatch.setattr("phlo.hooks.bus.get_hook_bus", lambda: bus)
+    handler = LogRouterHandler(service_name="router-service")
+    record = _make_record(msg="suppressed check")
+
+    with suppress_log_routing():
+        handler.emit(record)
+
+    assert bus.events == []
+
+    handler.emit(record)
+
+    assert len(bus.events) == 1
+    assert bus.events[0].message == "suppressed check"
+
+
+def test_log_event_falls_back_when_logger_rejects_structured_kwargs() -> None:
+    """Falls back to plain message formatting on `TypeError`."""
+
+    class LegacyLogger:
+        def __init__(self) -> None:
+            self.messages: list[str] = []
+
+        def info(self, message: str) -> None:
+            self.messages.append(message)
+
+    logger = LegacyLogger()
+
+    log_event(logger, "info", "legacy event", run_id="run-1", attempt=3)
+
+    assert logger.messages == ["legacy event run_id=run-1 attempt=3"]


### PR DESCRIPTION
## Summary
- add `_record_to_event` regression coverage for metadata extraction, tag normalization, and consumed correlation fields
- add `LogRouterHandler.emit` regression coverage for routing success and error handling
- add suppression-context regression coverage to verify emit is blocked inside `suppress_log_routing()` and restored after exit
- add `log_event` regression coverage for `TypeError` structured-logging fallback formatting

## Testing
- uv run ruff check tests/test_logging.py src/phlo/logging.py
- uv run pytest tests/test_logging.py

Closes #212

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
