### PR TITLE
docs: Define Phlo audit logging posture

### DIFF
--- a/docs/operations/audit-logging.md
+++ b/docs/operations/audit-logging.md
@@ -1,0 +1,98 @@
+# Audit Logging
+
+Use this page to define Phlo's audit-log posture for production deployments.
+
+## What Counts As Audit Logging
+
+Phlo distinguishes three signal types:
+
+- **Operational logs**: service health, startup, retries, throughput, and debugging detail.
+- **Security and audit logs**: authentication events, authorization denials, administrative actions, and storage access events.
+- **Query and access trails**: evidence of who queried data, from where, and through which surface.
+
+You need all three in production, but they have different owners and retention expectations.
+
+## Supported Posture
+
+| Surface | Signal Type | Phlo-Owned Path | Production Stance |
+|---------|-------------|-----------------|-------------------|
+| `phlo-api` / Observatory | Security and audit logs | Structured app logs, optionally exported through `phlo-otel` OTLP logs | Recommended |
+| MinIO | Storage audit trail | `MINIO_AUDIT_ENABLED` + `MINIO_AUDIT_ENDPOINT` in the bundled service package | Recommended |
+| PostgreSQL | Database audit trail | No bundled `pgaudit` automation today | Operator-managed |
+| Trino | Query and access trail | Coordinator logs and UI history are present; centralized retention/export is operator-managed | Recommended with external retention |
+| Nessie | Catalog API access trail | Nessie server logs and metrics; centralized retention/export is operator-managed | Optional, based on catalog exposure |
+
+## Default, Recommended, And External
+
+### Enabled by default
+
+- Phlo application logging remains on by default.
+- Trino coordinator query history remains available in the Trino UI.
+
+These defaults help with local debugging, but they are not sufficient by themselves to claim a durable audit trail.
+
+### Recommended and Phlo-supported
+
+- Route `phlo-api` and Observatory logs to a centralized log backend through `phlo-otel` with `OTEL_LOGS_EXPORTER=otlp`.
+- Enable MinIO audit webhooks with:
+
+```bash
+MINIO_AUDIT_ENABLED=on
+MINIO_AUDIT_ENDPOINT=http://loki:3100/loki/api/v1/push
+```
+
+- Keep application logs and storage audit logs in the same retention domain so an operator can correlate who accessed data with which app action triggered it.
+
+### External or operator-managed
+
+- PostgreSQL `pgaudit` remains external today because the bundled PostgreSQL service does not ship a `pgaudit`-enabled image or bootstrap automation.
+- Trino long-term query retention and export remain external. Phlo exposes the running coordinator, but retention policy and downstream archival are still an operator responsibility.
+- Nessie audit requirements depend on whether the catalog is exposed beyond internal service-to-service traffic.
+
+## Minimum Production Claim
+
+Treat a Phlo deployment as auditable only when all of the following are true:
+
+- authentication events and authorization denials from `phlo-api` are retained outside the container lifecycle
+- MinIO audit logging is enabled and routed to a durable backend
+- Trino query history is retained long enough for incident investigation, either in Trino itself or in an external sink
+- retention, access control, and backup expectations for the audit backend are documented
+- the operator has decided explicitly whether PostgreSQL and Nessie need separate audit controls in the target environment
+
+## Routing Pattern
+
+Phlo's recommended routing pattern is:
+
+```text
+application logs -> phlo-otel -> OTLP collector or Alloy -> durable log backend
+MinIO audit webhook -------------------------------> durable log backend
+Trino / Nessie / PostgreSQL audit sources --------> operator-managed sink
+```
+
+Phlo owns the application log envelope and the MinIO webhook configuration surface. Database-grade audit pipelines stay under operator control unless Phlo ships a dedicated integration for them.
+
+## Retention Expectations
+
+Phlo does not impose one global retention period, but the production baseline is:
+
+- keep application and storage audit evidence for the same incident review window
+- do not rely on container-local logs as the only audit record
+- define who can read, delete, and export audit records
+- verify that backup and restore procedures cover the audit backend itself
+
+## Checklist
+
+Before sign-off, verify:
+
+- `OTEL_LOGS_EXPORTER=otlp` is enabled for Phlo application logs, or an equivalent centralized log path exists
+- `MINIO_AUDIT_ENABLED=on` and `MINIO_AUDIT_ENDPOINT` points at a durable sink
+- the Trino query-history path is known to operators
+- retention and access policy for audit records are written down
+- any required PostgreSQL or Nessie audit controls are called out explicitly as external dependencies
+
+## Related Pages
+
+- [Security](../setup/security.md)
+- [Production Readiness](production-readiness.md)
+- [Configuration Reference](../reference/configuration-reference.md)
+- [phlo-minio](../packages/phlo-minio.md)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -15,6 +15,7 @@ flowchart LR
 ## In This Section
 
 - [Operations Guide](operations-guide.md): day-to-day operations
+- [Audit Logging](audit-logging.md): supported audit-log posture and checklist
 - [Best Practices](best-practices.md): baseline operating patterns
 - [Production Readiness](production-readiness.md): pre-production checklist
 - [Local Dev Troubleshooting](local-development-troubleshooting.md): symptom-first local issues

--- a/docs/operations/meta.json
+++ b/docs/operations/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "operations-guide",
+    "audit-logging",
     "production-readiness",
     "local-development-troubleshooting",
     "best-practices",

--- a/docs/operations/production-readiness.md
+++ b/docs/operations/production-readiness.md
@@ -8,6 +8,7 @@ Use this checklist before treating a Phlo stack as production-capable.
 - secrets are not left at defaults
 - storage, catalog, and metadata services have backup and recovery plans
 - observability is enabled and routed to a real backend
+- audit logging is enabled, retained outside container-local logs, and mapped to an owner
 - API surfaces are intentionally chosen, not all enabled by default
 - access controls are defined for users and services
 - data quality and promotion gates are enforced
@@ -32,6 +33,7 @@ Use this checklist before treating a Phlo stack as production-capable.
 - traces, metrics, and logs are emitted
 - dashboards or query paths exist for key incidents
 - alerting path is defined where needed
+- audit-log routing and retention are documented
 
 ### Access
 
@@ -42,6 +44,7 @@ Use this checklist before treating a Phlo stack as production-capable.
 ## Related Pages
 
 - [Operations Guide](operations-guide.md)
+- [Audit Logging](audit-logging.md)
 - [Security](../setup/security.md)
 - [Observability](../setup/observability.md)
 - [Deployment Profiles](../guides/deployment-profiles.md)

--- a/docs/packages/phlo-minio.md
+++ b/docs/packages/phlo-minio.md
@@ -25,7 +25,7 @@ phlo plugin install minio
 | `MINIO_SERVER_URL`      | -          | TLS server URL           |
 | `MINIO_OIDC_CONFIG_URL` | -          | OIDC provider config URL |
 | `MINIO_AUTO_ENCRYPTION` | `off`      | Auto-encryption mode     |
-| `MINIO_AUDIT_ENABLED`   | `off`      | Audit logging            |
+| `MINIO_AUDIT_ENABLED`   | `off`      | Audit webhook delivery   |
 
 ## Features
 
@@ -110,6 +110,17 @@ compose:
     phlo.metrics.path: "/minio/v2/metrics/cluster"
 ```
 
+## Audit Logging
+
+`phlo-minio` is the Phlo-owned audit-log integration point for storage access events.
+
+```bash
+MINIO_AUDIT_ENABLED=on
+MINIO_AUDIT_ENDPOINT=http://loki:3100/loki/api/v1/push
+```
+
+Keep MinIO audit logs in a durable backend. Do not treat container-local logs as the only audit record for production environments.
+
 ## Entry Points
 
 | Entry Point                     | Plugin                                  |
@@ -122,6 +133,7 @@ compose:
 - [phlo-iceberg](phlo-iceberg.md) - Table format
 - [phlo-nessie](phlo-nessie.md) - Catalog service
 - [phlo-prometheus](phlo-prometheus.md) - Metrics collection
+- [Audit Logging](../operations/audit-logging.md) - Production audit-log posture
 
 ## Next Steps
 

--- a/docs/packages/phlo-postgres.md
+++ b/docs/packages/phlo-postgres.md
@@ -149,6 +149,10 @@ compose:
     phlo.grafana.datasource.name: "PostgreSQL"
 ```
 
+## Audit Logging
+
+`phlo-postgres` does not currently ship a `pgaudit`-enabled image or bootstrap automation. If your deployment needs database-grade audit trails, treat them as an operator-managed control and document that dependency explicitly.
+
 ## Entry Points
 
 | Entry Point                     | Plugin                                                   |
@@ -162,6 +166,7 @@ compose:
 - [phlo-hasura](phlo-hasura.md) - GraphQL API
 - [phlo-grafana](phlo-grafana.md) - Visualization
 - [phlo-dagster](phlo-dagster.md) - Orchestration
+- [Audit Logging](../operations/audit-logging.md) - Platform audit-log posture
 
 ## Next Steps
 

--- a/docs/packages/phlo-trino.md
+++ b/docs/packages/phlo-trino.md
@@ -142,6 +142,10 @@ compose:
     phlo.grafana.datasource.name: "Trino"
 ```
 
+## Audit Logging
+
+`phlo-trino` provides query history and coordinator logs, which form the starting point for query and access trails. Long-term retention and export are still operator-managed, so do not rely on the local Trino container alone for production audit evidence.
+
 ## Entry Points
 
 | Entry Point                     | Plugin                                               |
@@ -156,6 +160,7 @@ compose:
 - [phlo-nessie](phlo-nessie.md) - Catalog service
 - [phlo-postgres](phlo-postgres.md) - Marts storage
 - [phlo-grafana](phlo-grafana.md) - Visualization
+- [Audit Logging](../operations/audit-logging.md) - Platform audit-log posture
 
 ## Next Steps
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -678,6 +678,8 @@ MINIO_AUDIT_ENABLED=off
 MINIO_AUDIT_ENDPOINT=http://audit-service:8080/logs
 ```
 
+`MINIO_AUDIT_ENABLED` and `MINIO_AUDIT_ENDPOINT` are Phlo's bundled audit-log automation surface for object storage events. In production, point the endpoint at a durable backend and pair it with centralized application logs. See [Audit Logging](../operations/audit-logging.md).
+
 #### PostgreSQL SSL
 
 ```bash

--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -4,7 +4,7 @@ This guide covers enterprise security configuration for Phlo, including authenti
 
 ## Overview
 
-Phlo's underlying services (Trino, Nessie, MinIO, PostgreSQL) support enterprise security features. This guide explains how to enable and configure them.
+Phlo's underlying services (Trino, Nessie, MinIO, PostgreSQL) support enterprise security features. This guide explains how to enable and configure them, and where Phlo's audit-log support stops and operator-owned controls begin.
 
 | Feature | Trino | Nessie | MinIO | PostgreSQL |
 |---------|-------|--------|-------|------------|
@@ -12,7 +12,7 @@ Phlo's underlying services (Trino, Nessie, MinIO, PostgreSQL) support enterprise
 | OAuth2/OIDC | Yes | Yes | Yes | No |
 | TLS/HTTPS | Yes | Yes | Yes | Yes |
 | Access Control | Yes | Yes | Yes (IAM) | Yes (RLS) |
-| Audit Logging | Yes | Yes | Yes | Yes |
+| Audit Logging | Query history and logs | Server logs | Webhook audit events | Operator-managed `pgaudit` |
 
 ## Quick Start
 
@@ -37,6 +37,26 @@ Generate strong passwords:
 ```bash
 openssl rand -base64 32
 ```
+
+## Audit-Log Posture
+
+Phlo does not treat every log line as an audit record. Use this distinction:
+
+- **Operational logs** are for debugging and service health.
+- **Security and audit logs** capture authentication, authorization, and administrative events.
+- **Query and access trails** show who read or queried data.
+
+The supported production posture is:
+
+| Surface | What You Get | Ownership |
+|---------|---------------|-----------|
+| `phlo-api` / Observatory | Structured application audit events and denials | Phlo-owned logging path |
+| MinIO | Storage access audit events through webhook delivery | Phlo-owned configuration surface |
+| Trino | Query history and coordinator logs | Shared, with retention/operator export left external |
+| PostgreSQL | `pgaudit` or equivalent database audit controls | Operator-managed |
+| Nessie | Server logs for catalog access visibility | Operator-managed retention |
+
+Use [Audit Logging](../operations/audit-logging.md) as the source of truth for routing, retention, and production checklist expectations.
 
 ## Authentication
 
@@ -318,7 +338,7 @@ MINIO_KMS_KES_KEY_NAME=my-key
 
 ### MinIO Audit Logs
 
-Send audit logs to a webhook:
+Phlo supports MinIO audit webhook wiring directly through the bundled service package. Send those audit logs to a durable backend:
 
 ```bash
 MINIO_AUDIT_ENABLED=on
@@ -335,7 +355,7 @@ MINIO_AUDIT_KAFKA_TOPIC=minio-audit
 
 ### PostgreSQL Audit Logging
 
-Enable pgaudit extension:
+PostgreSQL audit logging remains operator-managed today. Enable `pgaudit` on a PostgreSQL build that includes the extension:
 
 ```sql
 -- In PostgreSQL
@@ -346,12 +366,14 @@ SELECT pg_reload_conf();
 
 ### Trino Query Logging
 
-Trino logs all queries by default. Configure log retention:
+Trino query history is available by default in the coordinator UI, but long-term retention and centralized export are still operator-managed:
 
 ```properties
 # coordinator config
 query.max-history=10000
 ```
+
+If Trino query evidence is part of your compliance boundary, pair that history with an external retention path rather than relying on container-local logs alone.
 
 ## Existing Security Features
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -145,6 +145,8 @@ nav:
       - Extensions: observatory/extensions.md
   - Operations:
       - Operations Guide: operations/operations-guide.md
+      - Audit Logging: operations/audit-logging.md
+      - Production Readiness: operations/production-readiness.md
       - Best Practices: operations/best-practices.md
       - Testing: operations/testing.md
       - Troubleshooting: operations/troubleshooting.md

--- a/packages/phlo-minio/README.md
+++ b/packages/phlo-minio/README.md
@@ -25,7 +25,7 @@ phlo plugin install minio
 | `MINIO_SERVER_URL`      | -          | TLS server URL           |
 | `MINIO_OIDC_CONFIG_URL` | -          | OIDC provider config URL |
 | `MINIO_AUTO_ENCRYPTION` | `off`      | Auto-encryption mode     |
-| `MINIO_AUDIT_ENABLED`   | `off`      | Audit logging            |
+| `MINIO_AUDIT_ENABLED`   | `off`      | Audit webhook delivery   |
 
 ## Auto-Configuration
 
@@ -52,6 +52,17 @@ compose:
 ```bash
 phlo services start --service minio
 ```
+
+## Audit Logging
+
+The bundled MinIO service exposes Phlo's supported storage audit-log path:
+
+```bash
+MINIO_AUDIT_ENABLED=on
+MINIO_AUDIT_ENDPOINT=http://loki:3100/loki/api/v1/push
+```
+
+Route audit events to a durable backend and correlate them with centralized application logs. See `docs/operations/audit-logging.md` for the full platform posture.
 
 ## Endpoints
 


### PR DESCRIPTION
## Summary

Fixes #458 by defining a single audit-logging posture for Phlo and wiring it into the operator docs.

## What changed

- added a dedicated `docs/operations/audit-logging.md` page as the source of truth for audit-log coverage, ownership, routing, retention, and production checklist expectations
- linked that posture from operations navigation and production-readiness guidance
- updated the security guide to distinguish operational logs, security/audit logs, and query/access trails
- clarified the current automation boundary across MinIO, Trino, PostgreSQL, and Nessie
- updated MinIO, Trino, PostgreSQL, and configuration reference docs so the documented path matches the supported platform posture

## Why

Phlo had the underlying pieces for audit evidence, but the platform posture was fragmented across service docs and operator notes. That left it unclear which audit paths were supported by Phlo, which were recommended but opt-in, and which remained operator-managed.

## Root cause

The repo documented service-specific logging features independently, but it did not define one Phlo-level audit-log architecture or production-readiness expectation across the lakehouse stack.

## Impact

- operators now have one page that explains the supported audit-log architecture
- production-readiness guidance now includes audit-log ownership and retention expectations
- service docs now make the Phlo-owned versus operator-managed boundary explicit

## Validation

- `git diff --stat`
- pre-commit hooks during `git commit`
- `uv run mkdocs build --strict` still reports pre-existing repository-wide documentation warnings, but no new warnings were introduced by this change set

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
