### PR TITLE
fix: reject unsupported canonical deny policies

### DIFF
--- a/docs/reference/auth-and-access.md
+++ b/docs/reference/auth-and-access.md
@@ -20,6 +20,12 @@ flowchart TD
 - serving layers like `phlo-api`, `Hasura`, and `PostgREST` enforce those decisions in different ways
 - governance and backend systems may apply their own secondary controls
 
+## Canonical RBAC
+
+- canonical RBAC currently supports `allow` policies only
+- canonical `deny` rules are rejected by `phlo authz validate` and backend planning
+- do not model deny semantics in `.phlo/authorization/policies.yaml` until backend compilation support exists
+
 ## Where To Look
 
 - [Security](../setup/security.md) for operator setup and posture

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -63,6 +63,15 @@ phlo catalog             # Catalog operations (tables, describe, history)
 phlo lineage             # Asset lineage (show, export)
 ```
 
+**Authorization Commands:**
+
+```bash
+phlo authz validate      # Validate canonical RBAC config
+phlo authz plan          # Show backend policy changes without applying
+phlo authz sync          # Apply canonical RBAC to configured backends
+phlo authz verify        # Check backend state against desired RBAC state
+```
+
 **Quality Commands:**
 
 ```bash
@@ -192,6 +201,22 @@ phlo dbt compile --target prod
 # Run host dbt instead of the container
 phlo dbt test --local --select gold.*
 ```
+
+### phlo authz
+
+Manage canonical RBAC configuration and backend synchronization.
+
+```bash
+phlo authz validate [OPTIONS]
+phlo authz plan [OPTIONS]
+phlo authz sync [OPTIONS]
+phlo authz verify [OPTIONS]
+```
+
+Notes:
+
+- canonical RBAC accepts `allow` policies only
+- `deny` policies are rejected during validation and planning
 
 ## Services Commands
 

--- a/src/phlo/rbac/compiler.py
+++ b/src/phlo/rbac/compiler.py
@@ -19,6 +19,7 @@ from phlo.rbac.models import (
     CanonicalRBAC,
     PolicyChange,
     PolicyEffect,
+    PolicyRule,
     SyncPlan,
     VerifyResult,
 )
@@ -269,6 +270,14 @@ class GovernanceCompiler(ABC):
             data_masking=None,
         )
 
+    def _ensure_supported_policy_effect(self, policy: PolicyRule) -> None:
+        """Fail loudly when the canonical model uses unsupported effects."""
+        if policy.effect != PolicyEffect.ALLOW:
+            raise ValueError(
+                f"Backend {self.backend_name!r} does not support canonical "
+                f"{policy.effect.value!r} policies. Policy: {policy.policy_id}"
+            )
+
 
 class TrinoCompiler(GovernanceCompiler):
     """Compiler for Trino SQL grants."""
@@ -327,10 +336,9 @@ class TrinoCompiler(GovernanceCompiler):
         artifacts: list[BackendArtifact] = []
 
         for policy in rbac.policies.policies:
-            if not self.supports_action(policy.action):
-                continue
+            self._ensure_supported_policy_effect(policy)
 
-            if policy.effect != PolicyEffect.ALLOW:
+            if not self.supports_action(policy.action):
                 continue
 
             privileges = self.ACTION_MAPPING.get(policy.action, ())
@@ -614,10 +622,9 @@ class PostgreSQLCompiler(GovernanceCompiler):
         artifacts: list[BackendArtifact] = []
 
         for policy in rbac.policies.policies:
-            if not self.supports_action(policy.action):
-                continue
+            self._ensure_supported_policy_effect(policy)
 
-            if policy.effect != PolicyEffect.ALLOW:
+            if not self.supports_action(policy.action):
                 continue
 
             privileges = self.ACTION_MAPPING.get(policy.action, ())
@@ -691,10 +698,9 @@ class HasuraCompiler(GovernanceCompiler):
         import json
 
         for policy in rbac.policies.policies:
-            if not self.supports_action(policy.action):
-                continue
+            self._ensure_supported_policy_effect(policy)
 
-            if policy.effect != PolicyEffect.ALLOW:
+            if not self.supports_action(policy.action):
                 continue
 
             permission_type = self.ACTION_MAPPING.get(policy.action, "select")
@@ -765,10 +771,9 @@ class MinIOCompiler(GovernanceCompiler):
         import json
 
         for policy in rbac.policies.policies:
-            if not self.supports_action(policy.action):
-                continue
+            self._ensure_supported_policy_effect(policy)
 
-            if policy.effect != PolicyEffect.ALLOW:
+            if not self.supports_action(policy.action):
                 continue
 
             actions = self.ACTION_MAPPING.get(policy.action, [])
@@ -847,10 +852,9 @@ class NessieCompiler(GovernanceCompiler):
         import json
 
         for policy in rbac.policies.policies:
-            if not self.supports_action(policy.action):
-                continue
+            self._ensure_supported_policy_effect(policy)
 
-            if policy.effect != PolicyEffect.ALLOW:
+            if not self.supports_action(policy.action):
                 continue
 
             permissions = self.ACTION_MAPPING.get(policy.action, [])

--- a/src/phlo/rbac/models.py
+++ b/src/phlo/rbac/models.py
@@ -265,6 +265,18 @@ class CanonicalRBAC:
         """
         errors: list[str] = []
 
+        unsupported_effects = {
+            policy.effect.value
+            for policy in self.policies.policies
+            if policy.effect != PolicyEffect.ALLOW
+        }
+        for effect in sorted(unsupported_effects):
+            errors.append(
+                "Canonical RBAC does not support "
+                f"{effect!r} policies yet. Remove those rules until backend compilation "
+                "semantics are implemented."
+            )
+
         # Check that all principal roles exist
         for policy in self.policies.policies:
             for role in policy.principal_roles:

--- a/tests/test_cli_authz.py
+++ b/tests/test_cli_authz.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+import yaml
 from click.testing import CliRunner
 
 from phlo.cli.commands import authz as authz_mod
@@ -106,6 +107,41 @@ def test_validate_fails(runner, monkeypatch, tmp_path):
     assert result.exit_code == 1
     assert "Validation failed" in result.output
     assert "error1" in result.output
+
+
+def test_validate_rejects_deny_rules(runner, tmp_path):
+    auth_dir = tmp_path / "authorization"
+    auth_dir.mkdir()
+    (auth_dir / "roles.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "roles": {"admin": {"inherits": []}},
+            }
+        )
+    )
+    (auth_dir / "policies.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "policies": [
+                    {
+                        "policy_id": "deny_admin_read",
+                        "effect": "deny",
+                        "principal": {"roles": ["admin"]},
+                        "action": "dataset.read",
+                        "resource": {"type": "dataset", "id_pattern": "analytics.*"},
+                    }
+                ],
+            }
+        )
+    )
+
+    result = runner.invoke(authz_group, ["validate", "--path", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "Validation failed" in result.output
+    assert "does not support 'deny' policies yet" in result.output
 
 
 # -- plan ---------------------------------------------------------------------

--- a/tests/test_rbac_compiler.py
+++ b/tests/test_rbac_compiler.py
@@ -213,7 +213,7 @@ def test_trino_compile_allows_catch_all_resource_pattern() -> None:
     assert artifacts[0].metadata["resource"] == "%"
 
 
-def test_trino_compile_skips_deny_and_unsupported_actions() -> None:
+def test_trino_compile_rejects_deny_rules() -> None:
     compiler = TrinoCompiler()
     roles = RolesConfig.from_dict({"version": 1, "roles": {"admin": {"inherits": []}}})
     policies = PoliciesConfig.from_dict(
@@ -240,7 +240,32 @@ def test_trino_compile_skips_deny_and_unsupported_actions() -> None:
     rbac = CanonicalRBAC.from_configs(roles, policies)
     context = CompilerContext(environment="test", backend_name="trino")
 
-    assert compiler.compile(rbac, context) == []
+    with pytest.raises(ValueError, match="does not support canonical 'deny' policies"):
+        compiler.compile(rbac, context)
+
+
+def test_postgresql_compile_rejects_deny_rules() -> None:
+    compiler = PostgreSQLCompiler()
+    roles = RolesConfig.from_dict({"version": 1, "roles": {"admin": {"inherits": []}}})
+    policies = PoliciesConfig.from_dict(
+        {
+            "version": 1,
+            "policies": [
+                {
+                    "policy_id": "deny_service_read",
+                    "effect": "deny",
+                    "principal": {"roles": ["admin"]},
+                    "action": "service.read",
+                    "resource": {"type": "service", "id_pattern": "analytics"},
+                }
+            ],
+        }
+    )
+    rbac = CanonicalRBAC.from_configs(roles, policies)
+    context = CompilerContext(environment="test", backend_name="postgresql")
+
+    with pytest.raises(ValueError, match="does not support canonical 'deny' policies"):
+        compiler.compile(rbac, context)
 
 
 def test_trino_compile_rejects_unsafe_role_names() -> None:

--- a/tests/test_rbac_models.py
+++ b/tests/test_rbac_models.py
@@ -252,6 +252,41 @@ class TestCanonicalRBAC:
         errors = rbac.validate()
         assert errors == ["Role 'nonexistent_role' referenced in hierarchy does not exist"]
 
+    def test_validate_rejects_deny_policies(self):
+        """Test validation fails when canonical RBAC includes deny rules."""
+        roles_data = {
+            "version": 1,
+            "roles": {
+                "admin": {"inherits": []},
+            },
+        }
+        policies_data = {
+            "version": 1,
+            "policies": [
+                {
+                    "policy_id": "deny_admin_read",
+                    "effect": "deny",
+                    "principal": {"roles": ["admin"]},
+                    "action": "dataset.read",
+                    "resource": {
+                        "type": "dataset",
+                        "id_pattern": "analytics.*",
+                    },
+                }
+            ],
+        }
+
+        roles = RolesConfig.from_dict(roles_data)
+        policies = PoliciesConfig.from_dict(policies_data)
+        rbac = CanonicalRBAC.from_configs(roles, policies)
+
+        errors = rbac.validate()
+
+        assert errors == [
+            "Canonical RBAC does not support 'deny' policies yet. Remove those rules until "
+            "backend compilation semantics are implemented."
+        ]
+
 
 class TestRBACConfigLoader:
     """Tests for RBACConfigLoader."""


### PR DESCRIPTION
## What changed
Canonical RBAC now rejects unsupported `deny` policies instead of silently dropping them during backend compilation.

This change adds validation and compiler guards so `phlo authz validate`, planning, and backend compilation fail loudly when a canonical `deny` rule is present. It also updates the RBAC/authz docs and adds regression coverage for the new behavior.

## Why
The canonical RBAC model exposed `deny`, but the backend compiler layer skipped every non-`allow` rule. That created a dangerous mismatch where operators could write deny rules, pass validation, and believe enforcement existed when no backend artifact was generated.

This PR fixes that by making unsupported deny semantics explicit rather than silently ignored.

Closes #454.

## Impact
- Canonical RBAC currently supports `allow` policies only.
- `deny` rules in `.phlo/authorization/policies.yaml` now fail validation/planning instead of disappearing.
- Docs now state the current constraint clearly.

## Validation
- `uv run pytest tests/test_rbac_models.py tests/test_rbac_compiler.py tests/test_cli_authz.py`
- `uv run pytest tests/test_rbac_sync.py`
- `uv run ruff check src/phlo/rbac/compiler.py src/phlo/rbac/models.py tests/test_cli_authz.py tests/test_rbac_compiler.py tests/test_rbac_models.py`
- `make check`