### PR TITLE
docs: clarify phlo-api authorization configuration

### DIFF
--- a/docs/operations/production-readiness.md
+++ b/docs/operations/production-readiness.md
@@ -37,6 +37,7 @@ Use this checklist before treating a Phlo stack as production-capable.
 
 - default credentials are removed
 - authn/authz model is chosen per exposed surface
+- `phlo-api` authorization mode is explicit: `PHLO_AUTHORIZATION_MODE=optional` for open surfaces, or `required` to fail closed when no authz backend is configured
 - serving surfaces are exposed intentionally
 
 ## Related Pages

--- a/docs/reference/auth-and-access.md
+++ b/docs/reference/auth-and-access.md
@@ -20,6 +20,34 @@ flowchart TD
 - serving layers like `phlo-api`, `Hasura`, and `PostgREST` enforce those decisions in different ways
 - governance and backend systems may apply their own secondary controls
 
+## phlo-api Route Guard Semantics
+
+- `phlo-api` route guards only enforce authorization when an authorization backend is configured
+- with the default `PHLO_AUTHORIZATION_MODE=optional`, guarded routes remain reachable when `PHLO_AUTHORIZATION_BACKEND` is unset
+- set `PHLO_AUTHORIZATION_MODE=required` to fail closed with HTTP `503` on guarded routes when no authorization backend is configured
+- once a backend is configured, route guards evaluate the caller normally and still return `401` or `403` based on authentication and policy decisions
+
+You can declare these settings in `phlo.yaml` as either:
+
+```yaml
+api:
+  authorization:
+    backend: opa
+    mode: required
+```
+
+or, for a service-scoped override:
+
+```yaml
+services:
+  phlo-api:
+    authorization:
+      backend: opa
+      mode: required
+```
+
+Precedence is `env vars` -> `services.phlo-api.authorization` -> `api.authorization`.
+
 ## Canonical RBAC
 
 - canonical RBAC currently supports `allow` policies only

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -286,6 +286,8 @@ Observatory API runtime routing:
 ```bash
 PHLO_API_PORT=4000
 HOST=0.0.0.0
+PHLO_AUTHORIZATION_BACKEND=
+PHLO_AUTHORIZATION_MODE=optional
 PHLO_QUERY_ENGINE_URL=
 PHLO_QUERY_CATALOG=
 PHLO_DEFAULT_REF=
@@ -294,6 +296,9 @@ PHLO_API_DISCOVERY_SCHEMAS=
 
 Notes:
 
+- `PHLO_AUTHORIZATION_MODE=optional` keeps guarded `phlo-api` routes reachable when no authz backend is configured.
+- `PHLO_AUTHORIZATION_MODE=required` makes guarded `phlo-api` routes fail closed with HTTP `503` until `PHLO_AUTHORIZATION_BACKEND` resolves.
+- The same settings can be declared in `phlo.yaml` under `api.authorization` or `services.phlo-api.authorization`.
 - `PHLO_QUERY_ENGINE_URL` is required unless the resolved `query_engine` capability exposes `url`, `http_url`, or `host`/`port` metadata.
 - `PHLO_QUERY_CATALOG` is required unless the resolved `query_engine` capability exposes `default_catalog`.
 - `PHLO_DEFAULT_REF` is required for ref-dependent endpoints unless the resolved `query_engine` capability exposes `default_ref`.

--- a/docs/reference/phlo-api.md
+++ b/docs/reference/phlo-api.md
@@ -112,12 +112,38 @@ Configure via environment variables:
 # API Server
 PHLO_API_PORT=4000
 HOST=0.0.0.0
+PHLO_AUTHORIZATION_BACKEND=
+PHLO_AUTHORIZATION_MODE=optional
 
 # Backend Services
 TRINO_URL=http://trino:10005
 DAGSTER_GRAPHQL_URL=http://dagster:3000/graphql
 NESSIE_URL=http://nessie:19120/api/v2
 LOKI_URL=http://loki:3100
+```
+
+Authorization behavior on guarded routes is explicit:
+
+- `PHLO_AUTHORIZATION_MODE=optional` keeps route guards as no-ops until an authorization backend is configured
+- `PHLO_AUTHORIZATION_MODE=required` returns HTTP `503` on guarded routes until `PHLO_AUTHORIZATION_BACKEND` resolves
+
+These values can also be set in `phlo.yaml`:
+
+```yaml
+api:
+  authorization:
+    backend: opa
+    mode: required
+```
+
+or:
+
+```yaml
+services:
+  phlo-api:
+    authorization:
+      backend: opa
+      mode: required
 ```
 
 ## Architecture

--- a/docs/setup/security.md
+++ b/docs/setup/security.md
@@ -150,6 +150,12 @@ If using Keycloak as your identity provider:
 
 ## Authorization
 
+For `phlo-api`, route guards are backend-dependent. If no authorization backend is configured,
+the default `PHLO_AUTHORIZATION_MODE=optional` leaves guarded routes reachable. Set
+`PHLO_AUTHORIZATION_MODE=required` to fail closed with HTTP `503` on guarded routes until
+`PHLO_AUTHORIZATION_BACKEND` resolves. You can declare those settings in `phlo.yaml`
+under `api.authorization` or `services.phlo-api.authorization`.
+
 ### Trino Access Control
 
 Create an access control rules file:

--- a/packages/phlo-api/README.md
+++ b/packages/phlo-api/README.md
@@ -20,6 +20,15 @@ phlo plugin install api
 | --------------- | --------- | --------------- |
 | `PHLO_API_PORT` | `4000`    | API server port |
 | `HOST`          | `0.0.0.0` | API server host |
+| `PHLO_AUTHORIZATION_BACKEND` | unset | Authorization backend capability name |
+| `PHLO_AUTHORIZATION_MODE` | `optional` | Guard behavior when no authorization backend exists |
+
+With `PHLO_AUTHORIZATION_MODE=optional`, guarded routes remain reachable until an
+authorization backend is configured. Set `PHLO_AUTHORIZATION_MODE=required` to
+fail closed with HTTP `503` on guarded routes when no backend is available.
+
+You can also declare these settings in `phlo.yaml` via `api.authorization` or
+`services.phlo-api.authorization`.
 
 ## Auto-Configuration
 

--- a/packages/phlo-api/docs/api-reference.md
+++ b/packages/phlo-api/docs/api-reference.md
@@ -1291,12 +1291,21 @@ Configure the API using these environment variables:
 | ------------------------ | --------------------------------- | ------------------------------ |
 | `PHLO_API_PORT`          | `4000`                            | API server port                |
 | `HOST`                   | `0.0.0.0`                         | API server host                |
+| `PHLO_AUTHORIZATION_BACKEND` | unset                         | Authorization backend capability name |
+| `PHLO_AUTHORIZATION_MODE` | `optional`                      | Guard behavior when no authorization backend exists |
 | `TRINO_URL`              | `http://trino:8080`               | Trino HTTP API URL             |
 | `DAGSTER_GRAPHQL_URL`    | `http://dagster:3000/graphql`     | Dagster GraphQL endpoint       |
 | `NESSIE_URL`             | `http://nessie:19120/api/v2`      | Nessie REST API URL            |
 | `LOKI_URL`               | `http://loki:3100`                | Loki query API URL             |
 | `PHLO_LINEAGE_DB_URL`    | (from Dagster Postgres)           | Lineage database connection    |
 | `PHLO_PROJECT_PATH`      | `/app/project`                    | Path to phlo.yaml project root |
+
+`PHLO_AUTHORIZATION_MODE=optional` leaves guarded routes open until an authorization
+backend is configured. `PHLO_AUTHORIZATION_MODE=required` makes those guarded routes
+return HTTP `503` when `PHLO_AUTHORIZATION_BACKEND` is unavailable.
+
+These settings may also be declared in `phlo.yaml` under `api.authorization` or
+`services.phlo-api.authorization`.
 
 ## OpenAPI Documentation
 

--- a/packages/phlo-api/src/phlo_api/api/authorization.py
+++ b/packages/phlo-api/src/phlo_api/api/authorization.py
@@ -143,6 +143,8 @@ def get_authorization_mode() -> str:
     """Return how route guards behave when no authorization backend exists."""
     configured_mode = os.environ.get(_AUTHORIZATION_MODE_ENV)
     if configured_mode is not None:
+    configured_mode = os.environ.get(_AUTHORIZATION_MODE_ENV)
+    if configured_mode is not None:
         configured_mode = configured_mode.strip() or None
     if configured_mode is None:
         config = get_api_authorization_config()

--- a/packages/phlo-api/src/phlo_api/api/authorization.py
+++ b/packages/phlo-api/src/phlo_api/api/authorization.py
@@ -47,6 +47,7 @@ from phlo.capabilities import (
     resolve_capability,
 )
 from phlo.logging import get_logger
+from phlo.infrastructure.config import get_api_authorization_config
 
 from phlo_api.api.authentication import get_request_principal
 
@@ -63,6 +64,20 @@ _ACTION_SERVICE_MANAGE = "service.manage"
 _ACTION_ADMIN_READ = "admin.read"
 _ACTION_ADMIN_MANAGE = "admin.manage"
 _AUTHORIZATION_BACKEND_ENV = "PHLO_AUTHORIZATION_BACKEND"
+_AUTHORIZATION_MODE_ENV = "PHLO_AUTHORIZATION_MODE"
+_AUTHORIZATION_MODE_OPTIONAL = "optional"
+_AUTHORIZATION_MODE_REQUIRED = "required"
+
+
+def _configured_authorization_backend_name() -> str | None:
+    """Resolve the backend name from env first, then phlo.yaml."""
+    backend_name = os.environ.get(_AUTHORIZATION_BACKEND_ENV)
+    if backend_name is not None:
+        normalized = backend_name.strip()
+        return normalized or None
+
+    config = get_api_authorization_config()
+    return config.backend if config is not None else None
 
 
 def get_authorization_backend() -> AuthorizationPolicyBackend | None:
@@ -82,7 +97,7 @@ def get_authorization_backend() -> AuthorizationPolicyBackend | None:
             backends are available without explicit selection.
 
     """
-    backend_name = os.environ.get(_AUTHORIZATION_BACKEND_ENV)
+    backend_name = _configured_authorization_backend_name()
     result = resolve_capability("authorization_policy_backend", backend_name)
     if backend_name and result is None:
         raise RuntimeError(
@@ -122,6 +137,47 @@ def require_authorization_backend() -> AuthorizationPolicyBackend:
     if backend is None:
         raise RuntimeError("Authorization backend not configured")
     return backend
+
+
+def get_authorization_mode() -> str:
+    """Return how route guards behave when no authorization backend exists."""
+    configured_mode = os.environ.get(_AUTHORIZATION_MODE_ENV)
+    if configured_mode is None:
+        config = get_api_authorization_config()
+        configured_mode = (
+            config.mode
+            if config is not None and config.mode is not None
+            else _AUTHORIZATION_MODE_OPTIONAL
+        )
+
+    mode = configured_mode.strip().lower()
+    if mode not in {_AUTHORIZATION_MODE_OPTIONAL, _AUTHORIZATION_MODE_REQUIRED}:
+        raise RuntimeError(
+            f"Invalid {_AUTHORIZATION_MODE_ENV} value {mode!r}. "
+            f"Expected {_AUTHORIZATION_MODE_OPTIONAL!r} or {_AUTHORIZATION_MODE_REQUIRED!r}."
+        )
+    return mode
+
+
+def _get_backend_for_route_guard() -> AuthorizationPolicyBackend | None:
+    """Return the backend used by route guards or raise in strict mode."""
+    backend = get_authorization_backend()
+    if backend is not None:
+        return backend
+    if get_authorization_mode() == _AUTHORIZATION_MODE_OPTIONAL:
+        return None
+
+    logger.warning(
+        "authorization_backend_required_but_not_configured",
+        mode=_AUTHORIZATION_MODE_REQUIRED,
+    )
+    raise HTTPException(
+        status_code=503,
+        detail={
+            "error": "service_unavailable",
+            "reason": "authorization_backend_not_configured",
+        },
+    )
 
 
 def create_decision_context(
@@ -248,7 +304,7 @@ def check_dataset_read(
     require_auth: bool = True,
 ) -> None:
     """Check if the request can read the dataset."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return
 
@@ -280,7 +336,7 @@ def check_dataset_query(
     require_auth: bool = True,
 ) -> None:
     """Check if the request can query the dataset."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return
 
@@ -312,7 +368,7 @@ def check_asset_read(
     require_auth: bool = True,
 ) -> None:
     """Check if the request can read the asset."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return
 
@@ -344,7 +400,7 @@ def check_asset_execute(
     require_auth: bool = True,
 ) -> None:
     """Check if the request can execute the asset."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return
 
@@ -376,7 +432,7 @@ def check_service_read(
     require_auth: bool = True,
 ) -> None:
     """Check if the request can read the service."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return
 
@@ -408,7 +464,7 @@ def check_service_manage(
     require_auth: bool = True,
 ) -> None:
     """Check if the request can manage the service."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return
 
@@ -440,7 +496,7 @@ def check_admin_read(
     require_auth: bool = True,
 ) -> None:
     """Check if the request can read admin resources."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return
 
@@ -472,7 +528,7 @@ def check_admin_manage(
     require_auth: bool = True,
 ) -> None:
     """Check if the request can manage admin resources."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return
 
@@ -505,7 +561,7 @@ def filter_datasets(
     require_auth: bool = True,
 ) -> list[str]:
     """Filter a list of dataset IDs to only those the principal can access."""
-    backend = get_authorization_backend()
+    backend = _get_backend_for_route_guard()
     if backend is None:
         return dataset_ids
 

--- a/packages/phlo-api/src/phlo_api/api/authorization.py
+++ b/packages/phlo-api/src/phlo_api/api/authorization.py
@@ -142,6 +142,8 @@ def require_authorization_backend() -> AuthorizationPolicyBackend:
 def get_authorization_mode() -> str:
     """Return how route guards behave when no authorization backend exists."""
     configured_mode = os.environ.get(_AUTHORIZATION_MODE_ENV)
+    if configured_mode is not None:
+        configured_mode = configured_mode.strip() or None
     if configured_mode is None:
         config = get_api_authorization_config()
         configured_mode = (

--- a/packages/phlo-api/src/phlo_api/api/authorization.py
+++ b/packages/phlo-api/src/phlo_api/api/authorization.py
@@ -143,8 +143,6 @@ def get_authorization_mode() -> str:
     """Return how route guards behave when no authorization backend exists."""
     configured_mode = os.environ.get(_AUTHORIZATION_MODE_ENV)
     if configured_mode is not None:
-    configured_mode = os.environ.get(_AUTHORIZATION_MODE_ENV)
-    if configured_mode is not None:
         configured_mode = configured_mode.strip() or None
     if configured_mode is None:
         config = get_api_authorization_config()

--- a/packages/phlo-api/src/phlo_api/observatory_api/settings.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/settings.py
@@ -17,6 +17,9 @@ Example:
 
     Response includes connections, defaults, query, and UI configuration.
 
+Authorization is enforced when an authorization backend is configured.
+In strict mode, these endpoints fail closed if the backend is absent.
+
 """
 
 from __future__ import annotations

--- a/packages/phlo-api/src/phlo_api/observatory_api/trino.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/trino.py
@@ -5,7 +5,8 @@ Enables data preview, column profiling, and table metrics in Observatory.
 
 This module provides a comprehensive interface to Trino for data exploration,
 including table previews, column profiling, row lookups, and ad-hoc queries
-with guardrails. All operations respect dataset authorization policies.
+with guardrails. Dataset authorization is enforced when an authorization
+backend is configured, and strict mode fails closed when it is not.
 
 Key Endpoints:
     GET /connection: Check Trino connectivity.

--- a/packages/phlo-api/tests/test_authorization_api.py
+++ b/packages/phlo-api/tests/test_authorization_api.py
@@ -234,6 +234,22 @@ api:
     assert get_authorization_mode() == "required"
 
 
+def test_empty_env_authorization_mode_falls_back_to_phlo_yaml(monkeypatch, tmp_path: Path) -> None:
+    _write_phlo_config(
+        tmp_path,
+        """
+api:
+  authorization:
+    mode: required
+""".lstrip(),
+    )
+    monkeypatch.setenv("PHLO_AUTHORIZATION_MODE", "")
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    clear_config_cache()
+
+    assert get_authorization_mode() == "required"
+
+
 def test_get_authorization_backend_uses_service_specific_phlo_yaml(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/packages/phlo-api/tests/test_authorization_api.py
+++ b/packages/phlo-api/tests/test_authorization_api.py
@@ -2,20 +2,27 @@
 
 from __future__ import annotations
 
-from fastapi import Request
+from pathlib import Path
+
+from fastapi import HTTPException, Request
 
 from phlo.capabilities import AuthorizationPolicyBackendSpec, clear_capabilities
 from phlo.capabilities.authorization import DefaultAuthorizationPolicyBackend
 from phlo.capabilities.interfaces import Principal
 from phlo.capabilities.registry import register_authorization_policy_backend
+from phlo.infrastructure.config import clear_config_cache
 from phlo_api.api.authorization import (
+    check_admin_read,
+    filter_datasets,
     get_authorization_backend,
+    get_authorization_mode,
     resolve_request_principal,
 )
 
 
 def teardown_function() -> None:
     clear_capabilities()
+    clear_config_cache()
 
 
 def _make_request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
@@ -27,6 +34,10 @@ def _make_request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
             "headers": headers or [],
         }
     )
+
+
+def _write_phlo_config(tmp_path: Path, content: str) -> None:
+    (tmp_path / "phlo.yaml").write_text(content)
 
 
 def test_resolve_request_principal_ignores_forwarded_identity_headers() -> None:
@@ -109,5 +120,141 @@ def test_get_authorization_backend_resolves_named_backend(monkeypatch) -> None:
     )
 
     monkeypatch.setenv("PHLO_AUTHORIZATION_BACKEND", "opa")
+
+    assert get_authorization_backend() is backend
+
+
+def test_get_authorization_mode_defaults_to_optional(monkeypatch) -> None:
+    monkeypatch.delenv("PHLO_AUTHORIZATION_MODE", raising=False)
+
+    assert get_authorization_mode() == "optional"
+
+
+def test_get_authorization_mode_rejects_unknown_value(monkeypatch) -> None:
+    monkeypatch.setenv("PHLO_AUTHORIZATION_MODE", "fail-closed")
+
+    try:
+        get_authorization_mode()
+    except RuntimeError as exc:
+        assert "Invalid PHLO_AUTHORIZATION_MODE value" in str(exc)
+    else:
+        raise AssertionError("Expected invalid authorization mode error")
+
+
+def test_route_guard_allows_access_without_backend_in_optional_mode(monkeypatch) -> None:
+    monkeypatch.delenv("PHLO_AUTHORIZATION_BACKEND", raising=False)
+    monkeypatch.delenv("PHLO_AUTHORIZATION_MODE", raising=False)
+
+    check_admin_read(_make_request(), "observatory_settings")
+
+
+def test_route_guard_fails_closed_without_backend_in_required_mode(monkeypatch) -> None:
+    monkeypatch.delenv("PHLO_AUTHORIZATION_BACKEND", raising=False)
+    monkeypatch.setenv("PHLO_AUTHORIZATION_MODE", "required")
+
+    try:
+        check_admin_read(_make_request(), "observatory_settings")
+    except HTTPException as exc:
+        assert exc.status_code == 503
+        assert exc.detail == {
+            "error": "service_unavailable",
+            "reason": "authorization_backend_not_configured",
+        }
+    else:
+        raise AssertionError("Expected route guard to fail closed")
+
+
+def test_filter_datasets_fails_closed_without_backend_in_required_mode(monkeypatch) -> None:
+    monkeypatch.delenv("PHLO_AUTHORIZATION_BACKEND", raising=False)
+    monkeypatch.setenv("PHLO_AUTHORIZATION_MODE", "required")
+
+    try:
+        filter_datasets(_make_request(), ["raw.orders"])
+    except HTTPException as exc:
+        assert exc.status_code == 503
+        assert exc.detail == {
+            "error": "service_unavailable",
+            "reason": "authorization_backend_not_configured",
+        }
+    else:
+        raise AssertionError("Expected dataset filtering to fail closed")
+
+
+def test_get_authorization_mode_uses_top_level_phlo_yaml(monkeypatch, tmp_path: Path) -> None:
+    _write_phlo_config(
+        tmp_path,
+        """
+api:
+  authorization:
+    mode: required
+""".lstrip(),
+    )
+    monkeypatch.delenv("PHLO_AUTHORIZATION_MODE", raising=False)
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    clear_config_cache()
+
+    assert get_authorization_mode() == "required"
+
+
+def test_get_authorization_mode_prefers_service_specific_phlo_yaml(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _write_phlo_config(
+        tmp_path,
+        """
+api:
+  authorization:
+    mode: optional
+services:
+  phlo-api:
+    authorization:
+      mode: required
+""".lstrip(),
+    )
+    monkeypatch.delenv("PHLO_AUTHORIZATION_MODE", raising=False)
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    clear_config_cache()
+
+    assert get_authorization_mode() == "required"
+
+
+def test_env_authorization_mode_overrides_phlo_yaml(monkeypatch, tmp_path: Path) -> None:
+    _write_phlo_config(
+        tmp_path,
+        """
+api:
+  authorization:
+    mode: optional
+""".lstrip(),
+    )
+    monkeypatch.setenv("PHLO_AUTHORIZATION_MODE", "required")
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    clear_config_cache()
+
+    assert get_authorization_mode() == "required"
+
+
+def test_get_authorization_backend_uses_service_specific_phlo_yaml(
+    monkeypatch, tmp_path: Path
+) -> None:
+    backend = DefaultAuthorizationPolicyBackend()
+    register_authorization_policy_backend(
+        AuthorizationPolicyBackendSpec(name="default", provider=DefaultAuthorizationPolicyBackend())
+    )
+    register_authorization_policy_backend(
+        AuthorizationPolicyBackendSpec(name="opa", provider=backend)
+    )
+    _write_phlo_config(
+        tmp_path,
+        """
+services:
+  phlo-api:
+    authorization:
+      backend: opa
+""".lstrip(),
+    )
+    monkeypatch.delenv("PHLO_AUTHORIZATION_BACKEND", raising=False)
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    clear_config_cache()
 
     assert get_authorization_backend() is backend

--- a/src/phlo/cli/commands/services/utils.py
+++ b/src/phlo/cli/commands/services/utils.py
@@ -41,6 +41,19 @@ description: "{description}"
 #   POSTGRES_PORT: 10000
 #   DAGSTER_PORT: 10006
 #
+# phlo-api authorization policy:
+#
+# api:
+#   authorization:
+#     backend: opa
+#     mode: required
+#
+# services:
+#   phlo-api:
+#     authorization:
+#       backend: opa
+#       mode: required
+#
 # Project capability defaults:
 #
 # capabilities:

--- a/src/phlo/cli/config.py
+++ b/src/phlo/cli/config.py
@@ -14,7 +14,7 @@ from rich.console import Console
 from rich.syntax import Syntax
 from rich.table import Table
 
-from phlo.config_schema import InfrastructureConfig
+from phlo.config_schema import ApiConfig, InfrastructureConfig, ServiceOverride
 from phlo.infrastructure import clear_config_cache, load_infrastructure_config
 from phlo.logging import get_logger
 
@@ -87,17 +87,25 @@ def validate():
         error_console.print("[red]Error: phlo.yaml is empty[/red]")
         sys.exit(1)
 
-    if "infrastructure" not in project_config:
-        logger.info("config_validate_infrastructure_missing", path=str(config_path))
-        console.print("[yellow]Warning: No infrastructure section in phlo.yaml[/yellow]")
-        console.print(
-            "Using default configuration. Run [cyan]phlo config upgrade[/cyan] to add infrastructure section."
-        )
-        return
-
     try:
-        infra_data = project_config["infrastructure"]
-        infra_config = InfrastructureConfig(**infra_data)
+        if "infrastructure" in project_config:
+            infra_data = project_config["infrastructure"]
+            infra_config = InfrastructureConfig(**infra_data)
+        else:
+            infra_config = InfrastructureConfig()
+
+        api_data = project_config.get("api")
+        if api_data is not None:
+            ApiConfig(**api_data)
+
+        services_data = project_config.get("services", {})
+        if isinstance(services_data, dict):
+            for service_name, service_config in services_data.items():
+                if not isinstance(service_config, dict):
+                    continue
+                if service_name in {"enabled", "disabled"}:
+                    continue
+                ServiceOverride(**service_config)
     except ValidationError as e:
         logger.warning(
             "config_validate_failed",
@@ -118,6 +126,13 @@ def validate():
         path=str(config_path),
         service_count=len(infra_config.services),
     )
+
+    if "infrastructure" not in project_config:
+        logger.info("config_validate_infrastructure_missing", path=str(config_path))
+        console.print("[yellow]Warning: No infrastructure section in phlo.yaml[/yellow]")
+        console.print(
+            "Using default infrastructure configuration. Run [cyan]phlo config upgrade[/cyan] to add it.\n"
+        )
 
     table = Table(show_header=True, header_style="bold cyan")
     table.add_column("Check", style="cyan")

--- a/src/phlo/config_schema.py
+++ b/src/phlo/config_schema.py
@@ -11,6 +11,50 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 
+class ApiAuthorizationConfig(BaseModel):
+    """Authorization configuration for phlo-api."""
+
+    backend: str | None = Field(
+        default=None,
+        description="Authorization backend capability name.",
+    )
+    mode: str | None = Field(
+        default=None,
+        description="Guard behavior when no authorization backend exists.",
+    )
+
+    @field_validator("backend")
+    @classmethod
+    def validate_backend(cls, value: str | None) -> str | None:
+        """Validate backend names when provided."""
+        if value is None:
+            return value
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("backend cannot be empty")
+        return normalized
+
+    @field_validator("mode")
+    @classmethod
+    def validate_mode(cls, value: str | None) -> str | None:
+        """Validate supported authorization modes."""
+        if value is None:
+            return value
+        normalized = value.strip().lower()
+        if normalized not in {"optional", "required"}:
+            raise ValueError("mode must be 'optional' or 'required'")
+        return normalized
+
+
+class ApiConfig(BaseModel):
+    """Top-level phlo-api configuration."""
+
+    authorization: ApiAuthorizationConfig | None = Field(
+        default=None,
+        description="Authorization settings for phlo-api.",
+    )
+
+
 class ServiceOverride(BaseModel):
     """User overrides for a service in phlo.yaml.
 
@@ -52,6 +96,10 @@ class ServiceOverride(BaseModel):
     command: str | list[str] | None = Field(
         default=None,
         description="Container command override.",
+    )
+    authorization: ApiAuthorizationConfig | None = Field(
+        default=None,
+        description="Service-scoped authorization settings for phlo-api.",
     )
 
     # For inline custom services (type: inline)

--- a/src/phlo/infrastructure/config.py
+++ b/src/phlo/infrastructure/config.py
@@ -186,7 +186,7 @@ def get_api_authorization_config(project_root: Path | None = None) -> ApiAuthori
         phlo_api_service = services.get("phlo-api")
         if isinstance(phlo_api_service, dict):
             service_auth = phlo_api_service.get("authorization")
-            if service_auth is not None:
+            if isinstance(service_auth, dict):
                 return ApiAuthorizationConfig(**service_auth)
 
     api_config = project_config.get("api")

--- a/src/phlo/infrastructure/config.py
+++ b/src/phlo/infrastructure/config.py
@@ -185,7 +185,6 @@ def get_api_authorization_config(project_root: Path | None = None) -> ApiAuthori
     if isinstance(services, dict):
         phlo_api_service = services.get("phlo-api")
         if isinstance(phlo_api_service, dict):
-        if isinstance(phlo_api_service, dict):
             service_auth = phlo_api_service.get("authorization")
             if isinstance(service_auth, dict):
                 return ApiAuthorizationConfig(**service_auth)

--- a/src/phlo/infrastructure/config.py
+++ b/src/phlo/infrastructure/config.py
@@ -185,6 +185,7 @@ def get_api_authorization_config(project_root: Path | None = None) -> ApiAuthori
     if isinstance(services, dict):
         phlo_api_service = services.get("phlo-api")
         if isinstance(phlo_api_service, dict):
+        if isinstance(phlo_api_service, dict):
             service_auth = phlo_api_service.get("authorization")
             if isinstance(service_auth, dict):
                 return ApiAuthorizationConfig(**service_auth)

--- a/src/phlo/infrastructure/config.py
+++ b/src/phlo/infrastructure/config.py
@@ -15,7 +15,12 @@ from typing import Any
 import yaml
 from pydantic import ValidationError
 
-from phlo.config_schema import InfrastructureConfig, ServiceConfig
+from phlo.config_schema import (
+    ApiAuthorizationConfig,
+    ApiConfig,
+    InfrastructureConfig,
+    ServiceConfig,
+)
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
@@ -163,6 +168,33 @@ def get_capability_defaults_from_config(project_root: Path | None = None) -> dic
         if isinstance(key, str) and isinstance(value, str) and key and value:
             normalized[key] = value
     return normalized
+
+
+def get_api_authorization_config(project_root: Path | None = None) -> ApiAuthorizationConfig | None:
+    """Return validated phlo-api authorization settings from phlo.yaml.
+
+    Precedence inside phlo.yaml is:
+    1. services.phlo-api.authorization
+    2. api.authorization
+    """
+    project_config = load_project_config(project_root)
+    if not isinstance(project_config, dict) or not project_config:
+        return None
+
+    services = project_config.get("services", {})
+    if isinstance(services, dict):
+        phlo_api_service = services.get("phlo-api")
+        if isinstance(phlo_api_service, dict):
+            service_auth = phlo_api_service.get("authorization")
+            if service_auth is not None:
+                return ApiAuthorizationConfig(**service_auth)
+
+    api_config = project_config.get("api")
+    if isinstance(api_config, dict):
+        validated = ApiConfig(**api_config)
+        return validated.authorization
+
+    return None
 
 
 def get_service_config(service_key: str, project_root: Path | None = None) -> ServiceConfig | None:

--- a/tests/test_infrastructure_config.py
+++ b/tests/test_infrastructure_config.py
@@ -17,6 +17,7 @@ from phlo.infrastructure import (
     load_infrastructure_config,
     load_project_config,
 )
+from phlo.infrastructure.config import get_api_authorization_config
 
 
 @pytest.fixture(autouse=True)
@@ -129,6 +130,23 @@ def test_get_capability_defaults_from_config_reads_defaults_block(tmp_path: Path
     defaults = get_capability_defaults_from_config(tmp_path)
 
     assert defaults == {"table_store": "iceberg", "query_engine": "trino"}
+
+
+def test_get_api_authorization_config_ignores_non_mapping_service_auth(tmp_path: Path) -> None:
+    config_path = tmp_path / "phlo.yaml"
+    _write_phlo_yaml(
+        config_path,
+        {
+            "services": {"phlo-api": {"authorization": True}},
+            "api": {"authorization": {"mode": "required"}},
+        },
+    )
+
+    auth_config = get_api_authorization_config(tmp_path)
+
+    assert auth_config is not None
+    assert auth_config.mode == "required"
+    assert auth_config.backend is None
 
 
 def test_infrastructure_config_pattern_validation():


### PR DESCRIPTION
## Summary

Closes #452. This change by making `phlo-api` authorization behavior explicit and operator-configurable.

It does three things:

- keeps the existing default behavior explicit with `PHLO_AUTHORIZATION_MODE=optional`
- adds a strict `required` mode that fails closed on guarded routes when no authorization backend is configured
- adds first-class `phlo.yaml` support for both `api.authorization` and `services.phlo-api.authorization`

## What Changed

- added `PHLO_AUTHORIZATION_MODE` handling to `phlo-api` route guard helpers
- made guarded routes and dataset filtering return `503` with `authorization_backend_not_configured` in strict mode
- added validated `phlo.yaml` config models for:
  - `api.authorization`
  - `services.phlo-api.authorization`
- added config resolution precedence:
  - env vars
  - `services.phlo-api.authorization`
  - `api.authorization`
- updated `phlo config validate` so these new config shapes are checked
- updated auth/access, security, production-readiness, and API docs to describe the behavior and config options

## Why

Before this change, route guards silently became no-ops when no authorization backend was configured. That behavior appears intentional, but it was implicit and easy for operators to misread.

This PR makes the contract explicit and adds a supported fail-closed mode for deployments that want guarded routes to require a configured authorization backend.

## Validation

- `uv run pytest packages/phlo-api/tests/test_authorization_api.py`
- `uv run ruff check packages/phlo-api/src/phlo_api/api/authorization.py packages/phlo-api/tests/test_authorization_api.py src/phlo/config_schema.py src/phlo/infrastructure/config.py src/phlo/cli/config.py src/phlo/cli/commands/services/utils.py`

## Impact

Operators can now choose between:

- open-by-default guarded routes when authz is intentionally omitted
- fail-closed guarded routes when authz is expected but missing

and can declare that policy in `phlo.yaml` instead of relying only on raw environment variables.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->