### PR TITLE
feat: add services ports command

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -280,6 +280,55 @@ phlo services list --json
 # Error: Failed to discover services. Verify service plugins are installed and run `phlo plugins list` for diagnostics.
 ```
 
+### phlo services ports
+
+Show port mappings for all services.
+
+```bash
+phlo services ports [OPTIONS]
+```
+
+**Options**:
+
+```bash
+--json               # Output as JSON
+--all                # Include stopped services with defaults
+```
+
+**Source values**:
+
+- `env`: Port set via compose env resolution, including shell vars, `phlo.yaml` `env:`, or `.phlo/.env*`
+- `compose`: Literal host port from the compose mapping
+- `default`: Using the service.yaml default
+- `runtime`: Live port detected from the running container
+
+**Examples**:
+
+```bash
+phlo services ports
+phlo services ports --json
+phlo services ports --all
+```
+
+**Output**:
+
+```
+Service            Host Port   Container Port   Source     Status
+----------------------------------------------------------------------
+postgres           10000       5432             env       Running
+minio-api          10001       9000             env       Running
+dagster-webserver  10006       3000             env       Running
+clickhouse-http    8123        8123             default   Stopped
+```
+
+**Conflict detection**:
+
+When two services resolve to the same host port, both rows are highlighted with a `⚠` prefix:
+
+```bash
+⚠ Port conflict: trino and hasura both map to host port 8080
+```
+
 ### phlo services add
 
 Add an optional service to the project.

--- a/src/phlo/cli/commands/services/__init__.py
+++ b/src/phlo/cli/commands/services/__init__.py
@@ -8,6 +8,7 @@ from phlo.cli.commands.services.add import add_cmd
 from phlo.cli.commands.services.init import init_cmd
 from phlo.cli.commands.services.list import list_cmd
 from phlo.cli.commands.services.logs import logs_cmd
+from phlo.cli.commands.services.ports import ports_cmd
 from phlo.cli.commands.services.remove import remove_cmd
 from phlo.cli.commands.services.reset import reset_cmd
 from phlo.cli.commands.services.restart import restart_cmd
@@ -24,6 +25,7 @@ def services_group():
 # Register all commands
 services_group.add_command(init_cmd)
 services_group.add_command(list_cmd)
+services_group.add_command(ports_cmd)
 services_group.add_command(start_cmd)
 services_group.add_command(stop_cmd)
 services_group.add_command(reset_cmd)

--- a/src/phlo/cli/commands/services/ports.py
+++ b/src/phlo/cli/commands/services/ports.py
@@ -1,0 +1,397 @@
+"""Ports command for showing service port mappings."""
+
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import click
+import yaml
+
+from phlo.cli.commands.services.utils import _get_env_overrides, get_enabled_disabled_service_names
+from phlo.cli.infrastructure.command import run_command
+from phlo.cli.infrastructure.utils import get_project_name, parse_env_file
+from phlo.logging import get_logger
+from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
+
+logger = get_logger(__name__)
+
+PORT_PATTERN = re.compile(r"\$\{([^}:]+)(?::-([^}]*))?\}:(\d+)")
+DEFAULT_PORT_PATTERN = re.compile(r"\$\{([^}:]+):-(\d+)\}")
+
+
+@dataclass
+class PortMapping:
+    """Represents a resolved port mapping for a service."""
+
+    service: str
+    host_port: int
+    container_port: int
+    source: str
+    status: str
+    env_var: str | None = None
+
+
+@dataclass
+class ComposePortSpec:
+    """Represents a parsed compose port mapping."""
+
+    env_var: str | None
+    host_port: str | None
+    container_port: str
+
+
+def _parse_compose_port(port_str: str) -> tuple[str | None, str]:
+    """Parse a compose port string into (env_var, container_port).
+
+    Format: "${VAR:-default}:container" or "host:container"
+    """
+    spec = _parse_compose_port_spec(port_str)
+    return (spec.env_var, spec.container_port)
+
+
+def _parse_compose_port_spec(port_str: str) -> ComposePortSpec:
+    """Parse a compose port string into its env/literal host and container parts."""
+    normalized = port_str.strip().strip("\"'")
+    match = PORT_PATTERN.match(normalized)
+    if match:
+        return ComposePortSpec(
+            env_var=match.group(1),
+            host_port=match.group(2),
+            container_port=match.group(3),
+        )
+
+    if ":" in normalized:
+        host_part, container_part = normalized.rsplit(":", 1)
+        return ComposePortSpec(
+            env_var=None,
+            host_port=host_part.rsplit(":", 1)[-1],
+            container_port=container_part.split("/", 1)[0],
+        )
+
+    return ComposePortSpec(env_var=None, host_port=None, container_port=normalized)
+
+
+def _resolve_env_var(env_var: str | None, env: dict[str, str]) -> str | None:
+    """Resolve an environment variable from the loaded environment."""
+    if env_var is None:
+        return None
+    return env.get(env_var)
+
+
+def _load_environment(phlo_dir: Path, config: dict[str, Any]) -> dict[str, str]:
+    """Load effective compose environment with standard Phlo precedence."""
+    env: dict[str, str] = {}
+
+    env_file = phlo_dir / ".env"
+    env_local_file = phlo_dir / ".env.local"
+
+    for file_path in [env_file, env_local_file]:
+        if file_path.exists():
+            parsed = parse_env_file(file_path)
+            env.update(parsed)
+
+    env.update({k: str(v) for k, v in _get_env_overrides(config).items() if isinstance(k, str)})
+    env.update(os.environ)
+
+    return env
+
+
+def _get_running_container_ports(project_name: str) -> dict[str, list[dict]]:
+    """Get published ports from running containers."""
+    try:
+        result = run_command(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                f"label=com.docker.compose.project={project_name}",
+                "--format",
+                "{{json .}}",
+            ],
+            check=False,
+        )
+        containers = {}
+        if result.returncode == 0 and result.stdout.strip():
+            for line in result.stdout.strip().split("\n"):
+                info = json.loads(line)
+                service = None
+                for label in info.get("Labels", "").split(","):
+                    if label.startswith("com.docker.compose.service="):
+                        service = label.split("=", 1)[1]
+                        break
+                if service:
+                    ports_str = info.get("Ports", "")
+                    port_mappings: list[dict[str, str]] = []
+                    if ports_str:
+                        for port_entry in ports_str.split(", "):
+                            if "->" in port_entry:
+                                host_part, container_part = port_entry.split("->")
+                                host_ip = (
+                                    host_part.rsplit(":", 1)[0] if ":" in host_part else "0.0.0.0"
+                                )
+                                host_port = (
+                                    host_part.rsplit(":", 1)[-1] if ":" in host_part else host_part
+                                )
+                                port_mappings.append(
+                                    {
+                                        "host_port": host_port,
+                                        "host_ip": host_ip,
+                                        "container_port": container_part,
+                                    }
+                                )
+                    containers[service] = {
+                        "status": info.get("State", "running"),
+                        "ports": port_mappings,
+                    }
+        return containers
+    except Exception:
+        logger.warning("docker_ps_failed", exc_info=True)
+        return {}
+
+
+def _get_runtime_host_port(
+    running_containers: dict[str, Any],
+    service_name: str,
+    container_port: int,
+) -> int | None:
+    """Return the live host port for a running container port mapping, if present."""
+    container_info = running_containers.get(service_name, {})
+    for port_mapping in container_info.get("ports", []):
+        container_value = str(port_mapping.get("container_port", "")).split("/", 1)[0]
+        if container_value != str(container_port):
+            continue
+        host_port = port_mapping.get("host_port")
+        if host_port and str(host_port).isdigit():
+            return int(host_port)
+    return None
+
+
+def _get_default_host_port(port_str: str, port_spec: ComposePortSpec) -> int | None:
+    """Resolve a configured host port from a compose mapping when no runtime mapping exists."""
+    if port_spec.host_port and port_spec.host_port.isdigit():
+        return int(port_spec.host_port)
+
+    if port_spec.env_var:
+        default_match = DEFAULT_PORT_PATTERN.search(port_str)
+        if default_match:
+            return int(default_match.group(2))
+
+    return None
+
+
+def _get_service_ports(
+    service: ServiceDefinition,
+    env: dict[str, str],
+    running_containers: dict[str, Any],
+    show_all: bool,
+    service_override: dict[str, Any] | None = None,
+) -> list[PortMapping]:
+    """Get port mappings for a service."""
+    ports: list[PortMapping] = []
+    compose_ports = service.compose.get("ports", [])
+    if isinstance(service_override, dict) and service_override.get("ports"):
+        compose_ports = service_override["ports"]
+
+    if not compose_ports:
+        return ports
+
+    is_running = service.name in running_containers
+    if not show_all and not is_running:
+        return ports
+
+    for port_str in compose_ports:
+        port_spec = _parse_compose_port_spec(port_str)
+        container_port = int(port_spec.container_port)
+
+        resolved_host_port: int | None = None
+        source = "default"
+        resolved_env_var: str | None = None
+
+        if is_running:
+            resolved_host_port = _get_runtime_host_port(
+                running_containers, service.name, container_port
+            )
+            if resolved_host_port is not None:
+                source = "runtime"
+
+        if resolved_host_port is None and port_spec.env_var:
+            resolved_value = _resolve_env_var(port_spec.env_var, env)
+            if resolved_value and resolved_value.isdigit():
+                resolved_host_port = int(resolved_value)
+                source = "env"
+                resolved_env_var = port_spec.env_var
+
+        if resolved_host_port is None:
+            resolved_host_port = _get_default_host_port(port_str, port_spec)
+            if resolved_host_port is not None and port_spec.env_var is None and port_spec.host_port:
+                source = "compose"
+
+        if resolved_host_port is None:
+            continue
+
+        status = "Running" if is_running else "Stopped"
+
+        ports.append(
+            PortMapping(
+                service=service.name,
+                host_port=resolved_host_port,
+                container_port=container_port,
+                source=source,
+                status=status,
+                env_var=resolved_env_var,
+            )
+        )
+
+    return ports
+
+
+def _detect_conflicts(port_mappings: list[PortMapping]) -> list[tuple[str, str, int]]:
+    """Detect port conflicts. Returns list of (service1, service2, port) tuples."""
+    host_port_to_services: dict[int, list[str]] = {}
+    for pm in port_mappings:
+        if pm.host_port not in host_port_to_services:
+            host_port_to_services[pm.host_port] = []
+        if pm.service not in host_port_to_services[pm.host_port]:
+            host_port_to_services[pm.host_port].append(pm.service)
+
+    conflicts = []
+    for port, services in host_port_to_services.items():
+        if len(services) > 1:
+            for i in range(len(services) - 1):
+                conflicts.append((services[i], services[i + 1], port))
+    return conflicts
+
+
+def _format_table(port_mappings: list[PortMapping], conflicts: list[tuple[str, str, int]]) -> None:
+    """Format and print the port table."""
+    if not port_mappings:
+        click.echo("No port mappings found.")
+        return
+
+    conflict_ports = {c[2] for c in conflicts}
+
+    header = (
+        f"{'Service':<20} {'Host Port':<12} {'Container Port':<16} {'Source':<10} {'Status':<10}"
+    )
+    separator = "-" * 70
+
+    click.echo(header)
+    click.echo(separator)
+
+    for pm in sorted(port_mappings, key=lambda x: x.service):
+        prefix = "⚠ " if pm.host_port in conflict_ports else "  "
+        row = (
+            f"{prefix}{pm.service:<18} "
+            f"{pm.host_port:<12} "
+            f"{pm.container_port:<16} "
+            f"{pm.source:<10} "
+            f"{pm.status:<10}"
+        )
+        click.echo(row)
+
+    if conflicts:
+        click.echo("")
+        for s1, s2, port in conflicts:
+            click.echo(f"⚠ Port conflict: {s1} and {s2} both map to host port {port}")
+
+
+def _format_json(port_mappings: list[PortMapping]) -> None:
+    """Format and print JSON output."""
+    output = []
+    for pm in port_mappings:
+        output.append(
+            {
+                "service": pm.service,
+                "host_port": pm.host_port,
+                "container_port": pm.container_port,
+                "source": pm.source,
+                "status": pm.status.lower(),
+                "env_var": pm.env_var,
+            }
+        )
+    click.echo(json.dumps(output, indent=2))
+
+
+@click.command("ports")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.option("--all", "show_all", is_flag=True, help="Include stopped services with defaults")
+def ports_cmd(output_json: bool, show_all: bool):
+    """Show port mappings for all services.
+
+    Displays host port, container port, source (default/env/runtime), and status.
+
+    Examples:
+        phlo services ports
+        phlo services ports --json
+        phlo services ports --all
+    """
+    logger.info(
+        "services_ports_requested",
+        output_json=output_json,
+        show_all=show_all,
+    )
+
+    phlo_dir = Path.cwd() / ".phlo"
+    if not phlo_dir.exists():
+        click.echo("Error: .phlo directory not found. Run 'phlo services init' first.", err=True)
+        raise SystemExit(1)
+
+    config_file = Path.cwd() / "phlo.yaml"
+    existing_config: dict = {}
+    if config_file.exists():
+        try:
+            with config_file.open() as f:
+                existing_config = yaml.safe_load(f) or {}
+        except (OSError, yaml.YAMLError) as exc:
+            logger.error("config_read_failed", exc_info=True)
+            raise click.ClickException(f"Failed to read {config_file}.") from exc
+
+    _, disabled_services = get_enabled_disabled_service_names(existing_config)
+    service_overrides = existing_config.get("services", {})
+
+    env = _load_environment(phlo_dir, existing_config)
+
+    try:
+        discovery = ServiceDiscovery()
+        available_services = discovery.discover()
+    except Exception as exc:
+        logger.error("services_discovery_failed", exc_info=True)
+        raise click.ClickException(
+            "Failed to discover services. Verify service plugins are installed."
+        ) from exc
+
+    project_name = get_project_name()
+    running_containers = _get_running_container_ports(project_name)
+
+    port_mappings: list[PortMapping] = []
+
+    for svc in available_services.values():
+        if svc.name in disabled_services:
+            continue
+        service_override = (
+            service_overrides.get(svc.name, {}) if isinstance(service_overrides, dict) else {}
+        )
+        ports = _get_service_ports(
+            svc,
+            env,
+            running_containers,
+            show_all,
+            service_override=service_override if isinstance(service_override, dict) else None,
+        )
+        port_mappings.extend(ports)
+
+    conflicts = _detect_conflicts(port_mappings)
+
+    if output_json:
+        _format_json(port_mappings)
+    else:
+        _format_table(port_mappings, conflicts)
+
+    logger.info(
+        "services_ports_completed",
+        total_mappings=len(port_mappings),
+        conflicts=len(conflicts),
+    )

--- a/tests/test_cli_services_ports.py
+++ b/tests/test_cli_services_ports.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from subprocess import CompletedProcess
+
+import pytest
+from click.testing import CliRunner
+
+from phlo.cli.commands.services import ports as ports_module
+from phlo.plugins.discovery import ServiceDefinition
+
+
+def test_parse_compose_port_with_env_var() -> None:
+    env_var, container_port = ports_module._parse_compose_port("${POSTGRES_PORT:-5432}:5432")
+    assert env_var == "POSTGRES_PORT"
+    assert container_port == "5432"
+
+
+def test_parse_compose_port_with_default_only() -> None:
+    env_var, container_port = ports_module._parse_compose_port("${POSTGRES_PORT}:5432")
+    assert env_var == "POSTGRES_PORT"
+    assert container_port == "5432"
+
+
+def test_parse_compose_port_no_env() -> None:
+    env_var, container_port = ports_module._parse_compose_port("5432:5432")
+    assert env_var is None
+    assert container_port == "5432"
+
+
+def test_parse_compose_port_with_host_port() -> None:
+    env_var, container_port = ports_module._parse_compose_port("10000:5432")
+    assert env_var is None
+    assert container_port == "5432"
+
+
+def test_parse_compose_port_spec_with_host_port() -> None:
+    spec = ports_module._parse_compose_port_spec("127.0.0.1:10000:5432")
+    assert spec.env_var is None
+    assert spec.host_port == "10000"
+    assert spec.container_port == "5432"
+
+
+def test_resolve_env_var_found() -> None:
+    env = {"POSTGRES_PORT": "10000"}
+    result = ports_module._resolve_env_var("POSTGRES_PORT", env)
+    assert result == "10000"
+
+
+def test_resolve_env_var_not_found() -> None:
+    env: dict[str, str] = {}
+    result = ports_module._resolve_env_var("POSTGRES_PORT", env)
+    assert result is None
+
+
+def test_resolve_env_var_none() -> None:
+    env: dict[str, str] = {}
+    result = ports_module._resolve_env_var(None, env)
+    assert result is None
+
+
+def test_detect_conflicts_no_conflicts() -> None:
+    mappings = [
+        ports_module.PortMapping(
+            service="postgres",
+            host_port=10000,
+            container_port=5432,
+            source="env",
+            status="Running",
+            env_var="POSTGRES_PORT",
+        ),
+        ports_module.PortMapping(
+            service="minio",
+            host_port=10001,
+            container_port=9000,
+            source="env",
+            status="Running",
+            env_var="MINIO_PORT",
+        ),
+    ]
+    conflicts = ports_module._detect_conflicts(mappings)
+    assert conflicts == []
+
+
+def test_detect_conflicts_with_conflicts() -> None:
+    mappings = [
+        ports_module.PortMapping(
+            service="postgres",
+            host_port=10000,
+            container_port=5432,
+            source="env",
+            status="Running",
+            env_var="POSTGRES_PORT",
+        ),
+        ports_module.PortMapping(
+            service="trino", host_port=8080, container_port=8080, source="default", status="Running"
+        ),
+        ports_module.PortMapping(
+            service="hasura",
+            host_port=8080,
+            container_port=8080,
+            source="default",
+            status="Running",
+        ),
+    ]
+    conflicts = ports_module._detect_conflicts(mappings)
+    assert len(conflicts) == 1
+    assert (conflicts[0][0], conflicts[0][1], conflicts[0][2]) == ("trino", "hasura", 8080)
+
+
+def test_detect_conflicts_multiple_services_same_port() -> None:
+    mappings = [
+        ports_module.PortMapping(
+            service="service1",
+            host_port=8080,
+            container_port=8080,
+            source="default",
+            status="Running",
+        ),
+        ports_module.PortMapping(
+            service="service2",
+            host_port=8080,
+            container_port=8080,
+            source="default",
+            status="Running",
+        ),
+        ports_module.PortMapping(
+            service="service3",
+            host_port=8080,
+            container_port=8080,
+            source="default",
+            status="Running",
+        ),
+    ]
+    conflicts = ports_module._detect_conflicts(mappings)
+    assert len(conflicts) >= 1
+
+
+def test_ports_cmd_requires_phlo_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = CliRunner().invoke(ports_module.ports_cmd)
+    assert result.exit_code == 1
+    assert "Error: .phlo directory not found" in result.output
+
+
+def test_ports_cmd_handles_no_services(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    (tmp_path / ".phlo").mkdir()
+    (tmp_path / "phlo.yaml").write_text("name: test\n")
+
+    class FakeDiscovery:
+        def discover(self) -> dict[str, ServiceDefinition]:
+            return {}
+
+    monkeypatch.setattr(ports_module, "ServiceDiscovery", FakeDiscovery)
+    monkeypatch.setattr(ports_module, "get_project_name", lambda: "test")
+    monkeypatch.setattr(
+        ports_module,
+        "run_command",
+        lambda *_args, **_kwargs: CompletedProcess(["docker", "ps"], 0, "", ""),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(ports_module.ports_cmd)
+    assert result.exit_code == 0
+    assert "No port mappings found" in result.output
+
+
+def test_ports_cmd_json_output(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    (tmp_path / ".phlo").mkdir()
+    (tmp_path / "phlo.yaml").write_text("name: test\n")
+
+    class FakeDiscovery:
+        def discover(self) -> dict[str, ServiceDefinition]:
+            return {}
+
+    monkeypatch.setattr(ports_module, "ServiceDiscovery", FakeDiscovery)
+    monkeypatch.setattr(ports_module, "get_project_name", lambda: "test")
+    monkeypatch.setattr(
+        ports_module,
+        "run_command",
+        lambda *_args, **_kwargs: CompletedProcess(["docker", "ps"], 0, "", ""),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(ports_module.ports_cmd, ["--json"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "[]"
+
+
+def test_get_service_ports_with_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = {"POSTGRES_PORT": "10000"}
+    running_containers = {"postgres": {"status": "running", "ports": []}}
+    show_all = False
+
+    service = ServiceDefinition(
+        name="postgres",
+        description="PostgreSQL",
+        compose={"ports": ["${POSTGRES_PORT:-5432}:5432"]},
+    )
+
+    ports = ports_module._get_service_ports(service, env, running_containers, show_all)
+    assert len(ports) == 1
+    assert ports[0].host_port == 10000
+    assert ports[0].container_port == 5432
+    assert ports[0].source == "env"
+    assert ports[0].env_var == "POSTGRES_PORT"
+
+
+def test_get_service_ports_with_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    env: dict[str, str] = {}
+    running_containers: dict[str, dict] = {}
+    show_all = True
+
+    service = ServiceDefinition(
+        name="postgres",
+        description="PostgreSQL",
+        compose={"ports": ["${POSTGRES_PORT:-5432}:5432"]},
+    )
+
+    ports = ports_module._get_service_ports(service, env, running_containers, show_all)
+    assert len(ports) == 1
+    assert ports[0].host_port == 5432
+    assert ports[0].container_port == 5432
+    assert ports[0].source == "default"
+
+
+def test_get_service_ports_with_explicit_compose_host_port() -> None:
+    env: dict[str, str] = {}
+    running_containers: dict[str, dict] = {}
+    show_all = True
+
+    service = ServiceDefinition(
+        name="postgres",
+        description="PostgreSQL",
+        compose={"ports": ["15432:5432"]},
+    )
+
+    ports = ports_module._get_service_ports(service, env, running_containers, show_all)
+    assert len(ports) == 1
+    assert ports[0].host_port == 15432
+    assert ports[0].source == "compose"
+
+
+def test_get_service_ports_prefers_runtime_mapping_over_default() -> None:
+    env: dict[str, str] = {}
+    running_containers = {
+        "postgres": {
+            "status": "running",
+            "ports": [{"host_port": "15432", "container_port": "5432/tcp"}],
+        }
+    }
+    show_all = False
+
+    service = ServiceDefinition(
+        name="postgres",
+        description="PostgreSQL",
+        compose={"ports": ["${POSTGRES_PORT:-5432}:5432"]},
+    )
+
+    ports = ports_module._get_service_ports(service, env, running_containers, show_all)
+    assert len(ports) == 1
+    assert ports[0].host_port == 15432
+    assert ports[0].source == "runtime"
+
+
+def test_load_environment_merges_config_and_shell_overrides(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / ".env").write_text("POSTGRES_PORT=5432\nMINIO_PORT=9000\n")
+    (phlo_dir / ".env.local").write_text("MINIO_PORT=9001\n")
+    monkeypatch.setenv("POSTGRES_PORT", "15432")
+
+    env = ports_module._load_environment(
+        phlo_dir,
+        {"env": {"POSTGRES_PORT": 15431, "TRINO_PORT": 18080}},
+    )
+
+    assert env["POSTGRES_PORT"] == "15432"
+    assert env["MINIO_PORT"] == "9001"
+    assert env["TRINO_PORT"] == "18080"
+
+
+def test_get_service_ports_no_ports() -> None:
+    env: dict[str, str] = {}
+    running_containers: dict[str, dict] = {}
+    show_all = False
+
+    service = ServiceDefinition(
+        name="postgres",
+        description="PostgreSQL",
+        compose={},
+    )
+
+    ports = ports_module._get_service_ports(service, env, running_containers, show_all)
+    assert ports == []
+
+
+def test_get_service_ports_filters_stopped_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    env: dict[str, str] = {}
+    running_containers: dict[str, dict] = {}
+    show_all = False
+
+    service = ServiceDefinition(
+        name="postgres",
+        description="PostgreSQL",
+        compose={"ports": ["${POSTGRES_PORT:-5432}:5432"]},
+    )
+
+    ports = ports_module._get_service_ports(service, env, running_containers, show_all)
+    assert ports == []
+
+
+def test_ports_cmd_uses_phlo_yaml_env_and_service_port_overrides(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    (tmp_path / ".phlo").mkdir()
+    (tmp_path / "phlo.yaml").write_text(
+        """
+name: test
+env:
+  POSTGRES_PORT: 15432
+services:
+  postgres:
+    ports:
+      - "16432:5432"
+"""
+    )
+
+    class FakeDiscovery:
+        def discover(self) -> dict[str, ServiceDefinition]:
+            return {
+                "postgres": ServiceDefinition(
+                    name="postgres",
+                    description="PostgreSQL",
+                    compose={"ports": ["${POSTGRES_PORT:-5432}:5432"]},
+                )
+            }
+
+    monkeypatch.setattr(ports_module, "ServiceDiscovery", FakeDiscovery)
+    monkeypatch.setattr(ports_module, "get_project_name", lambda: "test")
+    monkeypatch.setattr(ports_module, "_get_running_container_ports", lambda _project_name: {})
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(ports_module.ports_cmd, ["--all", "--json"])
+    assert result.exit_code == 0
+    assert result.output.strip() == (
+        "[\n"
+        "  {\n"
+        '    "service": "postgres",\n'
+        '    "host_port": 16432,\n'
+        '    "container_port": 5432,\n'
+        '    "source": "compose",\n'
+        '    "status": "stopped",\n'
+        '    "env_var": null\n'
+        "  }\n"
+        "]"
+    )


### PR DESCRIPTION
### TL;DR

Added a new `phlo services ports` command to display port mappings for all services with conflict detection and multiple output formats.

### What changed?

- Added `phlo services ports` command that shows host port, container port, source (env/compose/default/runtime), and status for each service
- Implemented port conflict detection that highlights services mapping to the same host port with warning indicators
- Added support for `--json` and `--all` flags for different output formats and including stopped services
- Created comprehensive port resolution logic that handles environment variables, compose literals, defaults, and runtime container inspection
- Added extensive test coverage for port parsing, conflict detection, and command functionality

### How to test?

```bash
# Basic usage
phlo services ports

# Include stopped services with their default ports
phlo services ports --all

# JSON output format
phlo services ports --json

# Test with conflicting port configurations to see warning indicators
```

### Why make this change?

This command provides visibility into service port mappings and helps developers identify port conflicts before they cause runtime issues. It consolidates port information from multiple sources (environment variables, compose files, running containers) into a single view, making it easier to debug connectivity issues and manage port allocations across services.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/293" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
