### PR TITLE
fix: CLI and plugin system correctness fixes

### DIFF
--- a/src/phlo/cli/commands/services/restart.py
+++ b/src/phlo/cli/commands/services/restart.py
@@ -5,6 +5,7 @@ from subprocess import TimeoutExpired
 
 import click
 
+from phlo.cli.commands.services.start import _validate_requested_profiles
 from phlo.cli.commands.services.utils import (
     ensure_phlo_dir,
     get_profile_service_names,
@@ -58,6 +59,7 @@ def restart_cmd(
 
     phlo_dir = ensure_phlo_dir()
     project_name = get_project_name()
+    profile = _validate_requested_profiles(profile)
     logger.info(
         "services_restart_requested",
         project_name=project_name,

--- a/src/phlo/cli/commands/services/stop.py
+++ b/src/phlo/cli/commands/services/stop.py
@@ -106,8 +106,8 @@ def stop_cmd(volumes: bool, stop_native: bool, profile: tuple[str, ...], service
                 metadata={"native": True},
             )
 
-    # If we only needed to stop native services, skip Docker.
-    if stop_native and not service and not volumes and not profile:
+    # If --native was explicitly requested, skip Docker unless --volumes or --profile also given.
+    if stop_native and not volumes and not profile:
         logger.info("services_stop_native_only_completed", project_name=get_project_name())
         click.echo("Stopped native services.")
         return

--- a/src/phlo/cli/env.py
+++ b/src/phlo/cli/env.py
@@ -103,6 +103,7 @@ def _load_project_config() -> dict[str, Any]:
             return yaml.safe_load(f) or {}
     except (OSError, yaml.YAMLError):
         logger.warning("env_export_config_load_failed", path=str(config_path), exc_info=True)
+        click.echo(f"Warning: failed to parse {config_path}, using defaults", err=True)
         return {}
 
 

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -123,7 +123,10 @@ def test(
             sys.exit(1)
 
     if marker:
-        pytest_args.extend(["-m", marker])
+        if local:
+            pytest_args.extend(["-m", f"({marker}) and not integration"])
+        else:
+            pytest_args.extend(["-m", marker])
     elif local:
         # Skip integration tests that require Docker
         pytest_args.extend(["-m", "not integration"])

--- a/src/phlo/plugins/discovery/registry.py
+++ b/src/phlo/plugins/discovery/registry.py
@@ -262,6 +262,11 @@ class PluginRegistry:
         """List all registered transformation plugins."""
         return list(self._transformations.keys())
 
+    def remove_service(self, name: str) -> None:
+        """Remove a registered service plugin by name."""
+        self._services.pop(name, None)
+        self._all_plugins.pop(f"service:{name}", None)
+
     def list_services(self) -> list[str]:
         """List all registered service plugins."""
         return list(self._services.keys())

--- a/src/phlo/plugins/discovery/services.py
+++ b/src/phlo/plugins/discovery/services.py
@@ -149,8 +149,7 @@ class ServiceDiscovery:
         """
         registry = get_global_registry()
         for service_name in list(registry.list_services()):
-            registry._services.pop(service_name, None)  # noqa: SLF001
-            registry._all_plugins.pop(f"service:{service_name}", None)  # noqa: SLF001
+            registry.remove_service(service_name)
 
         cached_service_count = len(self._services)
         was_loaded = self._loaded


### PR DESCRIPTION
## Summary

Batch of CLI and plugin system correctness fixes from audit issues.

### Fixes

| Fix | Issue |
|-----|-------|
| Combine `--local` and `--marker` flags in test command (were mutually exclusive via `elif`) | #347 |
| `stop --native --service X` now stays native-only instead of falling through to Docker | #347 |
| Add profile validation to `restart` command (matching `start`) | #347 |
| Surface config parse failures to CLI user in `env export` | #347 |
| Add `remove_service()` to plugin registry; `ServiceDiscovery.clear_cache` uses public API | #349 |

### Testing

- `uv run ruff check` — all clean
- `uv run pytest tests/` — 396 passed, 1 skipped

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
