### PR TITLE
fix: normalize services enabled/disabled config lists

### DIFF
--- a/src/phlo/cli/commands/services/add.py
+++ b/src/phlo/cli/commands/services/add.py
@@ -11,6 +11,7 @@ from phlo.cli.commands.services.utils import (
     PHLO_CONFIG_FILE,
     _regenerate_compose,
     get_phlo_dir,
+    normalize_services_enabled_disabled_config,
 )
 from phlo.cli.infrastructure.command import run_command
 from phlo.cli.infrastructure.compose import compose_base_cmd
@@ -81,31 +82,25 @@ def add_cmd(service_name: str, no_start: bool):
     service = all_services[service_name]
 
     # Update config
-    if not isinstance(config.get("services"), dict):
-        config["services"] = {}
-    if not isinstance(config["services"].get("enabled"), list):
-        config["services"]["enabled"] = []
-    if not isinstance(config["services"].get("disabled"), list):
-        config["services"]["disabled"] = []
+    enabled, disabled = normalize_services_enabled_disabled_config(config)
+    canonical_service_name = service.name
 
-    enabled = config["services"]["enabled"]
-    disabled = config["services"]["disabled"]
-
-    is_enabled = service_name in enabled
-    is_disabled = service_name in disabled
+    is_enabled = canonical_service_name in enabled
+    is_disabled = canonical_service_name in disabled
 
     if is_enabled and not is_disabled:
-        logger.info("services_add_already_enabled", service_name=service_name)
-        click.echo(f"Service '{service_name}' is already enabled.")
+        logger.info("services_add_already_enabled", service_name=canonical_service_name)
+        click.echo(f"Service '{canonical_service_name}' is already enabled.")
         return
 
     if not is_enabled:
-        enabled.append(service_name)
+        enabled.append(canonical_service_name)
     if is_disabled:
-        disabled = [name for name in disabled if name != service_name]
+        disabled = [name for name in disabled if name != canonical_service_name]
 
-    config["services"]["enabled"] = sorted(set(enabled))
-    config["services"]["disabled"] = sorted(set(disabled))
+    config["services"]["enabled"] = enabled
+    config["services"]["disabled"] = disabled
+    normalize_services_enabled_disabled_config(config)
 
     # Write updated config
     with open(config_file, "w") as f:

--- a/src/phlo/cli/commands/services/remove.py
+++ b/src/phlo/cli/commands/services/remove.py
@@ -11,6 +11,7 @@ from phlo.cli.commands.services.utils import (
     PHLO_CONFIG_FILE,
     _regenerate_compose,
     get_phlo_dir,
+    normalize_services_enabled_disabled_config,
 )
 from phlo.cli.infrastructure.command import run_command
 from phlo.cli.infrastructure.compose import compose_base_cmd
@@ -113,23 +114,15 @@ def remove_cmd(service_name: str, keep_running: bool):
             click.echo(f"Warning: Could not stop {service_name}.", err=True)
 
     # Update config
-    if not isinstance(config.get("services"), dict):
-        config["services"] = {}
-    if "disabled" not in config["services"]:
-        config["services"]["disabled"] = []
-    if "enabled" not in config["services"]:
-        config["services"]["enabled"] = []
+    enabled, disabled = normalize_services_enabled_disabled_config(config)
+    canonical_service_name = service.name
 
-    # Remove from enabled if present
-    enabled = config["services"]["enabled"]
-    if service_name in enabled:
-        enabled.remove(service_name)
-
-    # Add to disabled
-    disabled = config["services"]["disabled"]
-    if service_name not in disabled:
-        disabled.append(service_name)
-        config["services"]["disabled"] = sorted(set(disabled))
+    # Remove from enabled if present; add to disabled.
+    enabled = [name for name in enabled if name != canonical_service_name]
+    disabled.append(canonical_service_name)
+    config["services"]["enabled"] = enabled
+    config["services"]["disabled"] = disabled
+    normalize_services_enabled_disabled_config(config)
 
     # Write updated config
     with open(config_file, "w") as f:

--- a/src/phlo/cli/commands/services/utils.py
+++ b/src/phlo/cli/commands/services/utils.py
@@ -6,6 +6,7 @@ import signal
 import sys
 import time
 from pathlib import Path
+from typing import cast
 
 import click
 
@@ -152,6 +153,55 @@ def _get_env_overrides(config: dict) -> dict[str, object]:
     """
     env_overrides = config.get("env", {})
     return env_overrides if isinstance(env_overrides, dict) else {}
+
+
+def _normalize_service_name_list(names: object) -> list[str]:
+    """Normalize a service name list to unique lowercase names."""
+    if not isinstance(names, list):
+        return []
+
+    normalized_names: list[str] = []
+    seen_names: set[str] = set()
+    for name in names:
+        if not isinstance(name, str):
+            continue
+        normalized_name = name.strip().lower()
+        if not normalized_name or normalized_name in seen_names:
+            continue
+        normalized_names.append(normalized_name)
+        seen_names.add(normalized_name)
+    return normalized_names
+
+
+def normalize_services_enabled_disabled_config(
+    config: dict[str, object],
+) -> tuple[list[str], list[str]]:
+    """Normalize services enabled/disabled lists and resolve contradictions.
+
+    Rules:
+        - Missing/non-list values become empty lists.
+        - Service names are stripped, lowercased, deduplicated.
+        - Deterministic ordering via sort.
+        - If a name appears in both lists, disabled takes precedence.
+    """
+    services_config_value = config.get("services")
+    if isinstance(services_config_value, dict):
+        services_config = cast(dict[str, object], services_config_value)
+    else:
+        services_config = {}
+        config["services"] = services_config
+
+    enabled_names = _normalize_service_name_list(services_config.get("enabled"))
+    disabled_names = _normalize_service_name_list(services_config.get("disabled"))
+    conflicted_names = set(enabled_names).intersection(disabled_names)
+    if conflicted_names:
+        enabled_names = [name for name in enabled_names if name not in conflicted_names]
+
+    enabled_names = sorted(enabled_names)
+    disabled_names = sorted(disabled_names)
+    services_config["enabled"] = enabled_names
+    services_config["disabled"] = disabled_names
+    return enabled_names, disabled_names
 
 
 def _warn_secret_env_overrides(env_overrides: dict[str, object], services: list) -> None:
@@ -545,9 +595,8 @@ def _regenerate_compose(discovery, config: dict, phlo_dir: Path):
     # Get default services
     default_services = discovery.get_default_services()
 
-    # Get enabled services from config
-    enabled_names = config.get("services", {}).get("enabled", [])
-    disabled_names = config.get("services", {}).get("disabled", [])
+    # Get enabled/disabled services from normalized config
+    enabled_names, disabled_names = normalize_services_enabled_disabled_config(config)
 
     services_to_install = select_services_to_install(
         all_services=all_services,

--- a/tests/test_cli_services.py
+++ b/tests/test_cli_services.py
@@ -9,7 +9,11 @@ import yaml
 from click.testing import CliRunner
 from phlo_dagster.containers import find_dagster_container
 
-from phlo.cli.commands.services.utils import detect_phlo_source_path, get_profile_service_names
+from phlo.cli.commands.services.utils import (
+    detect_phlo_source_path,
+    get_profile_service_names,
+    normalize_services_enabled_disabled_config,
+)
 from phlo.cli.infrastructure.selection import select_services_to_install
 from phlo.plugins.compose.generator import ComposeGenerator
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
@@ -60,6 +64,37 @@ def test_select_services_to_install_respects_enabled_disabled_and_profiles() -> 
     )
 
     assert [s.name for s in services_to_install] == ["postgres", "prometheus", "grafana"]
+
+
+def test_normalize_services_enabled_disabled_config_dedupes_and_resolves_conflicts() -> None:
+    """Normalize enabled/disabled lists with disabled taking precedence on conflicts."""
+    config: dict[str, object] = {
+        "services": {
+            "enabled": [" Prometheus ", "postgres", "PROMETHEUS", "", 3],
+            "disabled": ["postgres", " Postgres ", "MINIO", None],
+        }
+    }
+
+    enabled, disabled = normalize_services_enabled_disabled_config(config)
+
+    assert enabled == ["prometheus"]
+    assert disabled == ["minio", "postgres"]
+    assert config["services"] == {"enabled": ["prometheus"], "disabled": ["minio", "postgres"]}
+
+
+def test_normalize_services_enabled_disabled_config_handles_missing_or_invalid_sections() -> None:
+    """Coerce invalid/missing sections into normalized enabled/disabled lists."""
+    invalid_services_config: dict[str, object] = {"services": "not-a-mapping"}
+    enabled, disabled = normalize_services_enabled_disabled_config(invalid_services_config)
+    assert enabled == []
+    assert disabled == []
+    assert invalid_services_config["services"] == {"enabled": [], "disabled": []}
+
+    empty_config: dict[str, object] = {}
+    enabled, disabled = normalize_services_enabled_disabled_config(empty_config)
+    assert enabled == []
+    assert disabled == []
+    assert empty_config["services"] == {"enabled": [], "disabled": []}
 
 
 def test_find_dagster_container_prefers_configured_name(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cli_services_add.py
+++ b/tests/test_cli_services_add.py
@@ -83,3 +83,48 @@ def test_services_add_clears_disabled_after_remove_and_reenables_install_selecti
     assert after_add["services"]["enabled"] == ["prometheus"]
     assert after_add["services"]["disabled"] == []
     assert "prometheus" in selected_names
+
+
+def test_services_add_normalizes_enabled_disabled_lists(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Verify add command normalizes configured enabled/disabled service lists."""
+    postgres = _service("postgres", default=True)
+    minio = _service("minio", default=True)
+    prometheus = _service("prometheus")
+    services = {svc.name: svc for svc in [postgres, minio, prometheus]}
+
+    class FakeDiscovery:
+        """Minimal service discovery stub for add command normalization tests."""
+
+        def discover(self) -> dict[str, ServiceDefinition]:
+            return services
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".phlo").mkdir()
+    config_file = tmp_path / "phlo.yaml"
+    config_file.write_text(
+        yaml.dump(
+            {
+                "services": {
+                    "enabled": [" prometheus ", "PROMETHEUS", "minio", "", 42],
+                    "disabled": [" prometheus ", " POSTGRES ", None],
+                }
+            },
+            sort_keys=False,
+        )
+    )
+
+    from phlo.cli.commands.services import add as add_module
+
+    monkeypatch.setattr(add_module, "ServiceDiscovery", FakeDiscovery)
+    monkeypatch.setattr(add_module, "_regenerate_compose", lambda *_args, **_kwargs: None)
+
+    runner = CliRunner()
+    add_result = runner.invoke(add_module.add_cmd, ["prometheus", "--no-start"])
+    assert add_result.exit_code == 0
+
+    after_add = yaml.safe_load(config_file.read_text())
+    assert after_add["services"]["enabled"] == ["minio", "prometheus"]
+    assert after_add["services"]["disabled"] == ["postgres"]


### PR DESCRIPTION
## Summary
- add a shared helper to normalize `services.enabled` and `services.disabled`
- dedupe/trim/lowercase entries and resolve conflicts with disabled precedence
- wire add/remove and compose regeneration paths to use shared normalization
- add helper unit tests and add-command integration coverage

Closes #231