### PR TITLE
chore: modernise Ruff rules

### DIFF
--- a/.github/scripts/publish_plan.py
+++ b/.github/scripts/publish_plan.py
@@ -115,8 +115,7 @@ def select_changed_packages(
 
         if (
             file == "pyproject.toml"
-            or file.startswith("src/phlo/")
-            or file.startswith("registry/")
+            or file.startswith(("src/phlo/", "registry/"))
             or file in {"README.md", "CHANGELOG.md"}
         ):
             changed_packages.add(root_name)
@@ -125,7 +124,7 @@ def select_changed_packages(
 
 
 def topo_sort(selected: set[str], dep_map: dict[str, list[str]]) -> list[str]:
-    in_deg = {name: 0 for name in selected}
+    in_deg = dict.fromkeys(selected, 0)
     dependents: dict[str, list[str]] = {name: [] for name in selected}
     for name in selected:
         for dep in dep_map.get(name, []):
@@ -175,7 +174,7 @@ def parse_target_packages(raw: str, available: set[str]) -> set[str]:
 
 
 def main() -> None:
-    root = Path(".")
+    root = Path()
     package_paths, package_meta = load_packages(root)
     internal = set(package_paths)
 
@@ -208,8 +207,8 @@ def main() -> None:
         "dry_run": "true" if dry_run else "false",
     }
 
-    output_path = os.environ["GITHUB_OUTPUT"]
-    with open(output_path, "a", encoding="utf-8") as fh:
+    output_path = Path(os.environ["GITHUB_OUTPUT"])
+    with output_path.open("a", encoding="utf-8") as fh:
         for key, value in outputs.items():
             fh.write(f"{key}={value}\n")
 

--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,8 @@ os.environ["DAGSTER_TELEMETRY_ENABLED"] = "False"
 os.environ["DAGSTER_DISABLE_TELEMETRY"] = "True"
 os.environ["DO_NOT_TRACK"] = "1"  # General standard
 
+import contextlib
+
 import pytest
 
 # Add src to path for imports
@@ -172,10 +174,8 @@ def iceberg_catalog(minio_service, tmp_path):
             secret=minio_service.secret_key,
             client_kwargs={"region_name": "us-east-1"},
         )
-        try:
+        with contextlib.suppress(FileExistsError):
             fs.mkdir("warehouse")
-        except FileExistsError:
-            pass
     else:
         (tmp_path / "warehouse").mkdir(exist_ok=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ line-length = 100
 target-version = "py311"
 
 [tool.ruff.lint]
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "UP", "SIM", "RET", "C4", "PIE", "B", "DTZ", "PTH"]
 ignore = ["E501"]  # Line too long - let the formatter handle this
 
 [tool.ty.src]

--- a/scripts/run_golden_path.py
+++ b/scripts/run_golden_path.py
@@ -31,7 +31,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import date, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -531,7 +531,7 @@ def http_get_basic(
     timeout: int = 30,
 ) -> dict | list | str:
     """Make an HTTP GET request with basic auth."""
-    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    token = base64.b64encode(f"{username}:{password}".encode()).decode("ascii")
     headers = {"Authorization": f"Basic {token}"}
     return http_get(url, headers=headers, timeout=timeout)
 
@@ -1143,7 +1143,9 @@ def main() -> int:
         if not wait_for_tcp("127.0.0.1", nessie_port, name="Nessie", timeout=120):
             return 1
 
-        partition_date = args.partition_date or (date.today() - timedelta(days=1)).isoformat()
+        partition_date = (
+            args.partition_date or (datetime.now(UTC).date() - timedelta(days=1)).isoformat()
+        )
         log_info(f"Using partition date: {partition_date}")
 
         # Step 5: Run DLT ingestion

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -110,7 +110,7 @@ class GovernanceBackend(Protocol):
         """List access policies, optionally filtered by table."""
         ...
 
-    def apply_policy(self, *, policy: "AccessPolicy") -> None:
+    def apply_policy(self, *, policy: AccessPolicy) -> None:
         """Apply an access policy to the backend."""
         ...
 

--- a/src/phlo/capabilities/specs.py
+++ b/src/phlo/capabilities/specs.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import date
-from typing import Any, Callable, Iterable
+from typing import Any
 
 from phlo.capabilities.runtime import RuntimeContext
 
@@ -22,7 +23,7 @@ class PartitionSpec:
 class RunSpec:
     """Execution details for an asset."""
 
-    fn: Callable[[RuntimeContext], Iterable["RunResult"]]
+    fn: Callable[[RuntimeContext], Iterable[RunResult]]
     max_runtime_seconds: int | None = None
     max_retries: int | None = None
     retry_delay_seconds: int | None = None
@@ -36,7 +37,7 @@ class AssetCheckSpec:
 
     name: str
     asset_key: str
-    fn: Callable[[RuntimeContext], "CheckResult"] | None = None
+    fn: Callable[[RuntimeContext], CheckResult] | None = None
     blocking: bool = True
     description: str | None = None
     severity: str | None = None

--- a/src/phlo/cli/commands/migrate.py
+++ b/src/phlo/cli/commands/migrate.py
@@ -128,10 +128,7 @@ def status(limit: int, fmt: str) -> None:
     for entry in entries:
         raw_metadata = entry.get("metadata")
         metadata: dict[str, object]
-        if isinstance(raw_metadata, dict):
-            metadata = raw_metadata
-        else:
-            metadata = {}
+        metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
         table.add_row(
             str(entry.get("name", "")),
             str(entry.get("status", "")),

--- a/src/phlo/cli/commands/plugin/__init__.py
+++ b/src/phlo/cli/commands/plugin/__init__.py
@@ -16,7 +16,6 @@ from phlo.cli.commands.plugin.update import update_cmd
 @click.group(name="plugin")
 def plugin_group():
     """Manage Phlo plugins."""
-    pass
 
 
 # Register commands

--- a/src/phlo/cli/commands/plugin/create.py
+++ b/src/phlo/cli/commands/plugin/create.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 
@@ -44,7 +43,7 @@ logger = get_logger(__name__)
     type=click.Path(),
     help="Path for new plugin package (default: ./phlo-plugin-{name})",
 )
-def create_cmd(plugin_name: str, plugin_type: str, path: Optional[str]):
+def create_cmd(plugin_name: str, plugin_type: str, path: str | None):
     """Create scaffolding for a new plugin.
 
     Examples:

--- a/src/phlo/cli/commands/schema_migrate.py
+++ b/src/phlo/cli/commands/schema_migrate.py
@@ -12,7 +12,7 @@ import json
 import os
 import sys
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -249,7 +249,7 @@ def export_contract_for_table(
     """Export a schema contract for a table and return output path."""
     migrator, desired, native_schema = _resolve_desired_schema(table_name, schema_class)
     migration_plan = migrator.diff_schema(table_name=table_name, desired=desired)
-    now = datetime.now(timezone.utc).isoformat()
+    now = datetime.now(UTC).isoformat()
 
     contract = {
         "contract_version": schema_migrate_contracts.CONTRACT_VERSION,
@@ -666,7 +666,7 @@ def _build_scaffold_payload_from_contract(
         table_name=table_name,
         contract=contract,
         migration_plan=migration_plan,
-        generated_at=datetime.now(timezone.utc).isoformat(),
+        generated_at=datetime.now(UTC).isoformat(),
     )
 
 

--- a/src/phlo/cli/commands/schema_migrate_contracts.py
+++ b/src/phlo/cli/commands/schema_migrate_contracts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -43,11 +43,11 @@ def list_recent_contract_paths(
     if not contracts_dir.exists():
         return []
 
-    cutoff = datetime.now(timezone.utc) - timedelta(hours=since_hours)
+    cutoff = datetime.now(UTC) - timedelta(hours=since_hours)
     candidates: list[tuple[float, Path]] = []
     for path in contracts_dir.glob("*.json"):
         mtime = path.stat().st_mtime
-        if datetime.fromtimestamp(mtime, tz=timezone.utc) >= cutoff:
+        if datetime.fromtimestamp(mtime, tz=UTC) >= cutoff:
             candidates.append((mtime, path))
 
     ordered = [path for _, path in sorted(candidates, key=lambda item: item[0], reverse=True)]

--- a/src/phlo/cli/commands/schema_registry_cli.py
+++ b/src/phlo/cli/commands/schema_registry_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import click
 from rich.console import Console
@@ -53,7 +54,7 @@ def snapshot(table: str, schema_file: str, run_id: str | None, source: str) -> N
     """Snapshot a schema from a JSON file into the registry."""
     db_url = _require_registry_db_url()
 
-    with open(schema_file) as f:
+    with Path(schema_file).open() as f:
         schema = deserialize_schema(f.read())
 
     registry = SchemaRegistry(db_url)

--- a/src/phlo/cli/commands/services/__init__.py
+++ b/src/phlo/cli/commands/services/__init__.py
@@ -19,7 +19,6 @@ from phlo.cli.commands.services.stop import stop_cmd
 @click.group(name="services")
 def services_group():
     """Manage Phlo infrastructure services (Docker)."""
-    pass
 
 
 # Register all commands

--- a/src/phlo/cli/commands/services/add.py
+++ b/src/phlo/cli/commands/services/add.py
@@ -49,7 +49,7 @@ def add_cmd(service_name: str, no_start: bool):
 
     # Load project config
     if config_file.exists():
-        with open(config_file) as f:
+        with config_file.open() as f:
             config = yaml.safe_load(f) or {}
         if not isinstance(config, dict):
             logger.error("services_add_invalid_config_mapping", config_file=str(config_file))
@@ -103,7 +103,7 @@ def add_cmd(service_name: str, no_start: bool):
     normalize_services_enabled_disabled_config(config)
 
     # Write updated config
-    with open(config_file, "w") as f:
+    with config_file.open("w") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
 
     click.echo(f"Added '{service_name}' to phlo.yaml")

--- a/src/phlo/cli/commands/services/init.py
+++ b/src/phlo/cli/commands/services/init.py
@@ -97,11 +97,10 @@ def init_cmd(
 
     # Auto-enable dev mode if we can detect a local Phlo checkout and the user didn't opt out.
     phlo_src_path: str | None = None
-    if not dev and not no_dev and not phlo_source:
-        if detected := detect_phlo_source_path():
-            dev = True
-            phlo_src_path = detected
-            click.echo(f"Dev mode: auto-enabled (path: {phlo_src_path})")
+    if not dev and not no_dev and not phlo_source and (detected := detect_phlo_source_path()):
+        dev = True
+        phlo_src_path = detected
+        click.echo(f"Dev mode: auto-enabled (path: {phlo_src_path})")
 
     # Derive project name from directory if not specified
     if not project_name:
@@ -167,7 +166,7 @@ def init_cmd(
     # Load existing phlo.yaml config for user overrides
     existing_config = {}
     if config_file.exists():
-        with open(config_file) as f:
+        with config_file.open() as f:
             existing_config = yaml.safe_load(f) or {}
     user_overrides = existing_config.get("services", {})
     env_overrides = _get_env_overrides(existing_config)

--- a/src/phlo/cli/commands/services/list.py
+++ b/src/phlo/cli/commands/services/list.py
@@ -51,7 +51,7 @@ def list_cmd(show_all: bool, output_json: bool):
     )
     if config_file.exists():
         try:
-            with open(config_file) as f:
+            with config_file.open() as f:
                 existing_config = yaml.safe_load(f) or {}
                 if not isinstance(existing_config, dict):
                     raise click.ClickException(f"{config_file} must contain a top-level mapping.")

--- a/src/phlo/cli/commands/services/logs.py
+++ b/src/phlo/cli/commands/services/logs.py
@@ -2,7 +2,6 @@
 
 import sys
 from subprocess import TimeoutExpired
-from typing import Optional
 
 import click
 
@@ -19,7 +18,7 @@ logger = get_logger(__name__)
 @click.argument("service", required=False)
 @click.option("-f", "--follow", is_flag=True, help="Follow log output")
 @click.option("-n", "--tail", default=100, help="Number of lines to show")
-def logs_cmd(service: Optional[str], follow: bool, tail: int):
+def logs_cmd(service: str | None, follow: bool, tail: int):
     """View logs from Phlo infrastructure services.
 
     Examples:
@@ -88,4 +87,3 @@ def logs_cmd(service: Optional[str], follow: bool, tail: int):
             project_name=project_name,
             service_name=service,
         )
-        pass

--- a/src/phlo/cli/commands/services/remove.py
+++ b/src/phlo/cli/commands/services/remove.py
@@ -49,7 +49,7 @@ def remove_cmd(service_name: str, keep_running: bool):
 
     # Load project config
     if config_file.exists():
-        with open(config_file) as f:
+        with config_file.open() as f:
             config = yaml.safe_load(f) or {}
     else:
         logger.error("services_remove_missing_config", config_file=str(config_file))
@@ -125,7 +125,7 @@ def remove_cmd(service_name: str, keep_running: bool):
     normalize_services_enabled_disabled_config(config)
 
     # Write updated config
-    with open(config_file, "w") as f:
+    with config_file.open("w") as f:
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
     logger.info("services_remove_config_updated", service_name=service_name)
 

--- a/src/phlo/cli/commands/services/start.py
+++ b/src/phlo/cli/commands/services/start.py
@@ -552,7 +552,7 @@ def start_cmd(
         logger.error("services_start_docker_not_found", project_name=project_name, exc_info=True)
         raise click.ClickException(
             "docker command not found. Install Docker: https://docs.docker.com/get-docker/"
-        )
+        ) from None
     except (subprocess.SubprocessError, OSError) as exc:
         logger.error(
             "services_start_unexpected_error",

--- a/src/phlo/cli/commands/services/utils.py
+++ b/src/phlo/cli/commands/services/utils.py
@@ -116,9 +116,8 @@ def detect_phlo_source_path() -> str | None:
     """
     # Strategy 1: Environment variable
     env_path = os.environ.get("PHLO_DEV_SOURCE")
-    if env_path:
-        if resolved := resolve_phlo_package_dir(Path(env_path)):
-            return relpath_from_phlo_dir(resolved)
+    if env_path and (resolved := resolve_phlo_package_dir(Path(env_path))):
+        return relpath_from_phlo_dir(resolved)
 
     # Strategy 2: Common directory patterns
     candidates: list[Path] = []
@@ -508,7 +507,7 @@ def _load_native_state(project_root: Path) -> dict[str, dict]:
     if not path.exists():
         return {}
     try:
-        with open(path) as f:
+        with path.open() as f:
             return json.load(f) or {}
     except (json.JSONDecodeError, OSError) as e:
         click.echo(f"Warning: Failed to read native state file {path}: {e}", err=True)

--- a/src/phlo/cli/config.py
+++ b/src/phlo/cli/config.py
@@ -26,7 +26,6 @@ logger = get_logger(__name__)
 @click.group()
 def config():
     """Manage infrastructure configuration."""
-    pass
 
 
 @config.command("show")
@@ -80,7 +79,7 @@ def validate():
 
     console.print(f"Validating: {config_path}\n")
 
-    with open(config_path) as f:
+    with config_path.open() as f:
         project_config = yaml.safe_load(f)
 
     if not project_config:
@@ -164,7 +163,7 @@ def upgrade(force: bool):
         error_console.print("Run [cyan]phlo services init[/cyan] to create a new project")
         sys.exit(1)
 
-    with open(config_path) as f:
+    with config_path.open() as f:
         project_config = yaml.safe_load(f) or {}
 
     if "infrastructure" in project_config and not force:
@@ -178,7 +177,7 @@ def upgrade(force: bool):
     default_infra = InfrastructureConfig()
     project_config["infrastructure"] = default_infra.model_dump(exclude_none=False, mode="python")
 
-    with open(config_path, "w") as f:
+    with config_path.open("w") as f:
         yaml.dump(
             project_config,
             f,

--- a/src/phlo/cli/env.py
+++ b/src/phlo/cli/env.py
@@ -99,7 +99,7 @@ def _load_project_config() -> dict[str, Any]:
     if not config_path.exists():
         return {}
     try:
-        with open(config_path) as f:
+        with config_path.open() as f:
             return yaml.safe_load(f) or {}
     except (OSError, yaml.YAMLError):
         logger.warning("env_export_config_load_failed", path=str(config_path), exc_info=True)

--- a/src/phlo/cli/infrastructure/command.py
+++ b/src/phlo/cli/infrastructure/command.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from subprocess import CompletedProcess
-from typing import Mapping, Sequence
 
 from phlo.logging import get_logger
 

--- a/src/phlo/cli/infrastructure/compose.py
+++ b/src/phlo/cli/infrastructure/compose.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 
 def compose_base_cmd(

--- a/src/phlo/cli/infrastructure/utils.py
+++ b/src/phlo/cli/infrastructure/utils.py
@@ -33,7 +33,7 @@ def get_project_config() -> dict:
     config_path = Path.cwd() / "phlo.yaml"
     if config_path.exists():
         try:
-            with open(config_path) as f:
+            with config_path.open() as f:
                 config = yaml.safe_load(f) or {}
                 if isinstance(config, Mapping):
                     return dict(config)

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 import click
 
@@ -80,11 +79,11 @@ _load_cli_plugin_commands()
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
 @click.option("-m", "--marker", help="Run tests with specific pytest marker")
 def test(
-    asset_name: Optional[str],
+    asset_name: str | None,
     local: bool,
     coverage: bool,
     verbose: bool,
-    marker: Optional[str],
+    marker: str | None,
 ):
     """
     Run tests for Phlo workflows.
@@ -150,7 +149,7 @@ def test(
     help="Project template to use",
 )
 @click.option("--force", is_flag=True, help="Initialize in non-empty directory")
-def init(project_name: Optional[str], template: str, force: bool):
+def init(project_name: str | None, template: str, force: bool):
     """
     Initialize a new Phlo project.
 

--- a/src/phlo/config_schema.py
+++ b/src/phlo/config_schema.py
@@ -6,7 +6,7 @@ Pydantic models for phlo.yaml infrastructure section.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -33,41 +33,41 @@ class ServiceOverride(BaseModel):
         default=True,
         description="Whether to include this service. Set to false to disable.",
     )
-    ports: Optional[list[str]] = Field(
+    ports: list[str] | None = Field(
         default=None,
         description="Port mappings to override (replaces package defaults).",
     )
-    environment: Optional[dict[str, str]] = Field(
+    environment: dict[str, str] | None = Field(
         default=None,
         description="Environment variables to add/override (merged with package defaults).",
     )
-    volumes: Optional[list[str]] = Field(
+    volumes: list[str] | None = Field(
         default=None,
         description="Volume mounts to add (appended to package defaults).",
     )
-    depends_on: Optional[list[str]] = Field(
+    depends_on: list[str] | None = Field(
         default=None,
         description="Service dependencies to override (replaces package defaults).",
     )
-    command: Optional[str | list[str]] = Field(
+    command: str | list[str] | None = Field(
         default=None,
         description="Container command override.",
     )
 
     # For inline custom services (type: inline)
-    type: Optional[str] = Field(
+    type: str | None = Field(
         default=None,
         description="Service type. Set to 'inline' for custom services defined in phlo.yaml.",
     )
-    image: Optional[str] = Field(
+    image: str | None = Field(
         default=None,
         description="Docker image for inline services.",
     )
-    build: Optional[dict[str, Any]] = Field(
+    build: dict[str, Any] | None = Field(
         default=None,
         description="Build configuration for inline services.",
     )
-    healthcheck: Optional[dict[str, Any]] = Field(
+    healthcheck: dict[str, Any] | None = Field(
         default=None,
         description="Healthcheck configuration for inline services.",
     )
@@ -76,25 +76,25 @@ class ServiceOverride(BaseModel):
 class ServiceConfig(BaseModel):
     """Configuration for a single service."""
 
-    container_name: Optional[str] = Field(
+    container_name: str | None = Field(
         default=None,
         description="Explicit container name override. If None, uses container_naming_pattern.",
     )
     service_name: str = Field(
         description="Docker compose service name (e.g., 'dagster-webserver', 'postgres')"
     )
-    host: Optional[str] = Field(
+    host: str | None = Field(
         default="localhost",
         description="External hostname for accessing the service",
     )
-    internal_host: Optional[str] = Field(
+    internal_host: str | None = Field(
         default=None,
         description="Internal Docker network hostname. If None, uses service_name.",
     )
 
     @field_validator("container_name")
     @classmethod
-    def validate_container_name(cls, v: Optional[str]) -> Optional[str]:
+    def validate_container_name(cls, v: str | None) -> str | None:
         """Validate `container_name` characters and format.
 
         Args:
@@ -155,7 +155,7 @@ class ServiceConfig(BaseModel):
 class NetworkConfig(BaseModel):
     """Docker network configuration."""
 
-    name: Optional[str] = Field(
+    name: str | None = Field(
         default=None,
         description="Network name. If None, uses docker compose default.",
     )
@@ -203,11 +203,11 @@ class InfrastructureConfig(BaseModel):
             )
         return v
 
-    def get_service(self, service_key: str) -> Optional[ServiceConfig]:
+    def get_service(self, service_key: str) -> ServiceConfig | None:
         """Get service configuration by key."""
         return self.services.get(service_key)
 
-    def get_container_name(self, service_key: str, project_name: str) -> Optional[str]:
+    def get_container_name(self, service_key: str, project_name: str) -> str | None:
         """Get container name for a service."""
         service = self.get_service(service_key)
         if not service:

--- a/src/phlo/exceptions.py
+++ b/src/phlo/exceptions.py
@@ -5,7 +5,6 @@ Structured error classes with error codes, contextual messages, and suggestions.
 """
 
 from enum import Enum
-from typing import List, Optional
 
 
 class PhloErrorCode(Enum):
@@ -62,8 +61,8 @@ class PhloError(Exception):
         self,
         message: str,
         code: PhloErrorCode,
-        suggestions: Optional[List[str]] = None,
-        cause: Optional[Exception] = None,
+        suggestions: list[str] | None = None,
+        cause: Exception | None = None,
     ):
         """
         Initialize PhloError.
@@ -113,7 +112,7 @@ class PhloError(Exception):
 class PhloDiscoveryError(PhloError):
     """Raised when assets cannot be discovered by Dagster."""
 
-    def __init__(self, message: str, suggestions: Optional[List[str]] = None):
+    def __init__(self, message: str, suggestions: list[str] | None = None):
         """Initialize a discovery error.
 
         Args:
@@ -130,7 +129,7 @@ class PhloDiscoveryError(PhloError):
 class PhloSchemaError(PhloError):
     """Raised when schema configuration is invalid."""
 
-    def __init__(self, message: str, suggestions: Optional[List[str]] = None):
+    def __init__(self, message: str, suggestions: list[str] | None = None):
         """Initialize a schema error.
 
         Args:
@@ -147,7 +146,7 @@ class PhloSchemaError(PhloError):
 class PhloCronError(PhloError):
     """Raised when cron expression is invalid."""
 
-    def __init__(self, message: str, suggestions: Optional[List[str]] = None):
+    def __init__(self, message: str, suggestions: list[str] | None = None):
         """Initialize a cron expression error.
 
         Args:
@@ -172,8 +171,8 @@ class PhloValidationError(PhloError):
     def __init__(
         self,
         message: str,
-        suggestions: Optional[List[str]] = None,
-        cause: Optional[Exception] = None,
+        suggestions: list[str] | None = None,
+        cause: Exception | None = None,
     ):
         """Initialize a validation error.
 
@@ -193,7 +192,7 @@ class PhloValidationError(PhloError):
 class PhloConfigError(PhloError):
     """Raised when decorator configuration is invalid."""
 
-    def __init__(self, message: str, suggestions: Optional[List[str]] = None):
+    def __init__(self, message: str, suggestions: list[str] | None = None):
         """Initialize a configuration error.
 
         Args:
@@ -213,8 +212,8 @@ class PhloIngestionError(PhloError):
     def __init__(
         self,
         message: str,
-        suggestions: Optional[List[str]] = None,
-        cause: Optional[Exception] = None,
+        suggestions: list[str] | None = None,
+        cause: Exception | None = None,
     ):
         """Initialize an ingestion error.
 
@@ -234,7 +233,7 @@ class PhloIngestionError(PhloError):
 class PhloTableError(PhloError):
     """Raised when Iceberg table operations fail."""
 
-    def __init__(self, message: str, suggestions: Optional[List[str]] = None):
+    def __init__(self, message: str, suggestions: list[str] | None = None):
         """Initialize a table operation error.
 
         Args:
@@ -254,8 +253,8 @@ class PhloInfrastructureError(PhloError):
     def __init__(
         self,
         message: str,
-        suggestions: Optional[List[str]] = None,
-        cause: Optional[Exception] = None,
+        suggestions: list[str] | None = None,
+        cause: Exception | None = None,
     ):
         """Initialize an infrastructure error.
 
@@ -275,7 +274,7 @@ class PhloInfrastructureError(PhloError):
 class SchemaConversionError(PhloError):
     """Raised when Pandera schema cannot be converted to PyIceberg."""
 
-    def __init__(self, message: str, suggestions: Optional[List[str]] = None):
+    def __init__(self, message: str, suggestions: list[str] | None = None):
         """Initialize a schema conversion error.
 
         Args:
@@ -295,8 +294,8 @@ class DLTPipelineError(PhloError):
     def __init__(
         self,
         message: str,
-        suggestions: Optional[List[str]] = None,
-        cause: Optional[Exception] = None,
+        suggestions: list[str] | None = None,
+        cause: Exception | None = None,
     ):
         """Initialize a DLT pipeline error.
 
@@ -319,8 +318,8 @@ class IcebergCatalogError(PhloError):
     def __init__(
         self,
         message: str,
-        suggestions: Optional[List[str]] = None,
-        cause: Optional[Exception] = None,
+        suggestions: list[str] | None = None,
+        cause: Exception | None = None,
     ):
         """Initialize an Iceberg catalog error.
 
@@ -342,9 +341,9 @@ class IcebergCatalogError(PhloError):
 
 def suggest_similar_field_names(
     invalid_field: str,
-    valid_fields: List[str],
+    valid_fields: list[str],
     max_suggestions: int = 3,
-) -> List[str]:
+) -> list[str]:
     """
     Generate "Did you mean?" suggestions for field name typos.
 
@@ -372,6 +371,6 @@ def suggest_similar_field_names(
     return [f"Available fields: {', '.join(valid_fields)}"]
 
 
-def format_field_list(fields: List[str]) -> str:
+def format_field_list(fields: list[str]) -> str:
     """Format a list of fields for error messages."""
     return ", ".join(f"'{field}'" for field in fields)

--- a/src/phlo/hooks/bus.py
+++ b/src/phlo/hooks/bus.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Iterable
+from typing import Any
 
 from phlo.hooks.events import HookEvent
 from phlo.logging import get_logger
@@ -195,9 +196,9 @@ class HookBus:
             event_asset_keys = _event_asset_keys(event)
             if not event_asset_keys or not filters.asset_keys.intersection(event_asset_keys):
                 return False
-        if filters.tags and not all(event.tags.get(k) == v for k, v in filters.tags.items()):
-            return False
-        return True
+        return not (
+            filters.tags and not all(event.tags.get(k) == v for k, v in filters.tags.items())
+        )
 
 
 def _event_asset_keys(event: HookEvent) -> set[str]:

--- a/src/phlo/hooks/events.py
+++ b/src/phlo/hooks/events.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 EVENT_VERSION = "1.0"
@@ -12,7 +12,7 @@ EVENT_VERSION = "1.0"
 def _utc_now() -> datetime:
     """Return the current UTC timestamp."""
 
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 @dataclass(kw_only=True)

--- a/src/phlo/infrastructure/config.py
+++ b/src/phlo/infrastructure/config.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import time
 from functools import lru_cache
 from pathlib import Path
-from typing import Optional
 
 import yaml
 from pydantic import ValidationError
@@ -21,7 +20,7 @@ logger = get_logger(__name__)
 
 
 @lru_cache(maxsize=1)
-def load_infrastructure_config(project_root: Optional[Path] = None) -> InfrastructureConfig:
+def load_infrastructure_config(project_root: Path | None = None) -> InfrastructureConfig:
     """Load infrastructure configuration from phlo.yaml."""
     started = time.perf_counter()
     if project_root is None:
@@ -45,7 +44,7 @@ def load_infrastructure_config(project_root: Optional[Path] = None) -> Infrastru
         return InfrastructureConfig()
 
     try:
-        with open(config_path) as f:
+        with config_path.open() as f:
             project_config = yaml.safe_load(f)
 
         if not project_config:
@@ -86,7 +85,7 @@ def load_infrastructure_config(project_root: Optional[Path] = None) -> Infrastru
         raise
 
 
-def get_project_name_from_config(project_root: Optional[Path] = None) -> Optional[str]:
+def get_project_name_from_config(project_root: Path | None = None) -> str | None:
     """Get project name from phlo.yaml."""
     if project_root is None:
         project_root = Path.cwd()
@@ -97,7 +96,7 @@ def get_project_name_from_config(project_root: Optional[Path] = None) -> Optiona
         return None
 
     try:
-        with open(config_path) as f:
+        with config_path.open() as f:
             project_config = yaml.safe_load(f)
         return project_config.get("name") if project_config else None
     except Exception:
@@ -105,9 +104,7 @@ def get_project_name_from_config(project_root: Optional[Path] = None) -> Optiona
         return None
 
 
-def get_service_config(
-    service_key: str, project_root: Optional[Path] = None
-) -> Optional[ServiceConfig]:
+def get_service_config(service_key: str, project_root: Path | None = None) -> ServiceConfig | None:
     """Get configuration for a specific service."""
     infra = load_infrastructure_config(project_root)
     return infra.get_service(service_key)
@@ -116,8 +113,8 @@ def get_service_config(
 def get_container_name(
     service_key: str,
     project_name: str,
-    project_root: Optional[Path] = None,
-) -> Optional[str]:
+    project_root: Path | None = None,
+) -> str | None:
     """Get container name for a service."""
     infra = load_infrastructure_config(project_root)
     return infra.get_container_name(service_key, project_name)

--- a/src/phlo/logging.py
+++ b/src/phlo/logging.py
@@ -11,11 +11,12 @@ import logging
 import os
 import sys
 import traceback
+from collections.abc import Mapping, MutableMapping
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Mapping, MutableMapping
+from typing import Any
 
 import structlog
 
@@ -64,7 +65,7 @@ class LoggingSettings:
     environment: str = "dev"
 
     @classmethod
-    def from_settings(cls) -> "LoggingSettings":
+    def from_settings(cls) -> LoggingSettings:
         """Build logging settings from global application settings.
 
         Returns:
@@ -308,7 +309,7 @@ def _record_to_event(record: logging.LogRecord, default_service: str) -> LogEven
 
     return LogEvent(
         event_type="log.record",
-        timestamp=datetime.fromtimestamp(record.created, tz=timezone.utc),
+        timestamp=datetime.fromtimestamp(record.created, tz=UTC),
         logger=record.name,
         level=record.levelname.lower(),
         message=message,
@@ -343,9 +344,12 @@ def _extract_message_and_extra(
     event_dict: dict[str, Any] | None = None
     if isinstance(record.msg, Mapping):
         event_dict = dict(record.msg)
-    elif isinstance(record.msg, (list, tuple)) and len(record.msg) == 1:
-        if isinstance(record.msg[0], Mapping):
-            event_dict = dict(record.msg[0])
+    elif (
+        isinstance(record.msg, (list, tuple))
+        and len(record.msg) == 1
+        and isinstance(record.msg[0], Mapping)
+    ):
+        event_dict = dict(record.msg[0])
 
     if event_dict:
         extra.update(event_dict)
@@ -437,7 +441,7 @@ def _render_log_file_path(template: str) -> Path | None:
     Returns:
         Path | None: Resolved path with parent directory created, or `None` if invalid.
     """
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     tokens = {
         "YMD": now.strftime("%Y%m%d"),
         "YM": now.strftime("%Y%m"),
@@ -519,7 +523,7 @@ def _mark_phlo_handler(handler: logging.Handler) -> None:
     Args:
         handler: Logging handler to mark.
     """
-    setattr(handler, "_phlo_handler", True)
+    setattr(handler, "_phlo_handler", True)  # noqa: B010
 
 
 def _remove_phlo_handlers(root: logging.Logger) -> None:

--- a/src/phlo/migrations/adapters.py
+++ b/src/phlo/migrations/adapters.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Iterator, Protocol
+from typing import Any, Protocol
 
 from phlo.capabilities import get_capability_registry
 from phlo.migrations.specs import MigrationSource

--- a/src/phlo/migrations/executor.py
+++ b/src/phlo/migrations/executor.py
@@ -6,7 +6,7 @@ import json
 import tempfile
 import time
 from dataclasses import asdict
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -170,7 +170,7 @@ class MigrationExecutor:
                     "source_type": spec.source.type,
                     "write_mode": spec.destination.write_mode,
                     "dry_run": dry_run,
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "timestamp": datetime.now(UTC).isoformat(),
                 },
             )
             emitter.emit(

--- a/src/phlo/operations/ingestion.py
+++ b/src/phlo/operations/ingestion.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any
 
 
 @dataclass
@@ -10,7 +10,7 @@ class IngestionResult:
     status: str
     rows_inserted: int
     rows_deleted: int
-    metadata: Dict[str, Any]
+    metadata: dict[str, Any]
 
 
 class BaseIngester(ABC):
@@ -34,14 +34,13 @@ class BaseIngester(ABC):
 
     @abstractmethod
     def run_ingestion(
-        self, partition_key: str | None, parameters: Dict[str, Any]
+        self, partition_key: str | None, parameters: dict[str, Any]
     ) -> IngestionResult:
         """
         Execute the ingestion logic for a specific partition.
 
         partition_key may be None for unpartitioned runs.
         """
-        pass
 
 
 class AsyncIngester(ABC):
@@ -65,11 +64,10 @@ class AsyncIngester(ABC):
 
     @abstractmethod
     async def run_ingestion(
-        self, partition_key: str | None, parameters: Dict[str, Any]
+        self, partition_key: str | None, parameters: dict[str, Any]
     ) -> IngestionResult:
         """
         Execute the ingestion logic for a specific partition.
 
         partition_key may be None for unpartitioned runs.
         """
-        pass

--- a/src/phlo/plugins/base/catalog.py
+++ b/src/phlo/plugins/base/catalog.py
@@ -54,7 +54,6 @@ class CatalogPlugin(Plugin, ABC):
 
         Examples: ["trino"], ["spark"], ["trino", "spark"].
         """
-        pass
 
     @property
     @abstractmethod
@@ -64,7 +63,6 @@ class CatalogPlugin(Plugin, ABC):
 
         This becomes the catalog identifier in the engine.
         """
-        pass
 
     @abstractmethod
     def get_properties(self) -> dict[str, Any]:
@@ -74,7 +72,6 @@ class CatalogPlugin(Plugin, ABC):
         Returns:
             Dictionary of config key -> value
         """
-        pass
 
     def supports_target(self, target: str) -> bool:
         """Return True if the catalog supports the requested engine target."""

--- a/src/phlo/plugins/base/governance.py
+++ b/src/phlo/plugins/base/governance.py
@@ -8,7 +8,8 @@ and policy enforcement.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from phlo.capabilities.interfaces import AccessPolicy
 from phlo.plugins.base.plugin import Plugin

--- a/src/phlo/plugins/base/ingestion_provider.py
+++ b/src/phlo/plugins/base/ingestion_provider.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from phlo.plugins.base.plugin import Plugin, PluginMetadata
 

--- a/src/phlo/plugins/base/orchestrator.py
+++ b/src/phlo/plugins/base/orchestrator.py
@@ -7,7 +7,8 @@ This module defines plugin types for orchestrator integration.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from phlo.capabilities.specs import AssetCheckSpec, AssetSpec, ResourceSpec
 from phlo.plugins.base.plugin import Plugin

--- a/src/phlo/plugins/base/plugin.py
+++ b/src/phlo/plugins/base/plugin.py
@@ -64,7 +64,6 @@ class Plugin(ABC):
         Returns:
             PluginMetadata with name, version, description, etc.
         """
-        pass
 
     def initialize(self, config: dict[str, Any]) -> None:
         """
@@ -79,7 +78,7 @@ class Plugin(ABC):
         Args:
             config: Configuration dictionary for the plugin
         """
-        pass
+        return
 
     def cleanup(self) -> None:
         """
@@ -91,4 +90,4 @@ class Plugin(ABC):
         - Releasing resources
         - Saving state
         """
-        pass
+        return

--- a/src/phlo/plugins/base/providers.py
+++ b/src/phlo/plugins/base/providers.py
@@ -7,7 +7,7 @@ This module defines plugin types that provide asset and resource specifications.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterable
+from collections.abc import Iterable
 
 from phlo.capabilities.specs import (
     AssetCheckSpec,

--- a/src/phlo/plugins/base/quality.py
+++ b/src/phlo/plugins/base/quality.py
@@ -79,4 +79,3 @@ class QualityCheckPlugin(Plugin, ABC, Generic[TQualityCheck]):
                 return CustomQualityCheck(column=column, threshold=threshold)
             ```
         """
-        pass

--- a/src/phlo/plugins/base/quality_provider.py
+++ b/src/phlo/plugins/base/quality_provider.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, TypeVar
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 from phlo.plugins.base.plugin import Plugin
 

--- a/src/phlo/plugins/base/service.py
+++ b/src/phlo/plugins/base/service.py
@@ -28,7 +28,6 @@ class ServicePlugin(Plugin, ABC):
 
         This is equivalent to the content of a service.yaml file.
         """
-        pass
 
     @property
     def category(self) -> str:

--- a/src/phlo/plugins/base/source.py
+++ b/src/phlo/plugins/base/source.py
@@ -86,7 +86,6 @@ class SourceConnectorPlugin(Plugin, ABC):
                     }
             ```
         """
-        pass
 
     def get_schema(self, config: dict[str, Any]) -> dict[str, str] | None:
         """

--- a/src/phlo/plugins/base/transform.py
+++ b/src/phlo/plugins/base/transform.py
@@ -73,7 +73,6 @@ class TransformationPlugin(Plugin, ABC):
                 return df
             ```
         """
-        pass
 
     def get_output_schema(
         self, input_schema: dict[str, str], config: dict[str, Any]

--- a/src/phlo/plugins/base/transformation_provider.py
+++ b/src/phlo/plugins/base/transformation_provider.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from phlo.plugins.base.plugin import Plugin, PluginMetadata
 

--- a/src/phlo/plugins/compose/native.py
+++ b/src/phlo/plugins/compose/native.py
@@ -193,7 +193,7 @@ class NativeProcessManager:
             if self.log_dir is not None:
                 self.log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = self.log_dir / f"{service.name}.log"
-                log_file = open(log_path, "a", encoding="utf-8")
+                log_file = log_path.open("a", encoding="utf-8")  # noqa: SIM115
                 stdout = log_file
             process = subprocess.Popen(
                 command,

--- a/src/phlo/plugins/discovery/_service_cycles.py
+++ b/src/phlo/plugins/discovery/_service_cycles.py
@@ -49,7 +49,7 @@ def _find_cycle_from_start(
 
 def _canonical_cycle(cycle_nodes: list[str]) -> tuple[str, ...]:
     if not cycle_nodes:
-        return tuple()
+        return ()
 
     rotations = [tuple(cycle_nodes[i:] + cycle_nodes[:i]) for i in range(len(cycle_nodes))]
     reverse = list(reversed(cycle_nodes))

--- a/src/phlo/plugins/discovery/_service_definition.py
+++ b/src/phlo/plugins/discovery/_service_definition.py
@@ -33,9 +33,9 @@ class ServiceDefinition:
     core: bool = False
 
     @classmethod
-    def from_yaml(cls, path: Path) -> "ServiceDefinition":
+    def from_yaml(cls, path: Path) -> ServiceDefinition:
         """Load a service definition from a YAML file."""
-        with open(path) as file_handle:
+        with path.open() as file_handle:
             data = yaml.safe_load(file_handle)
 
         if data.get("source_path"):
@@ -66,7 +66,7 @@ class ServiceDefinition:
         )
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any], source_path: Path | None) -> "ServiceDefinition":
+    def from_dict(cls, data: dict[str, Any], source_path: Path | None) -> ServiceDefinition:
         """Load a service definition from a dictionary."""
         return cls(
             name=data["name"],
@@ -90,7 +90,7 @@ class ServiceDefinition:
         )
 
     @classmethod
-    def from_inline(cls, name: str, config: dict[str, Any]) -> "ServiceDefinition":
+    def from_inline(cls, name: str, config: dict[str, Any]) -> ServiceDefinition:
         """Create a ServiceDefinition from inline config in phlo.yaml."""
         compose_keys = (
             "user",

--- a/src/phlo/plugins/discovery/plugins.py
+++ b/src/phlo/plugins/discovery/plugins.py
@@ -404,12 +404,7 @@ def discover_plugins(
                     plugin_class = entry_point.load()
 
                     # Instantiate the plugin
-                    if isinstance(plugin_class, type):
-                        # It's a class, instantiate it
-                        plugin = plugin_class()
-                    else:
-                        # It's already an instance
-                        plugin = plugin_class
+                    plugin = plugin_class() if isinstance(plugin_class, type) else plugin_class
 
                     # Validate plugin type
                     if not isinstance(plugin, Plugin):

--- a/src/phlo/plugins/discovery/registry.py
+++ b/src/phlo/plugins/discovery/registry.py
@@ -392,26 +392,26 @@ class PluginRegistry:
         # Type-specific validation
         if isinstance(plugin, SourceConnectorPlugin):
             return hasattr(plugin, "fetch_data") and callable(plugin.fetch_data)
-        elif isinstance(plugin, QualityCheckPlugin):
+        if isinstance(plugin, QualityCheckPlugin):
             return hasattr(plugin, "create_check") and callable(plugin.create_check)
-        elif isinstance(plugin, TransformationPlugin):
+        if isinstance(plugin, TransformationPlugin):
             return hasattr(plugin, "transform") and callable(plugin.transform)
-        elif isinstance(plugin, ServicePlugin):
+        if isinstance(plugin, ServicePlugin):
             try:
                 service_definition = plugin.service_definition
             except Exception:
                 logger.debug("plugin_validation_service_definition_failed", exc_info=True)
                 return False
             return isinstance(service_definition, dict)
-        elif isinstance(plugin, HookPlugin):
+        if isinstance(plugin, HookPlugin):
             return hasattr(plugin, "get_hooks") and callable(plugin.get_hooks)
-        elif isinstance(plugin, AssetProviderPlugin):
+        if isinstance(plugin, AssetProviderPlugin):
             return hasattr(plugin, "get_assets") and callable(plugin.get_assets)
-        elif isinstance(plugin, ResourceProviderPlugin):
+        if isinstance(plugin, ResourceProviderPlugin):
             return hasattr(plugin, "get_resources") and callable(plugin.get_resources)
-        elif isinstance(plugin, OrchestratorAdapterPlugin):
+        if isinstance(plugin, OrchestratorAdapterPlugin):
             return hasattr(plugin, "build_definitions") and callable(plugin.build_definitions)
-        elif isinstance(plugin, CatalogPlugin):
+        if isinstance(plugin, CatalogPlugin):
             has_catalog = hasattr(plugin, "catalog_name")
             has_targets = hasattr(plugin, "targets")
             has_properties = hasattr(plugin, "get_properties") and callable(plugin.get_properties)

--- a/src/phlo/plugins/hooks.py
+++ b/src/phlo/plugins/hooks.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
-from enum import Enum
-from typing import Awaitable, Callable, Iterable, Protocol, runtime_checkable
+from enum import StrEnum
+from typing import Protocol, runtime_checkable
 
 from phlo.hooks.events import HookEvent
 from phlo.plugins.base import Plugin
 
 
-class FailurePolicy(str, Enum):
+class FailurePolicy(StrEnum):
     """Failure handling policy for hook handlers."""
 
     IGNORE = "ignore"
@@ -43,8 +44,8 @@ class HookRegistration:
     handler: (
         Callable[[HookEvent], None]
         | Callable[[HookEvent], Awaitable[None]]
-        | "HookHandler"
-        | "AsyncHookHandler"
+        | HookHandler
+        | AsyncHookHandler
     )
     priority: int = 100
     filters: HookFilter | None = None

--- a/src/phlo/plugins/semantic.py
+++ b/src/phlo/plugins/semantic.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Iterable
+from typing import Any
 
 
 @dataclass(frozen=True)

--- a/src/phlo/quality.py
+++ b/src/phlo/quality.py
@@ -7,7 +7,8 @@ quality provider plugins. The primary provider is phlo-pandera.
 from __future__ import annotations
 
 import importlib
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 from phlo.logging import get_logger
 
@@ -39,7 +40,7 @@ dbt_check_name: Callable[[str, str], str] | None = None
 phlo_quality: Callable | None = None
 
 
-def _provider_api_module(provider: "QualityProviderPlugin") -> Any | None:
+def _provider_api_module(provider: QualityProviderPlugin) -> Any | None:
     """Resolve the provider package module that may expose helper exports."""
     provider_module = provider.__class__.__module__
     provider_package = provider_module.split(".", 1)[0]
@@ -49,7 +50,7 @@ def _provider_api_module(provider: "QualityProviderPlugin") -> Any | None:
         return None
 
 
-def _load_quality_provider() -> "QualityProviderPlugin | None":
+def _load_quality_provider() -> QualityProviderPlugin | None:
     """Load quality provider via plugin discovery, with fallback to direct import."""
     global phlo_quality
     global get_quality_checks

--- a/src/phlo/schema_registry.py
+++ b/src/phlo/schema_registry.py
@@ -97,7 +97,7 @@ class SchemaRegistry:
 
     def _setup_schema(self) -> None:
         sql_path = Path(__file__).parent / "sql" / "001_create_schema_registry.sql"
-        with open(sql_path) as f:
+        with sql_path.open() as f:
             schema_sql = f.read()
         with psycopg2.connect(self.connection_string) as conn:
             with conn.cursor() as cur:
@@ -149,10 +149,9 @@ class SchemaRegistry:
     def get_latest_snapshots(self, table_name: str, limit: int = 2) -> list[SchemaSnapshot]:
         """Get most recent snapshots for a table."""
         self._ensure_schema()
-        with psycopg2.connect(self.connection_string) as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
+        with psycopg2.connect(self.connection_string) as conn, conn.cursor() as cur:
+            cur.execute(
+                """
                     SELECT snapshot_id, table_name, schema, schema_hash,
                            created_at, run_id, source
                     FROM phlo.schema_snapshots
@@ -160,9 +159,9 @@ class SchemaRegistry:
                     ORDER BY created_at DESC
                     LIMIT %s
                     """,
-                    (table_name, limit),
-                )
-                rows = cur.fetchall()
+                (table_name, limit),
+            )
+            rows = cur.fetchall()
         return [
             SchemaSnapshot(
                 snapshot_id=r[0],

--- a/tests/benchmarks/discovery_registry_microbench.py
+++ b/tests/benchmarks/discovery_registry_microbench.py
@@ -92,10 +92,7 @@ def _write_service_fixture(services_root: Path, service_count: int) -> None:
         service_dir = services_root / f"group-{index % 8:02d}" / service_name
         service_dir.mkdir(parents=True, exist_ok=True)
 
-        if index == 0:
-            depends_on = "[]"
-        else:
-            depends_on = f"[benchmark-service-{index - 1:03d}]"
+        depends_on = "[]" if index == 0 else f"[benchmark-service-{index - 1:03d}]"
 
         service_yaml = (
             f"name: {service_name}\n"

--- a/tests/test_cli_error_contracts_golden.py
+++ b/tests/test_cli_error_contracts_golden.py
@@ -1,7 +1,7 @@
 """Golden tests for stable CLI error output contracts."""
 
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Mapping
 
 import pytest
 from click.testing import CliRunner, Result

--- a/tests/test_cli_plugin.py
+++ b/tests/test_cli_plugin.py
@@ -63,7 +63,7 @@ class DummyQuality(QualityCheckPlugin):
         Returns:
             None: No check object for this stub.
         """
-        return None
+        return
 
 
 class DummyTransform(TransformationPlugin):

--- a/tests/test_core_service_autoconfig.py
+++ b/tests/test_core_service_autoconfig.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Iterable, Mapping
+from collections.abc import Iterable, Mapping
+from typing import Any
 
 import pytest
 from phlo_dagster.plugin import DagsterServicePlugin

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -61,12 +61,14 @@ def test_default_executor_honors_force_flags() -> None:
 def test_build_definitions_merges_user_defs() -> None:
     """Builds Dagster definitions when workflow discovery returns user definitions."""
     empty_defs = dg.Definitions()
-    with patch("phlo_dagster.framework.definitions.get_settings", return_value=_Settings()):
-        with patch(
+    with (
+        patch("phlo_dagster.framework.definitions.get_settings", return_value=_Settings()),
+        patch(
             "phlo_dagster.framework.definitions.discover_user_workflows", return_value=empty_defs
-        ):
-            with patch("phlo_dagster.framework.definitions._default_executor", return_value=None):
-                from phlo_dagster.framework.definitions import build_definitions
+        ),
+        patch("phlo_dagster.framework.definitions._default_executor", return_value=None),
+    ):
+        from phlo_dagster.framework.definitions import build_definitions
 
-                result = build_definitions(workflows_path="workflows")
-                assert isinstance(result, dg.Definitions)
+        result = build_definitions(workflows_path="workflows")
+        assert isinstance(result, dg.Definitions)

--- a/tests/test_infrastructure_config.py
+++ b/tests/test_infrastructure_config.py
@@ -27,7 +27,7 @@ def _clear_infra_config_cache():
 
 def _write_phlo_yaml(config_path: Path, config: dict) -> None:
     """Write a phlo.yaml fixture payload."""
-    with open(config_path, "w") as f:
+    with config_path.open("w") as f:
         yaml.safe_dump(config, f, sort_keys=False)
 
 
@@ -145,7 +145,7 @@ def test_load_infrastructure_config_with_file():
             },
         }
 
-        with open(config_path, "w") as f:
+        with config_path.open("w") as f:
             yaml.dump(phlo_config, f)
 
         clear_config_cache()
@@ -173,7 +173,7 @@ def test_get_container_name_helper():
             },
         }
 
-        with open(config_path, "w") as f:
+        with config_path.open("w") as f:
             yaml.dump(phlo_config, f)
 
         clear_config_cache()

--- a/tests/test_orchestrator_selection.py
+++ b/tests/test_orchestrator_selection.py
@@ -29,10 +29,12 @@ def test_get_active_orchestrator_prefers_explicit_name_over_env() -> None:
     adapter = object()
     registry.get_orchestrator.return_value = adapter
 
-    with patch.dict(os.environ, {"PHLO_ORCHESTRATOR": "env_orchestrator"}, clear=False):
-        with patch("phlo.orchestrators.selection.discover_plugins") as discover_plugins_mock:
-            with patch("phlo.orchestrators.selection.get_global_registry", return_value=registry):
-                selected = get_active_orchestrator(" explicit_orchestrator ")
+    with (
+        patch.dict(os.environ, {"PHLO_ORCHESTRATOR": "env_orchestrator"}, clear=False),
+        patch("phlo.orchestrators.selection.discover_plugins") as discover_plugins_mock,
+        patch("phlo.orchestrators.selection.get_global_registry", return_value=registry),
+    ):
+        selected = get_active_orchestrator(" explicit_orchestrator ")
 
     assert selected is adapter
     discover_plugins_mock.assert_called_once_with(plugin_type="orchestrators", auto_register=True)
@@ -45,10 +47,12 @@ def test_get_active_orchestrator_uses_phlo_orchestrator_env_when_name_missing() 
     adapter = object()
     registry.get_orchestrator.return_value = adapter
 
-    with patch.dict(os.environ, {"PHLO_ORCHESTRATOR": " env_orchestrator "}, clear=False):
-        with patch("phlo.orchestrators.selection.discover_plugins"):
-            with patch("phlo.orchestrators.selection.get_global_registry", return_value=registry):
-                selected = get_active_orchestrator()
+    with (
+        patch.dict(os.environ, {"PHLO_ORCHESTRATOR": " env_orchestrator "}, clear=False),
+        patch("phlo.orchestrators.selection.discover_plugins"),
+        patch("phlo.orchestrators.selection.get_global_registry", return_value=registry),
+    ):
+        selected = get_active_orchestrator()
 
     assert selected is adapter
     registry.get_orchestrator.assert_called_once_with("env_orchestrator")
@@ -60,14 +64,16 @@ def test_get_active_orchestrator_missing_adapter_raises_guided_config_error() ->
     registry.get_orchestrator.return_value = None
     registry.list_orchestrators.return_value = ["dagster"]
 
-    with patch(
-        "phlo.orchestrators.selection.get_settings",
-        return_value=SimpleNamespace(phlo_orchestrator="missing_orchestrator"),
+    with (
+        patch(
+            "phlo.orchestrators.selection.get_settings",
+            return_value=SimpleNamespace(phlo_orchestrator="missing_orchestrator"),
+        ),
+        patch("phlo.orchestrators.selection.discover_plugins"),
+        patch("phlo.orchestrators.selection.get_global_registry", return_value=registry),
+        pytest.raises(PhloConfigError) as exc_info,
     ):
-        with patch("phlo.orchestrators.selection.discover_plugins"):
-            with patch("phlo.orchestrators.selection.get_global_registry", return_value=registry):
-                with pytest.raises(PhloConfigError) as exc_info:
-                    get_active_orchestrator()
+        get_active_orchestrator()
 
     assert "Orchestrator adapter 'missing_orchestrator' is not installed." in str(exc_info.value)
     assert exc_info.value.suggestions == [

--- a/tests/test_plugin_discovery_lifecycle.py
+++ b/tests/test_plugin_discovery_lifecycle.py
@@ -99,7 +99,7 @@ class _MultiTypeLifecyclePlugin(SourceConnectorPlugin, QualityCheckPlugin):
 
     def create_check(self, **kwargs):
         """Return no-op check for quality plugin interface."""
-        return None
+        return
 
 
 @pytest.fixture

--- a/tests/test_plugin_system.py
+++ b/tests/test_plugin_system.py
@@ -74,7 +74,7 @@ class DummyQualityPlugin(QualityCheckPlugin):
 
     def create_check(self, **kwargs):
         """Create test check."""
-        return None
+        return
 
 
 class DummyTransformPlugin(TransformationPlugin):
@@ -241,8 +241,6 @@ class TestPluginValidation:
 
         class BadPlugin:
             """Plugin-like object missing required metadata and methods."""
-
-            pass
 
         assert clean_registry.validate_plugin(BadPlugin()) is False
 


### PR DESCRIPTION
## Summary
- expand Ruff rule selection to include modern Python, simplification, return, comprehension, pie, bugbear, datetime, and pathlib checks
- apply Ruff `--fix --unsafe-fixes` and formatting across the repo
- make targeted manual follow-ups where unsafe fixes conflicted with runtime behavior or typing

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check src/phlo packages/phlo-alerting/src packages/phlo-alloy/src packages/phlo-api/src packages/phlo-core-plugins/src packages/phlo-dagster/src packages/phlo-dbt/src packages/phlo-dlt/src packages/phlo-grafana/src packages/phlo-hasura/src packages/phlo-iceberg/src packages/phlo-lineage/src packages/phlo-loki/src packages/phlo-metrics/src packages/phlo-minio/src packages/phlo-nessie/src packages/phlo-observatory-example/src packages/phlo-observatory/src packages/phlo-openmetadata/src packages/phlo-pgweb/src packages/phlo-postgres/src packages/phlo-postgrest/src packages/phlo-prometheus/src packages/phlo-pandera/src packages/phlo-superset/src packages/phlo-trino/src`
- `uv run pytest -m 'not integration'`
- `npm --prefix packages/phlo-observatory/src/phlo_observatory run lint`
- `npm --prefix packages/phlo-observatory/src/phlo_observatory run format -- --check .`
- `npm --prefix packages/phlo-observatory/src/phlo_observatory exec tsc -- -p packages/phlo-observatory/src/phlo_observatory/tsconfig.json --noEmit`

## Note
- `make check` still races because it fans out multiple `uv run` processes against one editable `.venv`; the code is green on the same checks when run sequentially.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
