### PR TITLE
chore: pin ReleaseX v1.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           version: "latest"
           enable-cache: false
 
-      - uses: iamgp/ReleaseX@ba476bbb8bacad3fb01f4ea2090784248e3397ee
+      - uses: iamgp/ReleaseX@24492b6809d16699dc785f93eaeed27aad1bc2f2
         with:
           command: release pr
         env:
@@ -53,7 +53,7 @@ jobs:
           version: "latest"
           enable-cache: false
 
-      - uses: iamgp/ReleaseX@ba476bbb8bacad3fb01f4ea2090784248e3397ee
+      - uses: iamgp/ReleaseX@24492b6809d16699dc785f93eaeed27aad1bc2f2
         with:
           command: release tag
         env:
@@ -85,7 +85,7 @@ jobs:
           uv build --out-dir "$repo_root/dist"
           for pkg in packages/*/; do uv build --directory "$pkg" --out-dir "$repo_root/dist"; done
 
-      - uses: iamgp/ReleaseX@ba476bbb8bacad3fb01f4ea2090784248e3397ee
+      - uses: iamgp/ReleaseX@24492b6809d16699dc785f93eaeed27aad1bc2f2
         with:
           command: release publish
         env:


### PR DESCRIPTION
## Summary
- pin the release workflow to ReleaseX `v1.1.2`
- pick up the `release_set` root-tag fix so repo releases tag on the `phlo` version line again
- pick up the non-unified publish fix for tag-triggered release publishes

## Why
`phlo`'s last merged release PR produced `v10pkgs-...` and the publish step then failed with `no releasable packages found in monorepo`. ReleaseX `v1.1.2` contains the fixes for both of those regressions.

## Validation
- parsed `.github/workflows/release.yml` with Ruby YAML
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/310" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
