### PR TITLE
feat: add column-level lineage tracking with dbt manifest parser

### DIFF
--- a/packages/phlo-lineage/src/phlo_lineage/__init__.py
+++ b/packages/phlo-lineage/src/phlo_lineage/__init__.py
@@ -1,10 +1,11 @@
 """Lineage tracking and visualization for Phlo assets."""
 
 from phlo_lineage.graph import LineageGraph, get_lineage_graph
-from phlo_lineage.store import LineageStore, generate_row_id
+from phlo_lineage.store import ColumnLineage, LineageStore, generate_row_id
 from phlo_lineage.settings import LineageSettings, get_settings
 
 __all__ = [
+    "ColumnLineage",
     "LineageGraph",
     "get_lineage_graph",
     "LineageStore",

--- a/packages/phlo-lineage/src/phlo_lineage/cli_lineage.py
+++ b/packages/phlo-lineage/src/phlo_lineage/cli_lineage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import Optional
@@ -9,6 +10,7 @@ from typing import Optional
 import click
 from rich.console import Console
 from rich.panel import Panel
+from rich.table import Table
 
 from phlo_lineage import get_lineage_graph
 
@@ -245,6 +247,122 @@ def lineage_status() -> None:
         console.print("\n[bold]Assets by Status:[/bold]")
         for status, count in sorted(status_counts.items()):
             console.print(f"  • {status}: {count}")
+
+
+@lineage_group.group(name="column")
+def column_group():
+    """Column-level lineage commands."""
+    pass
+
+
+@column_group.command(name="import-dbt")
+@click.option(
+    "--manifest",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="Path to dbt manifest.json",
+)
+def import_dbt(manifest: Path) -> None:
+    """Import column lineage from a dbt manifest.json.
+
+    Uses same-name heuristic matching between upstream and downstream
+    model columns.
+
+    Examples:
+        phlo lineage column import-dbt --manifest target/manifest.json
+    """
+    from phlo_lineage.dbt_column_lineage import extract_column_lineage
+    from phlo_lineage.store import LineageStore, resolve_lineage_db_url
+
+    with open(manifest) as f:
+        manifest_data = json.load(f)
+
+    mappings = extract_column_lineage(manifest_data)
+
+    if not mappings:
+        console.print("[yellow]⚠[/yellow]  No column lineage mappings found in manifest")
+        return
+
+    connection_string = resolve_lineage_db_url()
+    if not connection_string:
+        console.print("[red]✗[/red]  No lineage database configured")
+        return
+
+    store = LineageStore(connection_string)
+    count = store.record_column_lineage(mappings)
+    console.print(f"[green]✓[/green]  Imported {count} column lineage mapping(s)")
+
+
+@column_group.command(name="upstream")
+@click.argument("asset")
+@click.option("--column", default=None, help="Filter to a specific column")
+def column_upstream(asset: str, column: str | None) -> None:
+    """Show upstream column lineage for an asset.
+
+    Examples:
+        phlo lineage column upstream silver.stg_glucose
+        phlo lineage column upstream silver.stg_glucose --column glucose_value
+    """
+    from phlo_lineage.store import LineageStore, resolve_lineage_db_url
+
+    connection_string = resolve_lineage_db_url()
+    if not connection_string:
+        console.print("[red]✗[/red]  No lineage database configured")
+        return
+
+    store = LineageStore(connection_string)
+    results = store.get_upstream_columns(asset, target_column=column)
+
+    if not results:
+        console.print("[yellow]⚠[/yellow]  No upstream column lineage found")
+        return
+
+    table = Table(title=f"Upstream columns for {asset}")
+    table.add_column("Source Asset", style="cyan")
+    table.add_column("Source Column", style="green")
+    table.add_column("Target Column", style="green")
+    table.add_column("Source Type", style="dim")
+
+    for r in results:
+        table.add_row(r.source_asset, r.source_column, r.target_column, r.source_type)
+
+    console.print(table)
+
+
+@column_group.command(name="downstream")
+@click.argument("asset")
+@click.option("--column", default=None, help="Filter to a specific column")
+def column_downstream(asset: str, column: str | None) -> None:
+    """Show downstream column lineage for an asset.
+
+    Examples:
+        phlo lineage column downstream bronze.dlt_glucose
+        phlo lineage column downstream bronze.dlt_glucose --column glucose_value
+    """
+    from phlo_lineage.store import LineageStore, resolve_lineage_db_url
+
+    connection_string = resolve_lineage_db_url()
+    if not connection_string:
+        console.print("[red]✗[/red]  No lineage database configured")
+        return
+
+    store = LineageStore(connection_string)
+    results = store.get_downstream_columns(asset, source_column=column)
+
+    if not results:
+        console.print("[yellow]⚠[/yellow]  No downstream column lineage found")
+        return
+
+    table = Table(title=f"Downstream columns for {asset}")
+    table.add_column("Target Asset", style="cyan")
+    table.add_column("Target Column", style="green")
+    table.add_column("Source Column", style="green")
+    table.add_column("Source Type", style="dim")
+
+    for r in results:
+        table.add_row(r.target_asset, r.target_column, r.source_column, r.source_type)
+
+    console.print(table)
 
 
 if __name__ == "__main__":

--- a/packages/phlo-lineage/src/phlo_lineage/dbt_column_lineage.py
+++ b/packages/phlo-lineage/src/phlo_lineage/dbt_column_lineage.py
@@ -1,0 +1,107 @@
+"""Extract column-level lineage from dbt manifest.json.
+
+Uses same-name intersection heuristics — not full SQL parsing.
+Each mapping is tagged with source_type="dbt_heuristic" to signal this.
+
+Example:
+    >>> import json
+    >>> manifest = json.load(open("target/manifest.json"))
+    >>> mappings = extract_column_lineage(manifest)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from phlo.logging import get_logger
+from phlo_lineage.store import ColumnLineage
+
+logger = get_logger(__name__)
+
+
+def _resolve_asset_name(node: dict[str, Any]) -> str:
+    """Derive a qualified asset name from a dbt node.
+
+    Uses ``schema.alias`` when available, falling back to ``schema.name``.
+    """
+    schema = node.get("schema", "")
+    name = node.get("alias") or node.get("name", "")
+    return f"{schema}.{name}" if schema else name
+
+
+def _get_node_columns(node: dict[str, Any]) -> set[str]:
+    """Return the set of column names defined on a dbt node."""
+    columns: dict[str, Any] = node.get("columns", {})
+    return set(columns.keys())
+
+
+def extract_column_lineage(manifest: dict[str, Any]) -> list[ColumnLineage]:
+    """Extract column lineage from a dbt manifest using same-name heuristics.
+
+    For each dbt model node:
+    - Determine ``target_asset`` from node schema + alias/name.
+    - Collect ``target_columns`` from ``node["columns"]``.
+    - For each upstream node in ``depends_on["nodes"]``:
+        - Collect upstream columns.
+        - Create a ``ColumnLineage`` mapping for every column name that
+          appears in **both** the upstream and downstream node.
+
+    This is a heuristic: columns that share a name across an edge are
+    assumed to carry lineage.  The ``source_type`` field is set to
+    ``"dbt_heuristic"`` to make this explicit.
+
+    Args:
+        manifest: Parsed dbt ``manifest.json`` dict.
+
+    Returns:
+        List of ``ColumnLineage`` mappings.
+    """
+    nodes: dict[str, Any] = manifest.get("nodes", {})
+    mappings: list[ColumnLineage] = []
+
+    model_nodes = {key: node for key, node in nodes.items() if node.get("resource_type") == "model"}
+
+    logger.info(
+        "column_lineage_extraction_started",
+        model_count=len(model_nodes),
+    )
+
+    for node_key, node in model_nodes.items():
+        target_asset = _resolve_asset_name(node)
+        target_columns = _get_node_columns(node)
+
+        if not target_columns:
+            logger.debug(
+                "column_lineage_no_columns",
+                node_key=node_key,
+                target_asset=target_asset,
+            )
+            continue
+
+        upstream_keys: list[str] = node.get("depends_on", {}).get("nodes", [])
+
+        for upstream_key in upstream_keys:
+            upstream_node = nodes.get(upstream_key)
+            if upstream_node is None:
+                continue
+
+            source_asset = _resolve_asset_name(upstream_node)
+            source_columns = _get_node_columns(upstream_node)
+
+            shared = target_columns & source_columns
+            for col in sorted(shared):
+                mappings.append(
+                    ColumnLineage(
+                        source_asset=source_asset,
+                        source_column=col,
+                        target_asset=target_asset,
+                        target_column=col,
+                        source_type="dbt_heuristic",
+                    )
+                )
+
+    logger.info(
+        "column_lineage_extraction_completed",
+        mapping_count=len(mappings),
+    )
+    return mappings

--- a/packages/phlo-lineage/src/phlo_lineage/sql/002_create_column_lineage.sql
+++ b/packages/phlo-lineage/src/phlo_lineage/sql/002_create_column_lineage.sql
@@ -1,0 +1,18 @@
+-- Column-level lineage tracking
+CREATE TABLE IF NOT EXISTS phlo.column_lineage (
+    source_asset TEXT NOT NULL,
+    source_column TEXT NOT NULL,
+    target_asset TEXT NOT NULL,
+    target_column TEXT NOT NULL,
+    source_type TEXT NOT NULL DEFAULT 'dbt_heuristic',
+    metadata JSONB,
+    created_at TIMESTAMP DEFAULT NOW(),
+    PRIMARY KEY (source_asset, source_column, target_asset, target_column)
+);
+
+CREATE INDEX IF NOT EXISTS idx_column_lineage_target
+    ON phlo.column_lineage (target_asset, target_column);
+CREATE INDEX IF NOT EXISTS idx_column_lineage_source
+    ON phlo.column_lineage (source_asset, source_column);
+
+COMMENT ON TABLE phlo.column_lineage IS 'Tracks column-level lineage between assets';

--- a/packages/phlo-lineage/src/phlo_lineage/store.py
+++ b/packages/phlo-lineage/src/phlo_lineage/store.py
@@ -1,4 +1,4 @@
-"""Row-level lineage store for Phlo.
+"""Row-level and column-level lineage store for Phlo.
 
 Tracks individual row provenance across the data pipeline using ULIDs.
 Stores lineage metadata in PostgreSQL for deterministic querying.
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,19 @@ import ulid
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnLineage:
+    """A single column-to-column lineage mapping between two assets."""
+
+    source_asset: str
+    source_column: str
+    target_asset: str
+    target_column: str
+    source_type: str = "dbt_heuristic"
+    metadata: dict[str, Any] | None = None
+
 
 _LINEAGE_DB_KEYS = (
     "LINEAGE_DB_URL",
@@ -88,18 +102,21 @@ class LineageStore:
                 logger.warning("lineage_schema_init_failed", error=str(e))
 
     def setup_schema(self) -> None:
-        """Create the lineage schema and tables if they don't exist."""
-        sql_path = Path(__file__).parent / "sql" / "001_create_schema.sql"
+        """Create the lineage schema and tables if they don't exist.
 
-        with open(sql_path) as f:
-            schema_sql = f.read()
+        Executes all ``sql/*.sql`` files in sorted order to support
+        incremental schema migrations.
+        """
+        sql_dir = Path(__file__).parent / "sql"
+        sql_files = sorted(sql_dir.glob("*.sql"))
 
         with psycopg2.connect(self.connection_string) as conn:
             with conn.cursor() as cur:
-                cur.execute(schema_sql)
+                for sql_file in sql_files:
+                    cur.execute(sql_file.read_text())
             conn.commit()
 
-        logger.info("Lineage schema setup complete")
+        logger.info("lineage_schema_setup_complete", migration_count=len(sql_files))
 
     def record_row(
         self,
@@ -656,4 +673,165 @@ class LineageStore:
                 "metadata": row[5],
             }
             for row in rows
+        ]
+
+    # ------------------------------------------------------------------
+    # Column-level lineage
+    # ------------------------------------------------------------------
+
+    def record_column_lineage(self, mappings: list[ColumnLineage]) -> int:
+        """Batch-insert column lineage mappings.
+
+        Uses ``execute_values`` for efficiency.  Duplicate primary keys
+        are silently skipped (``ON CONFLICT DO NOTHING``).
+
+        Args:
+            mappings: Column lineage records to persist.
+
+        Returns:
+            Number of mappings submitted for insert.
+        """
+        if not mappings:
+            return 0
+
+        values = [
+            (
+                m.source_asset,
+                m.source_column,
+                m.target_asset,
+                m.target_column,
+                m.source_type,
+                json.dumps(m.metadata) if m.metadata else None,
+            )
+            for m in mappings
+        ]
+
+        logger.info("column_lineage_record_started", mapping_count=len(values))
+        try:
+            self._ensure_schema()
+            with psycopg2.connect(self.connection_string) as conn:
+                with conn.cursor() as cur:
+                    from psycopg2.extras import execute_values
+
+                    execute_values(
+                        cur,
+                        """
+                        INSERT INTO phlo.column_lineage
+                        (source_asset, source_column, target_asset, target_column,
+                         source_type, metadata)
+                        VALUES %s
+                        ON CONFLICT DO NOTHING
+                        """,
+                        values,
+                    )
+                conn.commit()
+            logger.info("column_lineage_record_succeeded", mapping_count=len(values))
+        except Exception:
+            logger.warning(
+                "column_lineage_record_failed",
+                mapping_count=len(values),
+                exc_info=True,
+            )
+            raise
+
+        return len(values)
+
+    def get_upstream_columns(
+        self,
+        target_asset: str,
+        target_column: str | None = None,
+    ) -> list[ColumnLineage]:
+        """Query upstream column lineage for a target asset.
+
+        Args:
+            target_asset: Asset key of the downstream asset.
+            target_column: Optional column name to narrow the query.
+
+        Returns:
+            List of ``ColumnLineage`` records.
+        """
+        self._ensure_schema()
+
+        if target_column is not None:
+            query = """
+                SELECT source_asset, source_column, target_asset, target_column,
+                       source_type, metadata
+                FROM phlo.column_lineage
+                WHERE target_asset = %s AND target_column = %s
+            """
+            params: tuple[str, ...] = (target_asset, target_column)
+        else:
+            query = """
+                SELECT source_asset, source_column, target_asset, target_column,
+                       source_type, metadata
+                FROM phlo.column_lineage
+                WHERE target_asset = %s
+            """
+            params = (target_asset,)
+
+        with psycopg2.connect(self.connection_string) as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, params)
+                rows = cur.fetchall()
+
+        return [
+            ColumnLineage(
+                source_asset=r[0],
+                source_column=r[1],
+                target_asset=r[2],
+                target_column=r[3],
+                source_type=r[4],
+                metadata=r[5],
+            )
+            for r in rows
+        ]
+
+    def get_downstream_columns(
+        self,
+        source_asset: str,
+        source_column: str | None = None,
+    ) -> list[ColumnLineage]:
+        """Query downstream column lineage for a source asset.
+
+        Args:
+            source_asset: Asset key of the upstream asset.
+            source_column: Optional column name to narrow the query.
+
+        Returns:
+            List of ``ColumnLineage`` records.
+        """
+        self._ensure_schema()
+
+        if source_column is not None:
+            query = """
+                SELECT source_asset, source_column, target_asset, target_column,
+                       source_type, metadata
+                FROM phlo.column_lineage
+                WHERE source_asset = %s AND source_column = %s
+            """
+            params: tuple[str, ...] = (source_asset, source_column)
+        else:
+            query = """
+                SELECT source_asset, source_column, target_asset, target_column,
+                       source_type, metadata
+                FROM phlo.column_lineage
+                WHERE source_asset = %s
+            """
+            params = (source_asset,)
+
+        with psycopg2.connect(self.connection_string) as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, params)
+                rows = cur.fetchall()
+
+        return [
+            ColumnLineage(
+                source_asset=r[0],
+                source_column=r[1],
+                target_asset=r[2],
+                target_column=r[3],
+                source_type=r[4],
+                metadata=r[5],
+            )
+            for r in rows
         ]

--- a/packages/phlo-lineage/tests/test_column_lineage.py
+++ b/packages/phlo-lineage/tests/test_column_lineage.py
@@ -1,0 +1,258 @@
+"""Tests for column-level lineage."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from phlo_lineage.dbt_column_lineage import extract_column_lineage
+from phlo_lineage.store import ColumnLineage, LineageStore
+
+
+# -------------------------------------------------------------------
+# ColumnLineage dataclass
+# -------------------------------------------------------------------
+
+
+class TestColumnLineageDataclass:
+    """Tests for the ColumnLineage frozen dataclass."""
+
+    def test_construction(self):
+        cl = ColumnLineage(
+            source_asset="bronze.raw_events",
+            source_column="user_id",
+            target_asset="silver.stg_events",
+            target_column="user_id",
+        )
+        assert cl.source_asset == "bronze.raw_events"
+        assert cl.source_column == "user_id"
+        assert cl.target_asset == "silver.stg_events"
+        assert cl.target_column == "user_id"
+        assert cl.source_type == "dbt_heuristic"
+        assert cl.metadata is None
+
+    def test_frozen(self):
+        cl = ColumnLineage(
+            source_asset="a",
+            source_column="b",
+            target_asset="c",
+            target_column="d",
+        )
+        with pytest.raises(AttributeError):
+            cl.source_asset = "x"  # type: ignore[misc]
+
+    def test_with_metadata(self):
+        cl = ColumnLineage(
+            source_asset="a",
+            source_column="b",
+            target_asset="c",
+            target_column="d",
+            metadata={"confidence": 0.9},
+        )
+        assert cl.metadata == {"confidence": 0.9}
+
+
+# -------------------------------------------------------------------
+# dbt manifest extraction
+# -------------------------------------------------------------------
+
+
+def _make_manifest(nodes: dict) -> dict:
+    return {"nodes": nodes}
+
+
+def _make_model_node(
+    *,
+    schema: str,
+    name: str,
+    columns: list[str],
+    depends_on_nodes: list[str] | None = None,
+    alias: str | None = None,
+) -> dict:
+    node: dict = {
+        "resource_type": "model",
+        "schema": schema,
+        "name": name,
+        "columns": {col: {"name": col} for col in columns},
+        "depends_on": {"nodes": depends_on_nodes or []},
+    }
+    if alias:
+        node["alias"] = alias
+    return node
+
+
+class TestExtractColumnLineageSameName:
+    """Two models sharing column names should produce mappings."""
+
+    def test_same_name_intersection(self):
+        manifest = _make_manifest(
+            {
+                "model.pkg.src_events": _make_model_node(
+                    schema="bronze",
+                    name="src_events",
+                    columns=["user_id", "event_type", "created_at"],
+                ),
+                "model.pkg.stg_events": _make_model_node(
+                    schema="silver",
+                    name="stg_events",
+                    columns=["user_id", "event_type", "processed_at"],
+                    depends_on_nodes=["model.pkg.src_events"],
+                ),
+            }
+        )
+        mappings = extract_column_lineage(manifest)
+
+        assert len(mappings) == 2
+        pairs = {(m.source_column, m.target_column) for m in mappings}
+        assert ("user_id", "user_id") in pairs
+        assert ("event_type", "event_type") in pairs
+
+        for m in mappings:
+            assert m.source_asset == "bronze.src_events"
+            assert m.target_asset == "silver.stg_events"
+            assert m.source_type == "dbt_heuristic"
+
+    def test_uses_alias_when_present(self):
+        manifest = _make_manifest(
+            {
+                "model.pkg.upstream": _make_model_node(
+                    schema="raw",
+                    name="upstream",
+                    columns=["id"],
+                    alias="raw_upstream",
+                ),
+                "model.pkg.downstream": _make_model_node(
+                    schema="staging",
+                    name="downstream",
+                    columns=["id"],
+                    depends_on_nodes=["model.pkg.upstream"],
+                ),
+            }
+        )
+        mappings = extract_column_lineage(manifest)
+        assert len(mappings) == 1
+        assert mappings[0].source_asset == "raw.raw_upstream"
+
+
+class TestExtractColumnLineageNoColumns:
+    """Model with no columns defined yields empty."""
+
+    def test_empty_columns(self):
+        manifest = _make_manifest(
+            {
+                "model.pkg.src": _make_model_node(schema="bronze", name="src", columns=["col_a"]),
+                "model.pkg.stg": _make_model_node(
+                    schema="silver",
+                    name="stg",
+                    columns=[],
+                    depends_on_nodes=["model.pkg.src"],
+                ),
+            }
+        )
+        assert extract_column_lineage(manifest) == []
+
+
+class TestExtractColumnLineageNoOverlap:
+    """No shared column names yields empty."""
+
+    def test_no_overlap(self):
+        manifest = _make_manifest(
+            {
+                "model.pkg.src": _make_model_node(
+                    schema="bronze", name="src", columns=["alpha", "beta"]
+                ),
+                "model.pkg.stg": _make_model_node(
+                    schema="silver",
+                    name="stg",
+                    columns=["gamma", "delta"],
+                    depends_on_nodes=["model.pkg.src"],
+                ),
+            }
+        )
+        assert extract_column_lineage(manifest) == []
+
+
+# -------------------------------------------------------------------
+# Store methods (mocked psycopg2)
+# -------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_pg():
+    """Provide a mocked psycopg2 connection + cursor."""
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn, mock_cursor
+
+
+class TestRecordColumnLineageMock:
+    """Verify batch insert SQL via mocked psycopg2."""
+
+    @patch("psycopg2.extras.execute_values")
+    @patch("phlo_lineage.store.psycopg2")
+    def test_batch_insert(self, mock_psycopg2, mock_execute_values, mock_pg):
+        mock_conn, mock_cursor = mock_pg
+        mock_psycopg2.connect.return_value = mock_conn
+
+        store = LineageStore("postgresql://test")
+        mappings = [
+            ColumnLineage(
+                source_asset="bronze.src",
+                source_column="id",
+                target_asset="silver.stg",
+                target_column="id",
+            ),
+        ]
+        count = store.record_column_lineage(mappings)
+
+        assert count == 1
+        sql = mock_execute_values.call_args[0][1]
+        assert "INSERT INTO phlo.column_lineage" in sql
+        assert "ON CONFLICT DO NOTHING" in sql
+
+    @patch("phlo_lineage.store.psycopg2")
+    def test_empty_returns_zero(self, mock_psycopg2):
+        store = LineageStore("postgresql://test")
+        assert store.record_column_lineage([]) == 0
+
+
+class TestGetUpstreamColumnsMock:
+    """Verify upstream query via mocked psycopg2."""
+
+    @patch("phlo_lineage.store.psycopg2")
+    def test_query_with_column(self, mock_psycopg2, mock_pg):
+        mock_conn, mock_cursor = mock_pg
+        mock_psycopg2.connect.return_value = mock_conn
+        mock_cursor.fetchall.return_value = [
+            ("bronze.src", "id", "silver.stg", "id", "dbt_heuristic", None),
+        ]
+
+        store = LineageStore("postgresql://test")
+        results = store.get_upstream_columns("silver.stg", target_column="id")
+
+        assert len(results) == 1
+        assert results[0].source_asset == "bronze.src"
+        assert results[0].source_column == "id"
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "target_asset" in sql
+        assert "target_column" in sql
+
+    @patch("phlo_lineage.store.psycopg2")
+    def test_query_without_column(self, mock_psycopg2, mock_pg):
+        mock_conn, mock_cursor = mock_pg
+        mock_psycopg2.connect.return_value = mock_conn
+        mock_cursor.fetchall.return_value = []
+
+        store = LineageStore("postgresql://test")
+        results = store.get_upstream_columns("silver.stg")
+
+        assert results == []
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "WHERE target_asset = %s" in sql
+        assert "target_column = %s" not in sql


### PR DESCRIPTION
## Summary

Adds column-to-column lineage tracking to phlo-lineage, completing the lineage story alongside existing row-level and asset-level tracking.

### Changes

**Schema** — `002_create_column_lineage.sql`:
- New `phlo.column_lineage` table with composite PK and indexes on source/target

**Store** — `store.py`:
- `ColumnLineage` dataclass for column mapping records
- `record_column_lineage()` — batch insert via `execute_values`
- `get_upstream_columns()` / `get_downstream_columns()` — query column lineage
- `setup_schema()` now executes all `sql/*.sql` files in sorted order

**dbt Parser** — `dbt_column_lineage.py`:
- `extract_column_lineage()` parses dbt `manifest.json` using same-name intersection heuristic
- Explicitly tagged as `source_type='dbt_heuristic'` to signal it's not full SQL parsing

**CLI** — `cli_lineage.py`:
- `phlo lineage column import-dbt --manifest PATH` — import from dbt manifest
- `phlo lineage column upstream ASSET [--column COL]` — show upstream columns
- `phlo lineage column downstream ASSET [--column COL]` — show downstream columns

### Testing
- 11 unit tests, all passing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
