### PR TITLE
docs: add consolidated release notes for issues #205-#215

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [Unreleased]
+
+### Core improvements (#205-#215)
+
+#### Operator-facing behavior changes
+
+* `phlo services add` clears the disabled flag when re-enabling a service, so the service can start immediately ([#205](https://github.com/phlohouse/phlo/issues/205))
+* Plugin discovery now invokes initialize/cleanup lifecycle hooks during replacement to avoid stale plugin state ([#206](https://github.com/phlohouse/phlo/issues/206))
+* Plugin bootstrap now honors `plugins_auto_discover` configuration precedence, including explicit opt-out ([#207](https://github.com/phlohouse/phlo/issues/207))
+* Service discovery now exposes cache refresh/invalidation APIs for runtime updates without full restart ([#208](https://github.com/phlohouse/phlo/issues/208))
+* `phlo services start --profile` now fails fast when the profile is invalid, before service startup ([#209](https://github.com/phlohouse/phlo/issues/209))
+* `phlo services list` now wraps config/discovery failures with clearer operator-facing error messages ([#210](https://github.com/phlohouse/phlo/issues/210))
+
+#### Regression test coverage
+
+* Added orchestrator selection behavior and error-guidance regression tests ([#211](https://github.com/phlohouse/phlo/issues/211))
+* Added logging regression tests for routing, metadata, and fallback behavior ([#212](https://github.com/phlohouse/phlo/issues/212))
+* Added registry client coverage for TTL caching, remote fallback, and payload validation ([#213](https://github.com/phlohouse/phlo/issues/213))
+* Added infrastructure config helper edge-case and cache invalidation tests ([#214](https://github.com/phlohouse/phlo/issues/214))
+* Added exceptions module tests for formatting and suggestion helpers ([#215](https://github.com/phlohouse/phlo/issues/215))
+
 ## [0.5.0](https://github.com/phlohouse/phlo/compare/v0.4.0...v0.5.0) (2026-02-18)
 
 

--- a/docs/operations/operations-guide.md
+++ b/docs/operations/operations-guide.md
@@ -658,6 +658,14 @@ phlo materialize --select "tag:critical" --partition $(date -d "yesterday" +%Y-%
 
 Phlo uses Release Please to manage versions and changelogs on `main`.
 
+### Core Release Notes (#205-#215)
+
+Recent core hardening focused on operator reliability and regression coverage.
+
+- Service behavior/UX hardening: [#205](https://github.com/phlohouse/phlo/issues/205), [#209](https://github.com/phlohouse/phlo/issues/209), [#210](https://github.com/phlohouse/phlo/issues/210)
+- Plugin discovery hardening: [#206](https://github.com/phlohouse/phlo/issues/206), [#207](https://github.com/phlohouse/phlo/issues/207), [#208](https://github.com/phlohouse/phlo/issues/208)
+- New core regression suites: [#211](https://github.com/phlohouse/phlo/issues/211), [#212](https://github.com/phlohouse/phlo/issues/212), [#213](https://github.com/phlohouse/phlo/issues/213), [#214](https://github.com/phlohouse/phlo/issues/214), [#215](https://github.com/phlohouse/phlo/issues/215)
+
 ### Release Please Configuration
 
 - Workflow: `.github/workflows/release-please.yml`


### PR DESCRIPTION
## Summary
- add an Unreleased changelog section with consolidated operator-facing notes for issues #205-#215
- document the same core improvements snapshot in the operations guide release management section
- include direct issue links for behavior and regression-test coverage items

Closes #228
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
