### PR TITLE
chore: tune pre-commit hooks for repo baseline

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = *.lock,uv.lock,*.svg,*/package-lock.json,package-lock.json,*.min.js
+ignore-words-list = iterm,temperatur,coo,vew

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,10 +5,14 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: check-ast
+      - id: check-docstring-first
       - id: check-yaml
       - id: check-toml
       - id: check-json
+        exclude: (^|/)tsconfig(\..+)?\.json$
       - id: debug-statements
+      - id: detect-private-key
       - id: check-added-large-files
         args: ["--maxkb=1024"]
 
@@ -18,6 +22,42 @@ repos:
       - id: ruff
         args: ["--fix"]
       - id: ruff-format
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.28.0
+    hooks:
+      - id: gitleaks-docker
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args: ["-c", ".yamllint"]
+        files: ^(\.github/|packages/.+/src/.+/service\.yaml$|.*\.ya?ml$)
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        files: ^(scripts/.*|.*\.sh)$
+
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.14.0
+    hooks:
+      - id: hadolint-docker
+        args: ["--failure-threshold", "error"]
+        files: (^|/)(Dockerfile|.*\.Dockerfile)$
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        args: ["--config=.codespellrc"]
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.9.1
+    hooks:
+      - id: commitizen
 
   - repo: local
     hooks:
@@ -31,6 +71,12 @@ repos:
         entry: uv run sqlfluff lint
         language: system
         files: ^workflows/transforms/dbt/.*\.sql$
+      - id: sqlfluff-dbt-fix
+        name: sqlfluff fix (dbt models)
+        entry: uv run sqlfluff fix workflows/transforms/dbt
+        language: system
+        pass_filenames: false
+        stages: [manual]
       - id: ty-check
         name: ty check (repo scope)
         entry: uv run ty check src/phlo packages

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  document-start: disable
+  truthy: disable
+  comments: disable
+  comments-indentation: disable
+  line-length:
+    max: 140
+    level: warning


### PR DESCRIPTION
## Summary
- split `ada3a68` from `feat/prek` into standalone branch
- tune pre-commit baseline config in existing repo setup
- add `.codespellrc` and `.yamllint` config files

## Notes
- extracted from `feat/prek` because PR #254 head remains at `c4a25475`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
