### PR TITLE
fix(docs): correct PostgREST view RLS docs mismatch

### DIFF
--- a/docs/setup/postgrest.md
+++ b/docs/setup/postgrest.md
@@ -75,7 +75,7 @@ This will:
 3. Create JWT signing/verification functions
 4. Create `api` schema with glucose views
 5. Implement API functions (`login`, `glucose_statistics`, `user_info`)
-6. Create PostgreSQL roles and RLS policies
+6. Create PostgreSQL roles and grant-based API access scaffolding
 
 **Verify migrations:**
 
@@ -136,6 +136,18 @@ postgrest | Admin server listening on port 3001
 postgrest | Attempting to connect to the database...
 postgrest | Connection successful
 ```
+
+## Authorization Model
+
+Generated PostgREST views under `api.*` are secured with `GRANT SELECT` statements based
+on dbt tags. Phlo does not generate `CREATE POLICY` statements for those views because
+PostgreSQL RLS does not apply directly to views.
+
+If you need row-level controls:
+
+- Enable RLS on the underlying tables exposed by the views.
+- Write policies against those tables using JWT/session claims exposed to PostgreSQL.
+- Keep the API views narrow and read-only so grants and table policies compose cleanly.
 
 ### Step 4: Verify Health Check
 
@@ -488,6 +500,7 @@ docker-compose logs postgrest
 
 1. **Database connection failed:** Verify `PGRST_DB_URI` in docker-compose.yml
 2. **Invalid configuration:** Check environment variables
+
 3. **Port conflict:** Ensure ports 10018/10019 are not in use
 
 **Verify database connection manually:**

--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -225,7 +225,10 @@ mc admin policy attach local readonly-lake --user analyst
 
 ### PostgreSQL Row-Level Security
 
-Phlo includes a pre-built RLS framework in PostgREST. Enable it:
+Phlo does not generate row-level policies for PostgREST API views. Generated `api.*`
+views get `GRANT` statements only. When you need row-level enforcement, enable RLS on
+the underlying tables and make sure your JWT/session context exposes the claims your
+policies read:
 
 ```sql
 -- Enable RLS on a table
@@ -244,7 +247,8 @@ CREATE POLICY admin_all ON marts.customers
   USING (true);
 ```
 
-The JWT token should include claims that set the user's role and context.
+For PostgREST-backed APIs, the JWT token must include the role and any custom claim
+values your table policies depend on.
 
 ## Encryption
 

--- a/packages/phlo-postgrest/src/phlo_postgrest/sql/004_roles.sql
+++ b/packages/phlo-postgrest/src/phlo_postgrest/sql/004_roles.sql
@@ -74,8 +74,8 @@ GRANT EXECUTE ON FUNCTION api.health TO anon;  -- Health check is public
 -- Row-Level Security Policies
 -- ============================================================================
 
--- Note: Views don't support RLS directly in PostgreSQL, but we can secure
--- the underlying tables or use security definer functions
+-- Note: PostgreSQL views do not support RLS policies directly.
+-- Secure the underlying tables or use security definer functions instead.
 
 -- View-level access is controlled through generated GRANT statements.
 -- Apply RLS to underlying tables when row-level restrictions are required.
@@ -84,10 +84,11 @@ GRANT EXECUTE ON FUNCTION api.health TO anon;  -- Health check is public
 -- Since views are read-only and based on marts tables,
 -- access is controlled via GRANT statements above.
 
--- If we needed row-level restrictions, we could do:
--- CREATE POLICY authenticated_read ON api.some_view
+-- Example underlying-table RLS:
+-- ALTER TABLE marts.some_table ENABLE ROW LEVEL SECURITY;
+-- CREATE POLICY authenticated_read ON marts.some_table
 --   FOR SELECT TO authenticated
---   USING (true);  -- Allow all rows for authenticated users
+--   USING (tenant_id = current_setting('request.jwt.claim.tenant_id', true));
 
 -- For admin-only operations (future):
 -- CREATE POLICY admin_only ON some_table

--- a/packages/phlo-postgrest/src/phlo_postgrest/views.py
+++ b/packages/phlo-postgrest/src/phlo_postgrest/views.py
@@ -359,10 +359,10 @@ COMMENT ON VIEW {self.api_schema}.{model.name} IS '{self._escape_string(model.de
         return sql
 
     def generate_permissions_sql(self, model: DbtModel) -> str:
-        """Generate GRANT and RLS policy SQL for a model.
+        """Generate GRANT SQL for a model.
 
         Maps dbt tags to database roles and generates appropriate
-        GRANT statements and Row-Level Security policies.
+        GRANT statements for generated API views.
 
         Tag-to-Role Mapping:
             - 'public' -> anon role
@@ -373,13 +373,13 @@ COMMENT ON VIEW {self.api_schema}.{model.name} IS '{self._escape_string(model.de
             model: DbtModel instance with tags to process.
 
         Returns:
-            str: SQL statements for grants and policies.
+            str: SQL statements for grants.
 
         Example:
             >>> sql = generator.generate_permissions_sql(model)
             >>> print(sql)
             GRANT SELECT ON api.mrt_orders TO analyst;
-            CREATE POLICY analyst_access ON api.mrt_orders ...
+            GRANT SELECT ON api.mrt_orders TO admin;
 
         """
         sql_parts = ["\n-- Permissions"]
@@ -398,14 +398,11 @@ COMMENT ON VIEW {self.api_schema}.{model.name} IS '{self._escape_string(model.de
                     sql_parts.append(f"GRANT SELECT ON {self.api_schema}.{model.name} TO {role};")
                     granted_roles.add(role)
 
-        # Generate RLS policies for tracked roles
         if granted_roles:
-            sql_parts.append("\n-- RLS Policy")
-            for role in granted_roles:
-                sql_parts.append(
-                    f"CREATE POLICY {role}_access ON {self.api_schema}.{model.name} "
-                    f"FOR SELECT TO {role} USING (true);"
-                )
+            sql_parts.append("\n-- Note: PostgreSQL views do not support RLS policies directly.")
+            sql_parts.append(
+                "-- Apply row-level controls to underlying tables or security-definer functions."
+            )
 
         return "\n".join(sql_parts)
 

--- a/packages/phlo-postgrest/tests/test_postgrest_views.py
+++ b/packages/phlo-postgrest/tests/test_postgrest_views.py
@@ -130,7 +130,7 @@ class TestViewGenerator:
         assert "COMMENT ON VIEW" in sql
 
     def test_generate_permissions_sql(self, manifest_file):
-        """Should generate correct GRANT statements."""
+        """Should generate correct GRANT statements without view-level RLS."""
         generator = ViewGenerator(manifest_file, source_schema="marts")
         models = generator.parser.parse()
         model = models["glucose_readings"]
@@ -140,11 +140,11 @@ class TestViewGenerator:
         # analyst and admin tags should grant to analyst and admin
         assert "GRANT SELECT ON api.glucose_readings TO analyst" in sql
         assert "GRANT SELECT ON api.glucose_readings TO admin" in sql
-        assert "CREATE POLICY analyst_access" in sql
-        assert "CREATE POLICY admin_access" in sql
+        assert "views do not support RLS policies directly" in sql
+        assert "CREATE POLICY" not in sql
 
     def test_generate_permissions_with_public_tag(self, manifest_file):
-        """Should grant to anon role for public tag."""
+        """Should grant to anon role for public tag without view-level RLS."""
         generator = ViewGenerator(manifest_file, source_schema="marts")
         models = generator.parser.parse()
         model = models["glucose_metrics"]
@@ -153,7 +153,7 @@ class TestViewGenerator:
 
         # public tag should grant to anon, analyst, and admin roles
         assert "GRANT SELECT ON api.glucose_metrics TO anon" in sql
-        assert "CREATE POLICY anon_access" in sql
+        assert "CREATE POLICY" not in sql
 
     def test_generate_all_views(self, manifest_file):
         """Should generate SQL for all views."""


### PR DESCRIPTION
## Summary

Fixes #453 by removing unsupported view-level RLS generation from `phlo-postgrest` and aligning the PostgREST security docs with the implementation.

## What Changed

- removed `CREATE POLICY ... ON api.<view>` generation from the PostgREST view generator
- updated the PostgREST regression tests to assert generated view SQL does not claim view-level RLS support
- corrected the packaged PostgREST SQL comments to show table-level RLS as the supported row-level enforcement path
- updated the security and PostgREST setup docs to describe grant-based access for generated API views and table-level RLS for row-level controls

## Root Cause

The generator emitted `CREATE POLICY` statements for generated `api.*` views even though PostgreSQL row-level security does not apply directly to views. The docs repeated that unsupported model, which left the package behavior and operator guidance out of sync.

## Impact

PostgREST-backed APIs now present one accurate security model:

- generated `api.*` views get automated `GRANT SELECT` statements only
- row-level enforcement must be applied to underlying tables or other PostgreSQL primitives such as security-definer functions

## Validation

- `uv run pytest packages/phlo-postgrest/tests/test_postgrest_views.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/463" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
