### PR TITLE
chore(release): phlo 0.8.0 + 25 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,130 @@
 # Changelog
 
+## [phlo 0.8.0 + 25 packages] - 2026-05-03
+
+### Added
+- phlo: pymdx driven docs (#327)
+- phlo: harden service discovery and add quickstart smoke (#451)
+- phlo: expand regulated surface coverage (#466)
+- phlo: add evidence, signatures, and governance operations (#467)
+- phlo: add phlo MCP trace inspection tools (#468)
+- phlo: add podman container backend
+- phlo: add phlo doctor diagnostics
+- phlo: polish workflow authoring path (#469)
+- phlo: add project template gallery (#472)
+- phlo: expand observatory v2 capability UI (#473)
+- phlo-alerting: expand regulated surface coverage (#466)
+- phlo-api: expand regulated surface coverage (#466)
+- phlo-api: add phlo MCP trace inspection tools (#468)
+- phlo-api: expand observatory v2 capability UI (#473)
+- phlo-clickhouse: expand regulated surface coverage (#466)
+- phlo-clickhouse: add podman container backend
+- phlo-clickstack: expand regulated surface coverage (#466)
+- phlo-clickstack: add phlo MCP trace inspection tools (#468)
+- phlo-clickstack: add podman container backend
+- phlo-dagster: expand regulated surface coverage (#466)
+- phlo-dagster: add phlo MCP trace inspection tools (#468)
+- phlo-dbt: expand regulated surface coverage (#466)
+- phlo-dbt: expand observatory v2 capability UI (#473)
+- phlo-delta: expand observatory v2 capability UI (#473)
+- phlo-dlt: expand regulated surface coverage (#466)
+- phlo-dlt: polish workflow authoring path (#469)
+- phlo-iceberg: expand observatory v2 capability UI (#473)
+- phlo-lineage: expand regulated surface coverage (#466)
+- phlo-mcp: add phlo MCP trace inspection tools (#468)
+- phlo-minio: expand regulated surface coverage (#466)
+- phlo-minio: add podman container backend
+- phlo-nessie: expand regulated surface coverage (#466)
+- phlo-oauth2-proxy: expand regulated surface coverage (#466)
+- phlo-observatory: expand observatory v2 capability UI (#473)
+- phlo-openmetadata: expand regulated surface coverage (#466)
+- phlo-pandera: expand regulated surface coverage (#466)
+- phlo-pandera: polish workflow authoring path (#469)
+- phlo-pandera: expand observatory v2 capability UI (#473)
+- phlo-postgres: expand regulated surface coverage (#466)
+- phlo-postgres: add podman container backend
+- phlo-sling: expand regulated surface coverage (#466)
+- phlo-testing: expand observatory v2 capability UI (#473)
+- phlo-trino: expand regulated surface coverage (#466)
+- phlo-trino: add podman container backend
+
+### Changed
+- phlo: code quality improvements batch (#369)
+- phlo: extract shared dependency expansion logic (#430)
+- phlo: hook and service test helpers (#434)
+- phlo: unify yaml service plugins and test doubles (#443)
+- phlo: consolidate plugin discovery cleanup paths (#444)
+- phlo-api: unify yaml service plugins and test doubles (#443)
+- phlo-clickhouse: unify yaml service plugins and test doubles (#443)
+- phlo-clickstack: code quality improvements batch (#369)
+- phlo-dagster: unify yaml service plugins and test doubles (#443)
+- phlo-hasura: unify yaml service plugins and test doubles (#443)
+- phlo-minio: unify yaml service plugins and test doubles (#443)
+- phlo-nessie: code quality improvements batch (#369)
+- phlo-observatory: unify yaml service plugins and test doubles (#443)
+- phlo-openmetadata: code quality improvements batch (#369)
+- phlo-postgres: code quality improvements batch (#369)
+- phlo-postgrest: unify yaml service plugins and test doubles (#443)
+- phlo-superset: unify yaml service plugins and test doubles (#443)
+- phlo-testing: unify yaml service plugins and test doubles (#443)
+- phlo-trino: code quality improvements batch (#369)
+- phlo-trino: extract shared dependency expansion logic (#430)
+
+### Fixed
+- phlo: add manual release publish trigger
+- phlo: accept bare version in manual release trigger
+- phlo: gather remaining release artifacts into root dist
+- phlo: simplify release publish and disable docs workflow
+- phlo: keep docs
+- phlo: clean deploy gh-pages, preserve cairn, move pymdx to dev deps
+- phlo: inject basePath into next.config for GitHub Pages
+- phlo: resolve pandera mutation, null column loop, hardcoded version, plugin registration (#357)
+- phlo: security hardening — SQL injection, timing attacks, path traversal, stub reverts (#358)
+- phlo: dev mode production guard, command injection, hardcoded creds, auth logging, CLI fixes (#359)
+- phlo: correctness fixes, dead code removal, and security hardening (#360)
+- phlo: security hardening and config correctness (#362)
+- phlo: CLI and plugin system correctness fixes (#361)
+- phlo: correct 4 CLI correctness issues from batch #347 (#364)
+- phlo: normalize tags dict in HookFilter.__post_init__ (#365)
+- phlo: prevent info leak from exception cause chain (#366)
+- phlo: proxy auth signing and project root resolution (#367)
+- phlo: restrict CORS to configured origins (#427)
+- phlo: resolve 10 audit findings across security batch (#431)
+- phlo: address CLI test fragility, add utils tests, add Prettier hook (#432)
+- phlo: harden plugin discovery imports (#435)
+- phlo: lazy-load observatory settings dependency (#437)
+- phlo: review regressions in Trino governance and pytest collection (#448)
+- phlo: cairn CI races and artifact gaps (#449)
+- phlo: address P1/P2 audit findings (#450)
+- phlo: reject unsupported canonical deny policies (#459)
+- phlo: correct PostgREST view RLS docs mismatch (#463)
+- phlo: escape angle brackets in docstrings for MDX compatibility
+- phlo: align scaffolding and service defaults (#474)
+- phlo-api: restrict CORS to configured origins (#427)
+- phlo-api: resolve 10 audit findings across security batch (#431)
+- phlo-core-plugins: address P1/P2 audit findings (#450)
+- phlo-dbt: security hardening — SQL injection, timing attacks, path traversal, stub reverts (#358)
+- phlo-dbt: dev mode production guard, command injection, hardcoded creds, auth logging, CLI fixes (#359)
+- phlo-dlt: resolve pandera mutation, null column loop, hardcoded version, plugin registration (#357)
+- phlo-dlt: align scaffolding and service defaults (#474)
+- phlo-hasura: resolve 10 audit findings across security batch (#431)
+- phlo-minio: align scaffolding and service defaults (#474)
+- phlo-nessie: align scaffolding and service defaults (#474)
+- phlo-openmetadata: review regressions in Trino governance and pytest collection (#448)
+- phlo-pandera: correctness fixes, dead code removal, and security hardening (#360)
+- phlo-pandera: align scaffolding and service defaults (#474)
+- phlo-postgres: align scaffolding and service defaults (#474)
+- phlo-postgrest: resolve 10 audit findings across security batch (#431)
+- phlo-postgrest: correct PostgREST view RLS docs mismatch (#463)
+- phlo-superset: resolve 10 audit findings across security batch (#431)
+- phlo-testing: resolve 10 audit findings across security batch (#431)
+- phlo-trino: review regressions in Trino governance and pytest collection (#448)
+- phlo-trino: align scaffolding and service defaults (#474)
+
+### Contributors
+Thanks to our contributors for this release:
+- @iamgp (139 commits)
+
 ## [phlo 0.7.10] - 2026-03-31
 
 ### Fixed

--- a/packages/phlo-alerting/pyproject.toml
+++ b/packages/phlo-alerting/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Alerting destinations and hooks for Phlo"
 name = "phlo-alerting"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-api/pyproject.toml
+++ b/packages/phlo-api/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 description = "Phlo API - Backend service exposing Phlo internals to Observatory"
 name = "phlo-api"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-clickhouse/pyproject.toml
+++ b/packages/phlo-clickhouse/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "ClickHouse service and resource plugin for Phlo"
 name = "phlo-clickhouse"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-clickstack/pyproject.toml
+++ b/packages/phlo-clickstack/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "clickstack service plugin for Phlo"
 name = "phlo-clickstack"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"
@@ -22,11 +22,11 @@ name = "Phlo Team"
 [project.entry-points."phlo.plugins.cli"]
 clickstack = "phlo_clickstack.cli_plugin:ClickStackCliPlugin"
 
-[project.entry-points."phlo.plugins.services"]
-clickstack = "phlo_clickstack.plugin:ClickStackServicePlugin"
-
 [project.entry-points."phlo.plugins.resources"]
 clickstack = "phlo_clickstack.resource_provider:ClickStackResourceProvider"
+
+[project.entry-points."phlo.plugins.services"]
+clickstack = "phlo_clickstack.plugin:ClickStackServicePlugin"
 
 [project.license]
 text = "MIT"

--- a/packages/phlo-core-plugins/pyproject.toml
+++ b/packages/phlo-core-plugins/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "Core plugin package for Phlo"
 name = "phlo-core-plugins"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/pyproject.toml
+++ b/packages/phlo-dagster/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Dagster service plugin for Phlo"
 name = "phlo-dagster"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/src/phlo_dagster/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "authorize_daemon_run",
     "create_daemon_principal",
 ]
-__version__ = "0.2.3"
+__version__ = "0.3.0"

--- a/packages/phlo-dbt/pyproject.toml
+++ b/packages/phlo-dbt/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "dbt integration capability plugin for Phlo"
 name = "phlo-dbt"
 requires-python = ">=3.11"
-version = "0.2.5"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-delta/pyproject.toml
+++ b/packages/phlo-delta/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Delta Lake table-store capability plugin for Phlo"
 name = "phlo-delta"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dlt/pyproject.toml
+++ b/packages/phlo-dlt/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 description = "DLT ingestion engine capability plugin for Phlo"
 name = "phlo-dlt"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-hasura/pyproject.toml
+++ b/packages/phlo-hasura/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "hasura service plugin for Phlo"
 name = "phlo-hasura"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.2.5"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-iceberg/pyproject.toml
+++ b/packages/phlo-iceberg/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Iceberg table-store capability plugin for Phlo"
 name = "phlo-iceberg"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-lineage/pyproject.toml
+++ b/packages/phlo-lineage/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Lineage tracking and visualization for Phlo"
 name = "phlo-lineage"
 requires-python = ">=3.11"
-version = "0.2.5"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-mcp/pyproject.toml
+++ b/packages/phlo-mcp/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "MCP server for Phlo observability and lakehouse operations"
 name = "phlo-mcp"
 requires-python = ">=3.11"
-version = "0.1.0"
+version = "0.2.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-mcp/src/phlo_mcp/__init__.py
+++ b/packages/phlo-mcp/src/phlo_mcp/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/packages/phlo-minio/pyproject.toml
+++ b/packages/phlo-minio/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "MinIO service plugin for Phlo"
 name = "phlo-minio"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-nessie/pyproject.toml
+++ b/packages/phlo-nessie/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Nessie service plugin for Phlo"
 name = "phlo-nessie"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-oauth2-proxy/pyproject.toml
+++ b/packages/phlo-oauth2-proxy/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "oauth2-proxy service plugin for Phlo"
 name = "phlo-oauth2-proxy"
 requires-python = ">=3.11"
-version = "0.1.0"
+version = "0.2.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/pyproject.toml
+++ b/packages/phlo-observatory/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["phlo>=0.1.0"]
 description = "Phlo Observatory - Data platform UI (bundled with phlo core)"
 name = "phlo-observatory"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/src/phlo_observatory/__init__.py
+++ b/packages/phlo-observatory/src/phlo_observatory/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "get_settings",
     "get_settings_service",
 ]
-__version__ = "0.2.3"
+__version__ = "0.3.0"

--- a/packages/phlo-openmetadata/pyproject.toml
+++ b/packages/phlo-openmetadata/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "OpenMetadata integration for Phlo"
 name = "phlo-openmetadata"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-pandera/pyproject.toml
+++ b/packages/phlo-pandera/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Quality checks and schema utilities for Phlo"
 name = "phlo-pandera"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-postgres/pyproject.toml
+++ b/packages/phlo-postgres/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Postgres service plugin for Phlo"
 name = "phlo-postgres"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-postgres/src/phlo_postgres/__init__.py
+++ b/packages/phlo-postgres/src/phlo_postgres/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "PostgresSettings",
     "get_settings",
 ]
-__version__ = "0.2.4"
+__version__ = "0.3.0"

--- a/packages/phlo-postgrest/pyproject.toml
+++ b/packages/phlo-postgrest/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "postgrest service plugin for Phlo"
 name = "phlo-postgrest"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-sling/pyproject.toml
+++ b/packages/phlo-sling/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Sling replication ingestion provider for Phlo"
 name = "phlo-sling"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-superset/pyproject.toml
+++ b/packages/phlo-superset/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "superset service plugin for Phlo"
 name = "phlo-superset"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-testing/pyproject.toml
+++ b/packages/phlo-testing/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 description = "Testing utilities for Phlo"
 name = "phlo-testing"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-testing/src/phlo_testing/__init__.py
+++ b/packages/phlo-testing/src/phlo_testing/__init__.py
@@ -341,4 +341,4 @@ __all__ = [
 if _FIXTURES_AVAILABLE:
     __all__.extend(_FIXTURE_EXPORTS)
 
-__version__ = "0.2.3"
+__version__ = "0.3.0"

--- a/packages/phlo-trino/pyproject.toml
+++ b/packages/phlo-trino/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Trino service plugin for Phlo"
 name = "phlo-trino"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/src/phlo_trino/__init__.py
+++ b/packages/phlo-trino/src/phlo_trino/__init__.py
@@ -32,4 +32,4 @@ __all__ = [
     "TrinoSettings",
     "get_settings",
 ]
-__version__ = "0.2.4"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.7.10"
+version = "0.8.0"
 
 [project.entry-points."phlo.plugins.quality"]
 
@@ -174,20 +174,6 @@ select = [
     "PTH",
 ]
 
-[tool.ty.rules]
-invalid-argument-type = "warn"
-invalid-assignment = "warn"
-invalid-method-override = "warn"
-invalid-raise = "warn"
-invalid-return-type = "warn"
-invalid-type-form = "warn"
-missing-argument = "warn"
-no-matching-overload = "warn"
-too-many-positional-arguments = "warn"
-unknown-argument = "warn"
-unresolved-attribute = "warn"
-unsupported-operator = "warn"
-
 [tool.ty.environment]
 extra-paths = [
     "packages/phlo-alerting/src",
@@ -226,6 +212,20 @@ extra-paths = [
 ]
 python-version = "3.11"
 root = ["./src"]
+
+[tool.ty.rules]
+invalid-argument-type = "warn"
+invalid-assignment = "warn"
+invalid-method-override = "warn"
+invalid-raise = "warn"
+invalid-return-type = "warn"
+invalid-type-form = "warn"
+missing-argument = "warn"
+no-matching-overload = "warn"
+too-many-positional-arguments = "warn"
+unknown-argument = "warn"
+unresolved-attribute = "warn"
+unsupported-operator = "warn"
 
 [tool.ty.src]
 exclude = ["**/testing/**"]

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.7.10"
+__version__ = "0.8.0"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -307,4 +307,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.7.10"
+__version__ = "0.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3215,7 +3215,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.7.10"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3401,7 +3401,7 @@ dev = [
 
 [[package]]
 name = "phlo-alerting"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-alerting" }
 dependencies = [
     { name = "click" },
@@ -3453,7 +3453,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-api"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-api" }
 dependencies = [
     { name = "anyio" },
@@ -3493,7 +3493,7 @@ provides-extras = ["dev", "lineage"]
 
 [[package]]
 name = "phlo-clickhouse"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-clickhouse" }
 dependencies = [
     { name = "clickhouse-connect" },
@@ -3529,7 +3529,7 @@ provides-extras = ["dbt", "dev"]
 
 [[package]]
 name = "phlo-clickstack"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-clickstack" }
 dependencies = [
     { name = "phlo" },
@@ -3553,7 +3553,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-core-plugins"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-core-plugins" }
 dependencies = [
     { name = "phlo" },
@@ -3583,7 +3583,7 @@ provides-extras = ["dev", "quality"]
 
 [[package]]
 name = "phlo-dagster"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-dagster" }
 dependencies = [
     { name = "dagster-graphql" },
@@ -3627,7 +3627,7 @@ provides-extras = ["alerting", "dev", "iceberg", "nessie", "observatory"]
 
 [[package]]
 name = "phlo-dbt"
-version = "0.2.5"
+version = "0.3.0"
 source = { editable = "packages/phlo-dbt" }
 dependencies = [
     { name = "dbt-core" },
@@ -3663,7 +3663,7 @@ provides-extras = ["dagster", "dev", "quality"]
 
 [[package]]
 name = "phlo-delta"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "packages/phlo-delta" }
 dependencies = [
     { name = "deltalake" },
@@ -3695,7 +3695,7 @@ provides-extras = ["dev", "minio"]
 
 [[package]]
 name = "phlo-dlt"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-dlt" }
 dependencies = [
     { name = "dlt" },
@@ -3751,7 +3751,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-hasura"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "packages/phlo-hasura" }
 dependencies = [
     { name = "phlo" },
@@ -3781,7 +3781,7 @@ provides-extras = ["dev", "postgres"]
 
 [[package]]
 name = "phlo-iceberg"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "packages/phlo-iceberg" }
 dependencies = [
     { name = "pandera" },
@@ -3815,7 +3815,7 @@ provides-extras = ["dev", "minio", "nessie"]
 
 [[package]]
 name = "phlo-lineage"
-version = "0.2.5"
+version = "0.3.0"
 source = { editable = "packages/phlo-lineage" }
 dependencies = [
     { name = "click" },
@@ -3877,7 +3877,7 @@ provides-extras = ["dev", "observatory"]
 
 [[package]]
 name = "phlo-mcp"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/phlo-mcp" }
 dependencies = [
     { name = "httpx" },
@@ -3907,7 +3907,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-minio"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "packages/phlo-minio" }
 dependencies = [
     { name = "phlo" },
@@ -3931,7 +3931,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-nessie"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "packages/phlo-nessie" }
 dependencies = [
     { name = "marshmallow" },
@@ -3973,7 +3973,7 @@ provides-extras = ["dev", "iceberg-cli", "observatory", "trino"]
 
 [[package]]
 name = "phlo-oauth2-proxy"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/phlo-oauth2-proxy" }
 dependencies = [
     { name = "phlo" },
@@ -3997,7 +3997,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-observatory"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-observatory" }
 dependencies = [
     { name = "phlo" },
@@ -4038,7 +4038,7 @@ requires-dist = [
 
 [[package]]
 name = "phlo-openmetadata"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-openmetadata" }
 dependencies = [
     { name = "phlo" },
@@ -4114,7 +4114,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-pandera"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-pandera" }
 dependencies = [
     { name = "click" },
@@ -4172,7 +4172,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-postgres"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "packages/phlo-postgres" }
 dependencies = [
     { name = "phlo" },
@@ -4198,7 +4198,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-postgrest"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-postgrest" }
 dependencies = [
     { name = "phlo" },
@@ -4280,7 +4280,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-sling"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-sling" }
 dependencies = [
     { name = "phlo" },
@@ -4306,7 +4306,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-superset"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-superset" }
 dependencies = [
     { name = "phlo" },
@@ -4330,7 +4330,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-testing"
-version = "0.2.3"
+version = "0.3.0"
 source = { editable = "packages/phlo-testing" }
 dependencies = [
     { name = "dlt" },
@@ -4398,7 +4398,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-trino"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "packages/phlo-trino" }
 dependencies = [
     { name = "phlo" },


### PR DESCRIPTION
## Release summary

## [phlo 0.8.0 + 25 packages] - 2026-05-03

### Added
- phlo: pymdx driven docs (#327)
- phlo: harden service discovery and add quickstart smoke (#451)
- phlo: expand regulated surface coverage (#466)
- phlo: add evidence, signatures, and governance operations (#467)
- phlo: add phlo MCP trace inspection tools (#468)
- phlo: add podman container backend
- phlo: add phlo doctor diagnostics
- phlo: polish workflow authoring path (#469)
- phlo: add project template gallery (#472)
- phlo: expand observatory v2 capability UI (#473)
- phlo-alerting: expand regulated surface coverage (#466)
- phlo-api: expand regulated surface coverage (#466)
- phlo-api: add phlo MCP trace inspection tools (#468)
- phlo-api: expand observatory v2 capability UI (#473)
- phlo-clickhouse: expand regulated surface coverage (#466)
- phlo-clickhouse: add podman container backend
- phlo-clickstack: expand regulated surface coverage (#466)
- phlo-clickstack: add phlo MCP trace inspection tools (#468)
- phlo-clickstack: add podman container backend
- phlo-dagster: expand regulated surface coverage (#466)
- phlo-dagster: add phlo MCP trace inspection tools (#468)
- phlo-dbt: expand regulated surface coverage (#466)
- phlo-dbt: expand observatory v2 capability UI (#473)
- phlo-delta: expand observatory v2 capability UI (#473)
- phlo-dlt: expand regulated surface coverage (#466)
- phlo-dlt: polish workflow authoring path (#469)
- phlo-iceberg: expand observatory v2 capability UI (#473)
- phlo-lineage: expand regulated surface coverage (#466)
- phlo-mcp: add phlo MCP trace inspection tools (#468)
- phlo-minio: expand regulated surface coverage (#466)
- phlo-minio: add podman container backend
- phlo-nessie: expand regulated surface coverage (#466)
- phlo-oauth2-proxy: expand regulated surface coverage (#466)
- phlo-observatory: expand observatory v2 capability UI (#473)
- phlo-openmetadata: expand regulated surface coverage (#466)
- phlo-pandera: expand regulated surface coverage (#466)
- phlo-pandera: polish workflow authoring path (#469)
- phlo-pandera: expand observatory v2 capability UI (#473)
- phlo-postgres: expand regulated surface coverage (#466)
- phlo-postgres: add podman container backend
- phlo-sling: expand regulated surface coverage (#466)
- phlo-testing: expand observatory v2 capability UI (#473)
- phlo-trino: expand regulated surface coverage (#466)
- phlo-trino: add podman container backend

### Changed
- phlo: code quality improvements batch (#369)
- phlo: extract shared dependency expansion logic (#430)
- phlo: hook and service test helpers (#434)
- phlo: unify yaml service plugins and test doubles (#443)
- phlo: consolidate plugin discovery cleanup paths (#444)
- phlo-api: unify yaml service plugins and test doubles (#443)
- phlo-clickhouse: unify yaml service plugins and test doubles (#443)
- phlo-clickstack: code quality improvements batch (#369)
- phlo-dagster: unify yaml service plugins and test doubles (#443)
- phlo-hasura: unify yaml service plugins and test doubles (#443)
- phlo-minio: unify yaml service plugins and test doubles (#443)
- phlo-nessie: code quality improvements batch (#369)
- phlo-observatory: unify yaml service plugins and test doubles (#443)
- phlo-openmetadata: code quality improvements batch (#369)
- phlo-postgres: code quality improvements batch (#369)
- phlo-postgrest: unify yaml service plugins and test doubles (#443)
- phlo-superset: unify yaml service plugins and test doubles (#443)
- phlo-testing: unify yaml service plugins and test doubles (#443)
- phlo-trino: code quality improvements batch (#369)
- phlo-trino: extract shared dependency expansion logic (#430)

### Fixed
- phlo: add manual release publish trigger
- phlo: accept bare version in manual release trigger
- phlo: gather remaining release artifacts into root dist
- phlo: simplify release publish and disable docs workflow
- phlo: keep docs
- phlo: clean deploy gh-pages, preserve cairn, move pymdx to dev deps
- phlo: inject basePath into next.config for GitHub Pages
- phlo: resolve pandera mutation, null column loop, hardcoded version, plugin registration (#357)
- phlo: security hardening — SQL injection, timing attacks, path traversal, stub reverts (#358)
- phlo: dev mode production guard, command injection, hardcoded creds, auth logging, CLI fixes (#359)
- phlo: correctness fixes, dead code removal, and security hardening (#360)
- phlo: security hardening and config correctness (#362)
- phlo: CLI and plugin system correctness fixes (#361)
- phlo: correct 4 CLI correctness issues from batch #347 (#364)
- phlo: normalize tags dict in HookFilter.__post_init__ (#365)
- phlo: prevent info leak from exception cause chain (#366)
- phlo: proxy auth signing and project root resolution (#367)
- phlo: restrict CORS to configured origins (#427)
- phlo: resolve 10 audit findings across security batch (#431)
- phlo: address CLI test fragility, add utils tests, add Prettier hook (#432)
- phlo: harden plugin discovery imports (#435)
- phlo: lazy-load observatory settings dependency (#437)
- phlo: review regressions in Trino governance and pytest collection (#448)
- phlo: cairn CI races and artifact gaps (#449)
- phlo: address P1/P2 audit findings (#450)
- phlo: reject unsupported canonical deny policies (#459)
- phlo: correct PostgREST view RLS docs mismatch (#463)
- phlo: escape angle brackets in docstrings for MDX compatibility
- phlo: align scaffolding and service defaults (#474)
- phlo-api: restrict CORS to configured origins (#427)
- phlo-api: resolve 10 audit findings across security batch (#431)
- phlo-core-plugins: address P1/P2 audit findings (#450)
- phlo-dbt: security hardening — SQL injection, timing attacks, path traversal, stub reverts (#358)
- phlo-dbt: dev mode production guard, command injection, hardcoded creds, auth logging, CLI fixes (#359)
- phlo-dlt: resolve pandera mutation, null column loop, hardcoded version, plugin registration (#357)
- phlo-dlt: align scaffolding and service defaults (#474)
- phlo-hasura: resolve 10 audit findings across security batch (#431)
- phlo-minio: align scaffolding and service defaults (#474)
- phlo-nessie: align scaffolding and service defaults (#474)
- phlo-openmetadata: review regressions in Trino governance and pytest collection (#448)
- phlo-pandera: correctness fixes, dead code removal, and security hardening (#360)
- phlo-pandera: align scaffolding and service defaults (#474)
- phlo-postgres: align scaffolding and service defaults (#474)
- phlo-postgrest: resolve 10 audit findings across security batch (#431)
- phlo-postgrest: correct PostgREST view RLS docs mismatch (#463)
- phlo-superset: resolve 10 audit findings across security batch (#431)
- phlo-testing: resolve 10 audit findings across security batch (#431)
- phlo-trino: review regressions in Trino governance and pytest collection (#448)
- phlo-trino: align scaffolding and service defaults (#474)

### Contributors
Thanks to our contributors for this release:
- @iamgp (139 commits)

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release