### PR TITLE
chore(release): phlo 0.7.3, phlo-alerting 0.2.4, phlo-alloy 0.2.4, phlo-api 0.2.4, phlo-clickhouse 0.2.4, phlo-clickstack 0.2.4, phlo-core-plugins 0.2.4, phlo-dagster 0.2.4, phlo-dbt 0.2.4, phlo-delta 0.2.4, phlo-dlt 0.2.4, phlo-grafana 0.2.4, phlo-hasura 0.2.4, phlo-iceberg 0.2.4, phlo-lineage 0.2.4, phlo-loki 0.2.4, phlo-minio 0.2.4, phlo-nessie 0.2.4, phlo-observatory 0.2.4, phlo-observatory-example 0.2.4, phlo-openmetadata 0.2.4, phlo-otel 0.2.4, phlo-pandera 0.2.4, phlo-pgweb 0.2.4, phlo-postgres 0.2.4, phlo-postgrest 0.2.4, phlo-prometheus 0.2.4, phlo-rustfs 0.2.4, phlo-sling 0.2.4, phlo-superset 0.2.4, phlo-testing 0.2.4, phlo-traefik 0.2.4, phlo-trino 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [phlo 0.7.3, phlo-alerting 0.2.4, phlo-alloy 0.2.4, phlo-api 0.2.4, phlo-clickhouse 0.2.4, phlo-clickstack 0.2.4, phlo-core-plugins 0.2.4, phlo-dagster 0.2.4, phlo-dbt 0.2.4, phlo-delta 0.2.4, phlo-dlt 0.2.4, phlo-grafana 0.2.4, phlo-hasura 0.2.4, phlo-iceberg 0.2.4, phlo-lineage 0.2.4, phlo-loki 0.2.4, phlo-minio 0.2.4, phlo-nessie 0.2.4, phlo-observatory 0.2.4, phlo-observatory-example 0.2.4, phlo-openmetadata 0.2.4, phlo-otel 0.2.4, phlo-pandera 0.2.4, phlo-pgweb 0.2.4, phlo-postgres 0.2.4, phlo-postgrest 0.2.4, phlo-prometheus 0.2.4, phlo-rustfs 0.2.4, phlo-sling 0.2.4, phlo-superset 0.2.4, phlo-testing 0.2.4, phlo-traefik 0.2.4, phlo-trino 0.2.4] - 2026-03-28
+
+### Fixed
+- phlo: only tag merged release commits
+- phlo: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-delta: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-hasura: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-iceberg: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-lineage: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-minio: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-nessie: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-postgres: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-rustfs: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-trino: centralize Docker hostname resolution for host-side CLI portability (#308)
+
+### Contributors
+Thanks to our contributors for this release:
+- 🎉 @iamgp — first contribution!
+
 ## [phlo 0.7.2, phlo-alerting 0.2.3, phlo-alloy 0.2.3, phlo-api 0.2.3, phlo-clickhouse 0.2.3, phlo-clickstack 0.2.3, phlo-core-plugins 0.2.3, phlo-dagster 0.2.3, phlo-dbt 0.2.3, phlo-delta 0.2.3, phlo-dlt 0.2.3, phlo-grafana 0.2.3, phlo-hasura 0.2.3, phlo-iceberg 0.2.3, phlo-lineage 0.2.3, phlo-loki 0.2.3, phlo-minio 0.2.3, phlo-nessie 0.2.3, phlo-observatory 0.2.3, phlo-observatory-example 0.2.3, phlo-openmetadata 0.2.3, phlo-otel 0.2.3, phlo-pandera 0.2.3, phlo-pgweb 0.2.3, phlo-postgres 0.2.3, phlo-postgrest 0.2.3, phlo-prometheus 0.2.3, phlo-rustfs 0.2.3, phlo-sling 0.2.3, phlo-superset 0.2.3, phlo-testing 0.2.3, phlo-traefik 0.2.3, phlo-trino 0.2.3] - 2026-03-27
 
 ### Fixed

--- a/packages/phlo-alerting/pyproject.toml
+++ b/packages/phlo-alerting/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Alerting destinations and hooks for Phlo"
 name = "phlo-alerting"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-alloy/pyproject.toml
+++ b/packages/phlo-alloy/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "alloy service plugin for Phlo"
 name = "phlo-alloy"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-api/pyproject.toml
+++ b/packages/phlo-api/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 description = "Phlo API - Backend service exposing Phlo internals to Observatory"
 name = "phlo-api"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-clickhouse/pyproject.toml
+++ b/packages/phlo-clickhouse/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "ClickHouse service and resource plugin for Phlo"
 name = "phlo-clickhouse"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-clickhouse/src/phlo_clickhouse/__init__.py
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "ClickHouseSettings",
     "get_settings",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-clickstack/pyproject.toml
+++ b/packages/phlo-clickstack/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "clickstack service plugin for Phlo"
 name = "phlo-clickstack"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-core-plugins/pyproject.toml
+++ b/packages/phlo-core-plugins/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "Core plugin package for Phlo"
 name = "phlo-core-plugins"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-core-plugins/src/phlo_core/__init__.py
+++ b/packages/phlo-core-plugins/src/phlo_core/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     "SchemaCheckPlugin",
     "RestAPIPlugin",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-dagster/pyproject.toml
+++ b/packages/phlo-dagster/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Dagster service plugin for Phlo"
 name = "phlo-dagster"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/src/phlo_dagster/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/__init__.py
@@ -11,4 +11,4 @@ __all__ = [
     "DagsterSettings",
     "get_settings",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-dbt/pyproject.toml
+++ b/packages/phlo-dbt/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "dbt integration capability plugin for Phlo"
 name = "phlo-dbt"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-delta/pyproject.toml
+++ b/packages/phlo-delta/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Delta Lake table-store capability plugin for Phlo"
 name = "phlo-delta"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dlt/pyproject.toml
+++ b/packages/phlo-dlt/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 description = "DLT ingestion engine capability plugin for Phlo"
 name = "phlo-dlt"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-grafana/pyproject.toml
+++ b/packages/phlo-grafana/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "grafana service plugin for Phlo"
 name = "phlo-grafana"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-hasura/pyproject.toml
+++ b/packages/phlo-hasura/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "hasura service plugin for Phlo"
 name = "phlo-hasura"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-iceberg/pyproject.toml
+++ b/packages/phlo-iceberg/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Iceberg table-store capability plugin for Phlo"
 name = "phlo-iceberg"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-lineage/pyproject.toml
+++ b/packages/phlo-lineage/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Lineage tracking and visualization for Phlo"
 name = "phlo-lineage"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-loki/pyproject.toml
+++ b/packages/phlo-loki/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "loki service plugin for Phlo"
 name = "phlo-loki"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-minio/pyproject.toml
+++ b/packages/phlo-minio/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "MinIO service plugin for Phlo"
 name = "phlo-minio"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-minio/src/phlo_minio/__init__.py
+++ b/packages/phlo-minio/src/phlo_minio/__init__.py
@@ -4,4 +4,4 @@ from phlo_minio.plugin import MinioServicePlugin
 from phlo_minio.settings import MinioSettings, get_settings
 
 __all__ = ["MinioServicePlugin", "MinioSettings", "get_settings"]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-nessie/pyproject.toml
+++ b/packages/phlo-nessie/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Nessie service plugin for Phlo"
 name = "phlo-nessie"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-nessie/src/phlo_nessie/__init__.py
+++ b/packages/phlo-nessie/src/phlo_nessie/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     "NessieSettings",
     "get_settings",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-observatory-example/pyproject.toml
+++ b/packages/phlo-observatory-example/pyproject.toml
@@ -11,7 +11,7 @@ description = "Example Observatory extension plugin"
 name = "phlo-observatory-example"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/pyproject.toml
+++ b/packages/phlo-observatory/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["phlo>=0.1.0"]
 description = "Phlo Observatory - Data platform UI (bundled with phlo core)"
 name = "phlo-observatory"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/src/phlo_observatory/__init__.py
+++ b/packages/phlo-observatory/src/phlo_observatory/__init__.py
@@ -42,4 +42,4 @@ __all__ = [
     "get_settings",
     "get_settings_service",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-openmetadata/pyproject.toml
+++ b/packages/phlo-openmetadata/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "OpenMetadata integration for Phlo"
 name = "phlo-openmetadata"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-otel/pyproject.toml
+++ b/packages/phlo-otel/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "OpenTelemetry traces and metrics for Phlo"
 name = "phlo-otel"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-pandera/pyproject.toml
+++ b/packages/phlo-pandera/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Quality checks and schema utilities for Phlo"
 name = "phlo-pandera"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-pandera/src/phlo_pandera/__init__.py
+++ b/packages/phlo-pandera/src/phlo_pandera/__init__.py
@@ -80,4 +80,4 @@ __all__ = [
     "dbt_check_name",
 ]
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-pgweb/pyproject.toml
+++ b/packages/phlo-pgweb/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "pgweb service plugin for Phlo"
 name = "phlo-pgweb"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-postgres/pyproject.toml
+++ b/packages/phlo-postgres/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Postgres service plugin for Phlo"
 name = "phlo-postgres"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-postgres/src/phlo_postgres/__init__.py
+++ b/packages/phlo-postgres/src/phlo_postgres/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     "PostgresSettings",
     "get_settings",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-postgrest/pyproject.toml
+++ b/packages/phlo-postgrest/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "postgrest service plugin for Phlo"
 name = "phlo-postgrest"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-prometheus/pyproject.toml
+++ b/packages/phlo-prometheus/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "prometheus service plugin for Phlo"
 name = "phlo-prometheus"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-rustfs/pyproject.toml
+++ b/packages/phlo-rustfs/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "RustFS service plugin for Phlo"
 name = "phlo-rustfs"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-rustfs/src/phlo_rustfs/__init__.py
+++ b/packages/phlo-rustfs/src/phlo_rustfs/__init__.py
@@ -4,4 +4,4 @@ from phlo_rustfs.plugin import RustfsServicePlugin
 from phlo_rustfs.settings import RustfsSettings, get_settings
 
 __all__ = ["RustfsServicePlugin", "RustfsSettings", "get_settings"]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-sling/pyproject.toml
+++ b/packages/phlo-sling/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Sling replication ingestion provider for Phlo"
 name = "phlo-sling"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-superset/pyproject.toml
+++ b/packages/phlo-superset/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "superset service plugin for Phlo"
 name = "phlo-superset"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-testing/pyproject.toml
+++ b/packages/phlo-testing/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 description = "Testing utilities for Phlo"
 name = "phlo-testing"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-testing/src/phlo_testing/__init__.py
+++ b/packages/phlo-testing/src/phlo_testing/__init__.py
@@ -341,4 +341,4 @@ __all__ = [
 if _FIXTURES_AVAILABLE:
     __all__.extend(_FIXTURE_EXPORTS)
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-traefik/pyproject.toml
+++ b/packages/phlo-traefik/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "Traefik service plugin for Phlo"
 name = "phlo-traefik"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/pyproject.toml
+++ b/packages/phlo-trino/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Trino service plugin for Phlo"
 name = "phlo-trino"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/src/phlo_trino/__init__.py
+++ b/packages/phlo-trino/src/phlo_trino/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     "TrinoSettings",
     "get_settings",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.7.2"
+version = "0.7.3"
 
 [project.entry-points."phlo.plugins.quality"]
 

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -274,4 +274,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/uv.lock
+++ b/uv.lock
@@ -2838,7 +2838,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3014,7 +3014,7 @@ dev = [
 
 [[package]]
 name = "phlo-alerting"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-alerting" }
 dependencies = [
     { name = "click" },
@@ -3042,7 +3042,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-alloy"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-alloy" }
 dependencies = [
     { name = "phlo" },
@@ -3066,7 +3066,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-api"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-api" }
 dependencies = [
     { name = "anyio" },
@@ -3106,7 +3106,7 @@ provides-extras = ["dev", "lineage"]
 
 [[package]]
 name = "phlo-clickhouse"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-clickhouse" }
 dependencies = [
     { name = "clickhouse-connect" },
@@ -3142,7 +3142,7 @@ provides-extras = ["dbt", "dev"]
 
 [[package]]
 name = "phlo-clickstack"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-clickstack" }
 dependencies = [
     { name = "phlo" },
@@ -3166,7 +3166,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-core-plugins"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-core-plugins" }
 dependencies = [
     { name = "phlo" },
@@ -3196,7 +3196,7 @@ provides-extras = ["dev", "quality"]
 
 [[package]]
 name = "phlo-dagster"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-dagster" }
 dependencies = [
     { name = "dagster-graphql" },
@@ -3240,7 +3240,7 @@ provides-extras = ["alerting", "dev", "iceberg", "nessie", "observatory"]
 
 [[package]]
 name = "phlo-dbt"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-dbt" }
 dependencies = [
     { name = "dbt-core" },
@@ -3276,7 +3276,7 @@ provides-extras = ["dagster", "dev", "quality"]
 
 [[package]]
 name = "phlo-delta"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-delta" }
 dependencies = [
     { name = "deltalake" },
@@ -3306,7 +3306,7 @@ provides-extras = ["dev", "minio"]
 
 [[package]]
 name = "phlo-dlt"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-dlt" }
 dependencies = [
     { name = "dlt" },
@@ -3340,7 +3340,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-grafana"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-grafana" }
 dependencies = [
     { name = "phlo" },
@@ -3364,7 +3364,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-hasura"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-hasura" }
 dependencies = [
     { name = "phlo" },
@@ -3394,7 +3394,7 @@ provides-extras = ["dev", "postgres"]
 
 [[package]]
 name = "phlo-iceberg"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-iceberg" }
 dependencies = [
     { name = "pandera" },
@@ -3428,7 +3428,7 @@ provides-extras = ["dev", "minio", "nessie"]
 
 [[package]]
 name = "phlo-lineage"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-lineage" }
 dependencies = [
     { name = "click" },
@@ -3462,7 +3462,7 @@ provides-extras = ["dev", "observatory"]
 
 [[package]]
 name = "phlo-loki"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-loki" }
 dependencies = [
     { name = "phlo" },
@@ -3490,7 +3490,7 @@ provides-extras = ["dev", "observatory"]
 
 [[package]]
 name = "phlo-minio"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-minio" }
 dependencies = [
     { name = "phlo" },
@@ -3514,7 +3514,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-nessie"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-nessie" }
 dependencies = [
     { name = "marshmallow" },
@@ -3556,7 +3556,7 @@ provides-extras = ["dev", "iceberg-cli", "observatory", "trino"]
 
 [[package]]
 name = "phlo-observatory"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-observatory" }
 dependencies = [
     { name = "phlo" },
@@ -3582,7 +3582,7 @@ provides-extras = ["dev", "postgres"]
 
 [[package]]
 name = "phlo-observatory-example"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-observatory-example" }
 dependencies = [
     { name = "phlo" },
@@ -3597,7 +3597,7 @@ requires-dist = [
 
 [[package]]
 name = "phlo-openmetadata"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-openmetadata" }
 dependencies = [
     { name = "phlo" },
@@ -3645,7 +3645,7 @@ provides-extras = ["dbt", "dev", "lineage", "nessie", "postgres", "quality", "tr
 
 [[package]]
 name = "phlo-otel"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-otel" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -3673,7 +3673,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-pandera"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-pandera" }
 dependencies = [
     { name = "click" },
@@ -3707,7 +3707,7 @@ provides-extras = ["dev", "observatory"]
 
 [[package]]
 name = "phlo-pgweb"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-pgweb" }
 dependencies = [
     { name = "phlo" },
@@ -3731,7 +3731,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-postgres"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-postgres" }
 dependencies = [
     { name = "phlo" },
@@ -3757,7 +3757,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-postgrest"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-postgrest" }
 dependencies = [
     { name = "phlo" },
@@ -3791,7 +3791,7 @@ provides-extras = ["dbt", "dev", "postgres"]
 
 [[package]]
 name = "phlo-prometheus"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-prometheus" }
 dependencies = [
     { name = "phlo" },
@@ -3815,7 +3815,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-rustfs"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-rustfs" }
 dependencies = [
     { name = "phlo" },
@@ -3839,7 +3839,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-sling"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-sling" }
 dependencies = [
     { name = "phlo" },
@@ -3865,7 +3865,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-superset"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-superset" }
 dependencies = [
     { name = "phlo" },
@@ -3889,7 +3889,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-testing"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-testing" }
 dependencies = [
     { name = "dlt" },
@@ -3931,7 +3931,7 @@ provides-extras = ["dev", "dlt", "trino"]
 
 [[package]]
 name = "phlo-traefik"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-traefik" }
 dependencies = [
     { name = "phlo" },
@@ -3955,7 +3955,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-trino"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-trino" }
 dependencies = [
     { name = "phlo" },


### PR DESCRIPTION
## Release summary

## [phlo 0.7.3, phlo-alerting 0.2.4, phlo-alloy 0.2.4, phlo-api 0.2.4, phlo-clickhouse 0.2.4, phlo-clickstack 0.2.4, phlo-core-plugins 0.2.4, phlo-dagster 0.2.4, phlo-dbt 0.2.4, phlo-delta 0.2.4, phlo-dlt 0.2.4, phlo-grafana 0.2.4, phlo-hasura 0.2.4, phlo-iceberg 0.2.4, phlo-lineage 0.2.4, phlo-loki 0.2.4, phlo-minio 0.2.4, phlo-nessie 0.2.4, phlo-observatory 0.2.4, phlo-observatory-example 0.2.4, phlo-openmetadata 0.2.4, phlo-otel 0.2.4, phlo-pandera 0.2.4, phlo-pgweb 0.2.4, phlo-postgres 0.2.4, phlo-postgrest 0.2.4, phlo-prometheus 0.2.4, phlo-rustfs 0.2.4, phlo-sling 0.2.4, phlo-superset 0.2.4, phlo-testing 0.2.4, phlo-traefik 0.2.4, phlo-trino 0.2.4] - 2026-03-28

### Fixed
- phlo: only tag merged release commits
- phlo: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-delta: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-hasura: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-iceberg: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-lineage: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-minio: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-nessie: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-postgres: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-rustfs: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-trino: centralize Docker hostname resolution for host-side CLI portability (#308)

### Contributors
Thanks to our contributors for this release:
- 🎉 @iamgp — first contribution!

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release