### PR TITLE
docs: sync core behavior docs for services and discovery

### DIFF
--- a/docs/guides/compose-generation.md
+++ b/docs/guides/compose-generation.md
@@ -102,6 +102,38 @@ Each service package includes a `service.yaml` that declares:
 The `ServiceDiscovery` system collects these into `ServiceDefinition` objects that
 `ComposeGenerator` and `NativeProcessManager` consume.
 
+## ServiceDiscovery cache APIs
+
+`ServiceDiscovery` caches discovered service definitions per instance.
+
+| API | Behavior |
+| --- | --- |
+| `discover()` | Return cached definitions if already loaded. |
+| `discover(refresh=True)` | Clear cache, then rediscover and return new definitions. |
+| `clear_cache()` | Invalidate cached definitions; next `discover()` reloads. |
+| `refresh()` | Alias for `discover(refresh=True)`. |
+
+```python
+from phlo.plugins.discovery import ServiceDiscovery
+
+discovery = ServiceDiscovery()
+
+first = discovery.discover()   # loads and caches
+cached = discovery.discover()  # same in-memory map
+assert cached is first
+
+# Option 1: force reload inline
+reloaded = discovery.discover(refresh=True)
+assert reloaded is not first
+
+# Option 2: explicit cache invalidation
+discovery.clear_cache()
+reloaded_again = discovery.discover()
+
+# Option 3: refresh alias
+latest = discovery.refresh()
+```
+
 ## Environment file generation
 
 Generated files in `.phlo/`:

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -152,6 +152,7 @@ phlo services start [OPTIONS]
 ```bash
 --native                 # Run native dev services (phlo-api, Observatory) as subprocesses
 --profile PROFILE        # Additional service profiles
+--service SERVICE        # Start only specific service(s)
 --detach, -d             # Run in background
 --build                  # Rebuild containers before starting
 ```
@@ -183,6 +184,16 @@ phlo services start --profile observability --profile api
 
 # Rebuild and start
 phlo services start --build
+```
+
+**Validation behavior**:
+
+- `--profile` values are validated before Docker commands are executed.
+- Unknown profiles fail fast with a `ClickException` that includes valid options.
+
+```bash
+phlo services start --profile not-a-profile
+# Error: Invalid profile: not-a-profile. Valid profile options: api, observability
 ```
 
 **Services started**:
@@ -250,6 +261,22 @@ phlo services list --all
 phlo services list --json
 ```
 
+**Error behavior**:
+
+- Invalid `phlo.yaml` is surfaced with a targeted message:
+
+```bash
+phlo services list --json
+# Error: Failed to read /path/to/phlo.yaml. Check YAML syntax and file permissions, then retry.
+```
+
+- Discovery failures include next-step diagnostics:
+
+```bash
+phlo services list --json
+# Error: Failed to discover services. Verify service plugins are installed and run `phlo plugins list` for diagnostics.
+```
+
 ### phlo services add
 
 Add an optional service to the project.
@@ -271,6 +298,32 @@ phlo services add prometheus
 phlo services add grafana --no-start
 ```
 
+**State semantics**:
+
+- `add` ensures the service is present in `services.enabled`.
+- `add` removes that service from `services.disabled` if present.
+- If already enabled and not disabled, command exits without changing config.
+
+```yaml
+# Before
+services:
+  enabled: []
+  disabled:
+    - prometheus
+```
+
+```bash
+phlo services add prometheus --no-start
+```
+
+```yaml
+# After
+services:
+  enabled:
+    - prometheus
+  disabled: []
+```
+
 ### phlo services remove
 
 Remove a service from the project.
@@ -290,6 +343,32 @@ phlo services remove SERVICE_NAME [OPTIONS]
 ```bash
 phlo services remove prometheus
 phlo services remove grafana --keep-running
+```
+
+**State semantics**:
+
+- `remove` removes the service from `services.enabled`.
+- `remove` adds the service to `services.disabled`.
+- By default it stops the service first; `--keep-running` skips the stop step.
+
+```yaml
+# Before
+services:
+  enabled:
+    - prometheus
+  disabled: []
+```
+
+```bash
+phlo services remove prometheus --keep-running
+```
+
+```yaml
+# After
+services:
+  enabled: []
+  disabled:
+    - prometheus
 ```
 
 ### phlo services reset

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -465,6 +465,27 @@ PLUGIN_REGISTRY_CACHE_TTL_SECONDS=3600
 PLUGIN_REGISTRY_TIMEOUT_SECONDS=10
 ```
 
+`PLUGINS_AUTO_DISCOVER` is the default switch. `PHLO_NO_AUTO_DISCOVER` has disable
+override precedence at runtime:
+
+- Truthy values disable auto-discovery (`1`, `true`, `yes`, `on`).
+- Falsy values do not disable (`0`, `false`, `no`, `off`).
+- Any other non-empty value is treated as disable and logged as invalid.
+
+```bash
+# Disabled (env override wins)
+PLUGINS_AUTO_DISCOVER=true
+PHLO_NO_AUTO_DISCOVER=1
+
+# Enabled (falsy env does not disable)
+PLUGINS_AUTO_DISCOVER=true
+PHLO_NO_AUTO_DISCOVER=0
+
+# Disabled (settings already false; env cannot force enable)
+PLUGINS_AUTO_DISCOVER=false
+PHLO_NO_AUTO_DISCOVER=0
+```
+
 ## Infrastructure Configuration (phlo.yaml)
 
 Project-level configuration in `phlo.yaml`:

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -495,7 +495,8 @@ The entry point **name** becomes the plugin identifier. The **value** points to 
 
 ### Discovery behavior
 
-- Plugins are auto-discovered on import unless `PHLO_NO_AUTO_DISCOVER=1` is set.
+- Auto-discovery defaults to `plugins_auto_discover=true`.
+- `PHLO_NO_AUTO_DISCOVER` has disable precedence (truthy disables, falsy does not disable).
 - Plugins can be filtered via `plugins_whitelist` / `plugins_blacklist` in settings.
 - Discovery validates that each plugin is an instance of the expected base class for its entry point group.
 


### PR DESCRIPTION
## Summary
- sync docs for services add/remove state semantics (`services.enabled` / `services.disabled`)
- document `phlo services start --profile` fail-fast validation for invalid profiles
- document `phlo services list` error UX for config read/discovery failures
- clarify `plugins_auto_discover` vs `PHLO_NO_AUTO_DISCOVER` precedence
- add `ServiceDiscovery` cache API docs for `discover(refresh=True)`, `clear_cache()`, and `refresh()`

Closes #227

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
