### PR TITLE
fix: grant oidc to publish workflow callers

### DIFF
--- a/.github/workflows/publish-validate.yml
+++ b/.github/workflows/publish-validate.yml
@@ -20,6 +20,9 @@ permissions:
 
 jobs:
   publish-validate:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-packages.yml
     with:
       base_ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,9 @@ permissions:
 
 jobs:
   publish:
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/publish-packages.yml
     with:
       dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,7 @@ jobs:
     if: needs.release-please.outputs.release_created == 'true'
     permissions:
       contents: read
+      id-token: write
     uses: ./.github/workflows/publish-packages.yml
     with:
       current_tag: ${{ needs.release-please.outputs.tag_name }}


### PR DESCRIPTION
## Summary
- grant `id-token: write` to every caller of the reusable publish workflow
- keep caller permissions aligned with the nested publish job in `publish-packages.yml`

## Why
The merged release-flow refactor failed at workflow startup because the reusable workflow contains a nested publish job that requests `id-token: write`, but the caller jobs defaulted to `id-token: none`. GitHub rejects that workflow graph before any jobs start.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/299" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
