### PR TITLE
fix: cairn CI races and artifact gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
 
   test-core:
     runs-on: ubuntu-latest
+    environment: ci
     strategy:
       fail-fast: false
       matrix:
@@ -143,9 +144,18 @@ jobs:
         run: uv sync --dev
 
       - name: Run core regression suite
-        run: make test-core-regression
+        id: core_regression
+        shell: bash
+        run: |
+          set +e
+          make test-core-regression
+          regression_exit=$?
+          set -e
+
+          echo "regression_exit=${regression_exit}" >> "$GITHUB_OUTPUT"
 
       - name: Run tests
+        if: always()
         id: core_tests
         shell: bash
         env:
@@ -172,7 +182,7 @@ jobs:
           fi
 
           echo "pytest_exit=${pytest_exit}" >> "$GITHUB_OUTPUT"
-          exit "${pytest_exit}"
+          exit 0
 
       - name: Upload Cairn core test artifacts
         if: always()
@@ -182,8 +192,29 @@ jobs:
           path: cairn-artifacts/pytest-${{ matrix.python-version }}.xml
           if-no-files-found: warn
 
+      - name: Fail core test job on regression or test failures
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          regression_exit="${{ steps.core_regression.outputs.regression_exit || '0' }}"
+          pytest_exit="${{ steps.core_tests.outputs.pytest_exit || '0' }}"
+
+          if [ "${regression_exit}" -ne 0 ]; then
+            echo "Core regression suite failed with exit ${regression_exit}" >&2
+          fi
+
+          if [ "${pytest_exit}" -ne 0 ]; then
+            echo "Core pytest suite failed with exit ${pytest_exit}" >&2
+          fi
+
+          if [ "${regression_exit}" -ne 0 ] || [ "${pytest_exit}" -ne 0 ]; then
+            exit 1
+          fi
+
   test-packages:
     runs-on: ubuntu-latest
+    environment: ci
     strategy:
       fail-fast: false
       matrix:
@@ -397,6 +428,9 @@ jobs:
   cairn:
     runs-on: ubuntu-latest
     if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+    concurrency:
+      group: gh-pages-writers
+      cancel-in-progress: false
     needs:
       - lint
       - test-core

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-writers
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## What changed
- serialize `gh-pages` writers by adding a shared concurrency group to the CI Cairn job and the Docs deploy job
- keep `test-core` running long enough to always publish JUnit XML for Cairn, then fail the job in a final status step
- add a dedicated `ci` environment to the secret-consuming CI jobs so workflow lint passes without bypassing hooks

## Why
Cairn was failing for two separate workflow reasons:
- the CI Cairn job and Docs workflow were racing to push `gh-pages`
- when `make test-core-regression` failed early, Cairn still ran but had no `pytest-*.xml` artifact to ingest

## Impact
- should eliminate the recurring Cairn-only red CI runs on PRs and merges to `main`
- preserves failing test signals while still giving Cairn the artifacts it expects
- satisfies the existing `zizmor` hook without skipping validation

## Validation
- `git diff --check`
- repo pre-commit hooks on commit, including `zizmor`
- manual inspection of recent failing Actions logs for both CI and Docs workflows

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
