### PR TITLE
chore(release): phlo 0.7.3 + 9 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [phlo 0.7.3 + 9 packages] - 2026-03-28
+
+### Fixed
+- phlo: only tag merged release commits
+- phlo: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo: adopt ReleaseX release_set mode
+- phlo-delta: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-hasura: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-iceberg: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-lineage: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-minio: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-nessie: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-postgres: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-rustfs: centralize Docker hostname resolution for host-side CLI portability (#308)
+- phlo-trino: centralize Docker hostname resolution for host-side CLI portability (#308)
+
+### Contributors
+Thanks to our contributors for this release:
+- @iamgp (13 commits)
+
 ## [phlo 0.7.2, phlo-alerting 0.2.3, phlo-alloy 0.2.3, phlo-api 0.2.3, phlo-clickhouse 0.2.3, phlo-clickstack 0.2.3, phlo-core-plugins 0.2.3, phlo-dagster 0.2.3, phlo-dbt 0.2.3, phlo-delta 0.2.3, phlo-dlt 0.2.3, phlo-grafana 0.2.3, phlo-hasura 0.2.3, phlo-iceberg 0.2.3, phlo-lineage 0.2.3, phlo-loki 0.2.3, phlo-minio 0.2.3, phlo-nessie 0.2.3, phlo-observatory 0.2.3, phlo-observatory-example 0.2.3, phlo-openmetadata 0.2.3, phlo-otel 0.2.3, phlo-pandera 0.2.3, phlo-pgweb 0.2.3, phlo-postgres 0.2.3, phlo-postgrest 0.2.3, phlo-prometheus 0.2.3, phlo-rustfs 0.2.3, phlo-sling 0.2.3, phlo-superset 0.2.3, phlo-testing 0.2.3, phlo-traefik 0.2.3, phlo-trino 0.2.3] - 2026-03-27
 
 ### Fixed

--- a/packages/phlo-delta/pyproject.toml
+++ b/packages/phlo-delta/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Delta Lake table-store capability plugin for Phlo"
 name = "phlo-delta"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-hasura/pyproject.toml
+++ b/packages/phlo-hasura/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "hasura service plugin for Phlo"
 name = "phlo-hasura"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-iceberg/pyproject.toml
+++ b/packages/phlo-iceberg/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Iceberg table-store capability plugin for Phlo"
 name = "phlo-iceberg"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-lineage/pyproject.toml
+++ b/packages/phlo-lineage/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Lineage tracking and visualization for Phlo"
 name = "phlo-lineage"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-minio/pyproject.toml
+++ b/packages/phlo-minio/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "MinIO service plugin for Phlo"
 name = "phlo-minio"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-minio/src/phlo_minio/__init__.py
+++ b/packages/phlo-minio/src/phlo_minio/__init__.py
@@ -4,4 +4,4 @@ from phlo_minio.plugin import MinioServicePlugin
 from phlo_minio.settings import MinioSettings, get_settings
 
 __all__ = ["MinioServicePlugin", "MinioSettings", "get_settings"]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-nessie/pyproject.toml
+++ b/packages/phlo-nessie/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Nessie service plugin for Phlo"
 name = "phlo-nessie"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-nessie/src/phlo_nessie/__init__.py
+++ b/packages/phlo-nessie/src/phlo_nessie/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     "NessieSettings",
     "get_settings",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-postgres/pyproject.toml
+++ b/packages/phlo-postgres/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Postgres service plugin for Phlo"
 name = "phlo-postgres"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-postgres/src/phlo_postgres/__init__.py
+++ b/packages/phlo-postgres/src/phlo_postgres/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     "PostgresSettings",
     "get_settings",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-rustfs/pyproject.toml
+++ b/packages/phlo-rustfs/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "RustFS service plugin for Phlo"
 name = "phlo-rustfs"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-rustfs/src/phlo_rustfs/__init__.py
+++ b/packages/phlo-rustfs/src/phlo_rustfs/__init__.py
@@ -4,4 +4,4 @@ from phlo_rustfs.plugin import RustfsServicePlugin
 from phlo_rustfs.settings import RustfsSettings, get_settings
 
 __all__ = ["RustfsServicePlugin", "RustfsSettings", "get_settings"]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/packages/phlo-trino/pyproject.toml
+++ b/packages/phlo-trino/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Trino service plugin for Phlo"
 name = "phlo-trino"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/src/phlo_trino/__init__.py
+++ b/packages/phlo-trino/src/phlo_trino/__init__.py
@@ -13,4 +13,4 @@ __all__ = [
     "TrinoSettings",
     "get_settings",
 ]
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.7.2"
+version = "0.7.3"
 
 [project.entry-points."phlo.plugins.quality"]
 

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -274,4 +274,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/uv.lock
+++ b/uv.lock
@@ -2838,7 +2838,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3276,7 +3276,7 @@ provides-extras = ["dagster", "dev", "quality"]
 
 [[package]]
 name = "phlo-delta"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-delta" }
 dependencies = [
     { name = "deltalake" },
@@ -3364,7 +3364,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-hasura"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-hasura" }
 dependencies = [
     { name = "phlo" },
@@ -3394,7 +3394,7 @@ provides-extras = ["dev", "postgres"]
 
 [[package]]
 name = "phlo-iceberg"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-iceberg" }
 dependencies = [
     { name = "pandera" },
@@ -3428,7 +3428,7 @@ provides-extras = ["dev", "minio", "nessie"]
 
 [[package]]
 name = "phlo-lineage"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-lineage" }
 dependencies = [
     { name = "click" },
@@ -3490,7 +3490,7 @@ provides-extras = ["dev", "observatory"]
 
 [[package]]
 name = "phlo-minio"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-minio" }
 dependencies = [
     { name = "phlo" },
@@ -3514,7 +3514,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-nessie"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-nessie" }
 dependencies = [
     { name = "marshmallow" },
@@ -3731,7 +3731,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-postgres"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-postgres" }
 dependencies = [
     { name = "phlo" },
@@ -3815,7 +3815,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-rustfs"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-rustfs" }
 dependencies = [
     { name = "phlo" },
@@ -3955,7 +3955,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-trino"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-trino" }
 dependencies = [
     { name = "phlo" },


### PR DESCRIPTION
## Release summary

## [phlo 0.7.3 + 9 packages] - 2026-03-28

### Fixed
- phlo: only tag merged release commits
- phlo: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo: adopt ReleaseX release_set mode
- phlo-delta: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-hasura: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-iceberg: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-lineage: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-minio: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-nessie: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-postgres: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-rustfs: centralize Docker hostname resolution for host-side CLI portability (#308)
- phlo-trino: centralize Docker hostname resolution for host-side CLI portability (#308)

### Contributors
Thanks to our contributors for this release:
- @iamgp (13 commits)

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release