### PR TITLE
fix: review regressions in Trino governance and pytest collection

### DIFF
--- a/packages/phlo-openmetadata/tests/test_openmetadata_settings.py
+++ b/packages/phlo-openmetadata/tests/test_openmetadata_settings.py
@@ -5,6 +5,14 @@ from unittest.mock import Mock, patch
 from phlo_openmetadata.settings import OpenMetadataSettings
 
 
+def test_openmetadata_settings_defaults() -> None:
+    """Settings keep local-development credentials by default."""
+    settings = OpenMetadataSettings()
+
+    assert settings.openmetadata_username == "admin"
+    assert settings.openmetadata_password == "admin"
+
+
 def test_openmetadata_database_prefers_explicit_name():
     """Explicit configured database name wins over capability resolution."""
     settings = OpenMetadataSettings(openmetadata_database_name="warehouse")

--- a/packages/phlo-trino/src/phlo_trino/governance.py
+++ b/packages/phlo-trino/src/phlo_trino/governance.py
@@ -69,6 +69,16 @@ def _validate_identifier(value: str, label: str) -> str:
     return value
 
 
+def _quote_identifier(identifier: str) -> str:
+    """Quote a single validated Trino identifier."""
+    return f'"{identifier}"'
+
+
+def _quote_qualified_identifier(identifier: str) -> str:
+    """Quote each segment of a validated dotted Trino identifier."""
+    return ".".join(_quote_identifier(part) for part in identifier.split("."))
+
+
 class TrinoGovernanceBackend:
     """GovernanceBackend implementation using Trino SQL grants."""
 
@@ -80,7 +90,9 @@ class TrinoGovernanceBackend:
         """List grants, optionally filtered by table."""
         if table_name is not None:
             _validate_identifier(table_name, "table_name")
-        sql = f"SHOW GRANTS ON TABLE {table_name}" if table_name else "SHOW GRANTS"
+            sql = f"SHOW GRANTS ON TABLE {_quote_qualified_identifier(table_name)}"
+        else:
+            sql = "SHOW GRANTS"
         try:
             rows = self._trino.execute(sql)
         except Exception:
@@ -121,10 +133,12 @@ class TrinoGovernanceBackend:
         if policy.columns:
             logger.warning("trino_governance_column_grants_unsupported", columns=policy.columns)
 
+        table_ref = _quote_qualified_identifier(policy.table_pattern)
+        principal_ref = _quote_identifier(policy.principal)
         if policy.effect == "DENY":
-            sql = f"DENY {action} ON TABLE {policy.table_pattern} TO {policy.principal}"
+            sql = f"DENY {action} ON TABLE {table_ref} TO {principal_ref}"
         else:
-            sql = f"GRANT {action} ON TABLE {policy.table_pattern} TO {policy.principal}"
+            sql = f"GRANT {action} ON TABLE {table_ref} TO {principal_ref}"
 
         logger.info(
             "trino_governance_apply_policy",
@@ -146,7 +160,10 @@ class TrinoGovernanceBackend:
             raise ValueError(f"Unsupported action: {action!r}")
         _validate_identifier(table, "table")
         _validate_identifier(principal, "principal")
-        sql = f"REVOKE {action.upper()} ON TABLE {table} FROM {principal}"
+        sql = (
+            f"REVOKE {action.upper()} ON TABLE {_quote_qualified_identifier(table)} "
+            f"FROM {_quote_identifier(principal)}"
+        )
         logger.info("trino_governance_revoke_policy", sql=sql, policy_id=policy_id)
         self._trino.execute(sql)
 

--- a/packages/phlo-trino/src/phlo_trino/governance.py
+++ b/packages/phlo-trino/src/phlo_trino/governance.py
@@ -71,7 +71,8 @@ def _validate_identifier(value: str, label: str) -> str:
 
 def _quote_identifier(identifier: str) -> str:
     """Quote a single validated Trino identifier."""
-    return f'"{ identifier.replace('"', '""') }"'
+    escaped = identifier.replace('"', '""')
+    return f'"{escaped}"'
 
 
 def _quote_qualified_identifier(identifier: str) -> str:

--- a/packages/phlo-trino/src/phlo_trino/governance.py
+++ b/packages/phlo-trino/src/phlo_trino/governance.py
@@ -71,7 +71,7 @@ def _validate_identifier(value: str, label: str) -> str:
 
 def _quote_identifier(identifier: str) -> str:
     """Quote a single validated Trino identifier."""
-    return f'"{identifier}"'
+    return f'"{ identifier.replace('"', '""') }"'
 
 
 def _quote_qualified_identifier(identifier: str) -> str:

--- a/packages/phlo-trino/tests/test_governance.py
+++ b/packages/phlo-trino/tests/test_governance.py
@@ -1,0 +1,49 @@
+"""Tests for Trino governance SQL rendering."""
+
+from __future__ import annotations
+
+from phlo.capabilities.interfaces import AccessPolicy
+from phlo_trino.governance import TrinoGovernanceBackend
+
+
+class _FakeTrino:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def execute(self, query: str):
+        self.queries.append(query)
+        return []
+
+
+def test_list_policies_quotes_each_table_name_segment() -> None:
+    trino = _FakeTrino()
+    backend = TrinoGovernanceBackend(trino=trino)
+
+    backend.list_policies(table_name="marts.orders")
+
+    assert trino.queries == ['SHOW GRANTS ON TABLE "marts"."orders"']
+
+
+def test_apply_policy_preserves_qualified_table_names() -> None:
+    trino = _FakeTrino()
+    backend = TrinoGovernanceBackend(trino=trino)
+
+    backend.apply_policy(
+        policy=AccessPolicy(
+            table_pattern="marts.orders",
+            principal="analyst_role",
+            action="SELECT",
+            effect="GRANT",
+        )
+    )
+
+    assert trino.queries == ['GRANT SELECT ON TABLE "marts"."orders" TO "analyst_role"']
+
+
+def test_revoke_policy_preserves_qualified_table_names() -> None:
+    trino = _FakeTrino()
+    backend = TrinoGovernanceBackend(trino=trino)
+
+    backend.revoke_policy(policy_id="SELECT:marts.orders:analyst_role")
+
+    assert trino.queries == ['REVOKE SELECT ON TABLE "marts"."orders" FROM "analyst_role"']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ include = [
 packages = ["src/phlo"]
 
 [tool.pytest.ini_options]
-addopts = "--ignore=src --continue-on-collection-errors -m 'not integration'"
+addopts = "--ignore=src --continue-on-collection-errors --import-mode=importlib -m 'not integration'"
 filterwarnings = ["ignore:Using `@model_validator` with mode='after' on a classmethod is deprecated:DeprecationWarning"]
 markers = [
     "integration: marks tests as requiring external services or dbt manifest (run with '-m integration')",


### PR DESCRIPTION
## Summary
- fix Trino governance SQL quoting for qualified table names and principals
- add regression coverage for governance and OpenMetadata default settings
- switch pytest to importlib mode to avoid package test namespace collisions during full-suite collection

## Root cause
Recent hardening changed identifier handling and test collection behavior in ways that broke common runtime and test paths. Qualified Trino identifiers were being quoted as a single token, and the repo-wide test run could collide package-local `tests` modules with the repo-root `tests` package.

## Validation
- `make check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
