### PR TITLE
fix: dbt lineage import discovery cycle

### DIFF
--- a/packages/phlo-dbt/src/phlo_dbt/cli_plugin.py
+++ b/packages/phlo-dbt/src/phlo_dbt/cli_plugin.py
@@ -32,7 +32,6 @@ from phlo.cli.infrastructure.utils import get_project_name
 from phlo.logging import get_logger
 from phlo.plugins.base import CliCommandPlugin, PluginMetadata
 from phlo_dbt.cli_publishing import publishing
-from phlo_dbt.lineage_import import import_manifest_lineage
 from phlo_dbt.runtime_config import DEFAULT_DBT_TARGET, ensure_dbt_profile
 
 
@@ -109,6 +108,13 @@ def _resolve_exec_service_name() -> str:
     return service_name
 
 
+def _import_manifest_lineage(manifest_path: Path) -> dict[str, int]:
+    """Import dbt lineage lazily to avoid plugin discovery-time import cycles."""
+    from phlo_dbt.lineage_import import import_manifest_lineage
+
+    return import_manifest_lineage(manifest_path)
+
+
 def _run_dbt_in_container(
     *,
     subcommand: str,
@@ -168,7 +174,7 @@ def _import_lineage_after_run(
 
     manifest_path = project_dir / "target" / "manifest.json"
     try:
-        summary = import_manifest_lineage(manifest_path)
+        summary = _import_manifest_lineage(manifest_path)
     except Exception:
         logger.warning(
             "dbt_cli_lineage_import_failed",

--- a/packages/phlo-dbt/src/phlo_dbt/lineage_import.py
+++ b/packages/phlo-dbt/src/phlo_dbt/lineage_import.py
@@ -22,12 +22,29 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from phlo.capabilities.discovery import discover_capabilities
-from phlo.capabilities.resolver import resolve_capability
 from phlo.logging import get_logger
 from phlo_dbt.translator import DbtSpecTranslator
 
 logger = get_logger(__name__)
+
+
+def _discover_capabilities() -> None:
+    """Import and run capability discovery lazily.
+
+    This avoids importing capability discovery while dbt plugins are themselves
+    being discovered, which can otherwise create a circular import through
+    ``phlo.plugins.discovery``.
+    """
+    from phlo.capabilities.discovery import discover_capabilities
+
+    discover_capabilities()
+
+
+def _resolve_capability(capability_type: str) -> Any:
+    """Import capability resolution lazily to avoid discovery-time cycles."""
+    from phlo.capabilities.resolver import resolve_capability
+
+    return resolve_capability(capability_type)
 
 
 def load_dbt_manifest(manifest_path: Path) -> dict[str, Any] | None:
@@ -203,8 +220,8 @@ def import_manifest_lineage(manifest_path: Path) -> dict[str, int]:
     if manifest is None:
         return {"asset_edges": 0, "column_mappings": 0}
 
-    discover_capabilities()
-    resolution = resolve_capability("lineage_sink")
+    _discover_capabilities()
+    resolution = _resolve_capability("lineage_sink")
     if resolution is None:
         logger.info(
             "dbt_lineage_import_skipped_no_sink",

--- a/packages/phlo-dbt/tests/test_dbt_cli_plugin.py
+++ b/packages/phlo-dbt/tests/test_dbt_cli_plugin.py
@@ -48,7 +48,7 @@ def test_dbt_run_uses_active_orchestrator_container_by_default(monkeypatch, tmp_
     )
     imported_manifests: list[Path] = []
     monkeypatch.setattr(
-        "phlo_dbt.cli_plugin.import_manifest_lineage",
+        "phlo_dbt.cli_plugin._import_manifest_lineage",
         lambda manifest_path: (
             imported_manifests.append(manifest_path) or {"asset_edges": 1, "column_mappings": 0}
         ),
@@ -104,7 +104,7 @@ def test_dbt_run_local_uses_host_dbt(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("phlo_dbt.cli_plugin.ensure_dbt_profile", lambda *_args, **_kwargs: None)
     imported_manifests: list[Path] = []
     monkeypatch.setattr(
-        "phlo_dbt.cli_plugin.import_manifest_lineage",
+        "phlo_dbt.cli_plugin._import_manifest_lineage",
         lambda manifest_path: (
             imported_manifests.append(manifest_path) or {"asset_edges": 1, "column_mappings": 0}
         ),
@@ -188,7 +188,7 @@ def test_dbt_run_joins_multiple_select_flags(monkeypatch, tmp_path) -> None:
         lambda: SimpleNamespace(dbt_project_path=project_dir, dbt_profiles_path=profiles_dir),
     )
     monkeypatch.setattr(
-        "phlo_dbt.cli_plugin.import_manifest_lineage",
+        "phlo_dbt.cli_plugin._import_manifest_lineage",
         lambda _manifest_path: {"asset_edges": 1, "column_mappings": 0},
     )
 
@@ -225,7 +225,7 @@ def test_dbt_run_skips_lineage_import_on_failure(monkeypatch, tmp_path) -> None:
 
     imported_manifests: list[Path] = []
     monkeypatch.setattr(
-        "phlo_dbt.cli_plugin.import_manifest_lineage",
+        "phlo_dbt.cli_plugin._import_manifest_lineage",
         lambda manifest_path: (
             imported_manifests.append(manifest_path) or {"asset_edges": 1, "column_mappings": 0}
         ),
@@ -257,7 +257,7 @@ def test_dbt_compile_does_not_import_lineage(monkeypatch, tmp_path) -> None:
 
     imported_manifests: list[Path] = []
     monkeypatch.setattr(
-        "phlo_dbt.cli_plugin.import_manifest_lineage",
+        "phlo_dbt.cli_plugin._import_manifest_lineage",
         lambda manifest_path: (
             imported_manifests.append(manifest_path) or {"asset_edges": 1, "column_mappings": 0}
         ),

--- a/packages/phlo-dbt/tests/test_lineage_import.py
+++ b/packages/phlo-dbt/tests/test_lineage_import.py
@@ -78,9 +78,9 @@ def test_import_manifest_lineage_persists_assets_and_columns(monkeypatch, tmp_pa
         sink_calls.append((edges, asset_keys, metadata)) or len(edges)
     )
     sink.record_column_lineage = lambda mappings: column_calls.append(mappings) or len(mappings)
-    monkeypatch.setattr("phlo_dbt.lineage_import.discover_capabilities", lambda: None)
+    monkeypatch.setattr("phlo_dbt.lineage_import._discover_capabilities", lambda: None)
     monkeypatch.setattr(
-        "phlo_dbt.lineage_import.resolve_capability",
+        "phlo_dbt.lineage_import._resolve_capability",
         lambda capability_type: (
             SimpleNamespace(name="phlo-lineage", provider=sink)
             if capability_type == "lineage_sink"
@@ -123,9 +123,9 @@ def test_import_manifest_lineage_skips_when_no_sink(monkeypatch, tmp_path) -> No
     manifest_path.parent.mkdir(parents=True)
     manifest_path.write_text(json.dumps({"nodes": {}, "sources": {}}), encoding="utf-8")
 
-    monkeypatch.setattr("phlo_dbt.lineage_import.discover_capabilities", lambda: None)
+    monkeypatch.setattr("phlo_dbt.lineage_import._discover_capabilities", lambda: None)
     monkeypatch.setattr(
-        "phlo_dbt.lineage_import.resolve_capability",
+        "phlo_dbt.lineage_import._resolve_capability",
         lambda capability_type: None,
     )
 


### PR DESCRIPTION
## Summary

This fixes a circular import introduced by the new dbt lineage import path.

`phlo_dbt.lineage_import` was importing capability discovery at module import time, which fed back into plugin discovery while `phlo_dbt` itself was still being loaded. In practice that produced `plugin_load_failed` errors for the dbt asset provider and CLI plugin during workshop startup and command execution.

## What changed

- made capability discovery/resolution lazy in `phlo_dbt.lineage_import`
- made CLI lineage import lazy in `phlo_dbt.cli_plugin`
- updated the dbt tests to patch the new helper seams

## Why this approach

The issue was not the lineage import behavior itself, but *when* those imports happened.

Deferring capability and lineage imports until runtime keeps the new `phlo dbt run` lineage import behavior intact while avoiding import-time cycles during plugin discovery.

## Validation

Focused tests:

```bash
uv run --project /Users/garethprice/Developer/phlo pytest packages/phlo-dbt/tests/test_lineage_import.py packages/phlo-dbt/tests/test_dbt_cli_plugin.py -q
```

Result:
- `11 passed`

Manual validation against the workshop repo using local editable Phlo sources:

```bash
uv run --no-sync phlo dbt run --select "stg_pokemon stg_pokemon_types dim_types dim_pokemon fct_pokemon_by_generation"
uv run --no-sync workshop-runner --chapter 01-ingest-pokemon
uv run --no-sync workshop-runner --chapter 11-lineage
```

Results:
- `phlo dbt run` succeeds and logs `dbt_cli_lineage_import_succeeded`
- chapter `01-ingest-pokemon` passes again
- chapter `11-lineage` passes again

## Context

This surfaced immediately after the 0.7.8 lineage import fix when validating the workshop end-to-end without the local compatibility shim.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/323" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
