### PR TITLE
test: add 80 tests covering critical coverage gaps

### DIFF
--- a/tests/test_authorization_opa.py
+++ b/tests/test_authorization_opa.py
@@ -1,0 +1,232 @@
+"""Tests for OPA authorization policy backend."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from phlo.capabilities.authorization_opa import (
+    OPAAuthorizationPolicyBackend,
+    create_opa_provider,
+)
+from phlo.capabilities.interfaces import (
+    DecisionContext,
+    Principal,
+    ResourceRef,
+)
+
+pytestmark = pytest.mark.core_regression
+
+
+@pytest.fixture()
+def principal() -> Principal:
+    return Principal(subject="alice", principal_type="user", roles=("analyst",))
+
+
+@pytest.fixture()
+def resource() -> ResourceRef:
+    return ResourceRef(resource_type="dataset", resource_id="analytics.orders")
+
+
+@pytest.fixture()
+def backend() -> OPAAuthorizationPolicyBackend:
+    return OPAAuthorizationPolicyBackend()
+
+
+def test_init_rejects_invalid_url_scheme() -> None:
+    with pytest.raises(ValueError, match="http:// or https://"):
+        OPAAuthorizationPolicyBackend(opa_url="ftp://localhost:8181")
+
+
+def test_init_defaults_to_localhost() -> None:
+    b = OPAAuthorizationPolicyBackend()
+    assert b._opa_url == "http://localhost:8181"
+
+
+def test_build_input_structure(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+) -> None:
+    ctx = DecisionContext(environment="prod", request_id="r1")
+    result = backend._build_input(principal, "dataset.read", resource, ctx)
+
+    assert result["principal"]["subject"] == "alice"
+    assert result["principal"]["type"] == "user"
+    assert result["principal"]["roles"] == ["analyst"]
+    assert result["action"] == "dataset.read"
+    assert result["resource"]["type"] == "dataset"
+    assert result["resource"]["id"] == "analytics.orders"
+    assert result["context"]["environment"] == "prod"
+    assert result["context"]["request_id"] == "r1"
+
+
+def test_explain_decision_allow_bool_result(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(backend, "_evaluate", lambda _: {"result": True})
+    decision = backend.explain_decision(principal, "dataset.read", resource)
+    assert decision.allowed is True
+    assert decision.reason_code == "opa_allow"
+
+
+def test_explain_decision_deny_bool_result(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(backend, "_evaluate", lambda _: {"result": False})
+    decision = backend.explain_decision(principal, "dataset.read", resource)
+    assert decision.allowed is False
+    assert decision.reason_code == "opa_deny"
+
+
+def test_explain_decision_allow_dict_result(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        backend, "_evaluate", lambda _: {"result": {"allow": True, "reason": "custom"}}
+    )
+    decision = backend.explain_decision(principal, "dataset.read", resource)
+    assert decision.allowed is True
+    assert decision.explanation == "custom"
+
+
+def test_explain_decision_deny_dict_result(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        backend,
+        "_evaluate",
+        lambda _: {"result": {"allow": False, "reason_code": "custom_deny"}},
+    )
+    decision = backend.explain_decision(principal, "dataset.read", resource)
+    assert decision.allowed is False
+    assert decision.reason_code == "custom_deny"
+
+
+def test_explain_decision_none_response(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(backend, "_evaluate", lambda _: None)
+    decision = backend.explain_decision(principal, "dataset.read", resource)
+    assert decision.allowed is False
+    assert decision.reason_code == "backend_unavailable"
+
+
+def test_explain_decision_connect_error(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(_: object) -> None:
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(backend, "_evaluate", _raise)
+    decision = backend.explain_decision(principal, "dataset.read", resource)
+    assert decision.allowed is False
+    assert decision.reason_code == "backend_unavailable"
+
+
+def test_explain_decision_timeout(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(_: object) -> None:
+        raise httpx.TimeoutException("timed out")
+
+    monkeypatch.setattr(backend, "_evaluate", _raise)
+    decision = backend.explain_decision(principal, "dataset.read", resource)
+    assert decision.allowed is False
+    assert decision.reason_code == "backend_unavailable"
+
+
+def test_is_allowed_delegates_to_explain_decision(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    resource: ResourceRef,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(backend, "_evaluate", lambda _: {"result": True})
+    assert backend.is_allowed(principal, "dataset.read", resource) is True
+
+    monkeypatch.setattr(backend, "_evaluate", lambda _: {"result": False})
+    assert backend.is_allowed(principal, "dataset.read", resource) is False
+
+
+def test_filter_resources(
+    backend: OPAAuthorizationPolicyBackend,
+    principal: Principal,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    r1 = ResourceRef(resource_type="dataset", resource_id="a")
+    r2 = ResourceRef(resource_type="dataset", resource_id="b")
+    r3 = ResourceRef(resource_type="dataset", resource_id="c")
+
+    allowed_ids = {"a", "c"}
+
+    def fake_evaluate(input_data: object) -> dict:
+        rid = input_data["resource"]["id"]  # type: ignore[index]
+        return {"result": rid in allowed_ids}
+
+    monkeypatch.setattr(backend, "_evaluate", fake_evaluate)
+    result = backend.filter_resources(principal, [r1, r2, r3], "dataset.read")
+
+    assert len(result) == 2
+    assert {r.resource_id for r in result} == {"a", "c"}
+
+
+def test_health_check_success(
+    backend: OPAAuthorizationPolicyBackend,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeResponse:
+        status_code = 200
+
+    class FakeClient:
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def get(self, url: str) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(httpx, "Client", lambda **kw: FakeClient())
+    assert backend.health_check() is True
+
+
+def test_health_check_failure(
+    backend: OPAAuthorizationPolicyBackend,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise(**kw: object) -> None:
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(httpx, "Client", _raise)
+    assert backend.health_check() is False
+
+
+def test_create_opa_provider_factory() -> None:
+    provider, support = create_opa_provider(opa_url="http://opa:8181")
+    assert isinstance(provider, OPAAuthorizationPolicyBackend)
+    assert provider._opa_url == "http://opa:8181"
+    assert support.supports_permissions is True
+    assert support.supports_attributes is True

--- a/tests/test_cli_authz.py
+++ b/tests/test_cli_authz.py
@@ -1,0 +1,266 @@
+"""Tests for authz CLI commands."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from phlo.cli.commands import authz as authz_mod
+from phlo.cli.commands.authz import authz_group
+from phlo.rbac.models import BackendArtifact, PolicyChange, SyncPlan, SyncResult, VerifyResult
+
+pytestmark = pytest.mark.core_regression
+
+_ARTIFACT = BackendArtifact(
+    backend="trino",
+    artifact_type="grant",
+    name="grant_reader_select",
+    statement="GRANT SELECT ON warehouse.* TO reader",
+)
+
+_CHANGE = PolicyChange(
+    change_type="create",
+    backend="trino",
+    artifact=_ARTIFACT,
+    revert_id="rev-001",
+)
+
+
+@pytest.fixture(autouse=True)
+def _noop_discover(monkeypatch):
+    monkeypatch.setattr(authz_mod, "discover_capabilities", lambda: None)
+
+
+@pytest.fixture()
+def runner():
+    return CliRunner()
+
+
+# -- helpers ------------------------------------------------------------------
+
+
+class _FakeLoader:
+    def __init__(self, *, valid=True, errors=None, **_kw):
+        self._valid = valid
+        self._errors = errors or []
+
+    def validate(self):
+        return self._valid, self._errors
+
+
+class _FakeController:
+    def __init__(self, **_kw):
+        self.plan_return = {}
+        self.sync_return = {}
+        self.verify_return = {}
+        self.revert_return = {}
+        self._sync_kwargs = {}
+
+    def plan(self, *, backends=None, environment="development"):
+        if isinstance(self.plan_return, Exception):
+            raise self.plan_return
+        return self.plan_return
+
+    def sync(self, *, backends=None, environment="development", dry_run=False):
+        self._sync_kwargs = {
+            "backends": backends,
+            "environment": environment,
+            "dry_run": dry_run,
+        }
+        if isinstance(self.sync_return, Exception):
+            raise self.sync_return
+        return self.sync_return
+
+    def verify(self, *, backends=None, environment="development"):
+        if isinstance(self.verify_return, Exception):
+            raise self.verify_return
+        return self.verify_return
+
+    def revert(self, *, revert_ids, backends=None, environment="development"):
+        if isinstance(self.revert_return, Exception):
+            raise self.revert_return
+        return self.revert_return
+
+
+def _patch(monkeypatch, *, loader=None, controller=None):
+    _loader = loader or _FakeLoader()
+    _ctrl = controller or _FakeController()
+    monkeypatch.setattr(authz_mod, "RBACConfigLoader", lambda **_kw: _loader)
+    monkeypatch.setattr(authz_mod, "SyncController", lambda **_kw: _ctrl)
+    return _loader, _ctrl
+
+
+# -- validate -----------------------------------------------------------------
+
+
+def test_validate_passes(runner, monkeypatch, tmp_path):
+    _patch(monkeypatch, loader=_FakeLoader(valid=True))
+    result = runner.invoke(authz_group, ["validate", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "Validation passed" in result.output
+
+
+def test_validate_fails(runner, monkeypatch, tmp_path):
+    _patch(monkeypatch, loader=_FakeLoader(valid=False, errors=["error1"]))
+    result = runner.invoke(authz_group, ["validate", "--path", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "Validation failed" in result.output
+    assert "error1" in result.output
+
+
+# -- plan ---------------------------------------------------------------------
+
+
+def test_plan_no_plans(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.plan_return = {}
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(authz_group, ["plan", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "No plans generated" in result.output
+
+
+def test_plan_with_changes(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.plan_return = {
+        "trino": SyncPlan(
+            version_hash="abc123",
+            backend="trino",
+            changes=(_CHANGE,),
+        ),
+    }
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(authz_group, ["plan", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "abc123" in result.output
+    assert "Changes: 1" in result.output
+    assert "grant_reader_select" in result.output
+
+
+def test_plan_exception(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.plan_return = RuntimeError("boom")
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(authz_group, ["plan", "--path", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "Planning failed" in result.output
+
+
+# -- sync ---------------------------------------------------------------------
+
+
+def test_sync_success(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.sync_return = {
+        "trino": SyncResult(
+            success=True,
+            backend="trino",
+            version_hash="abc123",
+            applied_count=2,
+            failed_count=0,
+            errors=(),
+        ),
+    }
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(authz_group, ["sync", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "Success: True" in result.output
+
+
+def test_sync_failure(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.sync_return = {
+        "trino": SyncResult(
+            success=False,
+            backend="trino",
+            version_hash="abc123",
+            applied_count=0,
+            failed_count=1,
+            errors=("grant failed",),
+        ),
+    }
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(authz_group, ["sync", "--path", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "Success: False" in result.output
+    assert "grant failed" in result.output
+
+
+def test_sync_dry_run(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.sync_return = {
+        "trino": SyncResult(
+            success=True,
+            backend="trino",
+            version_hash="abc123",
+            applied_count=0,
+            failed_count=0,
+            errors=(),
+        ),
+    }
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(authz_group, ["sync", "--path", str(tmp_path), "--dry-run"])
+    assert result.exit_code == 0
+    assert ctrl._sync_kwargs["dry_run"] is True
+
+
+# -- verify -------------------------------------------------------------------
+
+
+def test_verify_in_sync(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.verify_return = {
+        "trino": VerifyResult(backend="trino", in_sync=True),
+    }
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(authz_group, ["verify", "--path", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "In sync: True" in result.output
+
+
+def test_verify_drift(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.verify_return = {
+        "trino": VerifyResult(
+            backend="trino",
+            in_sync=False,
+            missing=(_ARTIFACT,),
+        ),
+    }
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(authz_group, ["verify", "--path", str(tmp_path)])
+    assert result.exit_code == 1
+    assert "Missing artifacts: 1" in result.output
+    assert "grant_reader_select" in result.output
+
+
+# -- revert -------------------------------------------------------------------
+
+
+def test_revert_success(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.revert_return = {
+        "trino": (["rev-001"], []),
+    }
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(
+        authz_group,
+        ["revert", "rev-001", "--path", str(tmp_path)],
+    )
+    assert result.exit_code == 0
+    assert "Reverted: 1" in result.output
+
+
+def test_revert_with_errors(runner, monkeypatch, tmp_path):
+    ctrl = _FakeController()
+    ctrl.revert_return = {
+        "trino": ([], ["revert failed"]),
+    }
+    _patch(monkeypatch, controller=ctrl)
+    result = runner.invoke(
+        authz_group,
+        ["revert", "rev-001", "--path", str(tmp_path)],
+    )
+    assert result.exit_code == 1
+    assert "Errors: 1" in result.output
+    assert "revert failed" in result.output

--- a/tests/test_hook_emitters.py
+++ b/tests/test_hook_emitters.py
@@ -6,7 +6,26 @@ from typing import Any
 
 import pytest
 
-from phlo.hooks.emitters import IngestionEventContext, IngestionEventEmitter
+from phlo.hooks.emitters import (
+    DataMigrationEventContext,
+    DataMigrationEventEmitter,
+    IngestionEventContext,
+    IngestionEventEmitter,
+    LineageEventContext,
+    LineageEventEmitter,
+    PublishEventContext,
+    PublishEventEmitter,
+    QualityResultEventContext,
+    QualityResultEventEmitter,
+    SchemaMigrationEventContext,
+    SchemaMigrationEventEmitter,
+    ServiceLifecycleEventContext,
+    ServiceLifecycleEventEmitter,
+    TelemetryEventContext,
+    TelemetryEventEmitter,
+    TransformEventContext,
+    TransformEventEmitter,
+)
 from phlo.logging import bind_context, clear_context
 
 pytestmark = pytest.mark.core_regression
@@ -45,3 +64,291 @@ def test_ingestion_emitter_merges_bound_correlation_context() -> None:
     assert event.correlation.job_name == "daily_orders"
     assert event.correlation.trace_id == "abc123"
     assert event.correlation.span_id == "def456"
+
+
+def test_transform_emitter_merges_bound_correlation_context() -> None:
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    emitter = TransformEventEmitter(
+        TransformEventContext(
+            tool="dbt",
+            project_dir="/tmp/dbt",
+            target="dev",
+            asset_key="gold.customers",
+            run_id="run-t1",
+            partition_key="2026-03-08",
+        ),
+        hook_bus=bus,
+    )
+
+    bind_context(trace_id="t1", span_id="s1", job_name="transform_job")
+    try:
+        emitter.emit_end(status="success", metrics={"models_run": 3})
+    finally:
+        clear_context()
+
+    event = bus.events[0]
+    assert event.event_type == "transform.end"
+    assert event.tool == "dbt"
+    assert event.status == "success"
+    assert event.metrics == {"models_run": 3}
+    assert event.correlation.run_id == "run-t1"
+    assert event.correlation.asset_key == "gold.customers"
+    assert event.correlation.job_name == "transform_job"
+    assert event.correlation.trace_id == "t1"
+
+
+def test_publish_emitter_merges_bound_correlation_context() -> None:
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    emitter = PublishEventEmitter(
+        PublishEventContext(
+            asset_key="gold.orders",
+            run_id="run-p1",
+            partition_key="2026-03-08",
+            target_system="warehouse",
+        ),
+        hook_bus=bus,
+    )
+
+    bind_context(trace_id="p1", span_id="ps1", job_name="publish_job")
+    try:
+        emitter.emit_end(status="success", metrics={"tables_published": 2})
+    finally:
+        clear_context()
+
+    event = bus.events[0]
+    assert event.event_type == "publish.end"
+    assert event.status == "success"
+    assert event.correlation.run_id == "run-p1"
+    assert event.correlation.asset_key == "gold.orders"
+    assert event.correlation.partition_key == "2026-03-08"
+    assert event.correlation.trace_id == "p1"
+
+
+def test_quality_result_emitter_merges_bound_correlation_context() -> None:
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    emitter = QualityResultEventEmitter(
+        QualityResultEventContext(
+            asset_key="silver.orders",
+            run_id="run-q1",
+            partition_key="2026-03-08",
+        ),
+        hook_bus=bus,
+    )
+
+    bind_context(trace_id="q1", span_id="qs1", job_name="quality_job")
+    try:
+        emitter.emit_result(
+            check_name="not_null_order_id",
+            passed=True,
+            severity="error",
+            check_type="pandera",
+        )
+    finally:
+        clear_context()
+
+    event = bus.events[0]
+    assert event.event_type == "quality.result"
+    assert event.check_name == "not_null_order_id"
+    assert event.passed is True
+    assert event.severity == "error"
+    assert event.correlation.run_id == "run-q1"
+    assert event.correlation.asset_key == "silver.orders"
+    assert event.correlation.check_name == "not_null_order_id"
+    assert event.correlation.trace_id == "q1"
+
+
+def test_lineage_emitter_merges_bound_correlation_context() -> None:
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    emitter = LineageEventEmitter(
+        LineageEventContext(),
+        hook_bus=bus,
+    )
+
+    bind_context(trace_id="l1", span_id="ls1", job_name="lineage_job")
+    try:
+        emitter.emit_edges(
+            edges=[("a", "b"), ("b", "c")],
+            asset_keys=["a", "b", "c"],
+            metadata={"source": "dbt"},
+        )
+    finally:
+        clear_context()
+
+    event = bus.events[0]
+    assert event.event_type == "lineage.edges"
+    assert event.edges == [("a", "b"), ("b", "c")]
+    assert event.asset_keys == ["a", "b", "c"]
+    assert event.metadata == {"source": "dbt"}
+    assert event.correlation.trace_id == "l1"
+    assert event.correlation.job_name == "lineage_job"
+
+
+def test_telemetry_emitter_merges_bound_correlation_context() -> None:
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    emitter = TelemetryEventEmitter(
+        TelemetryEventContext(),
+        hook_bus=bus,
+    )
+
+    bind_context(trace_id="tm1", span_id="tms1", job_name="telemetry_job")
+    try:
+        emitter.emit_metric(name="rows_processed", value=1000, unit="rows")
+    finally:
+        clear_context()
+
+    event = bus.events[0]
+    assert event.event_type == "telemetry.metric"
+    assert event.name == "rows_processed"
+    assert event.value == 1000
+    assert event.unit == "rows"
+    assert event.correlation.trace_id == "tm1"
+    assert event.correlation.job_name == "telemetry_job"
+
+
+def test_service_lifecycle_emitter_merges_bound_correlation_context() -> None:
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    emitter = ServiceLifecycleEventEmitter(
+        ServiceLifecycleEventContext(
+            service_name="dagster-webserver",
+            project_name="phlo",
+            container_name="dagster-webserver-1",
+        ),
+        hook_bus=bus,
+    )
+
+    bind_context(trace_id="sl1", span_id="sls1", job_name="service_job")
+    try:
+        emitter.emit(phase="start", status="healthy", metadata={"port": 3000})
+    finally:
+        clear_context()
+
+    event = bus.events[0]
+    assert event.event_type == "service.start"
+    assert event.service_name == "dagster-webserver"
+    assert event.phase == "start"
+    assert event.status == "healthy"
+    assert event.metadata == {"port": 3000}
+    assert event.tags["service"] == "dagster-webserver"
+    assert event.correlation.trace_id == "sl1"
+    assert event.correlation.job_name == "service_job"
+
+
+def test_schema_migration_emitter_merges_bound_correlation_context() -> None:
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    emitter = SchemaMigrationEventEmitter(
+        SchemaMigrationEventContext(table_name="orders"),
+        hook_bus=bus,
+    )
+
+    bind_context(trace_id="sm1", span_id="sms1", job_name="migration_job")
+    try:
+        emitter.emit(
+            status="applied",
+            classification="breaking",
+            change_count=2,
+            changes=[{"column": "price", "action": "drop"}],
+        )
+    finally:
+        clear_context()
+
+    event = bus.events[0]
+    assert event.event_type == "schema_migration.applied"
+    assert event.table_name == "orders"
+    assert event.classification == "breaking"
+    assert event.change_count == 2
+    assert event.changes == [{"column": "price", "action": "drop"}]
+    assert event.correlation.trace_id == "sm1"
+    assert event.correlation.job_name == "migration_job"
+
+
+def test_data_migration_emitter_merges_bound_correlation_context() -> None:
+    class RecordingBus:
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def emit(self, event: Any) -> None:
+            self.events.append(event)
+
+    bus = RecordingBus()
+    emitter = DataMigrationEventEmitter(
+        DataMigrationEventContext(
+            migration_name="backfill_orders",
+            source_type="postgres",
+            destination_table="silver.orders",
+            run_id="run-dm1",
+        ),
+        hook_bus=bus,
+    )
+
+    bind_context(trace_id="dm1", span_id="dms1", job_name="data_migration_job")
+    try:
+        emitter.emit(
+            status="completed",
+            rows_read=5000,
+            rows_written=4999,
+            chunk_index=3,
+        )
+    finally:
+        clear_context()
+
+    event = bus.events[0]
+    assert event.event_type == "data_migration.completed"
+    assert event.migration_name == "backfill_orders"
+    assert event.source_type == "postgres"
+    assert event.destination_table == "silver.orders"
+    assert event.rows_read == 5000
+    assert event.rows_written == 4999
+    assert event.chunk_index == 3
+    assert event.tags["source_type"] == "postgres"
+    assert event.correlation.run_id == "run-dm1"
+    assert event.correlation.trace_id == "dm1"
+    assert event.correlation.job_name == "data_migration_job"

--- a/tests/test_migration_adapters.py
+++ b/tests/test_migration_adapters.py
@@ -1,0 +1,94 @@
+"""Tests for migration source adapters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from phlo.migrations.adapters import CsvSourceAdapter, resolve_source_adapter
+from phlo.migrations.specs import MigrationSource
+
+
+def _csv_source(path: str | None = None, **kwargs: Any) -> MigrationSource:
+    return MigrationSource(type="csv", path=path, **kwargs)
+
+
+def _write_csv(path: Path, rows: list[str]) -> Path:
+    path.write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return path
+
+
+class TestCsvSourceAdapter:
+    def test_csv_source_type(self) -> None:
+        assert CsvSourceAdapter().source_type == "csv"
+
+    def test_validate_missing_path(self) -> None:
+        errors = CsvSourceAdapter().validate_config(_csv_source(path=None))
+        assert any("path" in e for e in errors)
+
+    def test_validate_nonexistent_file(self, tmp_path: Path) -> None:
+        errors = CsvSourceAdapter().validate_config(_csv_source(path=str(tmp_path / "nope.csv")))
+        assert any("not found" in e for e in errors)
+
+    def test_validate_with_query_unsupported(self, tmp_path: Path) -> None:
+        csv_file = _write_csv(tmp_path / "data.csv", ["a,b", "1,2"])
+        errors = CsvSourceAdapter().validate_config(
+            _csv_source(path=str(csv_file), query="SELECT 1")
+        )
+        assert any("query" in e for e in errors)
+
+    def test_validate_with_table_unsupported(self, tmp_path: Path) -> None:
+        csv_file = _write_csv(tmp_path / "data.csv", ["a,b", "1,2"])
+        errors = CsvSourceAdapter().validate_config(_csv_source(path=str(csv_file), table="t"))
+        assert any("table" in e for e in errors)
+
+    def test_validate_valid_csv(self, tmp_path: Path) -> None:
+        csv_file = _write_csv(tmp_path / "data.csv", ["a,b", "1,2"])
+        errors = CsvSourceAdapter().validate_config(_csv_source(path=str(csv_file)))
+        assert errors == []
+
+    def test_read_chunks_single_chunk(self, tmp_path: Path) -> None:
+        csv_file = _write_csv(tmp_path / "data.csv", ["a,b", "1,2", "3,4"])
+        chunks = list(
+            CsvSourceAdapter().read_chunks(_csv_source(path=str(csv_file)), chunk_size=50_000)
+        )
+        assert len(chunks) == 1
+        assert chunks[0] == [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
+
+    def test_read_chunks_multiple_chunks(self, tmp_path: Path) -> None:
+        csv_file = _write_csv(tmp_path / "data.csv", ["x", "1", "2", "3", "4", "5"])
+        chunks = list(CsvSourceAdapter().read_chunks(_csv_source(path=str(csv_file)), chunk_size=2))
+        assert len(chunks) == 3
+        assert len(chunks[0]) == 2
+        assert len(chunks[1]) == 2
+        assert len(chunks[2]) == 1
+
+    def test_read_chunks_missing_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="path"):
+            list(CsvSourceAdapter().read_chunks(_csv_source(path=None)))
+
+    def test_estimate_row_count(self, tmp_path: Path) -> None:
+        csv_file = _write_csv(tmp_path / "data.csv", ["a", "1", "2", "3"])
+        assert CsvSourceAdapter().estimate_row_count(_csv_source(path=str(csv_file))) == 3
+
+    def test_estimate_row_count_missing_path(self) -> None:
+        assert CsvSourceAdapter().estimate_row_count(_csv_source(path=None)) is None
+
+
+class _FakeRegistry:
+    def list_data_migration_sources(self) -> list:
+        return []
+
+
+class TestResolveSourceAdapter:
+    def test_resolve_csv_adapter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("phlo.migrations.adapters.get_capability_registry", _FakeRegistry)
+        adapter = resolve_source_adapter("csv")
+        assert adapter is not None
+        assert adapter.source_type == "csv"
+
+    def test_resolve_unknown_adapter(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("phlo.migrations.adapters.get_capability_registry", _FakeRegistry)
+        assert resolve_source_adapter("unknown") is None

--- a/tests/test_migration_parser.py
+++ b/tests/test_migration_parser.py
@@ -1,0 +1,110 @@
+"""Tests for migration spec parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from phlo.migrations.parser import MigrationSpecError, load_migration_spec
+
+
+def _write_yaml(path: Path, data: object) -> Path:
+    path.write_text(yaml.dump(data), encoding="utf-8")
+    return path
+
+
+def _valid_spec() -> dict:
+    return {
+        "name": "demo",
+        "source": {"type": "csv", "path": "input.csv"},
+        "destination": {"table": "warehouse.demo"},
+    }
+
+
+class TestLoadMigrationSpec:
+    def test_load_valid_spec(self, tmp_path: Path) -> None:
+        spec_file = _write_yaml(tmp_path / "spec.yaml", _valid_spec())
+        spec = load_migration_spec(spec_file)
+
+        assert spec.name == "demo"
+        assert spec.source.type == "csv"
+        assert spec.source.path == "input.csv"
+        assert spec.destination.table == "warehouse.demo"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(MigrationSpecError, match="not found"):
+            load_migration_spec(tmp_path / "missing.yaml")
+
+    def test_non_mapping_root_raises(self, tmp_path: Path) -> None:
+        spec_file = _write_yaml(tmp_path / "spec.yaml", ["a", "b"])
+        with pytest.raises(MigrationSpecError, match="mapping"):
+            load_migration_spec(spec_file)
+
+    def test_missing_name_raises(self, tmp_path: Path) -> None:
+        data = _valid_spec()
+        del data["name"]
+        spec_file = _write_yaml(tmp_path / "spec.yaml", data)
+        with pytest.raises(MigrationSpecError, match="name"):
+            load_migration_spec(spec_file)
+
+    def test_missing_source_raises(self, tmp_path: Path) -> None:
+        data = _valid_spec()
+        del data["source"]
+        spec_file = _write_yaml(tmp_path / "spec.yaml", data)
+        with pytest.raises(MigrationSpecError, match="source"):
+            load_migration_spec(spec_file)
+
+    def test_missing_destination_raises(self, tmp_path: Path) -> None:
+        data = _valid_spec()
+        del data["destination"]
+        spec_file = _write_yaml(tmp_path / "spec.yaml", data)
+        with pytest.raises(MigrationSpecError, match="destination"):
+            load_migration_spec(spec_file)
+
+    def test_chunk_size_zero_raises(self, tmp_path: Path) -> None:
+        data = _valid_spec()
+        data["options"] = {"chunk_size": 0}
+        spec_file = _write_yaml(tmp_path / "spec.yaml", data)
+        with pytest.raises(MigrationSpecError, match="chunk_size"):
+            load_migration_spec(spec_file)
+
+    def test_parallelism_zero_raises(self, tmp_path: Path) -> None:
+        data = _valid_spec()
+        data["options"] = {"parallelism": 0}
+        spec_file = _write_yaml(tmp_path / "spec.yaml", data)
+        with pytest.raises(MigrationSpecError, match="parallelism"):
+            load_migration_spec(spec_file)
+
+    def test_invalid_write_mode_raises(self, tmp_path: Path) -> None:
+        data = _valid_spec()
+        data["destination"]["write_mode"] = "invalid"
+        spec_file = _write_yaml(tmp_path / "spec.yaml", data)
+        with pytest.raises(MigrationSpecError, match="write_mode"):
+            load_migration_spec(spec_file)
+
+    def test_merge_without_unique_key_raises(self, tmp_path: Path) -> None:
+        data = _valid_spec()
+        data["destination"]["write_mode"] = "merge"
+        spec_file = _write_yaml(tmp_path / "spec.yaml", data)
+        with pytest.raises(MigrationSpecError, match="unique_key"):
+            load_migration_spec(spec_file)
+
+    def test_column_mapping_non_string_raises(self, tmp_path: Path) -> None:
+        data = _valid_spec()
+        data["column_mapping"] = {"col_a": 123}
+        spec_file = _write_yaml(tmp_path / "spec.yaml", data)
+        with pytest.raises(MigrationSpecError, match="column_mapping"):
+            load_migration_spec(spec_file)
+
+    def test_defaults_applied(self, tmp_path: Path) -> None:
+        spec_file = _write_yaml(tmp_path / "spec.yaml", _valid_spec())
+        spec = load_migration_spec(spec_file)
+
+        assert spec.version == "1.0"
+        assert spec.destination.write_mode == "append"
+        assert spec.options.chunk_size == 50_000
+        assert spec.options.parallelism == 1
+        assert spec.options.validate is True
+        assert spec.options.dry_run is False

--- a/tests/test_rbac_config.py
+++ b/tests/test_rbac_config.py
@@ -1,0 +1,100 @@
+"""Tests for RBAC config loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from phlo.rbac.config import RBACConfigLoader
+
+_ROLES_YAML = {"version": 1, "roles": {"admin": {"inherits": []}}}
+
+_POLICIES_YAML = {
+    "version": 1,
+    "policies": [
+        {
+            "policy_id": "allow_admin",
+            "effect": "allow",
+            "principal": {"roles": ["admin"]},
+            "action": "dataset.read",
+            "resource": {"type": "dataset", "id_pattern": "*"},
+        }
+    ],
+}
+
+
+def _write_rbac(base: Path, *, roles: bool = True, policies: bool = True) -> Path:
+    auth_dir = base / "authorization"
+    auth_dir.mkdir(parents=True, exist_ok=True)
+    if roles:
+        (auth_dir / "roles.yaml").write_text(yaml.dump(_ROLES_YAML))
+    if policies:
+        (auth_dir / "policies.yaml").write_text(yaml.dump(_POLICIES_YAML))
+    return base
+
+
+class TestRBACConfigLoader:
+    def test_load_roles_from_yaml(self, tmp_path: Path) -> None:
+        _write_rbac(tmp_path)
+        loader = RBACConfigLoader(base_path=tmp_path)
+        roles = loader.load_roles()
+        assert "admin" in roles.roles
+
+    def test_load_roles_file_not_found(self, tmp_path: Path) -> None:
+        loader = RBACConfigLoader(base_path=tmp_path)
+        with pytest.raises(FileNotFoundError):
+            loader.load_roles()
+
+    def test_load_policies_from_yaml(self, tmp_path: Path) -> None:
+        _write_rbac(tmp_path)
+        loader = RBACConfigLoader(base_path=tmp_path)
+        policies = loader.load_policies()
+        assert len(policies.policies) == 1
+        assert policies.policies[0].policy_id == "allow_admin"
+
+    def test_load_policies_file_not_found(self, tmp_path: Path) -> None:
+        loader = RBACConfigLoader(base_path=tmp_path)
+        with pytest.raises(FileNotFoundError):
+            loader.load_policies()
+
+    def test_load_combines_roles_and_policies(self, tmp_path: Path) -> None:
+        _write_rbac(tmp_path)
+        loader = RBACConfigLoader(base_path=tmp_path)
+        rbac = loader.load()
+        assert "admin" in rbac.roles.roles
+        assert len(rbac.policies.policies) == 1
+
+    def test_validate_valid_config(self, tmp_path: Path) -> None:
+        _write_rbac(tmp_path)
+        loader = RBACConfigLoader(base_path=tmp_path)
+        is_valid, errors = loader.validate()
+        assert is_valid is True
+        assert errors == []
+
+    def test_validate_missing_files(self, tmp_path: Path) -> None:
+        loader = RBACConfigLoader(base_path=tmp_path)
+        is_valid, errors = loader.validate()
+        assert is_valid is False
+        assert len(errors) > 0
+
+    def test_compute_version_hash_deterministic(self, tmp_path: Path) -> None:
+        _write_rbac(tmp_path)
+        loader = RBACConfigLoader(base_path=tmp_path)
+        assert loader.compute_version_hash() == loader.compute_version_hash()
+
+    def test_compute_version_hash_changes_with_content(self, tmp_path: Path) -> None:
+        _write_rbac(tmp_path)
+        loader = RBACConfigLoader(base_path=tmp_path)
+        hash1 = loader.compute_version_hash()
+
+        alt = {"version": 1, "roles": {"viewer": {"inherits": []}}}
+        (tmp_path / "authorization" / "roles.yaml").write_text(yaml.dump(alt))
+        hash2 = loader.compute_version_hash()
+
+        assert hash1 != hash2
+
+    def test_base_path_defaults_to_cwd(self) -> None:
+        loader = RBACConfigLoader()
+        assert loader.base_path == Path.cwd() / ".phlo"

--- a/tests/test_rbac_sync.py
+++ b/tests/test_rbac_sync.py
@@ -1,0 +1,242 @@
+"""Tests for RBAC sync controller."""
+
+from __future__ import annotations
+
+import pytest
+
+from phlo.rbac.compiler import CompilerContext, GovernanceCompiler
+from phlo.rbac.models import (
+    BackendArtifact,
+    CanonicalRBAC,
+    PoliciesConfig,
+    PolicyChange,
+    RolesConfig,
+    SyncPlan,
+    VerifyResult,
+)
+from phlo.rbac.sync import SyncController
+
+
+def _make_rbac() -> CanonicalRBAC:
+    roles = RolesConfig.from_dict({"version": 1, "roles": {"admin": {"inherits": []}}})
+    policies = PoliciesConfig.from_dict(
+        {
+            "version": 1,
+            "policies": [
+                {
+                    "policy_id": "p1",
+                    "effect": "allow",
+                    "principal": {"roles": ["admin"]},
+                    "action": "dataset.read",
+                    "resource": {"type": "dataset", "id_pattern": "*"},
+                },
+            ],
+        }
+    )
+    return CanonicalRBAC.from_configs(roles, policies)
+
+
+_ARTIFACT = BackendArtifact(
+    backend="fake",
+    artifact_type="grant",
+    name="phlo_admin_grant",
+    statement="GRANT SELECT ON *",
+)
+_CHANGE = PolicyChange(
+    change_type="create",
+    backend="fake",
+    artifact=_ARTIFACT,
+    revert_id="fake_abc123",
+)
+
+
+class _FakeLoader:
+    def __init__(self, rbac: CanonicalRBAC) -> None:
+        self._rbac = rbac
+
+    def load(self) -> CanonicalRBAC:
+        return self._rbac
+
+    def validate(self) -> tuple[bool, list[str]]:
+        return True, []
+
+
+class _FakeCompiler(GovernanceCompiler):
+    """Minimal compiler for injection via constructor."""
+
+    def __init__(
+        self,
+        *,
+        plan_result: SyncPlan | None = None,
+        apply_result: tuple[list[str], list[str]] | None = None,
+        apply_error: Exception | None = None,
+        verify_result: VerifyResult | None = None,
+        revert_result: tuple[list[str], list[str]] | None = None,
+        revert_error: Exception | None = None,
+    ) -> None:
+        super().__init__(backend=None)
+        self._plan_result = plan_result
+        self._apply_result = apply_result or ([], [])
+        self._apply_error = apply_error
+        self._verify_result = verify_result
+        self._revert_result = revert_result or ([], [])
+        self._revert_error = revert_error
+        self.plan_called = False
+        self.apply_called = False
+        self.revert_called = False
+
+    @property
+    def backend_name(self) -> str:
+        return "fake"
+
+    def supports_action(self, action: str) -> bool:
+        return True
+
+    def compile(self, rbac: CanonicalRBAC, context: CompilerContext) -> list[BackendArtifact]:
+        return []
+
+    def read_current_state(self, context: CompilerContext) -> list[BackendArtifact]:
+        return []
+
+    def plan(self, rbac: CanonicalRBAC, context: CompilerContext) -> SyncPlan:
+        self.plan_called = True
+        if self._plan_result is not None:
+            return self._plan_result
+        return SyncPlan(version_hash="abc", backend="fake", changes=())
+
+    def apply(self, plan: SyncPlan, context: CompilerContext) -> tuple[list[str], list[str]]:
+        self.apply_called = True
+        if self._apply_error:
+            raise self._apply_error
+        return self._apply_result
+
+    def verify(self, rbac: CanonicalRBAC, context: CompilerContext) -> VerifyResult:
+        if self._verify_result is not None:
+            return self._verify_result
+        return VerifyResult(backend="fake", in_sync=True)
+
+    def revert(
+        self, revert_ids: list[str], context: CompilerContext
+    ) -> tuple[list[str], list[str]]:
+        self.revert_called = True
+        if self._revert_error:
+            raise self._revert_error
+        return self._revert_result
+
+
+# -------------------------------------------------------------------
+# Tests
+# -------------------------------------------------------------------
+
+
+def test_plan_returns_plans_from_compilers() -> None:
+    rbac = _make_rbac()
+    plan = SyncPlan(version_hash="h1", backend="fake", changes=(_CHANGE,))
+    compiler = _FakeCompiler(plan_result=plan)
+    ctrl = SyncController(loader=_FakeLoader(rbac), compilers={"fake": compiler})
+
+    result = ctrl.plan(backends=["fake"], environment="dev")
+
+    assert "fake" in result
+    assert result["fake"] is plan
+    assert compiler.plan_called
+
+
+def test_plan_skips_unknown_backend() -> None:
+    rbac = _make_rbac()
+    ctrl = SyncController(loader=_FakeLoader(rbac), compilers={})
+
+    result = ctrl.plan(backends=["nonexistent"], environment="dev")
+
+    assert result == {}
+
+
+def test_sync_applies_changes() -> None:
+    rbac = _make_rbac()
+    plan = SyncPlan(version_hash="h1", backend="fake", changes=(_CHANGE,))
+    compiler = _FakeCompiler(
+        plan_result=plan,
+        apply_result=(["fake_abc123"], []),
+    )
+    ctrl = SyncController(loader=_FakeLoader(rbac), compilers={"fake": compiler})
+
+    result = ctrl.sync(backends=["fake"], environment="dev")
+
+    assert result["fake"].success is True
+    assert result["fake"].applied_count == 1
+    assert result["fake"].failed_count == 0
+    assert "fake_abc123" in result["fake"].revert_ids
+    assert compiler.apply_called
+
+
+def test_sync_dry_run_does_not_apply() -> None:
+    rbac = _make_rbac()
+    plan = SyncPlan(version_hash="h1", backend="fake", changes=(_CHANGE,))
+    compiler = _FakeCompiler(plan_result=plan)
+    ctrl = SyncController(loader=_FakeLoader(rbac), compilers={"fake": compiler})
+
+    result = ctrl.sync(backends=["fake"], environment="dev", dry_run=True)
+
+    assert result["fake"].success is True
+    assert result["fake"].applied_count == 0
+    assert not compiler.apply_called
+
+
+def test_sync_handles_apply_error() -> None:
+    rbac = _make_rbac()
+    plan = SyncPlan(version_hash="h1", backend="fake", changes=(_CHANGE,))
+    compiler = _FakeCompiler(
+        plan_result=plan,
+        apply_error=RuntimeError("connection lost"),
+    )
+    ctrl = SyncController(loader=_FakeLoader(rbac), compilers={"fake": compiler})
+
+    result = ctrl.sync(backends=["fake"], environment="dev")
+
+    assert result["fake"].success is False
+    assert "connection lost" in result["fake"].errors[0]
+
+
+def test_verify_returns_results() -> None:
+    rbac = _make_rbac()
+    vr = VerifyResult(backend="fake", in_sync=False, missing=(_ARTIFACT,))
+    compiler = _FakeCompiler(verify_result=vr)
+    ctrl = SyncController(loader=_FakeLoader(rbac), compilers={"fake": compiler})
+
+    result = ctrl.verify(backends=["fake"], environment="dev")
+
+    assert result["fake"] is vr
+    assert result["fake"].in_sync is False
+    assert len(result["fake"].missing) == 1
+
+
+def test_revert_calls_compiler_revert() -> None:
+    rbac = _make_rbac()
+    compiler = _FakeCompiler(revert_result=(["id1"], []))
+    ctrl = SyncController(loader=_FakeLoader(rbac), compilers={"fake": compiler})
+
+    result = ctrl.revert(revert_ids=["id1"], backends=["fake"], environment="dev")
+
+    assert compiler.revert_called
+    assert result["fake"] == (["id1"], [])
+
+
+def test_revert_handles_exception() -> None:
+    rbac = _make_rbac()
+    compiler = _FakeCompiler(revert_error=RuntimeError("revert failed"))
+    ctrl = SyncController(loader=_FakeLoader(rbac), compilers={"fake": compiler})
+
+    result = ctrl.revert(revert_ids=["id1"], backends=["fake"], environment="dev")
+
+    assert result["fake"] == ([], ["revert failed"])
+
+
+def test_list_available_backends(monkeypatch: pytest.MonkeyPatch) -> None:
+    from phlo.rbac import sync as sync_mod
+
+    monkeypatch.setattr(sync_mod, "COMPILER_REGISTRY", {"alpha": object, "beta": object})
+
+    ctrl = SyncController()
+    backends = ctrl.list_available_backends()
+
+    assert sorted(backends) == ["alpha", "beta"]


### PR DESCRIPTION
Closes #353

## Summary

Adds 80 new tests across 7 files to address the critical and high-priority test coverage gaps identified in the audit.

### Coverage Added

| Issue Item | Test File | Tests |
|---|---|---|
| 1. authz CLI commands | `test_cli_authz.py` | 12 — all 5 subcommands |
| 2. Hook event emitters | `test_hook_emitters.py` | 8 — all 8 previously untested emitter types |
| 3. RBAC SyncController | `test_rbac_sync.py` | 9 — plan/sync/verify/revert/dry-run/errors |
| 4. OPA authorization backend | `test_authorization_opa.py` | 15 — decisions, errors, filtering, health |
| 6. Migration source adapters | `test_migration_adapters.py` | 13 — CsvSourceAdapter + resolver |
| 7. Migration spec parser | `test_migration_parser.py` | 12 — valid spec + all edge cases |
| 10. RBAC config loader | `test_rbac_config.py` | 10 — load/validate/hash |

### Not Yet Covered

Items 5 (schema registry CLI), 8 (metrics CLI asset/export), and 9 (plugin discovery internals) already have partial existing coverage and can be addressed in a follow-up.

### Verification

All 1358 tests pass (`uv run pytest`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
