### PR TITLE
fix: default Delta S3 endpoint to localhost

### DIFF
--- a/packages/phlo-delta/src/phlo_delta/settings.py
+++ b/packages/phlo-delta/src/phlo_delta/settings.py
@@ -22,7 +22,7 @@ class DeltaSettings(BaseConfig):
         default="raw", description="Default namespace/schema for Delta tables"
     )
     delta_s3_endpoint: str | None = Field(
-        default="http://minio:9000",
+        default="http://localhost:9000",
         validation_alias=AliasChoices("DELTA_S3_ENDPOINT", "AWS_S3_ENDPOINT"),
         description="S3 endpoint URL for Delta I/O",
     )

--- a/packages/phlo-delta/tests/test_delta_settings.py
+++ b/packages/phlo-delta/tests/test_delta_settings.py
@@ -3,6 +3,13 @@
 from phlo_delta.settings import DeltaSettings
 
 
+def test_delta_settings_default_to_localhost_for_host_side_usage() -> None:
+    """Delta settings should default to a host-reachable MinIO endpoint."""
+    settings = DeltaSettings()
+
+    assert settings.delta_s3_endpoint == "http://localhost:9000"
+
+
 def test_delta_settings_use_standard_aws_aliases(monkeypatch) -> None:
     """Delta settings should honor the shared AWS env vars exposed in services."""
     monkeypatch.setenv("AWS_S3_ENDPOINT", "http://minio:9000")


### PR DESCRIPTION
## Summary
- default Delta's host-side S3 endpoint to `http://localhost:9000`
- keep container behavior unchanged by continuing to honor `AWS_S3_ENDPOINT`
- add a settings test for the localhost default alongside the existing env override coverage

Closes #301

## Testing
- uv run pytest /Users/garethprice/Developer/phlo/packages/phlo-delta/tests/test_delta_settings.py
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
