### PR TITLE
docs: document canonical RBAC workflow

### DIFF
--- a/docs/reference/auth-and-access.md
+++ b/docs/reference/auth-and-access.md
@@ -22,12 +22,23 @@ flowchart TD
 
 ## Canonical RBAC
 
+Phlo's canonical RBAC control plane lives under `.phlo/authorization/` and
+provides a single model for roles, subject assignment, policy validation,
+backend planning, sync, and drift verification.
+
+- source-of-truth files: `.phlo/authorization/roles.yaml` and
+  `.phlo/authorization/policies.yaml`
+- control commands: `phlo authz validate`, `phlo authz plan`, `phlo authz sync`,
+  and `phlo authz verify`
 - canonical RBAC currently supports `allow` policies only
-- canonical `deny` rules are rejected by `phlo authz validate` and backend planning
-- do not model deny semantics in `.phlo/authorization/policies.yaml` until backend compilation support exists
+- canonical `deny` rules are rejected by validation and backend compilation
+
+Use [Canonical RBAC](canonical-rbac.md) for the file format, workflow, command
+behavior, and backend support matrix.
 
 ## Where To Look
 
 - [Security](../setup/security.md) for operator setup and posture
+- [Canonical RBAC](canonical-rbac.md) for the control-plane model and workflow
 - [Python Reference](../python-reference/index.mdx) for capability-level auth interfaces
 - [API Surfaces](api-surfaces.md) for how access shows up across external entry points

--- a/docs/reference/canonical-rbac.md
+++ b/docs/reference/canonical-rbac.md
@@ -1,0 +1,272 @@
+# Canonical RBAC
+
+Phlo includes a canonical RBAC control plane for describing roles, subjects, and
+policies once and then compiling them into backend-native enforcement artifacts.
+
+Use this page when you need the source-of-truth model, file shapes, command
+behavior, or backend support boundaries.
+
+## Overview
+
+The canonical RBAC workflow centers on two files under `.phlo/authorization/`:
+
+- `roles.yaml`: role definitions, inheritance, and subject-to-role assignments
+- `policies.yaml`: canonical allow rules for actions on resource types
+
+The CLI drives the workflow:
+
+```bash
+phlo authz validate
+phlo authz plan
+phlo authz sync
+phlo authz verify
+```
+
+Typical flow:
+
+1. edit `.phlo/authorization/roles.yaml`
+2. edit `.phlo/authorization/policies.yaml`
+3. run `phlo authz validate`
+4. run `phlo authz plan`
+5. run `phlo authz sync`
+6. run `phlo authz verify`
+
+## Configuration Layout
+
+The loader reads RBAC configuration from `.phlo/authorization/` by default.
+Pass `--path` to point commands at a different `.phlo` directory root.
+
+### `roles.yaml`
+
+`roles.yaml` defines role names, optional inheritance, and subject assignment.
+
+```yaml
+version: 1
+roles:
+  viewer:
+    inherits: []
+    description: Read-only access
+  analyst:
+    inherits:
+      - viewer
+    description: Interactive query access
+  admin:
+    inherits:
+      - analyst
+    description: Administrative access
+subjects:
+  services:
+    dagster-agent:
+      - analyst
+  users:
+    alice@example.com:
+      - admin
+    bob@example.com:
+      - viewer
+```
+
+Fields:
+
+- `version`: schema version for the roles document
+- `roles`: mapping of role name to role definition
+- `roles.<name>.inherits`: parent roles to include in the hierarchy
+- `roles.<name>.description`: optional human-readable description
+- `subjects.services`: service principal to roles mapping
+- `subjects.users`: user principal to roles mapping
+
+Role hierarchy rules:
+
+- inherited roles must exist
+- cycles are rejected during validation
+- hierarchy expansion is available in the canonical model
+
+Current implementation note:
+
+- backend compilers compile policies for the roles listed in each policy rule
+  directly; they do not currently fan out grants to inherited roles for you
+
+### `policies.yaml`
+
+`policies.yaml` defines canonical permission rules.
+
+```yaml
+version: 1
+policies:
+  - policy_id: allow_analyst_dataset_read
+    effect: allow
+    principal:
+      roles:
+        - analyst
+    action: dataset.read
+    resource:
+      type: dataset
+      id_pattern: analytics.*
+
+  - policy_id: allow_platform_storage_write
+    effect: allow
+    principal:
+      roles:
+        - admin
+    action: object.write
+    resource:
+      type: object
+      id_pattern: platform-artifacts
+```
+
+Fields:
+
+- `policy_id`: stable identifier for the rule
+- `effect`: currently `allow` only
+- `principal.roles`: roles the rule applies to
+- `principal.attributes`: optional attribute map reserved in the model
+- `action`: canonical action name
+- `resource.type`: canonical resource type
+- `resource.id_pattern`: backend-specific identifier or wildcard pattern
+- `resource.attributes`: optional attribute map reserved in the model
+
+## Canonical Actions And Resource Types
+
+Canonical actions:
+
+- `dataset.read`
+- `dataset.query`
+- `asset.read`
+- `asset.execute`
+- `service.read`
+- `service.manage`
+- `admin.read`
+- `admin.manage`
+- `object.read`
+- `object.write`
+- `catalog.read`
+- `catalog.manage`
+
+Canonical resource types:
+
+- `dataset`
+- `asset`
+- `service`
+- `admin`
+- `object`
+- `catalog`
+
+## Validation Rules
+
+`phlo authz validate` checks:
+
+- `roles.yaml` and `policies.yaml` can be parsed
+- referenced roles exist
+- role inheritance has no cycles
+- the combined canonical RBAC model is internally consistent
+
+Important limitation:
+
+- canonical RBAC rejects `deny` policies today
+
+If a policy uses `effect: deny`, validation fails and planning or compilation
+will also reject it. Do not model deny semantics in canonical config until the
+backend compilation path supports them.
+
+## CLI Commands
+
+### `phlo authz validate`
+
+Validate canonical RBAC config under the target `.phlo` directory.
+
+```bash
+phlo authz validate [OPTIONS]
+```
+
+Options:
+
+- `--path PATH`: path to the `.phlo` directory root
+
+Use it to catch malformed YAML, missing roles, hierarchy cycles, and unsupported
+policy effects before you plan or apply changes.
+
+### `phlo authz plan`
+
+Generate backend-specific changes without mutating any backend.
+
+```bash
+phlo authz plan [OPTIONS]
+```
+
+Options:
+
+- `--path PATH`: path to the `.phlo` directory root
+- `--backend TEXT`: restrict planning to one or more backends
+- `--environment TEXT`: context label passed to compilers, default `development`
+
+Use it to review the version hash and planned artifact creation or deletion
+before syncing.
+
+### `phlo authz sync`
+
+Compile canonical RBAC into backend-native artifacts and apply them.
+
+```bash
+phlo authz sync [OPTIONS]
+```
+
+Options:
+
+- `--path PATH`: path to the `.phlo` directory root
+- `--backend TEXT`: restrict sync to one or more backends
+- `--environment TEXT`: context label passed to compilers, default `development`
+- `--dry-run`: plan without applying changes
+
+Use `--dry-run` when you want sync-style output but no mutation. A successful
+sync reports applied and failed artifact counts per backend.
+
+### `phlo authz verify`
+
+Compare desired compiled artifacts with backend state and report drift.
+
+```bash
+phlo authz verify [OPTIONS]
+```
+
+Options:
+
+- `--path PATH`: path to the `.phlo` directory root
+- `--backend TEXT`: restrict verification to one or more backends
+- `--environment TEXT`: context label passed to compilers, default `development`
+
+Verification reports:
+
+- `missing`: desired artifacts not found in the backend
+- `extra`: managed backend artifacts not present in desired state
+- `mismatched`: reserved for artifact content differences when supported
+
+## Backend Support Matrix
+
+| Backend | Supported canonical actions | Deny support | Verify coverage | Notes |
+|---------|-----------------------------|--------------|-----------------|-------|
+| `trino` | `dataset.read`, `dataset.query`, `asset.read`, `asset.execute`, `service.read`, `service.manage`, `admin.read`, `admin.manage` | No | Compares desired vs current managed grants; reports missing and extra artifacts | Best current drift coverage. Managed state is derived from governance backend `list_policies()` output and filtered to managed role names. |
+| `postgresql` | `dataset.read`, `dataset.query`, `asset.read`, `asset.execute`, `service.read`, `service.manage`, `admin.read`, `admin.manage` | No | Desired-state only; current-state introspection is not implemented | Plan and verify cannot detect extra live grants. Expect manual review or backend-native inspection after sync. |
+| `hasura` | `dataset.read`, `dataset.query`, `asset.read`, `asset.execute`, `service.read`, `service.manage`, `admin.read`, `admin.manage` | No | Desired-state only; current-state introspection is not implemented | Canonical actions map to Hasura permission artifacts, but verify cannot confirm live metadata drift yet. |
+| `minio` | `object.read`, `object.write` | No | Desired-state only; current-state introspection is not implemented | Sync compiles IAM policy documents. Follow up with MinIO admin inspection if you need live-state confirmation. |
+| `nessie` | `catalog.read`, `catalog.manage` | No | Desired-state only; current-state introspection is not implemented | Sync compiles Nessie authorization rules. Verify cannot yet read current Nessie authz state. |
+
+## Backend-Specific Follow-Up
+
+After `phlo authz sync`, backend-specific setup still matters:
+
+- Trino: confirm the governance backend is registered and exposes current grants
+  if you want meaningful drift verification
+- PostgreSQL: check live grants and any row-level security or schema ownership
+  rules outside the canonical compiler output
+- Hasura: confirm permissions are reflected in Hasura metadata and JWT role
+  claims align with the roles you compiled
+- MinIO: confirm OIDC or IAM subject mapping attaches the generated policies to
+  the principals you expect
+- Nessie: confirm the server-side authorization backend is enabled and reading
+  the compiled rules you applied
+
+## Related Docs
+
+- [Auth And Access Model](auth-and-access.md) for the larger authn/authz picture
+- [CLI Reference](cli-reference.md) for command-level reference
+- [Security](../setup/security.md) for backend-specific security setup after the
+  canonical RBAC model is defined

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -217,6 +217,39 @@ Notes:
 
 - canonical RBAC accepts `allow` policies only
 - `deny` policies are rejected during validation and planning
+- config is loaded from `.phlo/authorization/roles.yaml` and `.phlo/authorization/policies.yaml`
+
+Common workflow:
+
+```bash
+phlo authz validate
+phlo authz plan --backend trino
+phlo authz sync --backend trino
+phlo authz verify --backend trino
+```
+
+Command behavior:
+
+- `validate`: parse and validate canonical RBAC config, including role references
+  and hierarchy cycles
+- `plan`: compile desired backend artifacts and show creates or deletes without
+  applying them
+- `sync`: apply compiled backend artifacts; use `--dry-run` to skip mutation
+- `verify`: compare desired compiled artifacts against current backend state and
+  report drift
+
+Options shared across these commands:
+
+- `--path PATH`: path to the `.phlo` directory root
+- `--backend TEXT`: restrict work to one or more backends where supported
+- `--environment TEXT`: compiler context label, default `development`
+
+Additional sync option:
+
+- `--dry-run`: show sync results without applying changes
+
+Use [Canonical RBAC](canonical-rbac.md) for the full file format and backend
+support details.
 
 ## Services Commands
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -28,6 +28,7 @@ flowchart TD
 ## Current Reference Pages
 
 - [CLI Reference](cli-reference.md): commands, flags, and examples.
+- [Canonical RBAC](canonical-rbac.md): source-of-truth RBAC config, authz workflow, and backend support.
 - [Configuration Reference](configuration-reference.md): env vars, defaults, and precedence.
 - [Architecture](architecture.md): system model and component boundaries.
 - [Plugin API](plugin-api.md): extension contracts and base types.

--- a/docs/reference/meta.json
+++ b/docs/reference/meta.json
@@ -6,6 +6,7 @@
     "platform-topology",
     "api-surfaces",
     "auth-and-access",
+    "canonical-rbac",
     "glossary",
     "faq",
     "phlo-api",

--- a/docs/setup/index.md
+++ b/docs/setup/index.md
@@ -11,6 +11,7 @@ These guides focus on the operational decisions and configuration that turn a ru
 - [OpenMetadata](openmetadata.md): register services, ingest metadata, and make the catalog searchable.
 - [Observability](observability.md): route logs, traces, and metrics into the observability backend you want to run.
 - [Security](security.md): apply authentication, secrets, and security posture across the stack.
+- [Canonical RBAC](../reference/canonical-rbac.md): define source-of-truth roles and policies before wiring backend-specific authorization.
 
 ## Typical Uses
 

--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -150,6 +150,15 @@ If using Keycloak as your identity provider:
 
 ## Authorization
 
+Phlo's canonical authorization workflow starts in `.phlo/authorization/` and
+then compiles into backend-native enforcement. Define roles and policies there
+first, validate them with `phlo authz validate`, preview with `phlo authz plan`,
+apply with `phlo authz sync`, and use the service-specific setup below to make
+those compiled artifacts effective in each backend.
+
+Use [Canonical RBAC](../reference/canonical-rbac.md) for the source-of-truth
+model, command behavior, and backend support limits.
+
 ### Trino Access Control
 
 Create an access control rules file:
@@ -190,6 +199,12 @@ TRINO_ACCESS_CONTROL_CONFIG_FILE=/etc/trino/access-control.json
 
 Mount the rules file in your service configuration.
 
+Canonical RBAC note:
+
+- Trino currently has the strongest `phlo authz verify` coverage because the
+  compiler can compare desired grants with current managed grants exposed by the
+  governance backend.
+
 ### Nessie Authorization
 
 Enable authorization:
@@ -199,6 +214,11 @@ NESSIE_AUTHZ_ENABLED=true
 ```
 
 Nessie authorization rules are configured through the Nessie server. See [Nessie Authorization](https://projectnessie.org/features/authz/) for details.
+
+Canonical RBAC note:
+
+- `phlo authz` can compile Nessie authorization rules, but current verify
+  coverage does not introspect live Nessie state for drift yet.
 
 ### MinIO IAM Policies
 
@@ -222,6 +242,11 @@ EOF
 # Attach to user
 mc admin policy attach local readonly-lake --user analyst
 ```
+
+Canonical RBAC note:
+
+- `phlo authz` can compile MinIO IAM policy documents for object access, but you
+  still need principal-to-policy attachment through MinIO IAM or OIDC claims.
 
 ### PostgreSQL Row-Level Security
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
   - Reference:
       - Architecture: reference/architecture.md
       - API Reference: reference/phlo-api.md
+      - Canonical RBAC: reference/canonical-rbac.md
       - CLI Reference: reference/cli-reference.md
       - Configuration: reference/configuration-reference.md
       - Plugin API: reference/plugin-api.md


### PR DESCRIPTION
## Summary

This PR documents Phlo's canonical RBAC control plane and the `phlo authz` workflow.

It adds a dedicated reference page for:
- `.phlo/authorization/roles.yaml`
- `.phlo/authorization/policies.yaml`
- role hierarchy and subject assignment
- canonical actions and resource types
- `phlo authz validate`, `plan`, `sync`, and `verify`
- backend support limits for deny handling and drift verification

It also links that material from the existing auth/access, CLI, reference index, setup index, and security docs so the canonical flow connects cleanly to backend-specific setup guidance.

## Why

Closes #457. Issue identified that the canonical RBAC layer exists in code, but operators do not have first-class user-facing documentation for the control plane, command flow, or backend limitations.

## Impact

Operators now have one place to understand:
- where canonical RBAC config lives
- how to validate and preview changes
- how sync and verify behave
- which backends support which parts of the workflow
- what manual backend follow-up is still required

## Validation

- `uv run mkdocs build -q`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->