### PR TITLE
fix(plugins): normalize tags dict in HookFilter.__post_init__

### DIFF
--- a/src/phlo/plugins/hooks.py
+++ b/src/phlo/plugins/hooks.py
@@ -34,6 +34,8 @@ class HookFilter:
             object.__setattr__(self, "event_types", set(self.event_types))
         if self.asset_keys is not None:
             object.__setattr__(self, "asset_keys", set(self.asset_keys))
+        if self.tags is not None:
+            object.__setattr__(self, "tags", dict(self.tags))
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Addresses part of issue #349 - Plugin system correctness issues batch.

After examining the 7 items in the batch, most appear to be either:
- Already fixed in current codebase
- Style/design concerns rather than bugs  
- Issue descriptions that don't match current code

The one concrete fix identified is normalizing the `tags` field in `HookFilter.__post_init__` for consistency with how `event_types` and `asset_keys` are normalized.

## Change

**File:** `src/phlo/plugins/hooks.py`

Added normalization for `tags` field in `HookFilter.__post_init__`:

```python
if self.tags is not None:
    object.__setattr__(self, "tags", dict(self.tags))
```

This ensures `tags` is always a plain dict (not a dict subclass) for consistency with the frozen dataclass pattern used for `event_types` and `asset_keys`.

## Testing

- All 396 tests pass
- Ruff linting passes

## Notes

Other items in issue #349 were reviewed but not addressed:
- No-op string replacement - Not found in current code (may be fixed)
- ServiceDiscovery.clear_cache - Uses public API correctly
- Import name shadowing - Intentional compatibility wrapper
- Inconsistent logging format - Code already uses structured logging
- File handle leak - Exception handling already closes file properly
- Unreachable cleanup - Code logic is correct

If there are specific bugs that need fixing in this batch, please clarify in comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
