### PR TITLE
docs: expand Hasura permission sync coverage

### DIFF
--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -381,8 +381,9 @@ curl http://localhost:10018/customers \
 
 Located in `packages/phlo-hasura/src/phlo_hasura/permissions.py`:
 
-- Full RBAC with row and column-level permissions
-- Configure via Hasura console or API
+- Hasura itself supports row-level and column-level permissions across select, insert, update, and delete operations
+- Phlo's packaged permission sync automates select, insert, update, and delete permission definitions from config
+- Configure permissions either through the Hasura console/API directly or via Phlo's permission sync workflow
 
 ### Observatory Token Auth
 

--- a/packages/phlo-hasura/src/phlo_hasura/client.py
+++ b/packages/phlo-hasura/src/phlo_hasura/client.py
@@ -392,6 +392,106 @@ class HasuraClient:
 
         return self._request("POST", data, f"create_insert_permission({schema}.{table}.{role})")
 
+    def create_update_permission(
+        self,
+        schema: str,
+        table: str,
+        role: str,
+        filter: dict[str, Any] | None = None,
+        check: dict[str, Any] | None = None,
+        columns: list[str] | None = None,
+        set: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Create UPDATE permission for a role on a table.
+
+        Grants UPDATE access to a specific role on a tracked table.
+        Supports row filters for selecting updatable rows, check expressions
+        for validating updated rows, column allow-lists, and preset values.
+
+        Args:
+            schema: Schema name containing the table.
+            table: Table name to grant permissions on.
+            role: Role name to grant permissions to.
+            filter: Row-level filter expression controlling which rows can be updated.
+            check: Validation check expression for updated rows.
+            columns: Allowed columns for update (default: ["*"] for all).
+            set: Preset values to automatically set on update.
+
+        Returns:
+            API response dictionary.
+
+        Raises:
+            requests.RequestException: If the API call fails.
+
+        """
+        if filter is None:
+            filter = {}
+        if check is None:
+            check = {}
+
+        permission: dict[str, Any] = {
+            "columns": columns or ["*"],
+            "filter": filter,
+            "check": check,
+        }
+
+        if set:
+            permission["set"] = set
+
+        data = {
+            "type": "pg_create_update_permission",
+            "args": {
+                "schema": schema,
+                "table": table,
+                "role": role,
+                "permission": permission,
+            },
+        }
+
+        return self._request("POST", data, f"create_update_permission({schema}.{table}.{role})")
+
+    def create_delete_permission(
+        self,
+        schema: str,
+        table: str,
+        role: str,
+        filter: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create DELETE permission for a role on a table.
+
+        Grants DELETE access to a specific role on a tracked table.
+        Supports row-level filters controlling which rows can be deleted.
+
+        Args:
+            schema: Schema name containing the table.
+            table: Table name to grant permissions on.
+            role: Role name to grant permissions to.
+            filter: Row-level filter expression controlling which rows can be deleted.
+
+        Returns:
+            API response dictionary.
+
+        Raises:
+            requests.RequestException: If the API call fails.
+
+        """
+        if filter is None:
+            filter = {}
+
+        data = {
+            "type": "pg_create_delete_permission",
+            "args": {
+                "schema": schema,
+                "table": table,
+                "role": role,
+                "permission": {
+                    "filter": filter,
+                },
+            },
+        }
+
+        return self._request("POST", data, f"create_delete_permission({schema}.{table}.{role})")
+
     def drop_permission(
         self, schema: str, table: str, role: str, permission_type: str = "select"
     ) -> dict[str, Any]:

--- a/packages/phlo-hasura/src/phlo_hasura/permissions.py
+++ b/packages/phlo-hasura/src/phlo_hasura/permissions.py
@@ -106,8 +106,8 @@ class HasuraPermissionManager:
         """Apply permissions from config to Hasura.
 
         Synchronizes permissions defined in the config dictionary with
-        the actual Hasura instance. Creates or updates SELECT and INSERT
-        permissions for all tables and roles specified.
+        the actual Hasura instance. Creates or updates SELECT, INSERT,
+        UPDATE, and DELETE permissions for all tables and roles specified.
 
         Args:
             config: Permission configuration dictionary with structure:
@@ -115,7 +115,11 @@ class HasuraPermissionManager:
                     "tables": {
                         "schema.table": {
                             "select": {"role": {"filter": {}, "columns": []}},
-                            "insert": {"role": {"check": {}, "columns": []}}
+                            "insert": {"role": {"check": {}, "columns": [], "set": {}}},
+                            "update": {
+                                "role": {"filter": {}, "check": {}, "columns": [], "set": {}}
+                            },
+                            "delete": {"role": {"filter": {}}}
                         }
                     }
                 }
@@ -160,57 +164,62 @@ class HasuraPermissionManager:
             if verbose:
                 logger.info("Syncing %s...", table_path)
 
-            # Sync SELECT permissions
-            select_perms = permissions.get("select", {})
-            for role, perm_config in select_perms.items():
-                if perm_config is False:
-                    # Explicitly disabled
-                    continue
+            permission_syncers = {
+                "select": lambda role, perm_config: self.client.create_select_permission(
+                    schema,
+                    table,
+                    role,
+                    filter=perm_config.get("filter", {}),
+                    columns=perm_config.get("columns"),
+                ),
+                "insert": lambda role, perm_config: self.client.create_insert_permission(
+                    schema,
+                    table,
+                    role,
+                    check=perm_config.get("check", {}),
+                    columns=perm_config.get("columns"),
+                    set=perm_config.get("set"),
+                ),
+                "update": lambda role, perm_config: self.client.create_update_permission(
+                    schema,
+                    table,
+                    role,
+                    filter=perm_config.get("filter", {}),
+                    check=perm_config.get("check", {}),
+                    columns=perm_config.get("columns"),
+                    set=perm_config.get("set"),
+                ),
+                "delete": lambda role, perm_config: self.client.create_delete_permission(
+                    schema,
+                    table,
+                    role,
+                    filter=perm_config.get("filter", {}),
+                ),
+            }
 
-                try:
-                    if verbose:
-                        logger.info("  SELECT for %s...", role)
+            for perm_type, sync_permission in permission_syncers.items():
+                for role, perm_config in permissions.get(perm_type, {}).items():
+                    if perm_config is False:
+                        continue
 
-                    filter_expr = perm_config.get("filter", {})
-                    columns = perm_config.get("columns", None)
+                    try:
+                        if verbose:
+                            logger.info("  %s for %s...", perm_type.upper(), role)
 
-                    self.client.create_select_permission(
-                        schema, table, role, filter=filter_expr, columns=columns
-                    )
+                        sync_permission(role, perm_config)
 
-                    results["select"][(table_path, role)] = True
-                    if verbose:
-                        logger.info("  SELECT for %s ✓", role)
-                except Exception as e:
-                    results["select"][(table_path, role)] = False
-                    if verbose:
-                        logger.warning("  SELECT for %s ✗ (%s)", role, str(e)[:200])
-
-            # Sync INSERT permissions
-            insert_perms = permissions.get("insert", {})
-            for role, perm_config in insert_perms.items():
-                if perm_config is False:
-                    continue
-
-                try:
-                    if verbose:
-                        logger.info("  INSERT for %s...", role)
-
-                    check = perm_config.get("check", {})
-                    columns = perm_config.get("columns", None)
-                    set_values = perm_config.get("set", None)
-
-                    self.client.create_insert_permission(
-                        schema, table, role, check=check, columns=columns, set=set_values
-                    )
-
-                    results["insert"][(table_path, role)] = True
-                    if verbose:
-                        logger.info("  INSERT for %s ✓", role)
-                except Exception as e:
-                    results["insert"][(table_path, role)] = False
-                    if verbose:
-                        logger.warning("  INSERT for %s ✗ (%s)", role, str(e)[:200])
+                        results[perm_type][(table_path, role)] = True
+                        if verbose:
+                            logger.info("  %s for %s ✓", perm_type.upper(), role)
+                    except Exception as e:
+                        results[perm_type][(table_path, role)] = False
+                        if verbose:
+                            logger.warning(
+                                "  %s for %s ✗ (%s)",
+                                perm_type.upper(),
+                                role,
+                                str(e)[:200],
+                            )
 
         if verbose:
             logger.info("=" * 60)
@@ -275,15 +284,18 @@ class HasuraPermissionManager:
                         role = perm.get("role")
                         permission = perm.get("permission", {})
 
-                        config["tables"][table_path][perm_type][role] = {
-                            "filter": permission.get("filter", {}),
-                            "columns": permission.get("columns", ["*"]),
-                        }
+                        exported_permission: dict[str, Any] = {}
 
-                        if perm_type == "insert":
-                            config["tables"][table_path][perm_type][role]["check"] = permission.get(
-                                "check", {}
-                            )
+                        if "filter" in permission or perm_type in {"select", "update", "delete"}:
+                            exported_permission["filter"] = permission.get("filter", {})
+                        if "columns" in permission or perm_type in {"select", "insert", "update"}:
+                            exported_permission["columns"] = permission.get("columns", ["*"])
+                        if "check" in permission or perm_type in {"insert", "update"}:
+                            exported_permission["check"] = permission.get("check", {})
+                        if "set" in permission:
+                            exported_permission["set"] = permission["set"]
+
+                        config["tables"][table_path][perm_type][role] = exported_permission
 
         return config
 

--- a/packages/phlo-hasura/tests/test_hasura.py
+++ b/packages/phlo-hasura/tests/test_hasura.py
@@ -30,6 +30,35 @@ def sample_metadata():
                                 "permission": {"columns": ["*"], "filter": {}},
                             }
                         ],
+                        "insert_permissions": [
+                            {
+                                "role": "loader",
+                                "permission": {
+                                    "columns": ["reading_id", "sgv"],
+                                    "check": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+                                    "set": {"tenant_id": "x-hasura-tenant-id"},
+                                },
+                            }
+                        ],
+                        "update_permissions": [
+                            {
+                                "role": "editor",
+                                "permission": {
+                                    "columns": ["sgv"],
+                                    "filter": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+                                    "check": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+                                    "set": {"updated_by": "x-hasura-user-id"},
+                                },
+                            }
+                        ],
+                        "delete_permissions": [
+                            {
+                                "role": "admin",
+                                "permission": {
+                                    "filter": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}}
+                                },
+                            }
+                        ],
                         "array_relationships": [],
                         "object_relationships": [],
                     }
@@ -109,6 +138,62 @@ class TestHasuraClient:
         # Verify permission structure
         payload = mock_request.call_args[1]["json"]
         assert payload["args"]["permission"]["columns"] == ["reading_id", "sgv"]
+
+    @patch("phlo_hasura.client.requests.request")
+    def test_create_update_permission(self, mock_request):
+        """Should create UPDATE permission."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": "success"}
+        mock_request.return_value = mock_response
+
+        client = HasuraClient(admin_secret="test-secret")
+        result = client.create_update_permission(
+            "api",
+            "glucose_readings",
+            "editor",
+            filter={"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+            check={"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+            columns=["sgv"],
+            set={"updated_by": "x-hasura-user-id"},
+        )
+
+        assert result["message"] == "success"
+
+        payload = mock_request.call_args[1]["json"]
+        assert payload["type"] == "pg_create_update_permission"
+        assert payload["args"]["permission"]["filter"] == {
+            "tenant_id": {"_eq": "X-Hasura-Tenant-Id"}
+        }
+        assert payload["args"]["permission"]["check"] == {
+            "tenant_id": {"_eq": "X-Hasura-Tenant-Id"}
+        }
+        assert payload["args"]["permission"]["columns"] == ["sgv"]
+        assert payload["args"]["permission"]["set"] == {"updated_by": "x-hasura-user-id"}
+
+    @patch("phlo_hasura.client.requests.request")
+    def test_create_delete_permission(self, mock_request):
+        """Should create DELETE permission."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"message": "success"}
+        mock_request.return_value = mock_response
+
+        client = HasuraClient(admin_secret="test-secret")
+        result = client.create_delete_permission(
+            "api",
+            "glucose_readings",
+            "admin",
+            filter={"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+        )
+
+        assert result["message"] == "success"
+
+        payload = mock_request.call_args[1]["json"]
+        assert payload["type"] == "pg_create_delete_permission"
+        assert payload["args"]["permission"]["filter"] == {
+            "tenant_id": {"_eq": "X-Hasura-Tenant-Id"}
+        }
 
     @patch("phlo_hasura.client.requests.request")
     def test_export_metadata(self, mock_request, sample_metadata):
@@ -254,21 +339,54 @@ class TestHasuraPermissionManager:
 
         assert loaded["tables"]["api.glucose_readings"] == config["tables"]["api.glucose_readings"]
 
+    @patch.object(HasuraClient, "create_delete_permission")
+    @patch.object(HasuraClient, "create_update_permission")
+    @patch.object(HasuraClient, "create_insert_permission")
     @patch.object(HasuraClient, "create_select_permission")
-    def test_sync_permissions(self, mock_perm):
-        """Should sync permissions from config."""
+    def test_sync_permissions(
+        self,
+        mock_select,
+        mock_insert,
+        mock_update,
+        mock_delete,
+    ):
+        """Should sync all supported permission types from config."""
         config = {
             "tables": {
-                "api.glucose_readings": {"select": {"analyst": {"columns": ["*"], "filter": {}}}}
+                "api.glucose_readings": {
+                    "select": {"analyst": {"columns": ["*"], "filter": {}}},
+                    "insert": {
+                        "loader": {
+                            "columns": ["reading_id", "sgv"],
+                            "check": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+                            "set": {"tenant_id": "x-hasura-tenant-id"},
+                        }
+                    },
+                    "update": {
+                        "editor": {
+                            "columns": ["sgv"],
+                            "filter": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+                            "check": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+                            "set": {"updated_by": "x-hasura-user-id"},
+                        }
+                    },
+                    "delete": {"admin": {"filter": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}}}},
+                }
             }
         }
-        mock_perm.return_value = {"message": "success"}
+        mock_select.return_value = {"message": "success"}
+        mock_insert.return_value = {"message": "success"}
+        mock_update.return_value = {"message": "success"}
+        mock_delete.return_value = {"message": "success"}
 
         manager = HasuraPermissionManager(client=HasuraClient(admin_secret="test-secret"))
         results = manager.sync_permissions(config, verbose=False)
 
         assert ("api.glucose_readings", "analyst") in results["select"]
         assert results["select"][("api.glucose_readings", "analyst")] is True
+        assert results["insert"][("api.glucose_readings", "loader")] is True
+        assert results["update"][("api.glucose_readings", "editor")] is True
+        assert results["delete"][("api.glucose_readings", "admin")] is True
 
     @patch.object(HasuraClient, "export_metadata")
     def test_export_permissions(self, mock_export, sample_metadata):
@@ -281,6 +399,20 @@ class TestHasuraPermissionManager:
         assert "tables" in exported
         assert "api.glucose_readings" in exported["tables"]
         assert "select" in exported["tables"]["api.glucose_readings"]
+        assert exported["tables"]["api.glucose_readings"]["insert"]["loader"] == {
+            "columns": ["reading_id", "sgv"],
+            "check": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+            "set": {"tenant_id": "x-hasura-tenant-id"},
+        }
+        assert exported["tables"]["api.glucose_readings"]["update"]["editor"] == {
+            "filter": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+            "columns": ["sgv"],
+            "check": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}},
+            "set": {"updated_by": "x-hasura-user-id"},
+        }
+        assert exported["tables"]["api.glucose_readings"]["delete"]["admin"] == {
+            "filter": {"tenant_id": {"_eq": "X-Hasura-Tenant-Id"}}
+        }
 
 
 class TestRoleHierarchy:


### PR DESCRIPTION
## Summary

Fixes #456 by expanding Phlo's packaged Hasura permission sync to cover all four permission types instead of only `select` and `insert`.

## What changed

- added Hasura client helpers for `pg_create_update_permission` and `pg_create_delete_permission`
- extended `HasuraPermissionManager.sync_permissions()` to apply `select`, `insert`, `update`, and `delete` permissions from config
- updated permission export to preserve the right fields for each permission type, including `check` and `set` where applicable
- clarified the security docs so they distinguish Hasura capability from Phlo-managed automation
- added focused tests for update/delete creation, full permission sync coverage, and export round-tripping

## Root cause

The packaged sync workflow advertised broader permission coverage than it actually implemented. The result structure and exported metadata already implied `update` and `delete`, but the sync path only created `select` and `insert` permissions.

## Impact

Users can now manage Hasura `update` and `delete` permissions through the same Phlo permission sync workflow that already handled `select` and `insert`, and the docs now match the shipped behavior.

## Validation

- `uv run pytest packages/phlo-hasura/tests/test_hasura.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
