### PR TITLE
chore(release): phlo 0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [phlo 0.7.6] - 2026-03-28
+
+### Fixed
+- phlo: fetch tags for release publish
+- phlo: sync phlo version to v0.7.5
+
+### Contributors
+Thanks to our contributors for this release:
+- @iamgp (2 commits)
+
 ## [phlo 0.7.4] - 2026-03-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.7.5"
+version = "0.7.6"
 
 [project.entry-points."phlo.plugins.quality"]
 

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -274,4 +274,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/uv.lock
+++ b/uv.lock
@@ -2838,7 +2838,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },


### PR DESCRIPTION
## Release summary

## [phlo 0.7.6] - 2026-03-28

### Fixed
- phlo: fetch tags for release publish
- phlo: sync phlo version to v0.7.5

### Contributors
Thanks to our contributors for this release:
- @iamgp (2 commits)

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
