### PR TITLE
fix: security hardening — SQL injection, timing attacks, path traversal, stub reverts

### DIFF
--- a/packages/phlo-dbt/src/phlo_dbt/dbt_inject.py
+++ b/packages/phlo-dbt/src/phlo_dbt/dbt_inject.py
@@ -26,11 +26,21 @@ Example:
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
+
+_SQL_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _validate_identifier(value: str, label: str) -> str:
+    """Validate that *value* is a safe SQL identifier (alphanumeric + underscore)."""
+    if not _SQL_IDENTIFIER_RE.match(value):
+        raise ValueError(f"Unsafe SQL identifier for {label}: {value!r}")
+    return value
 
 
 def _resolve_logger(context: Any | None) -> Any:
@@ -89,6 +99,9 @@ def inject_row_ids_to_table(
         ...     print(f"Added IDs to {result['rows_updated']} rows")
 
     """
+    _validate_identifier(catalog, "catalog")
+    _validate_identifier(schema, "schema")
+    _validate_identifier(table, "table")
     cursor = trino_connection.cursor()
     logger_ = _resolve_logger(context)
 

--- a/packages/phlo-dbt/src/phlo_dbt/translator.py
+++ b/packages/phlo-dbt/src/phlo_dbt/translator.py
@@ -121,6 +121,15 @@ def get_compiled_sql_from_resource_props(
 
     compiled_path = dbt_resource_props.get("compiled_path")
     if compiled_path:
+        compiled_path_str = str(compiled_path)
+        if ".." in compiled_path_str.split("/") or compiled_path_str.startswith("/"):
+            logger.warning(
+                "dbt_translator_compiled_path_rejected",
+                compiled_path=compiled_path_str,
+                reason="path_traversal",
+            )
+            compiled_path = None
+    if compiled_path:
         compiled_file = get_settings().dbt_project_path / str(compiled_path)
         try:
             if compiled_file.exists():

--- a/src/phlo/capabilities/authentication.py
+++ b/src/phlo/capabilities/authentication.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import ipaddress
 import json
 import os
@@ -178,8 +179,13 @@ class StaticAuthenticationProvider:
 
     def validate_token(self, token: str) -> AuthenticatedSession | None:
         """Validate a bearer token."""
-        if token in self._static_users:
-            user_data = self._static_users[token]
+        matched_key: str | None = None
+        for key in self._static_users:
+            if hmac.compare_digest(key, token):
+                matched_key = key
+                break
+        if matched_key is not None:
+            user_data = self._static_users[matched_key]
             principal = AuthPrincipal(
                 subject=user_data.get("subject", token),
                 principal_type=user_data.get("principal_type", "user"),
@@ -388,8 +394,13 @@ class ServiceTokenAuthenticationProvider:
 
     def validate_token(self, token: str) -> AuthenticatedSession | None:
         """Validate a service token."""
-        if token in self._service_tokens:
-            service_data = self._service_tokens[token]
+        matched_key: str | None = None
+        for key in self._service_tokens:
+            if hmac.compare_digest(key, token):
+                matched_key = key
+                break
+        if matched_key is not None:
+            service_data = self._service_tokens[matched_key]
             principal = AuthPrincipal(
                 subject=service_data.get("subject", token),
                 principal_type="service",

--- a/src/phlo/rbac/compiler.py
+++ b/src/phlo/rbac/compiler.py
@@ -7,6 +7,7 @@ RBAC policies into backend-native artifacts.
 from __future__ import annotations
 
 import base64
+import re
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -21,6 +22,19 @@ from phlo.rbac.models import (
     SyncPlan,
     VerifyResult,
 )
+
+_SQL_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.%* -]*$")
+
+
+def _validate_sql_identifier(value: str, label: str) -> str:
+    """Validate that *value* is a safe SQL identifier fragment.
+
+    Raises ``ValueError`` when *value* contains characters outside the
+    allowed set (alphanumeric, underscore, dot, percent, asterisk, hyphen).
+    """
+    if not _SQL_IDENTIFIER_RE.match(value):
+        raise ValueError(f"Unsafe {label}: {value!r}")
+    return value
 
 
 @dataclass
@@ -268,10 +282,13 @@ class TrinoCompiler(GovernanceCompiler):
             privileges = self.ACTION_MAPPING.get(policy.action, ())
 
             for role_name in policy.principal_roles:
+                _validate_sql_identifier(role_name, "role_name")
                 resource_id = policy.resource_id_pattern.replace("*", "%")
+                _validate_sql_identifier(resource_id, "resource_id")
                 artifact_name = f"{role_name}_{policy.resource_type}_{resource_id}"
 
                 for privilege in privileges:
+                    _validate_sql_identifier(privilege, "privilege")
                     if policy.resource_type == "dataset":
                         statement = f"GRANT {privilege} ON TABLE {resource_id} TO ROLE {role_name}"
                     elif policy.resource_type == "service":
@@ -551,9 +568,12 @@ class PostgreSQLCompiler(GovernanceCompiler):
             privileges = self.ACTION_MAPPING.get(policy.action, ())
 
             for role_name in policy.principal_roles:
+                _validate_sql_identifier(role_name, "role_name")
                 resource_id = policy.resource_id_pattern.replace("*", "%")
+                _validate_sql_identifier(resource_id, "resource_id")
 
                 for privilege in privileges:
+                    _validate_sql_identifier(privilege, "privilege")
                     statement = f"GRANT {privilege} ON SCHEMA {resource_id} TO {role_name}"
 
                     artifacts.append(
@@ -659,7 +679,7 @@ class PostgreSQLCompiler(GovernanceCompiler):
         revert_ids: list[str],
         context: CompilerContext,
     ) -> tuple[list[str], list[str]]:
-        return [], []
+        raise NotImplementedError("PostgreSQLCompiler.revert is not implemented")
 
     def read_current_state(
         self,
@@ -826,7 +846,7 @@ class HasuraCompiler(GovernanceCompiler):
         revert_ids: list[str],
         context: CompilerContext,
     ) -> tuple[list[str], list[str]]:
-        return [], []
+        raise NotImplementedError("HasuraCompiler.revert is not implemented")
 
     def read_current_state(
         self,
@@ -995,7 +1015,7 @@ class MinIOCompiler(GovernanceCompiler):
         revert_ids: list[str],
         context: CompilerContext,
     ) -> tuple[list[str], list[str]]:
-        return [], []
+        raise NotImplementedError("MinIOCompiler.revert is not implemented")
 
     def read_current_state(
         self,
@@ -1154,7 +1174,7 @@ class NessieCompiler(GovernanceCompiler):
         revert_ids: list[str],
         context: CompilerContext,
     ) -> tuple[list[str], list[str]]:
-        return [], []
+        raise NotImplementedError("NessieCompiler.revert is not implemented")
 
     def read_current_state(
         self,


### PR DESCRIPTION
## Summary

Batch of 6 security and correctness fixes.

### Fixes

- **CRITICAL #331 + #332** — SQL injection in Trino & PostgreSQL RBAC compilers: policy values (`role_name`, `resource_id`, `privilege`) were interpolated into SQL via f-strings. Added `_validate_sql_identifier()` to reject unsafe characters.

- **HIGH #340** — SQL injection in `dbt_inject.py`: `catalog`, `schema`, and `table` parameters interpolated unsanitized into SQL. Added `_validate_identifier()` validation at function entry.

- **HIGH #341** — Path traversal in dbt translator: `compiled_path` from manifest used without validation, allowing reads like `../../../etc/passwd`. Now rejects paths containing `..` or starting with `/`.

- **HIGH #337** — Timing attack in token validation: replaced `token in dict` lookups with `hmac.compare_digest()` for constant-time comparison in both static user and service token providers.

- **HIGH #342** — RBAC compiler stub reverts: PostgreSQL, Hasura, MinIO, and Nessie compilers had `revert()` returning `[], []`, silently swallowing rollback requests. Now raise `NotImplementedError`.

### Testing

All 396 repo tests + 59 phlo-dbt package tests pass. Lints clean.

Closes #331, closes #332, closes #337, closes #340, closes #341, closes #342
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
