### PR TITLE
refactor: consolidate utils and service dependency helpers

### DIFF
--- a/packages/phlo-openmetadata/src/phlo_openmetadata/openmetadata.py
+++ b/packages/phlo-openmetadata/src/phlo_openmetadata/openmetadata.py
@@ -44,7 +44,7 @@ class OpenMetadataColumn:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict, excluding None values."""
-        return {k: v for k, v in asdict(self).items() if v is not None}
+        return compact_dict(asdict(self))
 
 
 @dataclass(slots=True)
@@ -614,7 +614,7 @@ class OpenMetadataClient:
         }
         if parameter_definition is not None:
             data_new["parameterDefinition"] = parameter_definition
-        data_new = {k: v for k, v in data_new.items() if v is not None}
+        data_new = compact_dict(data_new)
 
         data_legacy: dict[str, Any] = {
             "name": sanitized_name,
@@ -624,7 +624,7 @@ class OpenMetadataClient:
         }
         if parameter_definition is not None:
             data_legacy["parameterDefinition"] = parameter_definition
-        data_legacy = {k: v for k, v in data_legacy.items() if v is not None}
+        data_legacy = compact_dict(data_legacy)
 
         try:
             return self._request_fallback(
@@ -667,7 +667,7 @@ class OpenMetadataClient:
             "basicEntityReference": table_fqn,
             "description": description,
         }
-        data = {k: v for k, v in data.items() if v is not None}
+        data = compact_dict(data)
         return self._request("POST", "/v1/dataQuality/testSuites", data=data)
 
     def ensure_test_suite(

--- a/packages/phlo-trino/src/phlo_trino/publishing.py
+++ b/packages/phlo-trino/src/phlo_trino/publishing.py
@@ -24,6 +24,7 @@ from phlo.hooks import (
 )
 from phlo.config.base import BaseConfig
 from phlo.logging import get_logger
+from phlo.utils import dedupe_preserve_order
 from pydantic import Field
 
 logger = get_logger(__name__)
@@ -325,14 +326,7 @@ def _trino_table_ref_candidates(name: str) -> list[str]:
         plain_schema_table = ".".join(part for part, _was_quoted in schema_table_parts)
         candidates.extend([quoted_schema_table, plain_schema_table])
 
-    deduped: list[str] = []
-    seen: set[str] = set()
-    for candidate in candidates:
-        if candidate in seen:
-            continue
-        seen.add(candidate)
-        deduped.append(candidate)
-    return deduped
+    return dedupe_preserve_order(candidates)
 
 
 def _describe_trino_table(trino: Any, source_table: str) -> tuple[list[tuple[str, str, str]], str]:

--- a/src/phlo/cli/commands/services/utils.py
+++ b/src/phlo/cli/commands/services/utils.py
@@ -13,6 +13,7 @@ import click
 from phlo.cli.infrastructure.command import run_command
 from phlo.cli.infrastructure.utils import _resolve_container_name
 from phlo.logging import get_logger
+from phlo.utils import dedupe_preserve_order
 
 logger = get_logger(__name__)
 
@@ -210,17 +211,8 @@ def _normalize_service_name_list(names: object) -> list[str]:
     if not isinstance(names, list):
         return []
 
-    normalized_names: list[str] = []
-    seen_names: set[str] = set()
-    for name in names:
-        if not isinstance(name, str):
-            continue
-        normalized_name = name.strip().lower()
-        if not normalized_name or normalized_name in seen_names:
-            continue
-        normalized_names.append(normalized_name)
-        seen_names.add(normalized_name)
-    return normalized_names
+    normalized = [name.strip().lower() for name in names if isinstance(name, str) and name.strip()]
+    return dedupe_preserve_order(normalized)
 
 
 def normalize_services_enabled_disabled_config(

--- a/src/phlo/plugins/discovery/_service_dependency_resolution.py
+++ b/src/phlo/plugins/discovery/_service_dependency_resolution.py
@@ -3,12 +3,22 @@
 from __future__ import annotations
 
 from collections import deque
+from typing import Protocol, TypeVar
 
 from phlo.plugins.discovery._service_cycles import find_cycles
-from phlo.plugins.discovery._service_definition import ServiceDefinition
 
 
-def resolve_service_dependencies(services: list[ServiceDefinition]) -> list[ServiceDefinition]:
+class _ServiceLike(Protocol):
+    """Structural type for service dependency resolution."""
+
+    name: str
+    depends_on: list[str]
+
+
+_ServiceT = TypeVar("_ServiceT", bound=_ServiceLike)
+
+
+def resolve_service_dependencies(services: list[_ServiceT]) -> list[_ServiceT]:
     """Resolve and sort services by dependencies (topological order)."""
     service_names = {service.name for service in services}
     graph: dict[str, set[str]] = {}

--- a/src/phlo/plugins/discovery/services.py
+++ b/src/phlo/plugins/discovery/services.py
@@ -4,8 +4,6 @@ Service Discovery Module
 Discovers and loads service definitions from installed plugins and optional directories.
 """
 
-from collections import deque
-from dataclasses import dataclass, field
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
@@ -14,6 +12,9 @@ import yaml
 
 from phlo.logging import get_logger, log_event
 from phlo.plugins.discovery import _service_loading
+from phlo.plugins.discovery._service_cycles import find_cycles as _find_cycles_impl
+from phlo.plugins.discovery._service_definition import ServiceDefinition
+from phlo.plugins.discovery._service_dependency_resolution import resolve_service_dependencies
 from phlo.plugins.discovery.registry import get_global_registry
 
 logger = get_logger(__name__)
@@ -47,187 +48,8 @@ def discover_plugins(plugin_type: str = "services", auto_register: bool = True):
 
 
 def _find_cycles(nodes: set[str], graph: dict[str, set[str]]) -> list[list[str]]:
-    """Extract closed dependency cycles from a graph subset.
-
-    ``graph`` is built as ``dependency -> dependents``. Convert that into
-    ``service -> dependencies`` first so cycle paths read in "depends-on"
-    order for user-facing diagnostics.
-    """
-    dependencies: dict[str, set[str]] = {name: set() for name in nodes}
-    for dependency, dependents in graph.items():
-        for dependent in dependents & nodes:
-            dependencies[dependent].add(dependency)
-
-    cycles: list[list[str]] = []
-    seen_signatures: set[tuple[str, ...]] = set()
-
-    for start in sorted(nodes):
-        cycle = _find_cycle_from_start(start, dependencies, nodes)
-        if not cycle:
-            continue
-        signature = _canonical_cycle(cycle[:-1])
-        if signature in seen_signatures:
-            continue
-        seen_signatures.add(signature)
-        cycles.append(cycle)
-
-    return cycles
-
-
-def _find_cycle_from_start(
-    start: str, dependencies: dict[str, set[str]], allowed: set[str]
-) -> list[str] | None:
-    stack: list[tuple[str, list[str], set[str]]] = [(start, [start], {start})]
-
-    while stack:
-        current, path, seen = stack.pop()
-        for dep in sorted(dependencies.get(current, set())):
-            if dep not in allowed:
-                continue
-            if dep == start and len(path) > 1:
-                return path + [start]
-            if dep in seen:
-                continue
-            stack.append((dep, path + [dep], seen | {dep}))
-
-    return None
-
-
-def _canonical_cycle(cycle_nodes: list[str]) -> tuple[str, ...]:
-    if not cycle_nodes:
-        return tuple()
-
-    rotations = [tuple(cycle_nodes[i:] + cycle_nodes[:i]) for i in range(len(cycle_nodes))]
-    reverse = list(reversed(cycle_nodes))
-    rotations_reverse = [tuple(reverse[i:] + reverse[:i]) for i in range(len(reverse))]
-    return min(rotations + rotations_reverse)
-
-
-@dataclass(slots=True)
-class ServiceDefinition:
-    """Represents a parsed service.yaml definition."""
-
-    name: str
-    description: str
-    category: str = "core"
-    version: str = "latest"
-    default: bool = False
-    profile: str | None = None
-    depends_on: list[str] = field(default_factory=list)
-    image: str | None = None
-    build: dict[str, Any] | None = None
-    compose: dict[str, Any] = field(default_factory=dict)
-    env_vars: dict[str, dict[str, Any]] = field(default_factory=dict)
-    files: list[dict[str, str]] = field(default_factory=list)
-    gitignore: list[str] = field(default_factory=list)
-    hooks: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
-    dev: dict[str, Any] = field(default_factory=dict)  # Dev mode config (subprocess or Docker)
-    source_path: Path | None = None
-    phlo_dev: bool = False  # Services that receive phlo source mount in dev mode
-    core: bool = False  # Core services bundled with phlo (not plugins)
-
-    @classmethod
-    def from_yaml(cls, path: Path) -> "ServiceDefinition":
-        """Load a service definition from a YAML file."""
-        with open(path) as f:
-            data = yaml.safe_load(f)
-
-        # Determine source_path: explicit value or default to yaml directory
-        if data.get("source_path"):
-            # Explicit source_path is relative to phlo package root
-            phlo_root = Path(__file__).parent.parent.parent.parent  # phlo repo root
-            source_path = phlo_root / data["source_path"]
-        else:
-            source_path = path.parent
-
-        return cls(
-            name=data["name"],
-            description=data["description"],
-            category=data.get("category", "core"),
-            version=data.get("version", "latest"),
-            default=data.get("default", False),
-            profile=data.get("profile"),
-            depends_on=data.get("depends_on", []),
-            image=data.get("image"),
-            build=data.get("build"),
-            compose=data.get("compose", {}),
-            env_vars=data.get("env_vars", {}),
-            files=data.get("files", []),
-            gitignore=data.get("gitignore", []),
-            hooks=data.get("hooks", {}),
-            dev=data.get("dev", {}),
-            source_path=source_path,
-            phlo_dev=data.get("phlo_dev", False),
-            core=data.get("core", False),
-        )
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any], source_path: Path | None) -> "ServiceDefinition":
-        """Load a service definition from a dictionary."""
-        return cls(
-            name=data["name"],
-            description=data.get("description", ""),
-            category=data.get("category", "core"),
-            version=data.get("version", "latest"),
-            default=data.get("default", False),
-            profile=data.get("profile"),
-            depends_on=data.get("depends_on", []),
-            image=data.get("image"),
-            build=data.get("build"),
-            compose=data.get("compose", {}),
-            env_vars=data.get("env_vars", {}),
-            files=data.get("files", []),
-            gitignore=data.get("gitignore", []),
-            hooks=data.get("hooks", {}),
-            dev=data.get("dev", {}),
-            source_path=source_path,
-            phlo_dev=data.get("phlo_dev", False),
-            core=data.get("core", False),
-        )
-
-    @classmethod
-    def from_inline(cls, name: str, config: dict[str, Any]) -> "ServiceDefinition":
-        """Create a ServiceDefinition from inline config in phlo.yaml.
-
-        Example phlo.yaml:
-            services:
-              custom-api:
-                type: inline
-                image: my-registry/api:latest
-                ports:
-                  - "4000:4000"
-                depends_on:
-                  - trino
-        """
-        # Build compose section from inline config
-        compose_keys = (
-            "user",
-            "container_name",
-            "labels",
-            "environment",
-            "ports",
-            "volumes",
-            "command",
-            "entrypoint",
-            "healthcheck",
-            "restart",
-            "mem_limit",
-            "mem_reservation",
-            "cpus",
-            "shm_size",
-        )
-        compose = {k: config[k] for k in compose_keys if k in config}
-
-        return cls(
-            name=name,
-            description=config.get("description", f"Custom service: {name}"),
-            category="custom",
-            default=True,  # Inline services are always included
-            depends_on=config.get("depends_on", []),
-            image=config.get("image"),
-            build=config.get("build"),
-            compose=compose,
-        )
+    """Compatibility wrapper around shared cycle-detection utilities."""
+    return _find_cycles_impl(nodes, graph)
 
 
 class ServiceDiscovery:
@@ -457,43 +279,7 @@ class ServiceDiscovery:
         """
         self.discover()
 
-        # Build dependency graph
-        service_names = {s.name for s in services}
-        graph: dict[str, set[str]] = {}
-        in_degree: dict[str, int] = {}
-
-        for service in services:
-            graph[service.name] = set()
-            in_degree[service.name] = 0
-
-        for service in services:
-            for dep in service.depends_on:
-                if dep in service_names:
-                    graph[dep].add(service.name)
-                    in_degree[service.name] += 1
-
-        # Kahn's algorithm for topological sort
-        queue = deque(name for name, degree in in_degree.items() if degree == 0)
-        result: list[str] = []
-
-        while queue:
-            node = queue.popleft()
-            result.append(node)
-
-            for neighbor in graph[node]:
-                in_degree[neighbor] -= 1
-                if in_degree[neighbor] == 0:
-                    queue.append(neighbor)
-
-        if len(result) != len(services):
-            remaining = set(in_degree.keys()) - set(result)
-            cycles = _find_cycles(remaining, graph)
-            cycle_detail = "; ".join(" → ".join(c) for c in cycles) if cycles else str(remaining)
-            raise ValueError(f"Circular dependency detected: {cycle_detail}")
-
-        # Return services in sorted order
-        name_to_service = {s.name: s for s in services}
-        return [name_to_service[name] for name in result]
+        return resolve_service_dependencies(services)
 
     def list_all(self) -> list[dict[str, Any]]:
         """List all services with their metadata.

--- a/src/phlo/utils.py
+++ b/src/phlo/utils.py
@@ -2,9 +2,24 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Iterable, Mapping
+from typing import Any, TypeVar
+
+_T = TypeVar("_T")
 
 
-def compact_dict(d: dict[str, Any]) -> dict[str, Any]:
+def compact_dict(d: Mapping[str, Any]) -> dict[str, Any]:
     """Remove None values from a dictionary."""
     return {k: v for k, v in d.items() if v is not None}
+
+
+def dedupe_preserve_order(values: Iterable[_T]) -> list[_T]:
+    """Return unique values in input order."""
+    seen: set[_T] = set()
+    deduped: list[_T] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped


### PR DESCRIPTION
## Summary
- expand `src/phlo/utils.py` with `dedupe_preserve_order` and broaden `compact_dict` input typing to `Mapping`
- consolidate duplicated service dependency/cycle logic by delegating `ServiceDiscovery.resolve_dependencies` to shared modules
- replace repeated `None`-filter comprehensions in OpenMetadata and Trino candidate dedupe with shared helpers

## Validation
- `uv run ruff check src/phlo/utils.py src/phlo/cli/commands/services/utils.py src/phlo/plugins/discovery/_service_dependency_resolution.py src/phlo/plugins/discovery/services.py packages/phlo-trino/src/phlo_trino/publishing.py packages/phlo-openmetadata/src/phlo_openmetadata/openmetadata.py`
- `uv run pytest tests/test_cli_services_discovery.py tests/test_services_discovery.py packages/phlo-openmetadata/tests packages/phlo-trino/tests/test_publishing.py -q`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
