### PR TITLE
test: lock plugin entry-point discovery coverage

### DIFF
--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -61,7 +61,7 @@ def test_entry_points_for_group_supports_legacy_mapping(
 @pytest.mark.parametrize(
     ("group", "expected_names"),
     [
-        ("phlo.plugins.cli", {"minio", "openmetadata", "sling"}),
+        ("phlo.plugins.cli", {"alerts", "minio", "openmetadata", "sling"}),
         ("phlo.plugins.services", {"loki", "minio", "openmetadata"}),
         ("phlo.plugins.hooks", {"alerting", "openmetadata"}),
         ("phlo.plugins.ingestion_providers", {"sling"}),

--- a/tests/test_plugin_entry_points.py
+++ b/tests/test_plugin_entry_points.py
@@ -56,3 +56,22 @@ def test_entry_points_for_group_supports_legacy_mapping(
     )
 
     assert list(entry_points_for_group("phlo.plugins.services")) == expected
+
+
+@pytest.mark.parametrize(
+    ("group", "expected_names"),
+    [
+        ("phlo.plugins.cli", {"minio", "openmetadata", "sling"}),
+        ("phlo.plugins.services", {"loki", "minio", "openmetadata"}),
+        ("phlo.plugins.hooks", {"alerting", "openmetadata"}),
+        ("phlo.plugins.ingestion_providers", {"sling"}),
+    ],
+)
+def test_workspace_entry_points_include_audit_flagged_plugins(
+    group: str,
+    expected_names: set[str],
+) -> None:
+    """Audit-flagged workspace plugins should still be present in installed entry points."""
+    names = {entry_point.name for entry_point in entry_points_for_group(group)}
+
+    assert expected_names <= names

--- a/tests/test_plugin_system.py
+++ b/tests/test_plugin_system.py
@@ -388,6 +388,30 @@ class TestPluginDiscovery:
                 registry = get_global_registry()
                 assert registry.validate_plugin(plugin)
 
+    @pytest.mark.parametrize(
+        ("plugin_type", "expected_names"),
+        [
+            ("cli_commands", {"alerts", "minio", "openmetadata", "sling"}),
+            ("services", {"loki", "minio", "openmetadata"}),
+            ("hooks", {"alerting", "openmetadata"}),
+            ("ingestion_providers", {"sling"}),
+        ],
+    )
+    def test_workspace_entry_point_plugins_are_discoverable(
+        self,
+        plugin_type: str,
+        expected_names: set[str],
+    ) -> None:
+        """Workspace plugins reported as dead should remain discoverable via entry points."""
+        result = discover_plugins(
+            plugin_type=plugin_type,
+            auto_register=False,
+            failure_level="debug",
+        )
+
+        discovered_names = {plugin.metadata.name for plugin in result[plugin_type]}
+        assert expected_names <= discovered_names
+
 
 class TestPluginAutoDiscoveryBootstrap:
     """Test import-time auto-discovery precedence."""


### PR DESCRIPTION
## Summary
- add regression coverage proving the audit-flagged workspace plugins are still present in installed entry points
- add discovery coverage proving those plugins still load through the real plugin discovery groups

## Verification
- uv run pytest packages/phlo-api/tests/test_integration_api.py tests/test_plugin_entry_points.py tests/test_plugin_system.py tests/test_rbac_models.py
- uv run pytest -m integration packages/phlo-api/tests/test_integration_api.py
- uv run ruff check packages/phlo-api/tests/test_integration_api.py tests/test_plugin_entry_points.py tests/test_plugin_system.py src/phlo/rbac/models.py

Closes #415
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
