### PR TITLE
feat(discovery): instrument plugin/service discovery observability signals (#234)

### DIFF
--- a/src/phlo/plugins/discovery/plugins.py
+++ b/src/phlo/plugins/discovery/plugins.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 import importlib.metadata
 import os
+from typing import Any
 
 from phlo.config import get_settings
-from phlo.logging import get_logger, suppress_log_routing
+from phlo.logging import get_logger, log_event, suppress_log_routing
 from phlo.plugins.base import (
     AssetProviderPlugin,
     CatalogPlugin,
@@ -114,6 +115,35 @@ def _is_plugin_allowed(plugin_name: str) -> bool:
     return True
 
 
+def _emit_plugin_lifecycle_signal(
+    *,
+    event_name: str,
+    level: str,
+    plugin_type: str,
+    plugin_name: str,
+    lifecycle_phase: str,
+    replace: bool,
+    reason: str | None = None,
+    error: Exception | None = None,
+    target_plugin_name: str | None = None,
+) -> None:
+    """Emit structured observability signals for plugin lifecycle operations."""
+    fields: dict[str, Any] = {
+        "plugin_type": plugin_type,
+        "plugin_name": plugin_name,
+        "lifecycle_phase": lifecycle_phase,
+        "replace": replace,
+    }
+    if reason is not None:
+        fields["reason"] = reason
+    if target_plugin_name is not None:
+        fields["target_plugin_name"] = target_plugin_name
+    if error is not None:
+        fields["error"] = str(error)
+        fields["error_type"] = type(error).__name__
+    log_event(logger, level, event_name, **fields)
+
+
 def _register_plugin_with_lifecycle(plugin_type: str, plugin: Plugin, replace: bool = True) -> None:
     """Register plugin with initialize/cleanup lifecycle hooks and rollback safeguards."""
     registry = get_global_registry()
@@ -124,7 +154,8 @@ def _register_plugin_with_lifecycle(plugin_type: str, plugin: Plugin, replace: b
         raise ValueError(f"Unknown plugin type: {plugin_type}")
 
     register_method = getattr(registry, register_method_name)
-    existing_plugin = getattr(registry, getter_method_name)(plugin.metadata.name)
+    plugin_name = plugin.metadata.name
+    existing_plugin = getattr(registry, getter_method_name)(plugin_name)
 
     # Let registry raise duplicate registration errors without initializing a plugin that
     # cannot be registered.
@@ -134,42 +165,144 @@ def _register_plugin_with_lifecycle(plugin_type: str, plugin: Plugin, replace: b
 
     try:
         plugin.initialize({})
-    except Exception:
+        _emit_plugin_lifecycle_signal(
+            event_name="plugin_lifecycle_initialize_succeeded",
+            level="info",
+            plugin_type=plugin_type,
+            plugin_name=plugin_name,
+            lifecycle_phase="incoming_plugin_initialize",
+            replace=replace,
+        )
+    except Exception as exc:
+        _emit_plugin_lifecycle_signal(
+            event_name="plugin_lifecycle_initialize_failed",
+            level="error",
+            plugin_type=plugin_type,
+            plugin_name=plugin_name,
+            lifecycle_phase="incoming_plugin_initialize",
+            replace=replace,
+            error=exc,
+        )
         try:
             plugin.cleanup()
-        except Exception:
+            _emit_plugin_lifecycle_signal(
+                event_name="plugin_lifecycle_cleanup_succeeded",
+                level="info",
+                plugin_type=plugin_type,
+                plugin_name=plugin_name,
+                lifecycle_phase="incoming_plugin_cleanup",
+                replace=replace,
+                reason="initialize_failed",
+            )
+        except Exception as cleanup_exc:
+            _emit_plugin_lifecycle_signal(
+                event_name="plugin_lifecycle_cleanup_failed",
+                level="error",
+                plugin_type=plugin_type,
+                plugin_name=plugin_name,
+                lifecycle_phase="incoming_plugin_cleanup",
+                replace=replace,
+                reason="initialize_failed",
+                error=cleanup_exc,
+            )
             logger.warning(
                 "plugin_cleanup_after_initialize_failed",
                 plugin_type=plugin_type,
-                plugin_name=plugin.metadata.name,
+                plugin_name=plugin_name,
                 exc_info=True,
             )
         raise
 
     existing_cleaned = False
+    existing_plugin_name = existing_plugin.metadata.name if existing_plugin else None
     try:
         if existing_plugin and replace:
-            existing_plugin.cleanup()
-            existing_cleaned = True
+            try:
+                existing_plugin.cleanup()
+                _emit_plugin_lifecycle_signal(
+                    event_name="plugin_lifecycle_cleanup_succeeded",
+                    level="info",
+                    plugin_type=plugin_type,
+                    plugin_name=existing_plugin_name or plugin_name,
+                    lifecycle_phase="existing_plugin_cleanup",
+                    replace=replace,
+                    reason="replacement",
+                    target_plugin_name=plugin_name,
+                )
+                existing_cleaned = True
+            except Exception as exc:
+                _emit_plugin_lifecycle_signal(
+                    event_name="plugin_lifecycle_cleanup_failed",
+                    level="error",
+                    plugin_type=plugin_type,
+                    plugin_name=existing_plugin_name or plugin_name,
+                    lifecycle_phase="existing_plugin_cleanup",
+                    replace=replace,
+                    reason="replacement",
+                    target_plugin_name=plugin_name,
+                    error=exc,
+                )
+                raise
         register_method(plugin, replace=replace)
     except Exception:
         if existing_cleaned:
+            assert existing_plugin is not None
             try:
                 existing_plugin.initialize({})
-            except Exception:
+                _emit_plugin_lifecycle_signal(
+                    event_name="plugin_lifecycle_initialize_succeeded",
+                    level="info",
+                    plugin_type=plugin_type,
+                    plugin_name=existing_plugin_name or plugin_name,
+                    lifecycle_phase="existing_plugin_recovery_initialize",
+                    replace=replace,
+                    reason="registration_failed_rollback",
+                    target_plugin_name=plugin_name,
+                )
+            except Exception as recovery_exc:
+                _emit_plugin_lifecycle_signal(
+                    event_name="plugin_lifecycle_initialize_failed",
+                    level="error",
+                    plugin_type=plugin_type,
+                    plugin_name=existing_plugin_name or plugin_name,
+                    lifecycle_phase="existing_plugin_recovery_initialize",
+                    replace=replace,
+                    reason="registration_failed_rollback",
+                    target_plugin_name=plugin_name,
+                    error=recovery_exc,
+                )
                 logger.error(
                     "plugin_recovery_initialize_failed",
                     plugin_type=plugin_type,
-                    plugin_name=plugin.metadata.name,
+                    plugin_name=plugin_name,
                     exc_info=True,
                 )
         try:
             plugin.cleanup()
-        except Exception:
+            _emit_plugin_lifecycle_signal(
+                event_name="plugin_lifecycle_cleanup_succeeded",
+                level="info",
+                plugin_type=plugin_type,
+                plugin_name=plugin_name,
+                lifecycle_phase="incoming_plugin_cleanup",
+                replace=replace,
+                reason="registration_failed",
+            )
+        except Exception as cleanup_exc:
+            _emit_plugin_lifecycle_signal(
+                event_name="plugin_lifecycle_cleanup_failed",
+                level="error",
+                plugin_type=plugin_type,
+                plugin_name=plugin_name,
+                lifecycle_phase="incoming_plugin_cleanup",
+                replace=replace,
+                reason="registration_failed",
+                error=cleanup_exc,
+            )
             logger.warning(
                 "plugin_cleanup_after_registration_failed",
                 plugin_type=plugin_type,
-                plugin_name=plugin.metadata.name,
+                plugin_name=plugin_name,
                 exc_info=True,
             )
         raise

--- a/src/phlo/plugins/discovery/services.py
+++ b/src/phlo/plugins/discovery/services.py
@@ -12,11 +12,33 @@ from typing import Any
 
 import yaml
 
-from phlo.logging import get_logger
+from phlo.logging import get_logger, log_event
 from phlo.plugins.discovery.plugins import discover_plugins
 from phlo.plugins.discovery.registry import get_global_registry
 
 logger = get_logger(__name__)
+
+
+def _services_dir_label(services_dir: Path | None) -> str:
+    """Normalize the services directory path for structured observability fields."""
+    return str(services_dir) if services_dir else "<plugins-only>"
+
+
+def _emit_service_discovery_signal(
+    *,
+    event_name: str,
+    level: str,
+    services_dir: Path | None,
+    **fields: Any,
+) -> None:
+    """Emit a structured observability event for service discovery flows."""
+    log_event(
+        logger,
+        level,
+        event_name,
+        services_dir=_services_dir_label(services_dir),
+        **fields,
+    )
 
 
 def _find_cycles(nodes: set[str], graph: dict[str, set[str]]) -> list[list[str]]:
@@ -227,16 +249,36 @@ class ServiceDiscovery:
             Dictionary mapping service names to their definitions.
         """
         if refresh:
+            _emit_service_discovery_signal(
+                event_name="service_discovery_refresh_requested",
+                level="info",
+                services_dir=self.services_dir,
+                cached_service_count=len(self._services),
+                cache_loaded=self._loaded,
+            )
             self.clear_cache()
 
         if self._loaded:
+            _emit_service_discovery_signal(
+                event_name="service_discovery_cache_hit",
+                level="debug",
+                services_dir=self.services_dir,
+                service_count=len(self._services),
+            )
             return self._services
 
+        _emit_service_discovery_signal(
+            event_name="service_discovery_cache_miss",
+            level="debug",
+            services_dir=self.services_dir,
+            refresh=refresh,
+        )
+
         self._services = {}
+        plugin_service_count = self._load_service_plugins()
+        file_service_count = 0
 
-        # Then load plugin services
-        self._load_service_plugins()
-
+        # Then load filesystem services
         if self.services_dir and self.services_dir.exists():
             # Search for service.yaml files in all subdirectories
             for yaml_path in self.services_dir.rglob("*.yaml"):
@@ -251,10 +293,26 @@ class ServiceDiscovery:
                     if service.name in self._services:
                         continue
                     self._services[service.name] = service
+                    file_service_count += 1
                 except (yaml.YAMLError, KeyError) as e:
-                    logger.warning("Failed to load %s: %s", yaml_path, e)
+                    _emit_service_discovery_signal(
+                        event_name="service_discovery_file_load_failed",
+                        level="warning",
+                        services_dir=self.services_dir,
+                        yaml_path=str(yaml_path),
+                        error=str(e),
+                        error_type=type(e).__name__,
+                    )
 
         self._loaded = True
+        _emit_service_discovery_signal(
+            event_name="service_discovery_completed",
+            level="info",
+            services_dir=self.services_dir,
+            service_count=len(self._services),
+            plugin_service_count=plugin_service_count,
+            file_service_count=file_service_count,
+        )
         return self._services
 
     def clear_cache(self) -> None:
@@ -262,15 +320,25 @@ class ServiceDiscovery:
 
         The next :meth:`discover` call will perform a full rediscovery.
         """
+        cached_service_count = len(self._services)
+        was_loaded = self._loaded
         self._services = {}
         self._loaded = False
+        _emit_service_discovery_signal(
+            event_name="service_discovery_cache_cleared",
+            level="info",
+            services_dir=self.services_dir,
+            cached_service_count=cached_service_count,
+            cache_was_loaded=was_loaded,
+        )
 
     def refresh(self) -> dict[str, ServiceDefinition]:
         """Force rediscovery and return refreshed service definitions."""
         return self.discover(refresh=True)
 
-    def _load_service_plugins(self) -> None:
+    def _load_service_plugins(self) -> int:
         """Load services from installed plugins."""
+        loaded_count = 0
         discover_plugins(plugin_type="services", auto_register=True)
         registry = get_global_registry()
         for name in registry.list_services():
@@ -286,20 +354,30 @@ class ServiceDiscovery:
             try:
                 service = ServiceDefinition.from_dict(service_definition, source_path)
                 self._services[service.name] = service
-                self._load_companion_service_files(source_path)
+                loaded_count += 1
+                loaded_count += self._load_companion_service_files(source_path)
             except KeyError as exc:
-                logger.warning("Service plugin %s missing field: %s", name, exc)
+                _emit_service_discovery_signal(
+                    event_name="service_discovery_plugin_load_failed",
+                    level="warning",
+                    services_dir=self.services_dir,
+                    plugin_name=name,
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+        return loaded_count
 
     @staticmethod
     def _is_service_yaml(filename: str) -> bool:
         """Check if filename is a recognized service YAML pattern."""
         return filename == "service.yaml" or filename.endswith(("-setup.yaml", "-daemon.yaml"))
 
-    def _load_companion_service_files(self, source_path: Path | None) -> None:
+    def _load_companion_service_files(self, source_path: Path | None) -> int:
         """Load companion service YAMLs (e.g., *-setup.yaml, *-daemon.yaml) from a package."""
         if not source_path or not source_path.exists():
-            return
+            return 0
 
+        loaded_count = 0
         for yaml_path in source_path.rglob("*.yaml"):
             filename = yaml_path.name
             if filename == "service.yaml":
@@ -311,8 +389,17 @@ class ServiceDiscovery:
                 if service.name in self._services:
                     continue
                 self._services[service.name] = service
+                loaded_count += 1
             except (yaml.YAMLError, KeyError) as exc:
-                logger.warning("Failed to load companion service %s: %s", yaml_path, exc)
+                _emit_service_discovery_signal(
+                    event_name="service_discovery_companion_file_load_failed",
+                    level="warning",
+                    services_dir=self.services_dir,
+                    yaml_path=str(yaml_path),
+                    error=str(exc),
+                    error_type=type(exc).__name__,
+                )
+        return loaded_count
 
     def get_service(self, name: str) -> ServiceDefinition | None:
         """Get a service definition by name."""

--- a/tests/test_plugin_discovery_lifecycle.py
+++ b/tests/test_plugin_discovery_lifecycle.py
@@ -97,6 +97,104 @@ def _patch_source_entry_points(
     )
 
 
+@pytest.fixture
+def lifecycle_signals(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Capture structured lifecycle observability signals emitted via log_event."""
+    signals: list[dict[str, object]] = []
+
+    def _capture_signal(
+        _logger: object,
+        level: str,
+        event: str,
+        **fields: object,
+    ) -> None:
+        signals.append({"level": level, "event": event, "fields": fields})
+
+    monkeypatch.setattr("phlo.plugins.discovery.plugins.log_event", _capture_signal)
+    return signals
+
+
+def test_discover_plugins_emits_lifecycle_success_signals(
+    clean_registry,
+    monkeypatch: pytest.MonkeyPatch,
+    lifecycle_signals: list[dict[str, object]],
+) -> None:
+    """Lifecycle success signals include initialize and replacement cleanup events."""
+    events: list[str] = []
+    existing = _LifecycleSourcePlugin(marker="old", events=events)
+    clean_registry.register_source_connector(existing)
+
+    incoming = _LifecycleSourcePlugin(marker="new", events=events)
+    _patch_source_entry_points(
+        monkeypatch, [_EntryPointStub(name="lifecycle_source", plugin=incoming)]
+    )
+
+    discover_plugins(plugin_type="source_connectors", auto_register=True)
+
+    signal_fields = [signal["fields"] for signal in lifecycle_signals]
+    assert any(
+        fields.get("lifecycle_phase") == "incoming_plugin_initialize"
+        and fields.get("plugin_type") == "source_connectors"
+        for fields in signal_fields
+        if fields and isinstance(fields, dict)
+    )
+    assert any(
+        fields.get("lifecycle_phase") == "existing_plugin_cleanup"
+        and fields.get("reason") == "replacement"
+        and fields.get("target_plugin_name") == "lifecycle_source"
+        for fields in signal_fields
+        if fields and isinstance(fields, dict)
+    )
+    assert any(
+        signal["event"] == "plugin_lifecycle_initialize_succeeded" for signal in lifecycle_signals
+    )
+    assert any(
+        signal["event"] == "plugin_lifecycle_cleanup_succeeded" for signal in lifecycle_signals
+    )
+
+
+def test_discover_plugins_emits_lifecycle_failure_signals(
+    clean_registry,
+    monkeypatch: pytest.MonkeyPatch,
+    lifecycle_signals: list[dict[str, object]],
+) -> None:
+    """Lifecycle failure signals include initialize and cleanup errors."""
+    events: list[str] = []
+    failing = _LifecycleSourcePlugin(
+        marker="new",
+        events=events,
+        fail_initialize=True,
+        fail_cleanup=True,
+    )
+    _patch_source_entry_points(
+        monkeypatch, [_EntryPointStub(name="lifecycle_source", plugin=failing)]
+    )
+
+    discover_plugins(plugin_type="source_connectors", auto_register=True)
+
+    initialize_failures = [
+        signal
+        for signal in lifecycle_signals
+        if signal["event"] == "plugin_lifecycle_initialize_failed"
+        and isinstance(signal["fields"], dict)
+        and signal["fields"].get("lifecycle_phase") == "incoming_plugin_initialize"
+    ]
+    cleanup_failures = [
+        signal
+        for signal in lifecycle_signals
+        if signal["event"] == "plugin_lifecycle_cleanup_failed"
+        and isinstance(signal["fields"], dict)
+        and signal["fields"].get("lifecycle_phase") == "incoming_plugin_cleanup"
+    ]
+
+    assert len(initialize_failures) == 1
+    assert initialize_failures[0]["fields"]["plugin_type"] == "source_connectors"
+    assert initialize_failures[0]["fields"]["error_type"] == "RuntimeError"
+    assert len(cleanup_failures) == 1
+    assert cleanup_failures[0]["fields"]["reason"] == "initialize_failed"
+    assert cleanup_failures[0]["fields"]["error_type"] == "RuntimeError"
+
+
 def test_discover_plugins_calls_initialize_before_registration(
     clean_registry, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_services_discovery.py
+++ b/tests/test_services_discovery.py
@@ -55,6 +55,23 @@ def clean_registry():
     registry.clear()
 
 
+@pytest.fixture
+def service_discovery_signals(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, object]]:
+    """Capture service discovery observability events emitted via log_event."""
+    signals: list[dict[str, object]] = []
+
+    def _capture_signal(
+        _logger: object,
+        level: str,
+        event: str,
+        **fields: object,
+    ) -> None:
+        signals.append({"level": level, "event": event, "fields": fields})
+
+    monkeypatch.setattr("phlo.plugins.discovery.services.log_event", _capture_signal)
+    return signals
+
+
 def test_service_discovery_includes_plugins(
     clean_registry: object,
     monkeypatch: pytest.MonkeyPatch,
@@ -126,6 +143,63 @@ def test_service_discovery_clear_cache_and_refresh_alias(
     _write_service_yaml(tmp_path, "gamma", "gamma")
     refreshed = discovery.refresh()
     assert set(refreshed) == {"alpha", "beta", "gamma"}
+
+
+def test_service_discovery_emits_cache_refresh_observability_signals(
+    clean_registry: object,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    service_discovery_signals: list[dict[str, object]],
+) -> None:
+    """Cache and refresh flows emit structured, queryable discovery signals."""
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.services.discover_plugins",
+        lambda plugin_type, auto_register: None,
+    )
+    _write_service_yaml(tmp_path, "alpha", "alpha")
+
+    discovery = ServiceDiscovery(services_dir=tmp_path)
+    first = discovery.discover()
+    assert set(first) == {"alpha"}
+
+    cached = discovery.discover()
+    assert cached is first
+
+    _write_service_yaml(tmp_path, "beta", "beta")
+    refreshed = discovery.discover(refresh=True)
+    assert set(refreshed) == {"alpha", "beta"}
+
+    events = [signal["event"] for signal in service_discovery_signals]
+    assert "service_discovery_cache_miss" in events
+    assert "service_discovery_cache_hit" in events
+    assert "service_discovery_refresh_requested" in events
+    assert "service_discovery_cache_cleared" in events
+    assert events.count("service_discovery_completed") == 2
+
+    cache_hit = next(
+        signal
+        for signal in service_discovery_signals
+        if signal["event"] == "service_discovery_cache_hit"
+    )
+    assert cache_hit["fields"]["service_count"] == 1
+    assert cache_hit["fields"]["services_dir"] == str(tmp_path)
+
+    refresh_requested = next(
+        signal
+        for signal in service_discovery_signals
+        if signal["event"] == "service_discovery_refresh_requested"
+    )
+    assert refresh_requested["fields"]["cached_service_count"] == 1
+    assert refresh_requested["fields"]["cache_loaded"] is True
+
+    completed = [
+        signal
+        for signal in service_discovery_signals
+        if signal["event"] == "service_discovery_completed"
+    ]
+    assert completed[0]["fields"]["plugin_service_count"] == 0
+    assert completed[0]["fields"]["file_service_count"] == 1
+    assert completed[1]["fields"]["file_service_count"] == 2
 
 
 def test_inline_service_creation() -> None:


### PR DESCRIPTION
## Summary
- emit structured plugin lifecycle observability events for initialize/cleanup success+failure paths in discovery registration
- emit service discovery refresh/cache observability events with queryable metadata for cache hit/miss, clear, and completion counts
- add lifecycle and service-discovery tests that assert emitted observability signal names and metadata fields

## Validation
- `uv run pytest tests/test_plugin_discovery_lifecycle.py tests/test_services_discovery.py`
- `make check`

Closes #234

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
