### PR TITLE
test: add core regression suite marker and command (#238)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev
 
+      - name: Run core regression suite
+        run: make test-core-regression
+
       - name: Run tests
         env:
           POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ CHECK_CMD := scripts/run-parallel \
 	"ts lint" "$(NPM_OBSERVATORY) run lint" \
 	"ts format" "$(NPM_OBSERVATORY) run format -- --check ." \
 	"ts typecheck" "$(NPM_OBSERVATORY) exec tsc -- -p $(OBSERVATORY_DIR)/tsconfig.json --noEmit"
+CORE_REGRESSION_TEST_PATHS ?= tests
+CORE_REGRESSION_PYTEST_ARGS ?= --tb=short
 
 # Docker Compose profiles
 PROFILE_CORE ?= postgres minio minio-setup dagster-webserver dagster-daemon hub
@@ -57,7 +59,7 @@ PROFILE_ALL ?= $(PROFILE_CORE) $(PROFILE_QUERY) $(PROFILE_BI) $(PROFILE_DOCS) $(
 	dagster-shell superset-shell postgres-shell minio-shell hub-shell trino-shell nessie-shell \
 	health-observability health-api health-catalog \
 	check lint lint-sql lint-python format-python typecheck-python \
-	lint-ts format-ts typecheck-ts fix-sql
+	lint-ts format-ts typecheck-ts test-core-regression fix-sql
 
 up:
 	$(COMPOSE) up -d $(SERVICE)
@@ -115,6 +117,9 @@ install-dagster:
 
 test:
 	uv run pytest
+
+test-core-regression:
+	uv run pytest $(CORE_REGRESSION_TEST_PATHS) -m core_regression $(CORE_REGRESSION_PYTEST_ARGS)
 
 dagster:
 	@open http://localhost:$${DAGSTER_PORT:-10006}

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -488,6 +488,12 @@ pytest tests/ -m "not integration" -v
 # Run only explicit unit marker tests
 pytest tests/ -m unit -v
 
+# Run focused core runtime regression suite
+make test-core-regression
+
+# Equivalent direct pytest invocation
+pytest tests/ -m core_regression -v
+
 # Run with verbose output
 pytest tests/ -v -s
 ```
@@ -855,6 +861,20 @@ name: Tests
 on: [push, pull_request]
 
 jobs:
+  core-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev]"
+      - name: Run focused core runtime regression checks
+        run: |
+          make test-core-regression CORE_REGRESSION_PYTEST_ARGS="--tb=short --cov=phlo --cov-report=term-missing"
+
   unit-tests:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ addopts = "--ignore=src --continue-on-collection-errors -m 'not integration'"
 markers = [
     "integration: marks tests as requiring external services or dbt manifest (run with '-m integration')",
     "unit: marks fast tests that do not require external services (run with '-m unit')",
+    "core_regression: marks high-signal core runtime regression checks (run with '-m core_regression')",
 ]
 filterwarnings = [
     # pyiceberg emits Pydantic v2.12 deprecations from @model_validator usage.

--- a/tests/test_capabilities_runtime.py
+++ b/tests/test_capabilities_runtime.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from phlo.capabilities import (
     CatalogSpec,
     QueryEngineSpec,
@@ -14,6 +16,8 @@ from phlo.capabilities import (
     resolve_capability,
 )
 from phlo.plugins.base import PluginMetadata
+
+pytestmark = pytest.mark.core_regression
 
 
 def teardown_function() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,11 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from phlo.config import Settings, _get_config
+
+pytestmark = pytest.mark.core_regression
 
 
 class TestConfigUnitTests:

--- a/tests/test_hook_bus.py
+++ b/tests/test_hook_bus.py
@@ -6,6 +6,8 @@ from phlo_testing.hooks import MockHookBus
 from phlo.hooks import QualityResultEvent
 from phlo.plugins.hooks import FailurePolicy, HookFilter, HookRegistration
 
+pytestmark = pytest.mark.core_regression
+
 
 def test_hook_bus_filters_and_ordering() -> None:
     """Verify hook execution order honors filters and priority."""

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -19,6 +19,8 @@ from phlo.logging import (
     suppress_log_routing,
 )
 
+pytestmark = pytest.mark.core_regression
+
 
 def _make_record(
     *,

--- a/tests/test_orchestrator_selection.py
+++ b/tests/test_orchestrator_selection.py
@@ -12,6 +12,8 @@ from phlo.config import _get_config
 from phlo.exceptions import PhloConfigError
 from phlo.orchestrators.selection import get_active_orchestrator
 
+pytestmark = pytest.mark.core_regression
+
 
 @pytest.fixture(autouse=True)
 def clear_settings_cache() -> None:

--- a/tests/test_plugin_discovery_lifecycle.py
+++ b/tests/test_plugin_discovery_lifecycle.py
@@ -9,6 +9,8 @@ import pytest
 from phlo.plugins import PluginMetadata, SourceConnectorPlugin, discover_plugins
 from phlo.plugins.discovery import get_global_registry
 
+pytestmark = pytest.mark.core_regression
+
 
 class _SettingsStub:
     """Test settings stub for plugin discovery."""

--- a/tests/test_plugin_system.py
+++ b/tests/test_plugin_system.py
@@ -30,6 +30,8 @@ from phlo.plugins import (
 )
 from phlo.plugins.discovery import get_global_registry
 
+pytestmark = pytest.mark.core_regression
+
 
 # Test plugins
 class DummySourcePlugin(SourceConnectorPlugin):

--- a/tests/test_services_discovery.py
+++ b/tests/test_services_discovery.py
@@ -7,6 +7,8 @@ import pytest
 from phlo.plugins import PluginMetadata, ServicePlugin
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery, get_global_registry
 
+pytestmark = pytest.mark.core_regression
+
 
 def _write_service_yaml(root: Path, folder: str, name: str) -> None:
     """Write a minimal service definition file for discovery tests."""


### PR DESCRIPTION
## Summary
- add `core_regression` pytest marker for focused core runtime checks
- tag high-signal core runtime test modules with `pytest.mark.core_regression`
- add `make test-core-regression` target for local/CI invocation
- document core-regression execution in testing docs
- run core-regression target in CI before full core test lane

## Validation
- `make test-core-regression`
- `make check`

Closes #238