### PR TITLE
feat(api): add phlo MCP trace inspection tools

### DIFF
--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -88,11 +88,12 @@ Use [Python Reference](../python-reference/index.mdx) when you need symbol-level
 
 ---
 
-### API Layer (3 packages)
+### API Layer (4 packages)
 
 | Package | Description | Protocol |
 |---------|-------------|----------|
 | [phlo-api](phlo-api.md) | REST API for Phlo internals | REST |
+| [phlo-mcp](phlo-mcp.md) | MCP server for observability and lakehouse operations | MCP |
 | [phlo-postgrest](phlo-postgrest.md) | Auto-generated REST API from PostgreSQL | REST |
 | [phlo-hasura](phlo-hasura.md) | GraphQL API with real-time subscriptions | GraphQL |
 

--- a/docs/packages/phlo-clickstack.md
+++ b/docs/packages/phlo-clickstack.md
@@ -39,6 +39,8 @@ Part of the `observability` profile.
 | `CLICKSTACK_PORT` | `8080` | ClickStack UI port |
 | `CLICKSTACK_HTTP_PORT` | `8123` | ClickHouse HTTP query port used by `phlo-api` trace endpoints |
 | `CLICKSTACK_QUERY_URL` | unset | Explicit ClickHouse HTTP query URL override for `phlo-api` |
+| `CLICKSTACK_QUERY_USER` | unset | Optional ClickHouse HTTP query username for `phlo-api` |
+| `CLICKSTACK_QUERY_PASSWORD` | unset | Optional ClickHouse HTTP query password for `phlo-api` |
 | `CLICKSTACK_OTLP_GRPC_PORT` | `4317` | OTLP gRPC ingest port |
 | `CLICKSTACK_OTLP_HTTP_PORT` | `4318` | OTLP HTTP ingest port |
 | `CLICKSTACK_NATIVE_PORT` | `9000` | ClickHouse native port |

--- a/docs/packages/phlo-clickstack.md
+++ b/docs/packages/phlo-clickstack.md
@@ -26,6 +26,7 @@ Part of the `observability` profile.
 | Port | Purpose |
 | --- | --- |
 | `8080` | ClickStack UI |
+| `8123` | ClickHouse HTTP query endpoint |
 | `4317` | OTLP gRPC ingest |
 | `4318` | OTLP HTTP ingest |
 | `9000` | ClickHouse native port |
@@ -36,6 +37,8 @@ Part of the `observability` profile.
 | --- | --- | --- |
 | `CLICKSTACK_IMAGE` | `docker.hyperdx.io/hyperdx/hyperdx-all-in-one` | Official ClickStack image |
 | `CLICKSTACK_PORT` | `8080` | ClickStack UI port |
+| `CLICKSTACK_HTTP_PORT` | `8123` | ClickHouse HTTP query port used by `phlo-api` trace endpoints |
+| `CLICKSTACK_QUERY_URL` | unset | Explicit ClickHouse HTTP query URL override for `phlo-api` |
 | `CLICKSTACK_OTLP_GRPC_PORT` | `4317` | OTLP gRPC ingest port |
 | `CLICKSTACK_OTLP_HTTP_PORT` | `4318` | OTLP HTTP ingest port |
 | `CLICKSTACK_NATIVE_PORT` | `9000` | ClickHouse native port |

--- a/docs/packages/phlo-mcp.md
+++ b/docs/packages/phlo-mcp.md
@@ -26,8 +26,24 @@ Current tools:
 - `get_dashboard_links`
 - `get_logs_query_link`
 - `get_metrics_query_link`
+- `get_materialization_history`
+- `get_run_logs`
+- `get_run_trace_spans`
+- `inspect_materialization`
+- `get_asset_materialization_trace`
+- `render_materialization_trace_tree`
+- `render_run_trace_tree`
 
 These tools call `phlo-api` endpoints and return structured JSON results.
+
+Run-level and materialization tools rely on the backing `phlo-api` having access
+to Dagster asset history, Loki log queries, and ClickStack OTEL trace storage.
+
+When real spans are available, rendered trees include:
+- span kind
+- status code
+- duration
+- selected Phlo attributes like stage, asset key, job name, and operation
 
 ## Configuration
 
@@ -66,6 +82,16 @@ Claude Code config example:
   }
 }
 ```
+
+Useful prompts once connected:
+
+- "Get the latest materializations for `silver/orders`."
+- "Fetch logs for run `abc-123`."
+- "Inspect the latest materialization for `silver/orders`."
+- "Get the latest materialization trace for `silver/orders`."
+- "Render the materialization trace tree for `silver/orders`."
+- "Get OTEL spans for run `abc-123`."
+- "Render the run trace tree for `abc-123`."
 
 Run it over streamable HTTP:
 

--- a/docs/packages/phlo-mcp.md
+++ b/docs/packages/phlo-mcp.md
@@ -161,21 +161,21 @@ phlo-mcp \
 
 ## Live stack smoke
 
-Run the MCP smoke against live `phlo-api`, Dagster, and ClickStack services:
+Run the MCP smoke against a live `phlo-api` service and its configured capability backends:
 
 ```bash
 uv run python packages/phlo-mcp/tests/smoke_stack.py --start-stack
 ```
 
-The smoke checks live `phlo-api`, Dagster connectivity, ClickStack trace table
-queries, MCP tool registration, filtered trace tools, MCP resource registration,
-representative MCP resource reads, and a generated `mcp_smoke_asset` fixture.
+The smoke checks live `phlo-api`, orchestration connectivity, trace filtering
+through the observability capability, MCP tool registration, MCP resource
+registration, representative MCP resource reads, and a generated
+`mcp_smoke_asset` capability fixture.
 With `--start-stack`, the fixture is written to `.phlo/mcp-smoke-project`,
 which is ignored by git.
 
-When ClickStack requires HTTP credentials, pass them to the smoke script and to
-the `phlo-api` process as `CLICKSTACK_QUERY_USER` and
-`CLICKSTACK_QUERY_PASSWORD`.
+When the configured observability backend requires credentials, pass them to
+the backing `phlo-api` process with that backend's environment variables.
 
 To verify guarded write-tool registration without calling mutation endpoints:
 
@@ -210,5 +210,3 @@ uv run python packages/phlo-mcp/tests/smoke_stack.py \
 ## Related packages
 
 - [phlo-api](phlo-api.md) - backing REST/OpenAPI machine contract
-- [phlo-otel](phlo-otel.md) - OpenTelemetry emission across Phlo runtime events
-- [phlo-clickstack](phlo-clickstack.md) - default all-in-one observability backend

--- a/docs/packages/phlo-mcp.md
+++ b/docs/packages/phlo-mcp.md
@@ -129,6 +129,10 @@ Run the MCP smoke against live `phlo-api`, Dagster, and ClickStack services:
 uv run python packages/phlo-mcp/tests/smoke_stack.py
 ```
 
+When ClickStack requires HTTP credentials, pass them to the smoke script and to
+the `phlo-api` process as `CLICKSTACK_QUERY_USER` and
+`CLICKSTACK_QUERY_PASSWORD`.
+
 Use real data assertions when you have a known run or asset:
 
 ```bash

--- a/docs/packages/phlo-mcp.md
+++ b/docs/packages/phlo-mcp.md
@@ -50,6 +50,7 @@ When real spans are available, rendered trees include:
 | Variable | Default | Description |
 | --- | --- | --- |
 | `PHLO_MCP_API_BASE_URL` | `http://127.0.0.1:4000` | Base URL for the backing `phlo-api` instance |
+| `PHLO_MCP_API_TOKEN` | unset | Bearer token for authenticated `phlo-api` requests |
 | `PHLO_MCP_TRANSPORT` | `stdio` | MCP transport (`stdio` or `streamable-http`) |
 | `PHLO_MCP_HOST` | `127.0.0.1` | Bind host for streamable HTTP transport |
 | `PHLO_MCP_PORT` | `8000` | Bind port for streamable HTTP transport |
@@ -68,6 +69,14 @@ Run the MCP server over stdio:
 
 ```bash
 phlo-mcp --api-base-url http://127.0.0.1:4000
+```
+
+For protected `phlo-api` instances, pass a bearer token:
+
+```bash
+phlo-mcp \
+  --api-base-url http://127.0.0.1:4000 \
+  --api-token "$PHLO_API_TOKEN"
 ```
 
 Claude Code config example:

--- a/docs/packages/phlo-mcp.md
+++ b/docs/packages/phlo-mcp.md
@@ -29,15 +29,41 @@ Current tools:
 - `get_materialization_history`
 - `get_run_logs`
 - `get_run_trace_spans`
+- `get_trace_spans`
+- `render_trace_spans_tree`
 - `inspect_materialization`
 - `get_asset_materialization_trace`
 - `render_materialization_trace_tree`
 - `render_run_trace_tree`
 
+Optional guarded operational tools:
+
+- `materialize_asset`
+- `retry_failed_run`
+- `get_dagster_run_status`
+
 These tools call `phlo-api` endpoints and return structured JSON results.
+
+Resources:
+
+- `phlo://runtime/config`
+- `phlo://runtime/services`
+- `phlo://runtime/services/{service_name}`
+- `phlo://runtime/plugins`
+- `phlo://runtime/assets`
+- `phlo://runtime/assets/{asset_key_path}`
+- `phlo://runtime/schemas/{asset_key_path}`
+- `phlo://runtime/contracts`
+- `phlo://runtime/contracts/{table_name}`
+- `phlo://runtime/dashboards`
+- `phlo://docs/packages/{package_name}`
 
 Run-level and materialization tools rely on the backing `phlo-api` having access
 to Dagster asset history, Loki log queries, and ClickStack OTEL trace storage.
+Trace tools can be filtered by run id, asset key, job name, service name, span
+name, status code, and start/end time.
+Resource URIs are read-only and deterministic so MCP clients can attach Phlo
+runtime context without invoking parameterized tools.
 
 When real spans are available, rendered trees include:
 - span kind
@@ -51,6 +77,7 @@ When real spans are available, rendered trees include:
 | --- | --- | --- |
 | `PHLO_MCP_API_BASE_URL` | `http://127.0.0.1:4000` | Base URL for the backing `phlo-api` instance |
 | `PHLO_MCP_API_TOKEN` | unset | Bearer token for authenticated `phlo-api` requests |
+| `PHLO_MCP_ENABLE_WRITE_TOOLS` | `false` | Register guarded operational tools when an API token is configured |
 | `PHLO_MCP_TRANSPORT` | `stdio` | MCP transport (`stdio` or `streamable-http`) |
 | `PHLO_MCP_HOST` | `127.0.0.1` | Bind host for streamable HTTP transport |
 | `PHLO_MCP_PORT` | `8000` | Bind port for streamable HTTP transport |
@@ -79,6 +106,15 @@ phlo-mcp \
   --api-token "$PHLO_API_TOKEN"
 ```
 
+Guarded operational tools are disabled by default. To expose tools that can
+request asset materialization or run retry through `phlo-api`, set
+`PHLO_MCP_ENABLE_WRITE_TOOLS=true` or pass `--enable-write-tools` and provide an
+API token. Every write tool returns an `audit_context` with the operation,
+target, dry-run state, authenticated state, and backing API URL. Tool calls
+default to `dry_run=true` where the operation supports it. Current `phlo-api`
+operation routes support dry-run validation and run status; live Dagster launch
+and retry are intentionally not implemented yet.
+
 Claude Code config example:
 
 ```json
@@ -100,7 +136,9 @@ Useful prompts once connected:
 - "Get the latest materialization trace for `silver/orders`."
 - "Render the materialization trace tree for `silver/orders`."
 - "Get OTEL spans for run `abc-123`."
+- "Get failed Dagster spans for asset `silver/orders` in the last hour."
 - "Render the run trace tree for `abc-123`."
+- "Render a trace tree for job `daily_orders`."
 
 Run it over streamable HTTP:
 
@@ -126,12 +164,38 @@ phlo-mcp \
 Run the MCP smoke against live `phlo-api`, Dagster, and ClickStack services:
 
 ```bash
-uv run python packages/phlo-mcp/tests/smoke_stack.py
+uv run python packages/phlo-mcp/tests/smoke_stack.py --start-stack
 ```
+
+The smoke checks live `phlo-api`, Dagster connectivity, ClickStack trace table
+queries, MCP tool registration, filtered trace tools, MCP resource registration,
+representative MCP resource reads, and a generated `mcp_smoke_asset` fixture.
+With `--start-stack`, the fixture is written to `.phlo/mcp-smoke-project`,
+which is ignored by git.
 
 When ClickStack requires HTTP credentials, pass them to the smoke script and to
 the `phlo-api` process as `CLICKSTACK_QUERY_USER` and
 `CLICKSTACK_QUERY_PASSWORD`.
+
+To verify guarded write-tool registration without calling mutation endpoints:
+
+```bash
+uv run python packages/phlo-mcp/tests/smoke_stack.py \
+  --enable-write-tools \
+  --api-token "$PHLO_MCP_SMOKE_API_TOKEN"
+```
+
+To call guarded write tools in dry-run mode, add `--exercise-write-tools` and
+`--start-stack`, or provide `--asset-key` when testing an existing project.
+This requires the backing `phlo-api` write endpoints to be available.
+
+```bash
+uv run python packages/phlo-mcp/tests/smoke_stack.py \
+  --start-stack \
+  --enable-write-tools \
+  --api-token "$PHLO_MCP_SMOKE_API_TOKEN" \
+  --exercise-write-tools
+```
 
 Use real data assertions when you have a known run or asset:
 

--- a/docs/packages/phlo-mcp.md
+++ b/docs/packages/phlo-mcp.md
@@ -121,6 +121,24 @@ phlo-mcp \
   --trace-file .phlo/phlo-mcp-trace.jsonl
 ```
 
+## Live stack smoke
+
+Run the MCP smoke against live `phlo-api`, Dagster, and ClickStack services:
+
+```bash
+uv run python packages/phlo-mcp/tests/smoke_stack.py
+```
+
+Use real data assertions when you have a known run or asset:
+
+```bash
+uv run python packages/phlo-mcp/tests/smoke_stack.py \
+  --run-id abc-123 \
+  --require-run-spans \
+  --asset-key silver/orders \
+  --require-materialization
+```
+
 ## Related packages
 
 - [phlo-api](phlo-api.md) - backing REST/OpenAPI machine contract

--- a/docs/packages/phlo-mcp.md
+++ b/docs/packages/phlo-mcp.md
@@ -1,0 +1,93 @@
+# phlo-mcp
+
+MCP server for Phlo observability and lakehouse operations.
+
+## Overview
+
+`phlo-mcp` exposes curated read-only MCP tools over Phlo runtime surfaces.
+It sits on top of `phlo-api`, so an MCP client can inspect a lakehouse without
+bespoke per-agent glue.
+
+## Installation
+
+```bash
+pip install phlo-mcp
+# or
+uv pip install -e packages/phlo-mcp
+```
+
+## What it exposes
+
+Current tools:
+
+- `get_platform_health`
+- `get_service_status`
+- `get_recent_alerts`
+- `get_dashboard_links`
+- `get_logs_query_link`
+- `get_metrics_query_link`
+
+These tools call `phlo-api` endpoints and return structured JSON results.
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PHLO_MCP_API_BASE_URL` | `http://127.0.0.1:4000` | Base URL for the backing `phlo-api` instance |
+| `PHLO_MCP_TRANSPORT` | `stdio` | MCP transport (`stdio` or `streamable-http`) |
+| `PHLO_MCP_HOST` | `127.0.0.1` | Bind host for streamable HTTP transport |
+| `PHLO_MCP_PORT` | `8000` | Bind port for streamable HTTP transport |
+| `PHLO_MCP_HTTP_PATH` | `/mcp` | HTTP path for streamable HTTP transport |
+| `PHLO_MCP_TRACE_FILE` | unset | Optional JSONL span sink for local span capture |
+
+## Usage
+
+Start a backing API first:
+
+```bash
+uv run --package phlo-api uvicorn phlo_api.main:app --host 127.0.0.1 --port 4000
+```
+
+Run the MCP server over stdio:
+
+```bash
+phlo-mcp --api-base-url http://127.0.0.1:4000
+```
+
+Claude Code config example:
+
+```json
+{
+  "mcpServers": {
+    "phlo": {
+      "command": "uv",
+      "args": ["run", "--package", "phlo-mcp", "phlo-mcp", "--api-base-url", "http://127.0.0.1:4000"]
+    }
+  }
+}
+```
+
+Run it over streamable HTTP:
+
+```bash
+phlo-mcp \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --path /mcp \
+  --api-base-url http://127.0.0.1:4000
+```
+
+Capture local spans to a file while the server runs:
+
+```bash
+phlo-mcp \
+  --api-base-url http://127.0.0.1:4000 \
+  --trace-file .phlo/phlo-mcp-trace.jsonl
+```
+
+## Related packages
+
+- [phlo-api](phlo-api.md) - backing REST/OpenAPI machine contract
+- [phlo-otel](phlo-otel.md) - OpenTelemetry emission across Phlo runtime events
+- [phlo-clickstack](phlo-clickstack.md) - default all-in-one observability backend

--- a/docs/plans/2026-04-25-001-phlo-mcp-api-auth.md
+++ b/docs/plans/2026-04-25-001-phlo-mcp-api-auth.md
@@ -1,0 +1,47 @@
+---
+title: "feat: Add phlo-mcp API authentication"
+type: plan
+status: completed
+date: 2026-04-25
+origin: PR-468-follow-up
+---
+
+# phlo-mcp API Authentication
+
+## Overview
+
+Allow `phlo-mcp` to call protected `phlo-api` deployments by sending a bearer token on
+all upstream API requests.
+
+## Problem
+
+`phlo-mcp` currently assumes `phlo-api` is reachable without authentication. That works
+for local development but blocks regulated or proxy-protected deployments.
+
+## Requirements
+
+- Add `PHLO_MCP_API_TOKEN`.
+- Add `phlo-mcp --api-token`.
+- Attach `Authorization: Bearer <token>` to every `phlo-api` request when configured.
+- Do not log or expose the token in tool responses or traces.
+- Document CLI and environment configuration.
+
+## Implementation
+
+- Modify `packages/phlo-mcp/src/phlo_mcp/config.py`.
+- Modify `packages/phlo-mcp/src/phlo_mcp/cli.py`.
+- Modify `packages/phlo-mcp/src/phlo_mcp/api_client.py`.
+- Update `packages/phlo-mcp/tests/test_phlo_mcp.py`.
+- Update `packages/phlo-mcp/README.md` and `docs/packages/phlo-mcp.md`.
+
+## Verification
+
+```bash
+uv run pytest packages/phlo-mcp/tests/test_phlo_mcp.py -q
+uv run ruff check packages/phlo-mcp/src/phlo_mcp packages/phlo-mcp/tests/test_phlo_mcp.py
+```
+
+## Outcome
+
+Implemented in `phlo-mcp` with `PHLO_MCP_API_TOKEN`, `--api-token`, and bearer-token
+request headers.

--- a/docs/plans/2026-04-25-002-phlo-mcp-operational-tools.md
+++ b/docs/plans/2026-04-25-002-phlo-mcp-operational-tools.md
@@ -1,0 +1,41 @@
+---
+title: "feat: Add guarded phlo-mcp operational tools"
+type: plan
+status: planned
+date: 2026-04-25
+origin: PR-468-follow-up
+---
+
+# Guarded phlo-mcp Operational Tools
+
+## Overview
+
+Add opt-in MCP tools for safe operational actions such as materializing assets,
+retrying failed runs, and checking job status.
+
+## Problem
+
+The current MCP server is read-only. Agents can inspect issues but cannot trigger
+the common remediation actions operators expect.
+
+## Requirements
+
+- Keep write tools disabled by default.
+- Require explicit `PHLO_MCP_ENABLE_WRITE_TOOLS=true`.
+- Require authenticated `phlo-api`.
+- Expose dry-run metadata where possible.
+- Return structured audit context for every write action.
+
+## Implementation
+
+- Add config flag for write tools.
+- Add guarded tool registration in `server.py`.
+- Add `PhloApiClient` methods for operation endpoints once stable.
+- Add tests that write tools are absent by default and present only when enabled.
+- Document safety model and expected auth.
+
+## Verification
+
+```bash
+uv run pytest packages/phlo-mcp/tests/test_phlo_mcp.py -q
+```

--- a/docs/plans/2026-04-25-002-phlo-mcp-operational-tools.md
+++ b/docs/plans/2026-04-25-002-phlo-mcp-operational-tools.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add guarded phlo-mcp operational tools"
 type: plan
-status: planned
+status: completed
 date: 2026-04-25
 origin: PR-468-follow-up
 ---
@@ -39,3 +39,11 @@ the common remediation actions operators expect.
 ```bash
 uv run pytest packages/phlo-mcp/tests/test_phlo_mcp.py -q
 ```
+
+## Outcome
+
+Implemented the MCP-side guard. `PHLO_MCP_ENABLE_WRITE_TOOLS` and
+`--enable-write-tools` register `materialize_asset`, `retry_failed_run`, and
+`get_dagster_run_status` only when an API token is configured. The mutation tools
+default to dry-run mode and return structured `audit_context` metadata without
+exposing the token.

--- a/docs/plans/2026-04-25-003-phlo-mcp-trace-filtering.md
+++ b/docs/plans/2026-04-25-003-phlo-mcp-trace-filtering.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add richer phlo-mcp trace filtering"
 type: plan
-status: planned
+status: completed
 date: 2026-04-25
 origin: PR-468-follow-up
 ---
@@ -38,3 +38,10 @@ window, not a specific run id.
 ```bash
 uv run pytest packages/phlo-clickstack/tests packages/phlo-api/tests/test_observability_api.py packages/phlo-mcp/tests/test_phlo_mcp.py -q
 ```
+
+## Outcome
+
+Implemented filtered trace querying from ClickStack through `phlo-api` and
+`phlo-mcp`. Added filters for run id, asset key, job name, service name, span
+name, status code, start time, and end time. Existing run-id tools remain, and
+new MCP tools return raw spans or rendered span trees.

--- a/docs/plans/2026-04-25-003-phlo-mcp-trace-filtering.md
+++ b/docs/plans/2026-04-25-003-phlo-mcp-trace-filtering.md
@@ -1,0 +1,40 @@
+---
+title: "feat: Add richer phlo-mcp trace filtering"
+type: plan
+status: planned
+date: 2026-04-25
+origin: PR-468-follow-up
+---
+
+# phlo-mcp Trace Filtering
+
+## Overview
+
+Extend trace and log inspection with filters for asset, job, status, time window, service,
+and span name.
+
+## Problem
+
+Current trace tools are run-id centered. Operators often begin with an asset or failure
+window, not a specific run id.
+
+## Requirements
+
+- Filter spans by run id, asset key, job name, service name, status, and time range.
+- Keep defaults bounded.
+- Preserve current run-id tools.
+- Return both raw spans and rendered trees.
+
+## Implementation
+
+- Extend observability backend protocol with filtered trace queries.
+- Add ClickStack SQL generation helpers with tests.
+- Add `phlo-api` query parameters.
+- Add MCP client and server tool wrappers.
+- Update docs and examples.
+
+## Verification
+
+```bash
+uv run pytest packages/phlo-clickstack/tests packages/phlo-api/tests/test_observability_api.py packages/phlo-mcp/tests/test_phlo_mcp.py -q
+```

--- a/docs/plans/2026-04-25-004-phlo-mcp-resources.md
+++ b/docs/plans/2026-04-25-004-phlo-mcp-resources.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Expose phlo-mcp resources"
 type: plan
-status: planned
+status: completed
 date: 2026-04-25
 origin: PR-468-follow-up
 ---
@@ -38,3 +38,9 @@ can be read as context without invoking parameterized tools.
 ```bash
 uv run pytest packages/phlo-mcp/tests/test_phlo_mcp.py -q
 ```
+
+## Outcome
+
+Implemented read-only MCP resources for runtime config, services, plugins,
+assets, schemas, contracts, dashboards, and package docs. Resource URIs are
+deterministic and backed by existing `phlo-api` endpoints or local package docs.

--- a/docs/plans/2026-04-25-004-phlo-mcp-resources.md
+++ b/docs/plans/2026-04-25-004-phlo-mcp-resources.md
@@ -1,0 +1,40 @@
+---
+title: "feat: Expose phlo-mcp resources"
+type: plan
+status: planned
+date: 2026-04-25
+origin: PR-468-follow-up
+---
+
+# phlo-mcp Resources
+
+## Overview
+
+Expose stable MCP resources for docs, package metadata, asset metadata, service status,
+and schema contracts.
+
+## Problem
+
+Tools are best for active queries. MCP clients also benefit from navigable resources that
+can be read as context without invoking parameterized tools.
+
+## Requirements
+
+- Add resources for package docs and runtime metadata.
+- Keep resources read-only.
+- Prefer existing `phlo-api` endpoints.
+- Use deterministic resource URIs.
+- Add tests for resource registration.
+
+## Implementation
+
+- Add resource registration in `server.py`.
+- Add API client helpers where needed.
+- Document resource URI conventions.
+- Add focused MCP server tests.
+
+## Verification
+
+```bash
+uv run pytest packages/phlo-mcp/tests/test_phlo_mcp.py -q
+```

--- a/docs/plans/2026-04-25-005-phlo-mcp-e2e-smoke.md
+++ b/docs/plans/2026-04-25-005-phlo-mcp-e2e-smoke.md
@@ -1,0 +1,39 @@
+---
+title: "test: Add phlo-mcp end-to-end smoke coverage"
+type: plan
+status: planned
+date: 2026-04-25
+origin: PR-468-follow-up
+---
+
+# phlo-mcp End-to-End Smoke Coverage
+
+## Overview
+
+Add an integration smoke test that starts `phlo-api` and exercises the MCP server against
+real HTTP routes.
+
+## Problem
+
+Unit tests verify tool registration and client wrapping, but not the full `phlo-mcp` to
+`phlo-api` path.
+
+## Requirements
+
+- Keep the test optional or integration-marked.
+- Avoid requiring ClickStack/Dagster for the minimal smoke.
+- Verify at least health, dashboard links, and error propagation.
+- Run in CI only when dependencies are available.
+
+## Implementation
+
+- Add `@pytest.mark.integration` smoke tests under `packages/phlo-mcp/tests`.
+- Start `phlo-api` via ASGI test client or subprocess.
+- Use mocked backend providers for deterministic responses.
+- Document how to run locally.
+
+## Verification
+
+```bash
+uv run pytest packages/phlo-mcp/tests -m integration -q
+```

--- a/docs/plans/2026-04-25-005-phlo-mcp-e2e-smoke.md
+++ b/docs/plans/2026-04-25-005-phlo-mcp-e2e-smoke.md
@@ -1,7 +1,7 @@
 ---
 title: "test: Add phlo-mcp end-to-end smoke coverage"
 type: plan
-status: planned
+status: completed
 date: 2026-04-25
 origin: PR-468-follow-up
 ---
@@ -37,3 +37,11 @@ Unit tests verify tool registration and client wrapping, but not the full `phlo-
 ```bash
 uv run pytest packages/phlo-mcp/tests -m integration -q
 ```
+
+## Outcome
+
+Implemented as `packages/phlo-mcp/tests/smoke_stack.py` with a pytest integration
+wrapper at `packages/phlo-mcp/tests/test_stack_smoke.py`. The smoke validates live
+`phlo-api`, Dagster connectivity, ClickStack trace-table queries, MCP stdio tool
+registration, and representative MCP tool calls. Strict run-span and materialization
+assertions can be enabled with `--require-run-spans` and `--require-materialization`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
           - phlo-alerting: packages/phlo-alerting.md
       - API Layer:
           - phlo-api: packages/phlo-api.md
+          - phlo-mcp: packages/phlo-mcp.md
           - phlo-postgrest: packages/phlo-postgrest.md
           - phlo-hasura: packages/phlo-hasura.md
       - Data Catalog:

--- a/packages/phlo-api/docs/api-reference.md
+++ b/packages/phlo-api/docs/api-reference.md
@@ -633,6 +633,87 @@ Get materialization history for an asset.
 ]
 ```
 
+### Asset Materialization Dry Run
+
+#### `POST /api/dagster/assets/{asset_key_path}/materialize`
+
+Validate an asset materialization request. Live launch is not implemented yet;
+send `dry_run: true` to validate the request shape and Dagster materialization
+permission.
+
+**Path Parameters:**
+- `asset_key_path`: Asset key path
+
+**Request:**
+```json
+{
+  "dry_run": true,
+  "partition_key": "2026-04-26"
+}
+```
+
+**Response:**
+```json
+{
+  "operation": "materialize_asset",
+  "dry_run": true,
+  "accepted": true,
+  "run_id": null,
+  "asset_key_path": "silver/orders",
+  "partition_key": "2026-04-26",
+  "status": "DRY_RUN",
+  "message": "Materialization request is valid.",
+  "details": {"op_names": ["orders_op"]}
+}
+```
+
+### Run Status
+
+#### `GET /api/dagster/runs/{run_id}/status`
+
+Get the current Dagster status for a run.
+
+**Response:**
+```json
+{
+  "run_id": "abc-123",
+  "status": "FAILURE",
+  "pipeline_name": "daily_orders",
+  "start_time": 1760000000.0,
+  "end_time": 1760000100.0,
+  "tags": {"asset": "silver/orders"}
+}
+```
+
+### Run Retry Dry Run
+
+#### `POST /api/dagster/runs/{run_id}/retry`
+
+Validate a Dagster run retry request. Live retry launch is not implemented yet;
+send `dry_run: true` to validate whether the run is a retry candidate.
+
+**Request:**
+```json
+{
+  "dry_run": true
+}
+```
+
+**Response:**
+```json
+{
+  "operation": "retry_failed_run",
+  "dry_run": true,
+  "accepted": true,
+  "run_id": "abc-123",
+  "asset_key_path": null,
+  "partition_key": null,
+  "status": "DRY_RUN",
+  "message": "Run retry request is valid.",
+  "details": {"run_status": "FAILURE"}
+}
+```
+
 ## Nessie Catalog
 
 Base path: `/api/nessie`

--- a/packages/phlo-api/src/phlo_api/api/observability.py
+++ b/packages/phlo-api/src/phlo_api/api/observability.py
@@ -46,7 +46,7 @@ import os
 from typing import Any
 
 from fastapi import APIRouter, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from phlo.capabilities import list_capabilities, resolve_capability
 from phlo.capabilities.discovery import discover_capabilities
@@ -128,6 +128,22 @@ class DashboardLinkResponse(BaseModel):
     title: str
     url: str
     category: str | None = None
+
+
+class TraceSpanResponse(BaseModel):
+    """Serialized OTEL trace span row."""
+
+    timestamp: str
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None = None
+    span_name: str
+    service_name: str | None = None
+    span_kind: str | None = None
+    duration_ms: float | None = None
+    status_code: str | None = None
+    span_attributes: dict[str, Any] = Field(default_factory=dict)
+    resource_attributes: dict[str, Any] = Field(default_factory=dict)
 
 
 @router.get("/health", response_model=HealthSummaryResponse | dict)
@@ -340,4 +356,20 @@ def get_metrics_query_link(
         return {"url": link}
     except Exception as exc:
         logger.exception("metrics_query_link_failed")
+        return {"error": str(exc)}
+
+
+@router.get("/traces/runs/{run_id}", response_model=list[TraceSpanResponse] | dict)
+async def get_run_trace_spans(
+    run_id: str,
+    limit: int = Query(default=500, le=5000),
+    backend: str | None = Query(default=None, description="Observability backend name"),
+) -> list[TraceSpanResponse] | dict[str, str]:
+    """Get OTEL spans correlated to a run id from the observability backend."""
+    try:
+        provider = _resolve_observability_backend(backend)
+        spans = provider.run_trace_spans(run_id, limit=limit)
+        return [TraceSpanResponse(**span.__dict__) for span in spans]
+    except Exception as exc:
+        logger.exception("run_trace_spans_load_failed", run_id=run_id)
         return {"error": str(exc)}

--- a/packages/phlo-api/src/phlo_api/api/observability.py
+++ b/packages/phlo-api/src/phlo_api/api/observability.py
@@ -48,7 +48,7 @@ from typing import Any
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
-from phlo.capabilities import list_capabilities, resolve_capability
+from phlo.capabilities import TraceSpanFilter, list_capabilities, resolve_capability
 from phlo.capabilities.discovery import discover_capabilities
 from phlo.logging import get_logger
 
@@ -368,8 +368,50 @@ def get_run_trace_spans(
     """Get OTEL spans correlated to a run id from the observability backend."""
     try:
         provider = _resolve_observability_backend(backend)
-        spans = provider.run_trace_spans(run_id, limit=limit)
+        if hasattr(provider, "trace_spans"):
+            spans = provider.trace_spans(TraceSpanFilter(run_id=run_id, limit=limit))
+        else:
+            spans = provider.run_trace_spans(run_id, limit=limit)
         return [TraceSpanResponse(**span.__dict__) for span in spans]
     except Exception as exc:
         logger.exception("run_trace_spans_load_failed", run_id=run_id)
+        return {"error": str(exc)}
+
+
+@router.get("/traces", response_model=list[TraceSpanResponse] | dict)
+def get_trace_spans(
+    run_id: str | None = Query(default=None),
+    asset_key: str | None = Query(default=None),
+    job_name: str | None = Query(default=None),
+    service_name: str | None = Query(default=None),
+    span_name: str | None = Query(default=None),
+    status_code: str | None = Query(default=None),
+    start_time: str | None = Query(default=None),
+    end_time: str | None = Query(default=None),
+    limit: int = Query(default=500, le=5000),
+    backend: str | None = Query(default=None, description="Observability backend name"),
+) -> list[TraceSpanResponse] | dict[str, str]:
+    """Get OTEL spans matching bounded observability filters."""
+    try:
+        provider = _resolve_observability_backend(backend)
+        filters = TraceSpanFilter(
+            run_id=run_id,
+            asset_key=asset_key,
+            job_name=job_name,
+            service_name=service_name,
+            span_name=span_name,
+            status_code=status_code,
+            start_time=start_time,
+            end_time=end_time,
+            limit=limit,
+        )
+        if hasattr(provider, "trace_spans"):
+            spans = provider.trace_spans(filters)
+        elif run_id:
+            spans = provider.run_trace_spans(run_id, limit=limit)
+        else:
+            spans = []
+        return [TraceSpanResponse(**span.__dict__) for span in spans]
+    except Exception as exc:
+        logger.exception("trace_spans_load_failed")
         return {"error": str(exc)}

--- a/packages/phlo-api/src/phlo_api/api/observability.py
+++ b/packages/phlo-api/src/phlo_api/api/observability.py
@@ -360,7 +360,7 @@ def get_metrics_query_link(
 
 
 @router.get("/traces/runs/{run_id}", response_model=list[TraceSpanResponse] | dict)
-async def get_run_trace_spans(
+def get_run_trace_spans(
     run_id: str,
     limit: int = Query(default=500, le=5000),
     backend: str | None = Query(default=None, description="Observability backend name"),

--- a/packages/phlo-api/src/phlo_api/observatory_api/dagster.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/dagster.py
@@ -240,6 +240,27 @@ query MaterializationHistory($assetKey: AssetKeyInput!, $limit: Int!) {
 }
 """
 
+RUN_STATUS_QUERY = """
+query RunStatus($runId: ID!) {
+    runOrError(runId: $runId) {
+        __typename
+        ... on Run {
+            runId
+            status
+            startTime
+            endTime
+            pipelineName
+            tags {
+                key
+                value
+            }
+        }
+        ... on RunNotFoundError { message }
+        ... on PythonError { message }
+    }
+}
+"""
+
 
 # --- Pydantic Models ---
 
@@ -318,6 +339,44 @@ class MaterializationEvent(BaseModel):
     step_key: str | None = None
     metadata: list[dict[str, str]] = []
     duration: int | None = None
+
+
+class MaterializeAssetRequest(BaseModel):
+    """Request to materialize one Dagster asset."""
+
+    dry_run: bool = True
+    partition_key: str | None = None
+
+
+class RetryRunRequest(BaseModel):
+    """Request to retry one Dagster run."""
+
+    dry_run: bool = True
+
+
+class DagsterOperationResponse(BaseModel):
+    """Structured response for Dagster operational API actions."""
+
+    operation: str
+    dry_run: bool
+    accepted: bool
+    run_id: str | None = None
+    asset_key_path: str | None = None
+    partition_key: str | None = None
+    status: str
+    message: str
+    details: dict[str, Any] = {}
+
+
+class DagsterRunStatus(BaseModel):
+    """Current Dagster run status."""
+
+    run_id: str
+    status: str | None = None
+    pipeline_name: str | None = None
+    start_time: float | None = None
+    end_time: float | None = None
+    tags: dict[str, str] = {}
 
 
 class GraphNode(BaseModel):
@@ -781,6 +840,120 @@ async def get_assets(dagster_url: str | None = None) -> list[Asset] | dict[str, 
         return {"error": str(e)}
 
 
+@router.get(
+    "/assets/{asset_key_path:path}/history", response_model=list[MaterializationEvent] | dict
+)
+async def get_materialization_history(
+    asset_key_path: str,
+    limit: int = Query(default=20, le=100),
+    dagster_url: str | None = None,
+) -> list[MaterializationEvent] | dict[str, str]:
+    """Get materialization history for an asset.
+
+    Args:
+        asset_key_path: Slash-delimited asset key path.
+        limit: Maximum number of materialization events to return.
+        dagster_url: Optional Dagster GraphQL URL override.
+
+    Returns:
+        List of MaterializationEvent objects or error dictionary.
+
+    Raises:
+        None: Exceptions are caught and returned in the response.
+
+    """
+    url = resolve_dagster_url(dagster_url)
+    asset_key = asset_key_path.split("/")
+
+    try:
+        result = await graphql_request(
+            url,
+            MATERIALIZATION_HISTORY_QUERY,
+            {"assetKey": {"path": asset_key}, "limit": limit},
+        )
+
+        if result.get("errors"):
+            return {"error": result["errors"][0].get("message", "GraphQL error")}
+
+        asset_or_error = result.get("data", {}).get("assetOrError", {})
+
+        if asset_or_error.get("message"):
+            return {"error": asset_or_error["message"]}
+
+        events = []
+        for mat in asset_or_error.get("assetMaterializations", []):
+            events.append(
+                MaterializationEvent(
+                    timestamp=mat["timestamp"],
+                    run_id=mat["runId"],
+                    status="SUCCESS",
+                    step_key=mat.get("stepKey"),
+                    metadata=[
+                        {
+                            "key": e["label"],
+                            "value": e.get("text")
+                            or str(e.get("intValue", ""))
+                            or str(e.get("floatValue", ""))
+                            or "",
+                        }
+                        for e in mat.get("metadataEntries", [])
+                    ],
+                )
+            )
+
+        return events
+    except Exception as e:
+        logger.exception("Failed to get materialization history")
+        return {"error": str(e)}
+
+
+@router.post(
+    "/assets/{asset_key_path:path}/materialize",
+    response_model=DagsterOperationResponse | dict,
+)
+async def materialize_asset(
+    asset_key_path: str,
+    payload: MaterializeAssetRequest,
+    dagster_url: str | None = None,
+) -> DagsterOperationResponse | dict[str, str]:
+    """Validate or request materialization for a Dagster asset."""
+    if not asset_key_path:
+        return {"error": "Asset key is required"}
+
+    if not payload.dry_run:
+        return {
+            "error": (
+                "Live Dagster materialization launch is not implemented yet. "
+                "Use dry_run=true to validate the request."
+            )
+        }
+
+    details = await get_asset_details(asset_key_path, dagster_url=dagster_url)
+    if isinstance(details, dict) and details.get("error"):
+        return details
+    if isinstance(details, dict):
+        has_permission = bool(details.get("has_materialize_permission"))
+        op_names = details.get("op_names") or []
+    else:
+        has_permission = details.has_materialize_permission
+        op_names = details.op_names
+
+    return DagsterOperationResponse(
+        operation="materialize_asset",
+        dry_run=True,
+        accepted=has_permission,
+        asset_key_path=asset_key_path,
+        partition_key=payload.partition_key,
+        status="DRY_RUN",
+        message=(
+            "Materialization request is valid."
+            if has_permission
+            else "Dagster reports this asset is not materializable by the current principal."
+        ),
+        details={"op_names": op_names},
+    )
+
+
 @router.get("/assets/{asset_key_path:path}", response_model=AssetDetails | dict)
 async def get_asset_details(
     asset_key_path: str, dagster_url: str | None = None
@@ -879,71 +1052,74 @@ async def get_asset_details(
         return {"error": str(e)}
 
 
-@router.get(
-    "/assets/{asset_key_path:path}/history", response_model=list[MaterializationEvent] | dict
-)
-async def get_materialization_history(
-    asset_key_path: str,
-    limit: int = Query(default=20, le=100),
+@router.get("/runs/{run_id}/status", response_model=DagsterRunStatus | dict)
+async def get_run_status(
+    run_id: str,
     dagster_url: str | None = None,
-) -> list[MaterializationEvent] | dict[str, str]:
-    """Get materialization history for an asset.
-
-    Args:
-        asset_key_path: Slash-delimited asset key path.
-        limit: Maximum number of materialization events to return.
-        dagster_url: Optional Dagster GraphQL URL override.
-
-    Returns:
-        List of MaterializationEvent objects or error dictionary.
-
-    Raises:
-        None: Exceptions are caught and returned in the response.
-
-    """
+) -> DagsterRunStatus | dict[str, str]:
+    """Get current status for a Dagster run."""
     url = resolve_dagster_url(dagster_url)
-    asset_key = asset_key_path.split("/")
 
     try:
-        result = await graphql_request(
-            url,
-            MATERIALIZATION_HISTORY_QUERY,
-            {"assetKey": {"path": asset_key}, "limit": limit},
-        )
-
+        result = await graphql_request(url, RUN_STATUS_QUERY, {"runId": run_id})
         if result.get("errors"):
             return {"error": result["errors"][0].get("message", "GraphQL error")}
 
-        asset_or_error = result.get("data", {}).get("assetOrError", {})
+        run_or_error = result.get("data", {}).get("runOrError", {})
+        if run_or_error.get("message"):
+            return {"error": run_or_error["message"]}
 
-        if asset_or_error.get("message"):
-            return {"error": asset_or_error["message"]}
-
-        events = []
-        for mat in asset_or_error.get("assetMaterializations", []):
-            events.append(
-                MaterializationEvent(
-                    timestamp=mat["timestamp"],
-                    run_id=mat["runId"],
-                    status="SUCCESS",
-                    step_key=mat.get("stepKey"),
-                    metadata=[
-                        {
-                            "key": e["label"],
-                            "value": e.get("text")
-                            or str(e.get("intValue", ""))
-                            or str(e.get("floatValue", ""))
-                            or "",
-                        }
-                        for e in mat.get("metadataEntries", [])
-                    ],
-                )
-            )
-
-        return events
+        tags = {
+            str(tag.get("key")): str(tag.get("value"))
+            for tag in run_or_error.get("tags", [])
+            if tag.get("key") is not None
+        }
+        return DagsterRunStatus(
+            run_id=run_or_error.get("runId") or run_id,
+            status=run_or_error.get("status"),
+            pipeline_name=run_or_error.get("pipelineName"),
+            start_time=run_or_error.get("startTime"),
+            end_time=run_or_error.get("endTime"),
+            tags=tags,
+        )
     except Exception as e:
-        logger.exception("Failed to get materialization history")
+        logger.exception("Failed to get run status")
         return {"error": str(e)}
+
+
+@router.post("/runs/{run_id}/retry", response_model=DagsterOperationResponse | dict)
+async def retry_run(
+    run_id: str,
+    payload: RetryRunRequest,
+    dagster_url: str | None = None,
+) -> DagsterOperationResponse | dict[str, str]:
+    """Validate or request retry for a Dagster run."""
+    status = await get_run_status(run_id, dagster_url=dagster_url)
+    if isinstance(status, dict) and status.get("error"):
+        return status
+
+    if not payload.dry_run:
+        return {
+            "error": (
+                "Live Dagster run retry launch is not implemented yet. "
+                "Use dry_run=true to validate the request."
+            )
+        }
+
+    run_status = status.get("status") if isinstance(status, dict) else status.status
+    return DagsterOperationResponse(
+        operation="retry_failed_run",
+        dry_run=True,
+        accepted=run_status == "FAILURE",
+        run_id=run_id,
+        status="DRY_RUN",
+        message=(
+            "Run retry request is valid."
+            if run_status == "FAILURE"
+            else f"Run status is {run_status}; only FAILURE runs are retry candidates."
+        ),
+        details={"run_status": run_status},
+    )
 
 
 @router.get("/graph", response_model=AssetGraphPayload | dict)

--- a/packages/phlo-api/src/phlo_api/observatory_api/loki.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/loki.py
@@ -198,7 +198,19 @@ def parse_loki_response(response: dict[str, Any]) -> list[LogEntry]:
                                 "asset_key": parsed.get("asset_key"),
                                 "job_name": parsed.get("job_name"),
                                 "partition_key": parsed.get("partition_key"),
-                                "fn": parsed.get("fn"),
+                                "check_name": parsed.get("check_name"),
+                                "service": parsed.get("service"),
+                                "module": parsed.get("module"),
+                                "function": parsed.get("function") or parsed.get("fn"),
+                                "line": str(parsed.get("line")) if parsed.get("line") else None,
+                                "trace_id": parsed.get("trace_id")
+                                or parsed.get("phlo.metadata.trace_id")
+                                or parsed.get("phlo_trace_id"),
+                                "span_id": parsed.get("span_id")
+                                or parsed.get("phlo.metadata.span_id")
+                                or parsed.get("phlo_span_id"),
+                                "trace_flags": parsed.get("trace_flags")
+                                or parsed.get("phlo.metadata.trace_flags"),
                                 "durationMs": str(parsed.get("durationMs"))
                                 if parsed.get("durationMs")
                                 else None,

--- a/packages/phlo-api/src/phlo_api/observatory_api/loki.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/loki.py
@@ -184,6 +184,7 @@ def parse_loki_response(response: dict[str, Any]) -> list[LogEntry]:
         for timestamp_ns, line in stream.get("values", []):
             try:
                 parsed = json.loads(line)
+                function_name = parsed.get("function") or parsed.get("fn")
                 entries.append(
                     LogEntry(
                         timestamp=datetime.fromtimestamp(
@@ -201,7 +202,8 @@ def parse_loki_response(response: dict[str, Any]) -> list[LogEntry]:
                                 "check_name": parsed.get("check_name"),
                                 "service": parsed.get("service"),
                                 "module": parsed.get("module"),
-                                "function": parsed.get("function") or parsed.get("fn"),
+                                "function": function_name,
+                                "fn": function_name,
                                 "line": str(parsed.get("line")) if parsed.get("line") else None,
                                 "trace_id": parsed.get("trace_id")
                                 or parsed.get("phlo.metadata.trace_id")

--- a/packages/phlo-api/src/phlo_api/service.yaml
+++ b/packages/phlo-api/src/phlo_api/service.yaml
@@ -22,6 +22,9 @@ compose:
         HOST: 0.0.0.0
         PORT: 4000
         PYTHONUNBUFFERED: "1"
+        CLICKSTACK_QUERY_URL: ${CLICKSTACK_QUERY_URL:-}
+        CLICKSTACK_QUERY_USER: ${CLICKSTACK_QUERY_USER:-}
+        CLICKSTACK_QUERY_PASSWORD: ${CLICKSTACK_QUERY_PASSWORD:-}
     ports:
         - "${PHLO_API_PORT:-4000}:4000"
     healthcheck:
@@ -63,5 +66,8 @@ dev:
         TRINO_URL: "http://127.0.0.1:${TRINO_PORT:-8080}"
         TRINO_USER: ${PHLO_API_TRINO_USER:-phlo-api}
         TRINO_ROLE: ${PHLO_API_TRINO_ROLE:-}
+        CLICKSTACK_QUERY_URL: ${CLICKSTACK_QUERY_URL:-}
+        CLICKSTACK_QUERY_USER: ${CLICKSTACK_QUERY_USER:-}
+        CLICKSTACK_QUERY_PASSWORD: ${CLICKSTACK_QUERY_PASSWORD:-}
     health_check: "http://127.0.0.1:4000/health"
     cwd: "{project_root}"

--- a/packages/phlo-api/tests/test_authentication_api.py
+++ b/packages/phlo-api/tests/test_authentication_api.py
@@ -131,3 +131,21 @@ def test_phlo_api_has_forward_auth_middleware() -> None:
         "X-Forwarded-Groups"
         in auth_labels["traefik.http.middlewares.phlo-api-auth.forwardauth.authResponseHeaders"]
     )
+
+
+def test_phlo_api_service_passes_clickstack_query_env() -> None:
+    import yaml
+    from importlib.resources import files
+
+    service_defn_path = files("phlo_api") / "service.yaml"
+
+    with open(service_defn_path) as f:
+        service_defn = yaml.safe_load(f)
+
+    compose_env = service_defn["compose"]["environment"]
+    dev_env = service_defn["dev"]["environment"]
+
+    for env in (compose_env, dev_env):
+        assert env["CLICKSTACK_QUERY_URL"] == "${CLICKSTACK_QUERY_URL:-}"
+        assert env["CLICKSTACK_QUERY_USER"] == "${CLICKSTACK_QUERY_USER:-}"
+        assert env["CLICKSTACK_QUERY_PASSWORD"] == "${CLICKSTACK_QUERY_PASSWORD:-}"

--- a/packages/phlo-api/tests/test_integration_api.py
+++ b/packages/phlo-api/tests/test_integration_api.py
@@ -497,6 +497,96 @@ class TestDagsterGraphEndpoints:
             },
         ]
 
+    def test_dagster_materialize_dry_run_validates_asset(self, monkeypatch):
+        """Dry-run materialize endpoint validates the asset without launching a run."""
+        from fastapi.testclient import TestClient
+        from phlo_api.main import app
+
+        async def fake_asset_details(asset_key_path: str, dagster_url: str | None = None):
+            return {
+                "key_path": asset_key_path,
+                "has_materialize_permission": True,
+                "op_names": ["orders_op"],
+            }
+
+        monkeypatch.setattr(
+            "phlo_api.observatory_api.dagster.get_asset_details", fake_asset_details
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/dagster/assets/silver/orders/materialize",
+            json={"dry_run": True, "partition_key": "2026-04-26"},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["operation"] == "materialize_asset"
+        assert payload["dry_run"] is True
+        assert payload["accepted"] is True
+        assert payload["asset_key_path"] == "silver/orders"
+        assert payload["partition_key"] == "2026-04-26"
+        assert payload["details"]["op_names"] == ["orders_op"]
+
+    def test_dagster_run_status_endpoint_transforms_payload(self, monkeypatch):
+        """Run status endpoint normalizes Dagster GraphQL run payloads."""
+        from fastapi.testclient import TestClient
+        from phlo_api.main import app
+
+        async def fake_graphql_request(url, query, variables=None, timeout=10.0, initiator=None):
+            assert variables == {"runId": "run-123"}
+            return {
+                "data": {
+                    "runOrError": {
+                        "__typename": "Run",
+                        "runId": "run-123",
+                        "status": "FAILURE",
+                        "startTime": 1.0,
+                        "endTime": 2.0,
+                        "pipelineName": "daily_orders",
+                        "tags": [{"key": "asset", "value": "silver/orders"}],
+                    }
+                }
+            }
+
+        monkeypatch.setattr(
+            "phlo_api.observatory_api.dagster.graphql_request", fake_graphql_request
+        )
+
+        client = TestClient(app)
+        response = client.get("/api/dagster/runs/run-123/status")
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "run_id": "run-123",
+            "status": "FAILURE",
+            "pipeline_name": "daily_orders",
+            "start_time": 1.0,
+            "end_time": 2.0,
+            "tags": {"asset": "silver/orders"},
+        }
+
+    def test_dagster_retry_dry_run_validates_failed_run(self, monkeypatch):
+        """Dry-run retry endpoint validates a failed run without launching retry."""
+        from fastapi.testclient import TestClient
+        from phlo_api.main import app
+        from phlo_api.observatory_api.dagster import DagsterRunStatus
+
+        async def fake_run_status(run_id: str, dagster_url: str | None = None):
+            return DagsterRunStatus(run_id=run_id, status="FAILURE")
+
+        monkeypatch.setattr("phlo_api.observatory_api.dagster.get_run_status", fake_run_status)
+
+        client = TestClient(app)
+        response = client.post("/api/dagster/runs/run-123/retry", json={"dry_run": True})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["operation"] == "retry_failed_run"
+        assert payload["dry_run"] is True
+        assert payload["accepted"] is True
+        assert payload["run_id"] == "run-123"
+
 
 class TestContributingRowsEndpoints:
     """Test contributing rows endpoints."""

--- a/packages/phlo-api/tests/test_loki_api.py
+++ b/packages/phlo-api/tests/test_loki_api.py
@@ -1,0 +1,59 @@
+"""Tests for Loki response normalization."""
+
+from __future__ import annotations
+
+import json
+
+from phlo_api.observatory_api.loki import parse_loki_response
+
+
+def test_parse_loki_response_emits_function_and_legacy_fn_metadata() -> None:
+    response = {
+        "data": {
+            "result": [
+                {
+                    "stream": {},
+                    "values": [
+                        [
+                            "1700000000000000000",
+                            json.dumps(
+                                {
+                                    "level": "info",
+                                    "message": "hello",
+                                    "function": "run_step",
+                                }
+                            ),
+                        ]
+                    ],
+                }
+            ]
+        }
+    }
+
+    entries = parse_loki_response(response)
+
+    assert entries[0].metadata["function"] == "run_step"
+    assert entries[0].metadata["fn"] == "run_step"
+
+
+def test_parse_loki_response_reads_legacy_fn_metadata() -> None:
+    response = {
+        "data": {
+            "result": [
+                {
+                    "stream": {},
+                    "values": [
+                        [
+                            "1700000000000000000",
+                            json.dumps({"level": "info", "message": "hello", "fn": "run_step"}),
+                        ]
+                    ],
+                }
+            ]
+        }
+    }
+
+    entries = parse_loki_response(response)
+
+    assert entries[0].metadata["function"] == "run_step"
+    assert entries[0].metadata["fn"] == "run_step"

--- a/packages/phlo-api/tests/test_observability_api.py
+++ b/packages/phlo-api/tests/test_observability_api.py
@@ -257,3 +257,51 @@ def test_get_run_trace_spans_uses_observability_backend(monkeypatch) -> None:
 
     assert isinstance(payload, list)
     assert payload[0].trace_id == "abc123"
+
+
+def test_get_trace_spans_passes_filters_to_observability_backend(monkeypatch) -> None:
+    """Filtered trace endpoint should pass all supported filters to the backend."""
+
+    class _TraceBackend(_MockObservabilityBackend):
+        def trace_spans(self, filters):
+            assert filters.run_id == "run-123"
+            assert filters.asset_key == "silver/orders"
+            assert filters.job_name == "daily_orders"
+            assert filters.service_name == "dagster"
+            assert filters.span_name == "materialize_orders"
+            assert filters.status_code == "STATUS_CODE_ERROR"
+            assert filters.start_time == "2026-04-26T00:00:00Z"
+            assert filters.end_time == "2026-04-26T01:00:00Z"
+            assert filters.limit == 25
+            return [
+                TraceSpan(
+                    timestamp="2026-04-26 00:30:00",
+                    trace_id="abc123",
+                    span_id="span-1",
+                    span_name="materialize_orders",
+                    service_name="dagster",
+                    status_code="STATUS_CODE_ERROR",
+                    span_attributes={"phlo.asset_key": "silver/orders"},
+                )
+            ]
+
+    monkeypatch.setattr(
+        observability,
+        "_resolve_observability_backend",
+        lambda backend=None: _TraceBackend(),
+    )
+
+    payload = observability.get_trace_spans(
+        run_id="run-123",
+        asset_key="silver/orders",
+        job_name="daily_orders",
+        service_name="dagster",
+        span_name="materialize_orders",
+        status_code="STATUS_CODE_ERROR",
+        start_time="2026-04-26T00:00:00Z",
+        end_time="2026-04-26T01:00:00Z",
+        limit=25,
+    )
+
+    assert isinstance(payload, list)
+    assert payload[0].status_code == "STATUS_CODE_ERROR"

--- a/packages/phlo-api/tests/test_observability_api.py
+++ b/packages/phlo-api/tests/test_observability_api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timezone
 
 import pytest
@@ -254,7 +253,7 @@ def test_get_run_trace_spans_uses_observability_backend(monkeypatch) -> None:
         lambda backend=None: _TraceBackend(),
     )
 
-    payload = asyncio.run(observability.get_run_trace_spans("run-123", limit=500))
+    payload = observability.get_run_trace_spans("run-123", limit=500)
 
     assert isinstance(payload, list)
     assert payload[0].trace_id == "abc123"

--- a/packages/phlo-api/tests/test_observability_api.py
+++ b/packages/phlo-api/tests/test_observability_api.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 
 import pytest
 
 from phlo.capabilities import (
     ObservabilityBackendSpec,
+    TraceSpan,
     clear_capabilities,
     register_observability_backend,
 )
@@ -222,3 +224,37 @@ def test_resolve_observability_backend_requires_selection_when_ambiguous(monkeyp
 
     with pytest.raises(RuntimeError, match="Multiple observability backends are installed"):
         observability._resolve_observability_backend()
+
+
+def test_get_run_trace_spans_uses_observability_backend(monkeypatch) -> None:
+    """Run trace endpoint should come from the resolved observability backend."""
+
+    class _TraceBackend(_MockObservabilityBackend):
+        def run_trace_spans(self, run_id: str, limit: int = 500):
+            assert run_id == "run-123"
+            assert limit == 500
+            return [
+                TraceSpan(
+                    timestamp="2026-01-01 00:00:00",
+                    trace_id="abc123",
+                    span_id="span-1",
+                    span_name="materialize_orders",
+                    service_name="dagster",
+                    span_kind="INTERNAL",
+                    duration_ms=12.5,
+                    status_code="STATUS_CODE_OK",
+                    span_attributes={"phlo.run_id": "run-123"},
+                    resource_attributes={"service.name": "dagster"},
+                )
+            ]
+
+    monkeypatch.setattr(
+        observability,
+        "_resolve_observability_backend",
+        lambda backend=None: _TraceBackend(),
+    )
+
+    payload = asyncio.run(observability.get_run_trace_spans("run-123", limit=500))
+
+    assert isinstance(payload, list)
+    assert payload[0].trace_id == "abc123"

--- a/packages/phlo-clickstack/pyproject.toml
+++ b/packages/phlo-clickstack/pyproject.toml
@@ -25,6 +25,9 @@ clickstack = "phlo_clickstack.cli_plugin:ClickStackCliPlugin"
 [project.entry-points."phlo.plugins.services"]
 clickstack = "phlo_clickstack.plugin:ClickStackServicePlugin"
 
+[project.entry-points."phlo.plugins.resources"]
+clickstack = "phlo_clickstack.resource_provider:ClickStackResourceProvider"
+
 [project.license]
 text = "MIT"
 

--- a/packages/phlo-clickstack/src/phlo_clickstack/observability_backend.py
+++ b/packages/phlo-clickstack/src/phlo_clickstack/observability_backend.py
@@ -1,0 +1,79 @@
+"""ClickStack-backed observability capability provider."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import requests
+
+from phlo.capabilities import (
+    CapabilitySupport,
+    DefaultObservabilityBackend,
+    ObservabilityBackendSpec,
+    TraceSpan,
+)
+
+_CLICKSTACK_QUERY_URL_ENV = "CLICKSTACK_QUERY_URL"
+_DEFAULT_CLICKSTACK_QUERY_URL = "http://clickstack:8123"
+
+
+class ClickStackObservabilityBackend(DefaultObservabilityBackend):
+    """Observability backend with OTEL span queries backed by ClickStack."""
+
+    def run_trace_spans(self, run_id: str, limit: int = 500) -> list[TraceSpan]:
+        query_url = self._resolve_clickstack_query_url()
+        escaped_run_id = _escape_clickhouse_string(run_id)
+        query = f"""
+SELECT
+    toString(Timestamp) AS timestamp,
+    TraceId AS trace_id,
+    SpanId AS span_id,
+    nullIf(ParentSpanId, '') AS parent_span_id,
+    SpanName AS span_name,
+    ServiceName AS service_name,
+    SpanKind AS span_kind,
+    round(Duration / 1000000, 3) AS duration_ms,
+    StatusCode AS status_code,
+    SpanAttributes AS span_attributes,
+    ResourceAttributes AS resource_attributes
+FROM default.otel_traces
+WHERE SpanAttributes['phlo.run_id'] = '{escaped_run_id}'
+ORDER BY Timestamp ASC
+LIMIT {limit}
+FORMAT JSONEachRow
+""".strip()
+        response = requests.post(query_url, data=query.encode("utf-8"), timeout=10)
+        response.raise_for_status()
+        spans: list[TraceSpan] = []
+        for line in response.text.splitlines():
+            if not line.strip():
+                continue
+            spans.append(TraceSpan(**json.loads(line)))
+        return spans
+
+    def _resolve_clickstack_query_url(self) -> str:
+        return os.environ.get(_CLICKSTACK_QUERY_URL_ENV, _DEFAULT_CLICKSTACK_QUERY_URL).rstrip("/")
+
+
+def build_clickstack_observability_spec() -> ObservabilityBackendSpec:
+    """Build the ClickStack observability capability spec."""
+    return ObservabilityBackendSpec(
+        name="default",
+        provider=ClickStackObservabilityBackend(),
+        metadata={
+            "default_stack": ["phlo-otel", "phlo-clickstack"],
+            "service_dependencies": ["clickstack"],
+            "backend": "clickstack",
+        },
+        support=CapabilitySupport(
+            supports_metrics=True,
+            supports_logs=True,
+            supports_dashboards=True,
+            supports_alerts=True,
+        ),
+    )
+
+
+def _escape_clickhouse_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")

--- a/packages/phlo-clickstack/src/phlo_clickstack/observability_backend.py
+++ b/packages/phlo-clickstack/src/phlo_clickstack/observability_backend.py
@@ -15,6 +15,8 @@ from phlo.capabilities import (
 )
 
 _CLICKSTACK_QUERY_URL_ENV = "CLICKSTACK_QUERY_URL"
+_CLICKSTACK_QUERY_USER_ENV = "CLICKSTACK_QUERY_USER"
+_CLICKSTACK_QUERY_PASSWORD_ENV = "CLICKSTACK_QUERY_PASSWORD"
 _CLICKSTACK_HTTP_PORT_ENV = "CLICKSTACK_HTTP_PORT"
 _DEFAULT_CLICKSTACK_HTTP_PORT = "8123"
 _CONTAINER_CLICKSTACK_QUERY_URL = f"http://clickstack:{_DEFAULT_CLICKSTACK_HTTP_PORT}"
@@ -45,7 +47,12 @@ ORDER BY Timestamp ASC
 LIMIT {limit}
 FORMAT JSONEachRow
 """.strip()
-        response = requests.post(query_url, data=query.encode("utf-8"), timeout=10)
+        response = requests.post(
+            query_url,
+            data=query.encode("utf-8"),
+            auth=self._resolve_clickstack_query_auth(),
+            timeout=10,
+        )
         response.raise_for_status()
         spans: list[TraceSpan] = []
         for line in response.text.splitlines():
@@ -62,6 +69,13 @@ FORMAT JSONEachRow
             return _CONTAINER_CLICKSTACK_QUERY_URL
         port = os.environ.get(_CLICKSTACK_HTTP_PORT_ENV, _DEFAULT_CLICKSTACK_HTTP_PORT)
         return f"http://127.0.0.1:{port}"
+
+    def _resolve_clickstack_query_auth(self) -> tuple[str, str] | None:
+        user = os.environ.get(_CLICKSTACK_QUERY_USER_ENV)
+        password = os.environ.get(_CLICKSTACK_QUERY_PASSWORD_ENV)
+        if user is None:
+            return None
+        return (user, password or "")
 
 
 def build_clickstack_observability_spec() -> ObservabilityBackendSpec:

--- a/packages/phlo-clickstack/src/phlo_clickstack/observability_backend.py
+++ b/packages/phlo-clickstack/src/phlo_clickstack/observability_backend.py
@@ -15,7 +15,9 @@ from phlo.capabilities import (
 )
 
 _CLICKSTACK_QUERY_URL_ENV = "CLICKSTACK_QUERY_URL"
-_DEFAULT_CLICKSTACK_QUERY_URL = "http://clickstack:8123"
+_CLICKSTACK_HTTP_PORT_ENV = "CLICKSTACK_HTTP_PORT"
+_DEFAULT_CLICKSTACK_HTTP_PORT = "8123"
+_CONTAINER_CLICKSTACK_QUERY_URL = f"http://clickstack:{_DEFAULT_CLICKSTACK_HTTP_PORT}"
 
 
 class ClickStackObservabilityBackend(DefaultObservabilityBackend):
@@ -53,7 +55,13 @@ FORMAT JSONEachRow
         return spans
 
     def _resolve_clickstack_query_url(self) -> str:
-        return os.environ.get(_CLICKSTACK_QUERY_URL_ENV, _DEFAULT_CLICKSTACK_QUERY_URL).rstrip("/")
+        query_url = os.environ.get(_CLICKSTACK_QUERY_URL_ENV)
+        if query_url:
+            return query_url.rstrip("/")
+        if _running_in_container():
+            return _CONTAINER_CLICKSTACK_QUERY_URL
+        port = os.environ.get(_CLICKSTACK_HTTP_PORT_ENV, _DEFAULT_CLICKSTACK_HTTP_PORT)
+        return f"http://127.0.0.1:{port}"
 
 
 def build_clickstack_observability_spec() -> ObservabilityBackendSpec:
@@ -77,3 +85,7 @@ def build_clickstack_observability_spec() -> ObservabilityBackendSpec:
 
 def _escape_clickhouse_string(value: str) -> str:
     return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _running_in_container() -> bool:
+    return os.path.exists("/.dockerenv")

--- a/packages/phlo-clickstack/src/phlo_clickstack/observability_backend.py
+++ b/packages/phlo-clickstack/src/phlo_clickstack/observability_backend.py
@@ -12,6 +12,7 @@ from phlo.capabilities import (
     DefaultObservabilityBackend,
     ObservabilityBackendSpec,
     TraceSpan,
+    TraceSpanFilter,
 )
 
 _CLICKSTACK_QUERY_URL_ENV = "CLICKSTACK_QUERY_URL"
@@ -26,27 +27,11 @@ class ClickStackObservabilityBackend(DefaultObservabilityBackend):
     """Observability backend with OTEL span queries backed by ClickStack."""
 
     def run_trace_spans(self, run_id: str, limit: int = 500) -> list[TraceSpan]:
+        return self.trace_spans(TraceSpanFilter(run_id=run_id, limit=limit))
+
+    def trace_spans(self, filters: TraceSpanFilter) -> list[TraceSpan]:
         query_url = self._resolve_clickstack_query_url()
-        escaped_run_id = _escape_clickhouse_string(run_id)
-        query = f"""
-SELECT
-    toString(Timestamp) AS timestamp,
-    TraceId AS trace_id,
-    SpanId AS span_id,
-    nullIf(ParentSpanId, '') AS parent_span_id,
-    SpanName AS span_name,
-    ServiceName AS service_name,
-    SpanKind AS span_kind,
-    round(Duration / 1000000, 3) AS duration_ms,
-    StatusCode AS status_code,
-    SpanAttributes AS span_attributes,
-    ResourceAttributes AS resource_attributes
-FROM default.otel_traces
-WHERE SpanAttributes['phlo.run_id'] = '{escaped_run_id}'
-ORDER BY Timestamp ASC
-LIMIT {limit}
-FORMAT JSONEachRow
-""".strip()
+        query = _build_trace_spans_query(filters)
         response = requests.post(
             query_url,
             data=query.encode("utf-8"),
@@ -76,6 +61,64 @@ FORMAT JSONEachRow
         if user is None:
             return None
         return (user, password or "")
+
+
+def _build_trace_spans_query(filters: TraceSpanFilter) -> str:
+    where_clauses = _trace_where_clauses(filters)
+    where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+    limit = _bounded_limit(filters.limit)
+    return f"""
+SELECT
+    toString(Timestamp) AS timestamp,
+    TraceId AS trace_id,
+    SpanId AS span_id,
+    nullIf(ParentSpanId, '') AS parent_span_id,
+    SpanName AS span_name,
+    ServiceName AS service_name,
+    SpanKind AS span_kind,
+    round(Duration / 1000000, 3) AS duration_ms,
+    StatusCode AS status_code,
+    SpanAttributes AS span_attributes,
+    ResourceAttributes AS resource_attributes
+FROM default.otel_traces
+{where_sql}
+ORDER BY Timestamp ASC
+LIMIT {limit}
+FORMAT JSONEachRow
+""".strip()
+
+
+def _trace_where_clauses(filters: TraceSpanFilter) -> list[str]:
+    clauses: list[str] = []
+    _append_span_attribute_clause(clauses, "phlo.run_id", filters.run_id)
+    _append_span_attribute_clause(clauses, "phlo.asset_key", filters.asset_key)
+    _append_span_attribute_clause(clauses, "phlo.job_name", filters.job_name)
+    _append_exact_clause(clauses, "ServiceName", filters.service_name)
+    _append_exact_clause(clauses, "SpanName", filters.span_name)
+    _append_exact_clause(clauses, "StatusCode", filters.status_code)
+    if filters.start_time:
+        clauses.append(
+            f"Timestamp >= parseDateTimeBestEffort('{_escape_clickhouse_string(filters.start_time)}')"
+        )
+    if filters.end_time:
+        clauses.append(
+            f"Timestamp <= parseDateTimeBestEffort('{_escape_clickhouse_string(filters.end_time)}')"
+        )
+    return clauses
+
+
+def _append_span_attribute_clause(clauses: list[str], key: str, value: str | None) -> None:
+    if value:
+        clauses.append(f"SpanAttributes['{key}'] = '{_escape_clickhouse_string(value)}'")
+
+
+def _append_exact_clause(clauses: list[str], column: str, value: str | None) -> None:
+    if value:
+        clauses.append(f"{column} = '{_escape_clickhouse_string(value)}'")
+
+
+def _bounded_limit(limit: int) -> int:
+    return min(max(limit, 1), 5000)
 
 
 def build_clickstack_observability_spec() -> ObservabilityBackendSpec:

--- a/packages/phlo-clickstack/src/phlo_clickstack/resource_provider.py
+++ b/packages/phlo-clickstack/src/phlo_clickstack/resource_provider.py
@@ -1,0 +1,26 @@
+"""Resource provider for ClickStack observability capabilities."""
+
+from __future__ import annotations
+
+from phlo.plugins import PluginMetadata, ResourceProviderPlugin
+
+from phlo_clickstack.observability_backend import build_clickstack_observability_spec
+
+
+class ClickStackResourceProvider(ResourceProviderPlugin):
+    """Expose ClickStack as the default observability backend capability."""
+
+    @property
+    def metadata(self) -> PluginMetadata:
+        return PluginMetadata(
+            name="clickstack",
+            version="0.1.0",
+            description="ClickStack observability capability provider",
+            tags=["observability", "logs", "metrics", "traces"],
+        )
+
+    def get_resources(self) -> list:
+        return []
+
+    def get_observability_backends(self):
+        return [build_clickstack_observability_spec()]

--- a/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
+++ b/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
@@ -11,6 +11,7 @@ compose:
   user: "0"
   ports:
     - "${CLICKSTACK_PORT:-8080}:8080"
+    - "${CLICKSTACK_HTTP_PORT:-8123}:8123"
     - "${CLICKSTACK_OTLP_GRPC_PORT:-4317}:4317"
     - "${CLICKSTACK_OTLP_HTTP_PORT:-4318}:4318"
     - "${CLICKSTACK_NATIVE_PORT:-9000}:9000"
@@ -37,6 +38,9 @@ env_vars:
   CLICKSTACK_PORT:
     default: 8080
     description: ClickStack UI port
+  CLICKSTACK_HTTP_PORT:
+    default: 8123
+    description: ClickHouse HTTP query port used by phlo-api trace endpoints
   CLICKSTACK_OTLP_GRPC_PORT:
     default: 4317
     description: ClickStack OTLP gRPC ingest port

--- a/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
+++ b/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
@@ -9,6 +9,8 @@ image: ${CLICKSTACK_IMAGE:-docker.hyperdx.io/hyperdx/hyperdx-all-in-one}
 compose:
   restart: unless-stopped
   user: "0"
+  environment:
+    FRONTEND_URL: ${CLICKSTACK_PUBLIC_URL:-}
   ports:
     - "${CLICKSTACK_PORT:-8080}:8080"
     - "${CLICKSTACK_HTTP_PORT:-8123}:8123"

--- a/packages/phlo-clickstack/tests/test_observability_backend.py
+++ b/packages/phlo-clickstack/tests/test_observability_backend.py
@@ -24,6 +24,27 @@ def test_build_clickstack_observability_spec_uses_default_name() -> None:
     assert spec.support.supports_logs is True
 
 
+def test_clickstack_backend_defaults_to_host_http_port(monkeypatch) -> None:
+    monkeypatch.delenv("CLICKSTACK_QUERY_URL", raising=False)
+    monkeypatch.delenv("CLICKSTACK_HTTP_PORT", raising=False)
+    monkeypatch.setattr(
+        "phlo_clickstack.observability_backend._running_in_container", lambda: False
+    )
+
+    backend = ClickStackObservabilityBackend()
+
+    assert backend._resolve_clickstack_query_url() == "http://127.0.0.1:8123"
+
+
+def test_clickstack_backend_uses_container_url_in_container(monkeypatch) -> None:
+    monkeypatch.delenv("CLICKSTACK_QUERY_URL", raising=False)
+    monkeypatch.setattr("phlo_clickstack.observability_backend._running_in_container", lambda: True)
+
+    backend = ClickStackObservabilityBackend()
+
+    assert backend._resolve_clickstack_query_url() == "http://clickstack:8123"
+
+
 def test_clickstack_backend_queries_trace_spans(monkeypatch) -> None:
     captured: dict[str, str] = {}
 

--- a/packages/phlo-clickstack/tests/test_observability_backend.py
+++ b/packages/phlo-clickstack/tests/test_observability_backend.py
@@ -46,17 +46,20 @@ def test_clickstack_backend_uses_container_url_in_container(monkeypatch) -> None
 
 
 def test_clickstack_backend_queries_trace_spans(monkeypatch) -> None:
-    captured: dict[str, str] = {}
+    captured: dict[str, object] = {}
 
-    def fake_post(url: str, data: bytes, timeout: int):  # noqa: ANN001
+    def fake_post(url: str, data: bytes, auth: tuple[str, str] | None, timeout: int):  # noqa: ANN001
         captured["url"] = url
         captured["query"] = data.decode("utf-8")
+        captured["auth"] = auth
         return _FakeResponse(
             '{"timestamp":"2026-01-01T00:00:00Z","trace_id":"abc123","span_id":"span-1","parent_span_id":null,"span_name":"materialize_orders","service_name":"dagster","span_kind":"INTERNAL","duration_ms":12.5,"status_code":"STATUS_CODE_OK","span_attributes":{"phlo.run_id":"run-123"},"resource_attributes":{"service.name":"dagster"}}\n'
         )
 
     monkeypatch.setattr("phlo_clickstack.observability_backend.requests.post", fake_post)
     monkeypatch.setenv("CLICKSTACK_QUERY_URL", "http://clickstack.test:8123")
+    monkeypatch.setenv("CLICKSTACK_QUERY_USER", "api")
+    monkeypatch.setenv("CLICKSTACK_QUERY_PASSWORD", "api")
 
     backend = ClickStackObservabilityBackend()
     spans = backend.run_trace_spans("run-123", limit=25)
@@ -65,4 +68,5 @@ def test_clickstack_backend_queries_trace_spans(monkeypatch) -> None:
     assert "otel_traces" in captured["query"]
     assert "run-123" in captured["query"]
     assert "LIMIT 25" in captured["query"]
+    assert captured["auth"] == ("api", "api")
     assert spans[0].trace_id == "abc123"

--- a/packages/phlo-clickstack/tests/test_observability_backend.py
+++ b/packages/phlo-clickstack/tests/test_observability_backend.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from phlo_clickstack.observability_backend import (
     ClickStackObservabilityBackend,
+    _build_trace_spans_query,
     build_clickstack_observability_spec,
 )
+from phlo.capabilities import TraceSpanFilter
 
 
 class _FakeResponse:
@@ -70,3 +72,29 @@ def test_clickstack_backend_queries_trace_spans(monkeypatch) -> None:
     assert "LIMIT 25" in captured["query"]
     assert captured["auth"] == ("api", "api")
     assert spans[0].trace_id == "abc123"
+
+
+def test_build_trace_spans_query_includes_filters() -> None:
+    query = _build_trace_spans_query(
+        TraceSpanFilter(
+            run_id="run-123",
+            asset_key="silver/orders",
+            job_name="daily_orders",
+            service_name="dagster",
+            span_name="materialize_orders",
+            status_code="STATUS_CODE_ERROR",
+            start_time="2026-04-26T00:00:00Z",
+            end_time="2026-04-26T01:00:00Z",
+            limit=25,
+        )
+    )
+
+    assert "SpanAttributes['phlo.run_id'] = 'run-123'" in query
+    assert "SpanAttributes['phlo.asset_key'] = 'silver/orders'" in query
+    assert "SpanAttributes['phlo.job_name'] = 'daily_orders'" in query
+    assert "ServiceName = 'dagster'" in query
+    assert "SpanName = 'materialize_orders'" in query
+    assert "StatusCode = 'STATUS_CODE_ERROR'" in query
+    assert "Timestamp >= parseDateTimeBestEffort('2026-04-26T00:00:00Z')" in query
+    assert "Timestamp <= parseDateTimeBestEffort('2026-04-26T01:00:00Z')" in query
+    assert "LIMIT 25" in query

--- a/packages/phlo-clickstack/tests/test_observability_backend.py
+++ b/packages/phlo-clickstack/tests/test_observability_backend.py
@@ -1,0 +1,47 @@
+"""Tests for ClickStack observability backend capability."""
+
+from __future__ import annotations
+
+from phlo_clickstack.observability_backend import (
+    ClickStackObservabilityBackend,
+    build_clickstack_observability_spec,
+)
+
+
+class _FakeResponse:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+def test_build_clickstack_observability_spec_uses_default_name() -> None:
+    spec = build_clickstack_observability_spec()
+
+    assert spec.name == "default"
+    assert spec.metadata["backend"] == "clickstack"
+    assert spec.support.supports_logs is True
+
+
+def test_clickstack_backend_queries_trace_spans(monkeypatch) -> None:
+    captured: dict[str, str] = {}
+
+    def fake_post(url: str, data: bytes, timeout: int):  # noqa: ANN001
+        captured["url"] = url
+        captured["query"] = data.decode("utf-8")
+        return _FakeResponse(
+            '{"timestamp":"2026-01-01T00:00:00Z","trace_id":"abc123","span_id":"span-1","parent_span_id":null,"span_name":"materialize_orders","service_name":"dagster","span_kind":"INTERNAL","duration_ms":12.5,"status_code":"STATUS_CODE_OK","span_attributes":{"phlo.run_id":"run-123"},"resource_attributes":{"service.name":"dagster"}}\n'
+        )
+
+    monkeypatch.setattr("phlo_clickstack.observability_backend.requests.post", fake_post)
+    monkeypatch.setenv("CLICKSTACK_QUERY_URL", "http://clickstack.test:8123")
+
+    backend = ClickStackObservabilityBackend()
+    spans = backend.run_trace_spans("run-123", limit=25)
+
+    assert captured["url"] == "http://clickstack.test:8123"
+    assert "otel_traces" in captured["query"]
+    assert "run-123" in captured["query"]
+    assert "LIMIT 25" in captured["query"]
+    assert spans[0].trace_id == "abc123"

--- a/packages/phlo-dagster/src/phlo_dagster/service.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/service.yaml
@@ -2,6 +2,7 @@ name: dagster
 description: Data orchestration platform for workflows and pipelines
 category: orchestration
 default: true
+profile: orchestration
 phlo_dev: true
 gitignore:
   - dagster/storage/

--- a/packages/phlo-dagster/tests/test_dagster_plugin.py
+++ b/packages/phlo-dagster/tests/test_dagster_plugin.py
@@ -10,3 +10,4 @@ def test_dagster_service_definition():
 
     assert service_definition["name"] == "dagster"
     assert service_definition["category"] == "orchestration"
+    assert service_definition["profile"] == "orchestration"

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -1,0 +1,68 @@
+# phlo-mcp
+
+MCP server for Phlo observability and lakehouse operations.
+
+## Overview
+
+`phlo-mcp` exposes curated read-only MCP tools over Phlo's observability and
+operator surfaces. It sits on top of `phlo-api` and gives MCP clients a stable,
+agent-friendly surface for lakehouse inspection.
+
+## Install
+
+```bash
+uv pip install -e packages/phlo-mcp
+```
+
+## Exposed tools
+
+- `get_platform_health`
+- `get_service_status`
+- `get_recent_alerts`
+- `get_dashboard_links`
+- `get_logs_query_link`
+- `get_metrics_query_link`
+
+## Usage
+
+Start a backing API first:
+
+```bash
+uv run --package phlo-api uvicorn phlo_api.main:app --host 127.0.0.1 --port 4000
+```
+
+Run the MCP server over stdio:
+
+```bash
+phlo-mcp --api-base-url http://127.0.0.1:4000
+```
+
+Claude Code example:
+
+```json
+{
+  "mcpServers": {
+    "phlo": {
+      "command": "uv",
+      "args": ["run", "--package", "phlo-mcp", "phlo-mcp", "--api-base-url", "http://127.0.0.1:4000"]
+    }
+  }
+}
+```
+
+Run it over streamable HTTP:
+
+```bash
+phlo-mcp \
+  --transport streamable-http \
+  --host 127.0.0.1 \
+  --port 8000 \
+  --path /mcp \
+  --api-base-url http://127.0.0.1:4000
+```
+
+Optional local span capture:
+
+```bash
+phlo-mcp --trace-file .phlo/phlo-mcp-trace.jsonl
+```

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -138,21 +138,21 @@ phlo-mcp --trace-file .phlo/phlo-mcp-trace.jsonl
 
 ## Live stack smoke
 
-Run the MCP smoke against live `phlo-api`, Dagster, and ClickStack services:
+Run the MCP smoke against a live `phlo-api` service and its configured capability backends:
 
 ```bash
 uv run python packages/phlo-mcp/tests/smoke_stack.py --start-stack
 ```
 
-The smoke checks live `phlo-api`, Dagster connectivity, ClickStack trace table
-queries, MCP tool registration, filtered trace tools, MCP resource registration,
-representative MCP resource reads, and a generated `mcp_smoke_asset` fixture.
+The smoke checks live `phlo-api`, orchestration connectivity, trace filtering
+through the observability capability, MCP tool registration, MCP resource
+registration, representative MCP resource reads, and a generated
+`mcp_smoke_asset` capability fixture.
 With `--start-stack`, the fixture is written to `.phlo/mcp-smoke-project`,
 which is ignored by git.
 
-When ClickStack requires HTTP credentials, pass them to the smoke script and to
-the `phlo-api` process as `CLICKSTACK_QUERY_USER` and
-`CLICKSTACK_QUERY_PASSWORD`.
+When the configured observability backend requires credentials, pass them to
+the backing `phlo-api` process with that backend's environment variables.
 
 To verify guarded write-tool registration without calling mutation endpoints:
 

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -109,6 +109,10 @@ Run the MCP smoke against live `phlo-api`, Dagster, and ClickStack services:
 uv run python packages/phlo-mcp/tests/smoke_stack.py
 ```
 
+When ClickStack requires HTTP credentials, pass them to the smoke script and to
+the `phlo-api` process as `CLICKSTACK_QUERY_USER` and
+`CLICKSTACK_QUERY_PASSWORD`.
+
 Use real data assertions when you have a known run or asset:
 
 ```bash

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -25,13 +25,39 @@ uv pip install -e packages/phlo-mcp
 - `get_materialization_history`
 - `get_run_logs`
 - `get_run_trace_spans`
+- `get_trace_spans`
+- `render_trace_spans_tree`
 - `inspect_materialization`
 - `get_asset_materialization_trace`
 - `render_materialization_trace_tree`
 - `render_run_trace_tree`
 
+Optional guarded operational tools:
+
+- `materialize_asset`
+- `retry_failed_run`
+- `get_dagster_run_status`
+
+Resources:
+
+- `phlo://runtime/config`
+- `phlo://runtime/services`
+- `phlo://runtime/services/{service_name}`
+- `phlo://runtime/plugins`
+- `phlo://runtime/assets`
+- `phlo://runtime/assets/{asset_key_path}`
+- `phlo://runtime/schemas/{asset_key_path}`
+- `phlo://runtime/contracts`
+- `phlo://runtime/contracts/{table_name}`
+- `phlo://runtime/dashboards`
+- `phlo://docs/packages/{package_name}`
+
 Run-level and materialization tools rely on the backing `phlo-api` having access
 to Dagster asset history, Loki log queries, and ClickStack OTEL trace storage.
+Trace tools can be filtered by run id, asset key, job name, service name, span
+name, status code, and start/end time.
+Resource URIs are read-only and deterministic so MCP clients can attach Phlo
+runtime context without invoking parameterized tools.
 
 When real spans are available, rendered trees include:
 - span kind
@@ -61,6 +87,13 @@ phlo-mcp \
   --api-token "$PHLO_API_TOKEN"
 ```
 
+Guarded operational tools are disabled by default. To expose asset
+materialization and run retry tools, set `PHLO_MCP_ENABLE_WRITE_TOOLS=true` or
+pass `--enable-write-tools` with an API token. Write tools return structured
+`audit_context` metadata and default to `dry_run=true` where supported. Current
+`phlo-api` operation routes support dry-run validation and run status; live
+Dagster launch and retry are intentionally not implemented yet.
+
 Claude Code example:
 
 ```json
@@ -82,7 +115,9 @@ Example prompts once connected:
 - "Get the latest materialization trace for `silver/orders`."
 - "Render the materialization trace tree for `silver/orders`."
 - "Get OTEL spans for run `abc-123`."
+- "Get failed Dagster spans for asset `silver/orders` in the last hour."
 - "Render the run trace tree for `abc-123`."
+- "Render a trace tree for job `daily_orders`."
 
 Run it over streamable HTTP:
 
@@ -106,12 +141,38 @@ phlo-mcp --trace-file .phlo/phlo-mcp-trace.jsonl
 Run the MCP smoke against live `phlo-api`, Dagster, and ClickStack services:
 
 ```bash
-uv run python packages/phlo-mcp/tests/smoke_stack.py
+uv run python packages/phlo-mcp/tests/smoke_stack.py --start-stack
 ```
+
+The smoke checks live `phlo-api`, Dagster connectivity, ClickStack trace table
+queries, MCP tool registration, filtered trace tools, MCP resource registration,
+representative MCP resource reads, and a generated `mcp_smoke_asset` fixture.
+With `--start-stack`, the fixture is written to `.phlo/mcp-smoke-project`,
+which is ignored by git.
 
 When ClickStack requires HTTP credentials, pass them to the smoke script and to
 the `phlo-api` process as `CLICKSTACK_QUERY_USER` and
 `CLICKSTACK_QUERY_PASSWORD`.
+
+To verify guarded write-tool registration without calling mutation endpoints:
+
+```bash
+uv run python packages/phlo-mcp/tests/smoke_stack.py \
+  --enable-write-tools \
+  --api-token "$PHLO_MCP_SMOKE_API_TOKEN"
+```
+
+To call guarded write tools in dry-run mode, add `--exercise-write-tools` and
+`--start-stack`, or provide `--asset-key` when testing an existing project.
+This requires the backing `phlo-api` write endpoints to be available.
+
+```bash
+uv run python packages/phlo-mcp/tests/smoke_stack.py \
+  --start-stack \
+  --enable-write-tools \
+  --api-token "$PHLO_MCP_SMOKE_API_TOKEN" \
+  --exercise-write-tools
+```
 
 Use real data assertions when you have a known run or asset:
 

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -22,6 +22,22 @@ uv pip install -e packages/phlo-mcp
 - `get_dashboard_links`
 - `get_logs_query_link`
 - `get_metrics_query_link`
+- `get_materialization_history`
+- `get_run_logs`
+- `get_run_trace_spans`
+- `inspect_materialization`
+- `get_asset_materialization_trace`
+- `render_materialization_trace_tree`
+- `render_run_trace_tree`
+
+Run-level and materialization tools rely on the backing `phlo-api` having access
+to Dagster asset history, Loki log queries, and ClickStack OTEL trace storage.
+
+When real spans are available, rendered trees include:
+- span kind
+- status code
+- duration
+- selected Phlo attributes like stage, asset key, job name, and operation
 
 ## Usage
 
@@ -49,6 +65,16 @@ Claude Code example:
   }
 }
 ```
+
+Example prompts once connected:
+
+- "Get the latest materializations for `silver/orders`."
+- "Fetch logs for run `abc-123`."
+- "Inspect the latest materialization for `silver/orders`."
+- "Get the latest materialization trace for `silver/orders`."
+- "Render the materialization trace tree for `silver/orders`."
+- "Get OTEL spans for run `abc-123`."
+- "Render the run trace tree for `abc-123`."
 
 Run it over streamable HTTP:
 

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -100,3 +100,21 @@ Optional local span capture:
 ```bash
 phlo-mcp --trace-file .phlo/phlo-mcp-trace.jsonl
 ```
+
+## Live stack smoke
+
+Run the MCP smoke against live `phlo-api`, Dagster, and ClickStack services:
+
+```bash
+uv run python packages/phlo-mcp/tests/smoke_stack.py
+```
+
+Use real data assertions when you have a known run or asset:
+
+```bash
+uv run python packages/phlo-mcp/tests/smoke_stack.py \
+  --run-id abc-123 \
+  --require-run-spans \
+  --asset-key silver/orders \
+  --require-materialization
+```

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -53,6 +53,14 @@ Run the MCP server over stdio:
 phlo-mcp --api-base-url http://127.0.0.1:4000
 ```
 
+For protected `phlo-api` instances, provide a bearer token:
+
+```bash
+phlo-mcp \
+  --api-base-url http://127.0.0.1:4000 \
+  --api-token "$PHLO_API_TOKEN"
+```
+
 Claude Code example:
 
 ```json

--- a/packages/phlo-mcp/pyproject.toml
+++ b/packages/phlo-mcp/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
 
 [project]
 dependencies = [
+    "phlo>=0.1.0",
     "phlo-api>=0.1.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.20.0",

--- a/packages/phlo-mcp/pyproject.toml
+++ b/packages/phlo-mcp/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "setuptools>=45",
+    "wheel",
+]
+
+[project]
+dependencies = [
+    "phlo>=0.1.0",
+    "phlo-api>=0.1.0",
+    "httpx>=0.28.1",
+    "mcp[cli]>=1.20.0",
+    "opentelemetry-sdk>=1.38.0",
+]
+description = "MCP server for Phlo observability and lakehouse operations"
+name = "phlo-mcp"
+requires-python = ">=3.11"
+version = "0.1.0"
+
+[[project.authors]]
+email = "team@phlo.dev"
+name = "Phlo Team"
+
+[project.license]
+text = "MIT"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "ruff>=0.1.0",
+]
+
+[project.readme]
+content-type = "text/plain"
+text = "MCP server for Phlo observability and lakehouse operations."
+
+[project.scripts]
+phlo-mcp = "phlo_mcp.cli:main"
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/phlo-mcp/pyproject.toml
+++ b/packages/phlo-mcp/pyproject.toml
@@ -7,7 +7,6 @@ requires = [
 
 [project]
 dependencies = [
-    "phlo>=0.1.0",
     "phlo-api>=0.1.0",
     "httpx>=0.28.1",
     "mcp[cli]>=1.20.0",

--- a/packages/phlo-mcp/src/phlo_mcp/__init__.py
+++ b/packages/phlo-mcp/src/phlo_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""Phlo MCP package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -1,0 +1,60 @@
+"""HTTP client helpers for phlo-mcp."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from opentelemetry import trace
+
+from phlo_mcp.config import McpConfig
+
+
+class PhloApiClient:
+    """Small typed wrapper around phlo-api observability routes."""
+
+    def __init__(self, config: McpConfig, *, tracer_name: str = "phlo.mcp") -> None:
+        self._config = config
+        self._tracer = trace.get_tracer(tracer_name)
+
+    @property
+    def api_base_url(self) -> str:
+        return self._config.api_base_url
+
+    def get_platform_health(self) -> dict[str, Any]:
+        return self._get_json("/api/observability/health")
+
+    def get_service_status(self) -> list[dict[str, Any]] | dict[str, Any]:
+        return self._get_json("/api/observability/services")
+
+    def get_recent_alerts(self, limit: int = 5) -> list[dict[str, Any]] | dict[str, Any]:
+        return self._get_json("/api/observability/alerts", params={"limit": limit})
+
+    def get_dashboard_links(self) -> list[dict[str, Any]] | dict[str, Any]:
+        return self._get_json("/api/observability/dashboards")
+
+    def get_logs_query_link(self, service: str | None = None) -> dict[str, Any]:
+        params = {"service": service} if service else None
+        return self._get_json("/api/observability/links/logs", params=params)
+
+    def get_metrics_query_link(self, metric: str | None = None) -> dict[str, Any]:
+        params = {"metric": metric} if metric else None
+        return self._get_json("/api/observability/links/metrics", params=params)
+
+    def _get_json(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        url = f"{self.api_base_url}{path}"
+        with self._tracer.start_as_current_span(
+            "http.client GET",
+            attributes={
+                "http.request.method": "GET",
+                "url.full": url,
+            },
+        ):
+            response = httpx.get(url, params=params, timeout=10.0)
+            response.raise_for_status()
+            return response.json()

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -33,6 +33,36 @@ class PhloApiClient:
     def get_dashboard_links(self) -> list[dict[str, Any]] | dict[str, Any]:
         return self._get_json("/api/observability/dashboards")
 
+    def get_run_logs(
+        self,
+        run_id: str,
+        *,
+        level: str | None = None,
+        limit: int = 200,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if level:
+            params["level"] = level
+        return self._get_json(f"/api/loki/runs/{run_id}", params=params)
+
+    def get_materialization_history(
+        self,
+        asset_key_path: str,
+        *,
+        limit: int = 10,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(
+            f"/api/dagster/assets/{asset_key_path}/history", params={"limit": limit}
+        )
+
+    def get_run_trace_spans(
+        self,
+        run_id: str,
+        *,
+        limit: int = 500,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(f"/api/observability/traces/runs/{run_id}", params={"limit": limit})
+
     def get_logs_query_link(self, service: str | None = None) -> dict[str, Any]:
         params = {"service": service} if service else None
         return self._get_json("/api/observability/links/logs", params=params)

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -21,6 +21,12 @@ class PhloApiClient:
     def api_base_url(self) -> str:
         return self._config.api_base_url
 
+    @property
+    def headers(self) -> dict[str, str]:
+        if self._config.api_token:
+            return {"Authorization": f"Bearer {self._config.api_token}"}
+        return {}
+
     def get_platform_health(self) -> dict[str, Any]:
         return self._get_json("/api/observability/health")
 
@@ -85,6 +91,6 @@ class PhloApiClient:
                 "url.full": url,
             },
         ):
-            response = httpx.get(url, params=params, timeout=10.0)
+            response = httpx.get(url, params=params, headers=self.headers, timeout=10.0)
             response.raise_for_status()
             return response.json()

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -30,6 +30,30 @@ class PhloApiClient:
     def get_platform_health(self) -> dict[str, Any]:
         return self._get_json("/api/observability/health")
 
+    def get_config(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json("/api/config")
+
+    def get_plugins(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json("/api/plugins")
+
+    def get_services(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json("/api/services")
+
+    def get_service_info(self, service_name: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(f"/api/services/{service_name}")
+
+    def get_assets(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json("/api/dagster/assets")
+
+    def get_asset_details(self, asset_key_path: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(f"/api/dagster/assets/{asset_key_path}")
+
+    def get_contracts(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json("/api/contracts")
+
+    def get_contract(self, table_name: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(f"/api/contracts/{table_name}")
+
     def get_service_status(self) -> list[dict[str, Any]] | dict[str, Any]:
         return self._get_json("/api/observability/services")
 
@@ -73,9 +97,60 @@ class PhloApiClient:
         params = {"service": service} if service else None
         return self._get_json("/api/observability/links/logs", params=params)
 
+    def get_trace_spans(
+        self,
+        *,
+        run_id: str | None = None,
+        asset_key: str | None = None,
+        job_name: str | None = None,
+        service_name: str | None = None,
+        span_name: str | None = None,
+        status_code: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int = 500,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        for key, value in {
+            "run_id": run_id,
+            "asset_key": asset_key,
+            "job_name": job_name,
+            "service_name": service_name,
+            "span_name": span_name,
+            "status_code": status_code,
+            "start_time": start_time,
+            "end_time": end_time,
+        }.items():
+            if value:
+                params[key] = value
+        return self._get_json("/api/observability/traces", params=params)
+
     def get_metrics_query_link(self, metric: str | None = None) -> dict[str, Any]:
         params = {"metric": metric} if metric else None
         return self._get_json("/api/observability/links/metrics", params=params)
+
+    def materialize_asset(
+        self,
+        asset_key_path: str,
+        *,
+        dry_run: bool = True,
+        partition_key: str | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        payload: dict[str, Any] = {"dry_run": dry_run}
+        if partition_key:
+            payload["partition_key"] = partition_key
+        return self._post_json(f"/api/dagster/assets/{asset_key_path}/materialize", json=payload)
+
+    def retry_run(
+        self,
+        run_id: str,
+        *,
+        dry_run: bool = True,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._post_json(f"/api/dagster/runs/{run_id}/retry", json={"dry_run": dry_run})
+
+    def get_run_status(self, run_id: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(f"/api/dagster/runs/{run_id}/status")
 
     def _get_json(
         self,
@@ -92,5 +167,23 @@ class PhloApiClient:
             },
         ):
             response = httpx.get(url, params=params, headers=self.headers, timeout=10.0)
+            response.raise_for_status()
+            return response.json()
+
+    def _post_json(
+        self,
+        path: str,
+        *,
+        json: dict[str, Any],
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        url = f"{self.api_base_url}{path}"
+        with self._tracer.start_as_current_span(
+            "http.client POST",
+            attributes={
+                "http.request.method": "POST",
+                "url.full": url,
+            },
+        ):
+            response = httpx.post(url, json=json, headers=self.headers, timeout=30.0)
             response.raise_for_status()
             return response.json()

--- a/packages/phlo-mcp/src/phlo_mcp/cli.py
+++ b/packages/phlo-mcp/src/phlo_mcp/cli.py
@@ -16,6 +16,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="MCP transport to use (defaults to PHLO_MCP_TRANSPORT or stdio)",
     )
     parser.add_argument("--api-base-url", help="Base URL for the backing phlo-api instance")
+    parser.add_argument("--api-token", help="Bearer token for authenticated phlo-api requests")
     parser.add_argument("--trace-file", help="Optional JSONL file to write local span events")
     parser.add_argument("--host", help="Bind host for streamable-http transport")
     parser.add_argument("--port", type=int, help="Bind port for streamable-http transport")
@@ -29,6 +30,7 @@ def parse_args() -> McpConfig:
     env_config = config_from_env()
     return McpConfig(
         api_base_url=(args.api_base_url or env_config.api_base_url).rstrip("/"),
+        api_token=args.api_token if args.api_token is not None else env_config.api_token,
         trace_file=args.trace_file if args.trace_file is not None else env_config.trace_file,
         transport=args.transport or env_config.transport,
         host=args.host or env_config.host,

--- a/packages/phlo-mcp/src/phlo_mcp/cli.py
+++ b/packages/phlo-mcp/src/phlo_mcp/cli.py
@@ -40,7 +40,7 @@ def parse_args() -> McpConfig:
         trace_file=args.trace_file if args.trace_file is not None else env_config.trace_file,
         transport=args.transport or env_config.transport,
         host=args.host or env_config.host,
-        port=args.port or env_config.port,
+        port=args.port if args.port is not None else env_config.port,
         streamable_http_path=args.path or env_config.streamable_http_path,
     )
 

--- a/packages/phlo-mcp/src/phlo_mcp/cli.py
+++ b/packages/phlo-mcp/src/phlo_mcp/cli.py
@@ -17,6 +17,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--api-base-url", help="Base URL for the backing phlo-api instance")
     parser.add_argument("--api-token", help="Bearer token for authenticated phlo-api requests")
+    parser.add_argument(
+        "--enable-write-tools",
+        action="store_true",
+        help="Register guarded operational tools (requires authenticated phlo-api)",
+    )
     parser.add_argument("--trace-file", help="Optional JSONL file to write local span events")
     parser.add_argument("--host", help="Bind host for streamable-http transport")
     parser.add_argument("--port", type=int, help="Bind port for streamable-http transport")
@@ -31,6 +36,7 @@ def parse_args() -> McpConfig:
     return McpConfig(
         api_base_url=(args.api_base_url or env_config.api_base_url).rstrip("/"),
         api_token=args.api_token if args.api_token is not None else env_config.api_token,
+        enable_write_tools=args.enable_write_tools or env_config.enable_write_tools,
         trace_file=args.trace_file if args.trace_file is not None else env_config.trace_file,
         transport=args.transport or env_config.transport,
         host=args.host or env_config.host,

--- a/packages/phlo-mcp/src/phlo_mcp/cli.py
+++ b/packages/phlo-mcp/src/phlo_mcp/cli.py
@@ -1,0 +1,47 @@
+"""CLI entrypoint for phlo-mcp."""
+
+from __future__ import annotations
+
+import argparse
+
+from phlo_mcp.config import McpConfig, config_from_env
+from phlo_mcp.server import create_server
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Phlo MCP server")
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "streamable-http"),
+        help="MCP transport to use (defaults to PHLO_MCP_TRANSPORT or stdio)",
+    )
+    parser.add_argument("--api-base-url", help="Base URL for the backing phlo-api instance")
+    parser.add_argument("--trace-file", help="Optional JSONL file to write local span events")
+    parser.add_argument("--host", help="Bind host for streamable-http transport")
+    parser.add_argument("--port", type=int, help="Bind port for streamable-http transport")
+    parser.add_argument("--path", help="HTTP path for streamable-http transport (default: /mcp)")
+    return parser
+
+
+def parse_args() -> McpConfig:
+    parser = build_parser()
+    args = parser.parse_args()
+    env_config = config_from_env()
+    return McpConfig(
+        api_base_url=(args.api_base_url or env_config.api_base_url).rstrip("/"),
+        trace_file=args.trace_file if args.trace_file is not None else env_config.trace_file,
+        transport=args.transport or env_config.transport,
+        host=args.host or env_config.host,
+        port=args.port or env_config.port,
+        streamable_http_path=args.path or env_config.streamable_http_path,
+    )
+
+
+def main() -> None:
+    config = parse_args()
+    server = create_server(config)
+    server.run(transport=config.transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/phlo-mcp/src/phlo_mcp/config.py
+++ b/packages/phlo-mcp/src/phlo_mcp/config.py
@@ -13,6 +13,7 @@ class McpConfig:
     """Runtime configuration for the Phlo MCP server."""
 
     api_base_url: str = _DEFAULT_API_BASE_URL
+    api_token: str | None = None
     trace_file: str | None = None
     transport: str = "stdio"
     host: str = "127.0.0.1"
@@ -25,6 +26,7 @@ def config_from_env() -> McpConfig:
     port = int(os.environ.get("PHLO_MCP_PORT", "8000"))
     return McpConfig(
         api_base_url=os.environ.get("PHLO_MCP_API_BASE_URL", _DEFAULT_API_BASE_URL).rstrip("/"),
+        api_token=os.environ.get("PHLO_MCP_API_TOKEN") or None,
         trace_file=os.environ.get("PHLO_MCP_TRACE_FILE") or None,
         transport=os.environ.get("PHLO_MCP_TRANSPORT", "stdio"),
         host=os.environ.get("PHLO_MCP_HOST", "127.0.0.1"),

--- a/packages/phlo-mcp/src/phlo_mcp/config.py
+++ b/packages/phlo-mcp/src/phlo_mcp/config.py
@@ -1,0 +1,33 @@
+"""Configuration helpers for phlo-mcp."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+_DEFAULT_API_BASE_URL = "http://127.0.0.1:4000"
+
+
+@dataclass(frozen=True, slots=True)
+class McpConfig:
+    """Runtime configuration for the Phlo MCP server."""
+
+    api_base_url: str = _DEFAULT_API_BASE_URL
+    trace_file: str | None = None
+    transport: str = "stdio"
+    host: str = "127.0.0.1"
+    port: int = 8000
+    streamable_http_path: str = "/mcp"
+
+
+def config_from_env() -> McpConfig:
+    """Load MCP configuration from environment variables."""
+    port = int(os.environ.get("PHLO_MCP_PORT", "8000"))
+    return McpConfig(
+        api_base_url=os.environ.get("PHLO_MCP_API_BASE_URL", _DEFAULT_API_BASE_URL).rstrip("/"),
+        trace_file=os.environ.get("PHLO_MCP_TRACE_FILE") or None,
+        transport=os.environ.get("PHLO_MCP_TRANSPORT", "stdio"),
+        host=os.environ.get("PHLO_MCP_HOST", "127.0.0.1"),
+        port=port,
+        streamable_http_path=os.environ.get("PHLO_MCP_HTTP_PATH", "/mcp"),
+    )

--- a/packages/phlo-mcp/src/phlo_mcp/config.py
+++ b/packages/phlo-mcp/src/phlo_mcp/config.py
@@ -14,11 +14,16 @@ class McpConfig:
 
     api_base_url: str = _DEFAULT_API_BASE_URL
     api_token: str | None = None
+    enable_write_tools: bool = False
     trace_file: str | None = None
     transport: str = "stdio"
     host: str = "127.0.0.1"
     port: int = 8000
     streamable_http_path: str = "/mcp"
+
+
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").lower() in {"1", "true", "yes", "on"}
 
 
 def config_from_env() -> McpConfig:
@@ -27,6 +32,7 @@ def config_from_env() -> McpConfig:
     return McpConfig(
         api_base_url=os.environ.get("PHLO_MCP_API_BASE_URL", _DEFAULT_API_BASE_URL).rstrip("/"),
         api_token=os.environ.get("PHLO_MCP_API_TOKEN") or None,
+        enable_write_tools=_truthy_env("PHLO_MCP_ENABLE_WRITE_TOOLS"),
         trace_file=os.environ.get("PHLO_MCP_TRACE_FILE") or None,
         transport=os.environ.get("PHLO_MCP_TRANSPORT", "stdio"),
         host=os.environ.get("PHLO_MCP_HOST", "127.0.0.1"),

--- a/packages/phlo-mcp/src/phlo_mcp/run_analysis.py
+++ b/packages/phlo-mcp/src/phlo_mcp/run_analysis.py
@@ -102,13 +102,19 @@ def render_span_tree(run_id: str, spans: list[dict[str, Any]]) -> str:
     for trace_index, trace_id in enumerate(trace_ids):
         trace_spans = spans_by_trace[trace_id]
         children: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+        span_ids = {span.get("span_id") for span in trace_spans if span.get("span_id")}
         for span in trace_spans:
             parent_id = span.get("parent_span_id") or None
             children[parent_id].append(span)
         for child_list in children.values():
             child_list.sort(key=lambda item: item.get("timestamp") or "")
 
-        roots = children.get(None, [])
+        roots = [
+            span
+            for span in trace_spans
+            if not span.get("parent_span_id") or span.get("parent_span_id") not in span_ids
+        ]
+        roots.sort(key=lambda item: item.get("timestamp") or "")
         trace_prefix = "└─" if trace_index == len(trace_ids) - 1 else "├─"
         lines.append(f"{trace_prefix} trace {trace_id[:16]}")
         child_prefix = "   " if trace_index == len(trace_ids) - 1 else "│  "

--- a/packages/phlo-mcp/src/phlo_mcp/run_analysis.py
+++ b/packages/phlo-mcp/src/phlo_mcp/run_analysis.py
@@ -1,0 +1,225 @@
+"""Helpers for materialization and run-level observability analysis."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any
+
+
+def summarize_run_logs(
+    run_id: str,
+    entries: list[dict[str, Any]],
+    *,
+    max_messages: int = 10,
+) -> dict[str, Any]:
+    """Build a compact summary of correlated run logs."""
+    level_counts = Counter(entry.get("level", "unknown") for entry in entries)
+    service_counts = Counter(
+        (entry.get("metadata") or {}).get("service") or "unknown" for entry in entries
+    )
+    trace_ids = sorted(
+        {
+            (entry.get("metadata") or {}).get("trace_id")
+            for entry in entries
+            if (entry.get("metadata") or {}).get("trace_id")
+        }
+    )
+    asset_keys = sorted(
+        {
+            (entry.get("metadata") or {}).get("asset_key")
+            for entry in entries
+            if (entry.get("metadata") or {}).get("asset_key")
+        }
+    )
+    messages = [
+        {
+            "timestamp": entry.get("timestamp"),
+            "level": entry.get("level"),
+            "service": (entry.get("metadata") or {}).get("service"),
+            "message": entry.get("message"),
+        }
+        for entry in entries[:max_messages]
+    ]
+    return {
+        "run_id": run_id,
+        "entry_count": len(entries),
+        "level_counts": dict(level_counts),
+        "service_counts": dict(service_counts),
+        "trace_ids": trace_ids,
+        "asset_keys": asset_keys,
+        "messages": messages,
+    }
+
+
+def render_run_trace_tree(run_id: str, entries: list[dict[str, Any]], *, limit: int = 40) -> str:
+    """Render a best-effort execution tree from correlated run logs."""
+    lines = [f"Run {run_id}"]
+    if not entries:
+        lines.append("└─ no logs found")
+        return "\n".join(lines)
+
+    trace_ids = [
+        (entry.get("metadata") or {}).get("trace_id")
+        for entry in entries
+        if (entry.get("metadata") or {}).get("trace_id")
+    ]
+    unique_trace_ids = sorted(set(trace_ids))
+    if unique_trace_ids:
+        for trace_index, trace_id in enumerate(unique_trace_ids):
+            trace_entries = [
+                entry
+                for entry in entries
+                if (entry.get("metadata") or {}).get("trace_id") == trace_id
+            ]
+            is_last_trace = trace_index == len(unique_trace_ids) - 1
+            trace_prefix = "└─" if is_last_trace else "├─"
+            lines.append(f"{trace_prefix} trace {trace_id[:16]}")
+            _append_entry_lines(
+                lines,
+                trace_entries,
+                prefix="   " if is_last_trace else "│  ",
+                limit=limit,
+            )
+    else:
+        lines.append("└─ logs")
+        _append_entry_lines(lines, entries, prefix="   ", limit=limit)
+    return "\n".join(lines)
+
+
+def render_span_tree(run_id: str, spans: list[dict[str, Any]]) -> str:
+    """Render a proper span tree from OTEL span rows."""
+    lines = [f"Run {run_id}"]
+    if not spans:
+        lines.append("└─ no spans found")
+        return "\n".join(lines)
+
+    spans_by_trace: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for span in spans:
+        trace_id = span.get("trace_id") or "unknown"
+        spans_by_trace[trace_id].append(span)
+
+    trace_ids = sorted(spans_by_trace)
+    for trace_index, trace_id in enumerate(trace_ids):
+        trace_spans = spans_by_trace[trace_id]
+        children: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+        for span in trace_spans:
+            parent_id = span.get("parent_span_id") or None
+            children[parent_id].append(span)
+        for child_list in children.values():
+            child_list.sort(key=lambda item: item.get("timestamp") or "")
+
+        roots = children.get(None, [])
+        trace_prefix = "└─" if trace_index == len(trace_ids) - 1 else "├─"
+        lines.append(f"{trace_prefix} trace {trace_id[:16]}")
+        child_prefix = "   " if trace_index == len(trace_ids) - 1 else "│  "
+        for root_index, root in enumerate(roots):
+            _append_span_lines(
+                lines,
+                root,
+                children,
+                prefix=child_prefix,
+                is_last=root_index == len(roots) - 1,
+            )
+    return "\n".join(lines)
+
+
+def _append_entry_lines(
+    lines: list[str],
+    entries: list[dict[str, Any]],
+    *,
+    prefix: str,
+    limit: int,
+) -> None:
+    # Loki responses are normalized newest-first; render the most recent entries
+    # in chronological order so the tree reads top-to-bottom.
+    display_entries = list(reversed(entries[:limit]))
+    for index, entry in enumerate(display_entries):
+        is_last = index == len(display_entries) - 1
+        connector = "└─" if is_last else "├─"
+        metadata = entry.get("metadata") or {}
+        service = metadata.get("service") or "unknown"
+        function = metadata.get("function")
+        duration_ms = metadata.get("durationMs")
+        context_bits = [service]
+        if function:
+            context_bits.append(function)
+        context = " / ".join(context_bits)
+        suffix = f" ({duration_ms}ms)" if duration_ms else ""
+        message = entry.get("message") or ""
+        lines.append(
+            f"{prefix}{connector} [{entry.get('level', 'info')}] {context}: {message}{suffix}"
+        )
+
+
+def _append_span_lines(
+    lines: list[str],
+    span: dict[str, Any],
+    children: dict[str | None, list[dict[str, Any]]],
+    *,
+    prefix: str,
+    is_last: bool,
+) -> None:
+    connector = "└─" if is_last else "├─"
+    service = (
+        span.get("service_name")
+        or (span.get("resource_attributes") or {}).get("service.name")
+        or "unknown"
+    )
+    kind = _normalize_span_kind(span.get("span_kind"))
+    status = _normalize_status_code(span.get("status_code"))
+    duration_ms = span.get("duration_ms")
+    duration_suffix = f" ({duration_ms}ms)" if duration_ms is not None else ""
+    detail_suffix = _span_detail_suffix(span)
+    lines.append(
+        f"{prefix}{connector} {service} / {span.get('span_name')} [{kind} {status}]"
+        f"{duration_suffix}{detail_suffix}"
+    )
+    span_id = span.get("span_id")
+    span_children = children.get(span_id, [])
+    child_prefix = prefix + ("   " if is_last else "│  ")
+    for index, child in enumerate(span_children):
+        _append_span_lines(
+            lines,
+            child,
+            children,
+            prefix=child_prefix,
+            is_last=index == len(span_children) - 1,
+        )
+
+
+def _normalize_span_kind(value: Any) -> str:
+    if not value:
+        return "internal"
+    return str(value).replace("SPAN_KIND_", "").lower()
+
+
+def _normalize_status_code(value: Any) -> str:
+    if not value:
+        return "unset"
+    normalized = str(value).replace("STATUS_CODE_", "").lower()
+    if normalized == "ok":
+        return "ok"
+    if normalized == "error":
+        return "error"
+    return normalized
+
+
+def _span_detail_suffix(span: dict[str, Any]) -> str:
+    span_attributes = span.get("span_attributes") or {}
+    resource_attributes = span.get("resource_attributes") or {}
+    details: list[str] = []
+    for label, key in (
+        ("stage", "phlo.stage"),
+        ("asset", "phlo.asset_key"),
+        ("job", "phlo.job_name"),
+        ("operation", "phlo.operation"),
+    ):
+        value = span_attributes.get(key)
+        if value:
+            details.append(f"{label}={value}")
+    service_version = resource_attributes.get("service.version")
+    if service_version:
+        details.append(f"service.version={service_version}")
+    if not details:
+        return ""
+    return " {" + ", ".join(details) + "}"

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -1,0 +1,118 @@
+"""MCP server exposing curated Phlo observability tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from opentelemetry import trace
+
+from phlo_mcp.api_client import PhloApiClient
+from phlo_mcp.config import McpConfig, config_from_env
+from phlo_mcp.tracing import configure_tracing
+
+
+def create_server(config: McpConfig | None = None) -> FastMCP:
+    """Create a configured FastMCP server instance."""
+    resolved = config or config_from_env()
+    configure_tracing(trace_file=resolved.trace_file)
+
+    mcp = FastMCP("phlo", json_response=True)
+    mcp.settings.host = resolved.host
+    mcp.settings.port = resolved.port
+    mcp.settings.streamable_http_path = resolved.streamable_http_path
+
+    tracer = trace.get_tracer("phlo.mcp")
+    client = PhloApiClient(resolved)
+
+    @mcp.tool()
+    def get_platform_health() -> dict[str, Any]:
+        """Get Phlo platform observability health from phlo-api."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_platform_health"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_platform_health"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.health"):
+                    payload = client.get_platform_health()
+                    return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def get_service_status() -> dict[str, Any]:
+        """Get current service status snapshot from phlo-api."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_service_status"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_service_status"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.services"):
+                    services = client.get_service_status()
+                    return {"api_base_url": client.api_base_url, "services": services}
+
+    @mcp.tool()
+    def get_recent_alerts(limit: int = 5) -> dict[str, Any]:
+        """Get recent observability alerts from phlo-api."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_recent_alerts"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_recent_alerts"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.alerts"):
+                    alerts = client.get_recent_alerts(limit)
+                    return {"api_base_url": client.api_base_url, "alerts": alerts}
+
+    @mcp.tool()
+    def get_dashboard_links() -> dict[str, Any]:
+        """Get available observability dashboard links from phlo-api."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_dashboard_links"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_dashboard_links"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.dashboards"):
+                    dashboards = client.get_dashboard_links()
+                    return {"api_base_url": client.api_base_url, "dashboards": dashboards}
+
+    @mcp.tool()
+    def get_logs_query_link(service: str | None = None) -> dict[str, Any]:
+        """Get a backend-specific log query link, optionally filtered by service."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_logs_query_link"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_logs_query_link"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.links.logs"):
+                    payload = client.get_logs_query_link(service)
+                    return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def get_metrics_query_link(metric: str | None = None) -> dict[str, Any]:
+        """Get a backend-specific metrics query link, optionally filtered by metric."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_metrics_query_link"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_metrics_query_link"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.links.metrics"):
+                    payload = client.get_metrics_query_link(metric)
+                    return {"api_base_url": client.api_base_url, "payload": payload}
+
+    return mcp

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -17,6 +18,17 @@ from phlo_mcp.run_analysis import (
 from phlo_mcp.tracing import configure_tracing
 
 
+def _read_package_doc(package_name: str) -> str:
+    safe_name = package_name.removesuffix(".md")
+    if "/" in safe_name or "\\" in safe_name or safe_name in {"", ".", ".."}:
+        return f"# {package_name}\n\nPackage documentation not found.\n"
+    for base in (Path.cwd(), *Path.cwd().parents):
+        candidate = base / "docs" / "packages" / f"{safe_name}.md"
+        if candidate.is_file():
+            return candidate.read_text(encoding="utf-8")
+    return f"# {package_name}\n\nPackage documentation not found.\n"
+
+
 def create_server(config: McpConfig | None = None) -> FastMCP:
     """Create a configured FastMCP server instance."""
     resolved = config or config_from_env()
@@ -29,6 +41,124 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
 
     tracer = trace.get_tracer("phlo.mcp")
     client = PhloApiClient(resolved)
+
+    @mcp.resource(
+        "phlo://runtime/config",
+        name="runtime_config",
+        mime_type="application/json",
+    )
+    def runtime_config() -> dict[str, Any] | list[dict[str, Any]]:
+        """Read the current phlo project configuration."""
+        return client.get_config()
+
+    @mcp.resource(
+        "phlo://runtime/services",
+        name="runtime_services",
+        mime_type="application/json",
+    )
+    def runtime_services() -> dict[str, Any] | list[dict[str, Any]]:
+        """Read discovered service metadata."""
+        return client.get_services()
+
+    @mcp.resource(
+        "phlo://runtime/plugins",
+        name="runtime_plugins",
+        mime_type="application/json",
+    )
+    def runtime_plugins() -> dict[str, Any] | list[dict[str, Any]]:
+        """Read installed plugin metadata."""
+        return client.get_plugins()
+
+    @mcp.resource(
+        "phlo://runtime/assets",
+        name="runtime_assets",
+        mime_type="application/json",
+    )
+    def runtime_assets() -> dict[str, Any] | list[dict[str, Any]]:
+        """Read Dagster asset metadata."""
+        return client.get_assets()
+
+    @mcp.resource(
+        "phlo://runtime/contracts",
+        name="runtime_contracts",
+        mime_type="application/json",
+    )
+    def runtime_contracts() -> dict[str, Any] | list[dict[str, Any]]:
+        """Read schema contract metadata."""
+        return client.get_contracts()
+
+    @mcp.resource(
+        "phlo://runtime/dashboards",
+        name="runtime_dashboards",
+        mime_type="application/json",
+    )
+    def runtime_dashboards() -> dict[str, Any] | list[dict[str, Any]]:
+        """Read observability dashboard metadata."""
+        return client.get_dashboard_links()
+
+    @mcp.resource(
+        "phlo://runtime/services/{service_name}",
+        name="runtime_service",
+        mime_type="application/json",
+    )
+    def runtime_service(service_name: str) -> dict[str, Any] | list[dict[str, Any]]:
+        """Read metadata for one service."""
+        return client.get_service_info(service_name)
+
+    @mcp.resource(
+        "phlo://runtime/assets/{asset_key_path}",
+        name="runtime_asset",
+        mime_type="application/json",
+    )
+    def runtime_asset(asset_key_path: str) -> dict[str, Any] | list[dict[str, Any]]:
+        """Read metadata for one Dagster asset."""
+        return client.get_asset_details(asset_key_path)
+
+    @mcp.resource(
+        "phlo://runtime/schemas/{asset_key_path}",
+        name="runtime_asset_schema",
+        mime_type="application/json",
+    )
+    def runtime_asset_schema(asset_key_path: str) -> dict[str, Any]:
+        """Read schema metadata for one Dagster asset."""
+        details = client.get_asset_details(asset_key_path)
+        if not isinstance(details, dict):
+            return {"asset_key_path": asset_key_path, "columns": []}
+        return {
+            "asset_key_path": asset_key_path,
+            "columns": details.get("columns") or [],
+            "column_lineage": details.get("column_lineage"),
+            "partition_definition": details.get("partition_definition"),
+        }
+
+    @mcp.resource(
+        "phlo://runtime/contracts/{table_name}",
+        name="runtime_contract",
+        mime_type="application/json",
+    )
+    def runtime_contract(table_name: str) -> dict[str, Any] | list[dict[str, Any]]:
+        """Read one schema contract."""
+        return client.get_contract(table_name)
+
+    @mcp.resource(
+        "phlo://docs/packages/{package_name}",
+        name="package_docs",
+        mime_type="text/markdown",
+    )
+    def package_docs(package_name: str) -> str:
+        """Read package documentation from the local docs tree."""
+        return _read_package_doc(package_name)
+
+    def _write_audit_context(
+        operation: str, target: dict[str, Any], dry_run: bool
+    ) -> dict[str, Any]:
+        return {
+            "operation": operation,
+            "target": target,
+            "dry_run": dry_run,
+            "authenticated": bool(resolved.api_token),
+            "api_base_url": client.api_base_url,
+        }
 
     @mcp.tool()
     def get_platform_health() -> dict[str, Any]:
@@ -177,6 +307,107 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         "spans": payload,
                     }
 
+    @mcp.tool()
+    def get_trace_spans(
+        run_id: str | None = None,
+        asset_key: str | None = None,
+        job_name: str | None = None,
+        service_name: str | None = None,
+        span_name: str | None = None,
+        status_code: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int = 500,
+    ) -> dict[str, Any]:
+        """Get OTEL spans filtered by run, asset, job, service, status, name, or time."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_trace_spans"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_trace_spans"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.trace_spans"):
+                    payload = client.get_trace_spans(
+                        run_id=run_id,
+                        asset_key=asset_key,
+                        job_name=job_name,
+                        service_name=service_name,
+                        span_name=span_name,
+                        status_code=status_code,
+                        start_time=start_time,
+                        end_time=end_time,
+                        limit=limit,
+                    )
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "filters": _trace_filter_payload(
+                            run_id=run_id,
+                            asset_key=asset_key,
+                            job_name=job_name,
+                            service_name=service_name,
+                            span_name=span_name,
+                            status_code=status_code,
+                            start_time=start_time,
+                            end_time=end_time,
+                            limit=limit,
+                        ),
+                        "spans": payload,
+                    }
+
+    @mcp.tool()
+    def render_trace_spans_tree(
+        run_id: str | None = None,
+        asset_key: str | None = None,
+        job_name: str | None = None,
+        service_name: str | None = None,
+        span_name: str | None = None,
+        status_code: str | None = None,
+        start_time: str | None = None,
+        end_time: str | None = None,
+        limit: int = 500,
+    ) -> dict[str, Any]:
+        """Render a trace tree for spans matching observability filters."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "render_trace_spans_tree"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "render_trace_spans_tree"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.trace_spans_tree"):
+                    payload = client.get_trace_spans(
+                        run_id=run_id,
+                        asset_key=asset_key,
+                        job_name=job_name,
+                        service_name=service_name,
+                        span_name=span_name,
+                        status_code=status_code,
+                        start_time=start_time,
+                        end_time=end_time,
+                        limit=limit,
+                    )
+                    spans = payload if isinstance(payload, list) else []
+                    label = run_id or asset_key or job_name or "filtered traces"
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "filters": _trace_filter_payload(
+                            run_id=run_id,
+                            asset_key=asset_key,
+                            job_name=job_name,
+                            service_name=service_name,
+                            span_name=span_name,
+                            status_code=status_code,
+                            start_time=start_time,
+                            end_time=end_time,
+                            limit=limit,
+                        ),
+                        "span_count": len(spans),
+                        "tree": render_span_tree(label, spans),
+                    }
+
     def _inspect_materialization_payload(
         asset_key_path: str,
         *,
@@ -213,6 +444,9 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 "spans": spans,
             },
         }
+
+    def _trace_filter_payload(**filters: Any) -> dict[str, Any]:
+        return {key: value for key, value in filters.items() if value is not None}
 
     @mcp.tool()
     def inspect_materialization(
@@ -326,5 +560,71 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         "entry_count": len(entries),
                         "source": "logs",
                     }
+
+    if resolved.enable_write_tools and resolved.api_token:
+
+        @mcp.tool()
+        def materialize_asset(
+            asset_key_path: str,
+            dry_run: bool = True,
+            partition_key: str | None = None,
+        ) -> dict[str, Any]:
+            """Materialize a Dagster asset through phlo-api when write tools are enabled."""
+            with tracer.start_as_current_span(
+                "mcp.request",
+                attributes={"mcp.tool.name": "materialize_asset"},
+            ):
+                with tracer.start_as_current_span(
+                    "mcp.tool.execute",
+                    attributes={"mcp.tool.name": "materialize_asset"},
+                ):
+                    with tracer.start_as_current_span("phlo.dagster.asset.materialize"):
+                        target = {"asset_key_path": asset_key_path}
+                        if partition_key:
+                            target["partition_key"] = partition_key
+                        audit_context = _write_audit_context("materialize_asset", target, dry_run)
+                        payload = client.materialize_asset(
+                            asset_key_path,
+                            dry_run=dry_run,
+                            partition_key=partition_key,
+                        )
+                        return {"audit_context": audit_context, "payload": payload}
+
+        @mcp.tool()
+        def retry_failed_run(run_id: str, dry_run: bool = True) -> dict[str, Any]:
+            """Retry a Dagster run through phlo-api when write tools are enabled."""
+            with tracer.start_as_current_span(
+                "mcp.request",
+                attributes={"mcp.tool.name": "retry_failed_run"},
+            ):
+                with tracer.start_as_current_span(
+                    "mcp.tool.execute",
+                    attributes={"mcp.tool.name": "retry_failed_run"},
+                ):
+                    with tracer.start_as_current_span("phlo.dagster.run.retry"):
+                        audit_context = _write_audit_context(
+                            "retry_failed_run", {"run_id": run_id}, dry_run
+                        )
+                        payload = client.retry_run(run_id, dry_run=dry_run)
+                        return {"audit_context": audit_context, "payload": payload}
+
+        @mcp.tool()
+        def get_dagster_run_status(run_id: str) -> dict[str, Any]:
+            """Get Dagster run status through phlo-api for operational follow-up."""
+            with tracer.start_as_current_span(
+                "mcp.request",
+                attributes={"mcp.tool.name": "get_dagster_run_status"},
+            ):
+                with tracer.start_as_current_span(
+                    "mcp.tool.execute",
+                    attributes={"mcp.tool.name": "get_dagster_run_status"},
+                ):
+                    with tracer.start_as_current_span("phlo.dagster.run.status"):
+                        payload = client.get_run_status(run_id)
+                        return {
+                            "api_base_url": client.api_base_url,
+                            "run_id": run_id,
+                            "payload": payload,
+                        }
 
     return mcp

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -9,6 +9,11 @@ from opentelemetry import trace
 
 from phlo_mcp.api_client import PhloApiClient
 from phlo_mcp.config import McpConfig, config_from_env
+from phlo_mcp.run_analysis import (
+    render_run_trace_tree as render_log_trace_tree_text,
+    render_span_tree,
+    summarize_run_logs,
+)
 from phlo_mcp.tracing import configure_tracing
 
 
@@ -114,5 +119,212 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 with tracer.start_as_current_span("phlo.observability.links.metrics"):
                     payload = client.get_metrics_query_link(metric)
                     return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def get_materialization_history(asset_key_path: str, limit: int = 10) -> dict[str, Any]:
+        """Get recent Dagster materializations for an asset."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_materialization_history"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_materialization_history"},
+            ):
+                with tracer.start_as_current_span("phlo.dagster.materialization_history"):
+                    events = client.get_materialization_history(asset_key_path, limit=limit)
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "asset_key_path": asset_key_path,
+                        "events": events,
+                    }
+
+    @mcp.tool()
+    def get_run_logs(run_id: str, limit: int = 200, level: str | None = None) -> dict[str, Any]:
+        """Get correlated logs for a specific run or materialization."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_run_logs"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_run_logs"},
+            ):
+                with tracer.start_as_current_span("phlo.loki.run_logs"):
+                    payload = client.get_run_logs(run_id, limit=limit, level=level)
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "run_id": run_id,
+                        "payload": payload,
+                    }
+
+    @mcp.tool()
+    def get_run_trace_spans(run_id: str, limit: int = 500) -> dict[str, Any]:
+        """Get OTEL spans correlated to a specific run id."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_run_trace_spans"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_run_trace_spans"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.run_spans"):
+                    payload = client.get_run_trace_spans(run_id, limit=limit)
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "run_id": run_id,
+                        "spans": payload,
+                    }
+
+    def _inspect_materialization_payload(
+        asset_key_path: str,
+        *,
+        limit: int,
+        log_limit: int,
+        span_limit: int = 500,
+    ) -> dict[str, Any]:
+        events = client.get_materialization_history(asset_key_path, limit=limit)
+        if not isinstance(events, list) or not events:
+            return {
+                "api_base_url": client.api_base_url,
+                "asset_key_path": asset_key_path,
+                "events": events,
+                "latest_run": None,
+            }
+        latest = events[0]
+        run_id = latest.get("run_id")
+        log_payload = client.get_run_logs(run_id, limit=log_limit) if run_id else {"entries": []}
+        entries = log_payload.get("entries", []) if isinstance(log_payload, dict) else []
+        span_payload = client.get_run_trace_spans(run_id, limit=span_limit) if run_id else []
+        spans = span_payload if isinstance(span_payload, list) else []
+        return {
+            "api_base_url": client.api_base_url,
+            "asset_key_path": asset_key_path,
+            "events": events,
+            "latest_run": {
+                "run_id": run_id,
+                "log_summary": summarize_run_logs(run_id or "unknown", entries),
+                "span_count": len(spans),
+                "trace_tree": render_span_tree(run_id or "unknown", spans)
+                if spans
+                else render_log_trace_tree_text(run_id or "unknown", entries),
+                "trace_source": "spans" if spans else "logs",
+                "spans": spans,
+            },
+        }
+
+    @mcp.tool()
+    def inspect_materialization(
+        asset_key_path: str, limit: int = 5, log_limit: int = 200
+    ) -> dict[str, Any]:
+        """Inspect recent materializations and correlated logs for the latest run."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "inspect_materialization"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "inspect_materialization"},
+            ):
+                with tracer.start_as_current_span("phlo.materialization.inspect"):
+                    return _inspect_materialization_payload(
+                        asset_key_path,
+                        limit=limit,
+                        log_limit=log_limit,
+                    )
+
+    @mcp.tool()
+    def get_asset_materialization_trace(
+        asset_key_path: str, limit: int = 5, span_limit: int = 500
+    ) -> dict[str, Any]:
+        """Resolve the latest materialization for an asset and return its trace payload."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_asset_materialization_trace"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_asset_materialization_trace"},
+            ):
+                with tracer.start_as_current_span("phlo.materialization.trace"):
+                    payload = _inspect_materialization_payload(
+                        asset_key_path,
+                        limit=limit,
+                        log_limit=50,
+                        span_limit=span_limit,
+                    )
+                    latest_run = payload.get("latest_run") or {}
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "asset_key_path": asset_key_path,
+                        "run_id": latest_run.get("run_id"),
+                        "trace_source": latest_run.get("trace_source"),
+                        "span_count": latest_run.get("span_count"),
+                        "spans": latest_run.get("spans", []),
+                        "events": payload.get("events", []),
+                    }
+
+    @mcp.tool()
+    def render_materialization_trace_tree(
+        asset_key_path: str, limit: int = 5, span_limit: int = 500
+    ) -> dict[str, Any]:
+        """Render the latest materialization trace tree for an asset key path."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "render_materialization_trace_tree"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "render_materialization_trace_tree"},
+            ):
+                with tracer.start_as_current_span("phlo.materialization.trace_tree"):
+                    payload = _inspect_materialization_payload(
+                        asset_key_path,
+                        limit=limit,
+                        log_limit=50,
+                        span_limit=span_limit,
+                    )
+                    latest_run = payload.get("latest_run") or {}
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "asset_key_path": asset_key_path,
+                        "run_id": latest_run.get("run_id"),
+                        "trace_source": latest_run.get("trace_source"),
+                        "span_count": latest_run.get("span_count"),
+                        "tree": latest_run.get("trace_tree"),
+                    }
+
+    @mcp.tool()
+    def render_run_trace_tree(run_id: str, limit: int = 200) -> dict[str, Any]:
+        """Render a run execution tree using real spans when available, else logs."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "render_run_trace_tree"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "render_run_trace_tree"},
+            ):
+                with tracer.start_as_current_span("phlo.run.trace_tree"):
+                    span_payload = client.get_run_trace_spans(run_id, limit=max(limit, 500))
+                    spans = span_payload if isinstance(span_payload, list) else []
+                    if spans:
+                        return {
+                            "api_base_url": client.api_base_url,
+                            "run_id": run_id,
+                            "tree": render_span_tree(run_id, spans),
+                            "span_count": len(spans),
+                            "source": "spans",
+                        }
+                    payload = client.get_run_logs(run_id, limit=limit)
+                    entries = payload.get("entries", []) if isinstance(payload, dict) else []
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "run_id": run_id,
+                        "tree": render_log_trace_tree_text(run_id, entries, limit=limit),
+                        "entry_count": len(entries),
+                        "source": "logs",
+                    }
 
     return mcp

--- a/packages/phlo-mcp/src/phlo_mcp/tracing.py
+++ b/packages/phlo-mcp/src/phlo_mcp/tracing.py
@@ -1,0 +1,155 @@
+"""Local tracing utilities for phlo-mcp."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+_TRACE_FILE_ENV = "PHLO_MCP_TRACE_FILE"
+_CONFIGURED_PATH: str | None = None
+
+
+class JsonLineSpanExporter(SpanExporter):
+    """Write spans to a JSONL file for local tracing/debug workflows."""
+
+    def __init__(self, path: str):
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def export(self, spans: list[ReadableSpan]) -> SpanExportResult:
+        with self._path.open("a", encoding="utf-8") as handle:
+            for span in spans:
+                parent_id = None
+                if span.parent is not None:
+                    parent_id = f"{span.parent.span_id:016x}"
+                payload = {
+                    "name": span.name,
+                    "context": {
+                        "trace_id": f"{span.context.trace_id:032x}",
+                        "span_id": f"{span.context.span_id:016x}",
+                        "parent_id": parent_id,
+                    },
+                    "start_time_ns": span.start_time,
+                    "end_time_ns": span.end_time,
+                    "attributes": dict(span.attributes),
+                    "status": {
+                        "code": getattr(
+                            span.status.status_code, "name", str(span.status.status_code)
+                        ),
+                        "description": span.status.description,
+                    },
+                }
+                handle.write(json.dumps(payload, sort_keys=True) + "\n")
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        return None
+
+
+def configure_tracing(
+    *, service_name: str = "phlo-mcp", trace_file: str | None = None
+) -> str | None:
+    """Configure local tracing if a trace file is configured."""
+    global _CONFIGURED_PATH
+    resolved_trace_file = trace_file or os.environ.get(_TRACE_FILE_ENV)
+    if _CONFIGURED_PATH == resolved_trace_file:
+        return resolved_trace_file
+    if _CONFIGURED_PATH is not None and _CONFIGURED_PATH != resolved_trace_file:
+        return _CONFIGURED_PATH
+    if not resolved_trace_file:
+        return None
+
+    resource = Resource.create(
+        {
+            "service.name": service_name,
+            "service.namespace": "phlo",
+            "phlo.package": "phlo-mcp",
+            "phlo.runtime": "python",
+        }
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(SimpleSpanProcessor(JsonLineSpanExporter(resolved_trace_file)))
+    trace.set_tracer_provider(provider)
+    _CONFIGURED_PATH = resolved_trace_file
+    return resolved_trace_file
+
+
+def load_spans(path: str | os.PathLike[str]) -> list[dict[str, Any]]:
+    trace_path = Path(path)
+    if not trace_path.exists():
+        return []
+    return [
+        json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines() if line
+    ]
+
+
+def render_trace_tree(path: str | os.PathLike[str]) -> str:
+    """Render a compact tree view for spans written by JsonLineSpanExporter."""
+    spans = load_spans(path)
+    if not spans:
+        return "(no spans captured)"
+
+    by_trace: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for span in spans:
+        by_trace[span["context"]["trace_id"]].append(span)
+
+    lines: list[str] = []
+    for trace_id, trace_spans in sorted(
+        by_trace.items(), key=lambda item: min(span["start_time_ns"] for span in item[1])
+    ):
+        children: dict[str | None, list[dict[str, Any]]] = defaultdict(list)
+        for span in trace_spans:
+            children[span["context"]["parent_id"]].append(span)
+        for node_list in children.values():
+            node_list.sort(key=lambda span: span["start_time_ns"])
+
+        root_spans = children[None]
+        total_ms = sum(_duration_ms(span) for span in root_spans)
+        lines.append(f"Trace {trace_id[:8]} ({total_ms:.1f}ms)")
+        for index, root in enumerate(root_spans):
+            _render_span(root, children, lines, prefix="", is_last=index == len(root_spans) - 1)
+    return "\n".join(lines)
+
+
+def _render_span(
+    span: dict[str, Any],
+    children: dict[str | None, list[dict[str, Any]]],
+    lines: list[str],
+    *,
+    prefix: str,
+    is_last: bool,
+) -> None:
+    connector = "└─ " if is_last else "├─ "
+    attrs = span.get("attributes", {})
+    suffix_parts: list[str] = []
+    tool_name = attrs.get("mcp.tool.name")
+    url = attrs.get("url.full") or attrs.get("http.url")
+    if tool_name:
+        suffix_parts.append(f"tool={tool_name}")
+    if url:
+        suffix_parts.append(str(url))
+    suffix = f" [{', '.join(suffix_parts)}]" if suffix_parts else ""
+    lines.append(f"{prefix}{connector}{span['name']} {_duration_ms(span):.1f}ms{suffix}")
+
+    child_prefix = prefix + ("   " if is_last else "│  ")
+    span_children = children.get(span["context"]["span_id"], [])
+    for index, child in enumerate(span_children):
+        _render_span(
+            child,
+            children,
+            lines,
+            prefix=child_prefix,
+            is_last=index == len(span_children) - 1,
+        )
+
+
+def _duration_ms(span: dict[str, Any]) -> float:
+    return (span["end_time_ns"] - span["start_time_ns"]) / 1_000_000

--- a/packages/phlo-mcp/tests/smoke_stack.py
+++ b/packages/phlo-mcp/tests/smoke_stack.py
@@ -184,6 +184,7 @@ def _start_stack(project_root: Path) -> None:
     project_root.mkdir(parents=True, exist_ok=True)
     phlo_dir = project_root / ".phlo"
     compose_file = phlo_dir / "docker-compose.yml"
+    env = _smoke_stack_env()
     if not compose_file.exists():
         _run(
             [
@@ -197,6 +198,7 @@ def _start_stack(project_root: Path) -> None:
                 "--force",
             ],
             project_root,
+            env=env,
         )
     _run(
         [
@@ -212,11 +214,27 @@ def _start_stack(project_root: Path) -> None:
             "--native",
         ],
         project_root,
+        env=env,
     )
 
 
-def _run(command: list[str], cwd: Path) -> None:
-    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True, timeout=600)
+def _smoke_stack_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault("MINIO_API_PORT", "19000")
+    env.setdefault("MINIO_CONSOLE_PORT", "19001")
+    env.setdefault("CLICKSTACK_NATIVE_PORT", "19002")
+    return env
+
+
+def _run(command: list[str], cwd: Path, *, env: dict[str, str] | None = None) -> None:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=600,
+        env=env,
+    )
     if result.returncode != 0:
         raise SmokeFailure(
             f"{' '.join(command)} failed with exit {result.returncode}\n{result.stderr}"

--- a/packages/phlo-mcp/tests/smoke_stack.py
+++ b/packages/phlo-mcp/tests/smoke_stack.py
@@ -77,6 +77,16 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         help="ClickStack ClickHouse HTTP query URL reachable from this host",
     )
     parser.add_argument(
+        "--clickstack-query-user",
+        default=os.environ.get("PHLO_MCP_SMOKE_CLICKSTACK_QUERY_USER"),
+        help="Optional ClickStack ClickHouse HTTP query user",
+    )
+    parser.add_argument(
+        "--clickstack-query-password",
+        default=os.environ.get("PHLO_MCP_SMOKE_CLICKSTACK_QUERY_PASSWORD", ""),
+        help="Optional ClickStack ClickHouse HTTP query password",
+    )
+    parser.add_argument(
         "--api-token",
         default=os.environ.get("PHLO_MCP_SMOKE_API_TOKEN"),
         help="Optional bearer token for protected phlo-api instances",
@@ -186,12 +196,12 @@ def _check_phlo_api(args: argparse.Namespace) -> None:
 
 
 def _check_clickstack(args: argparse.Namespace) -> None:
-    exists = _clickstack_query(args.clickstack_query_url, "EXISTS TABLE default.otel_traces")
+    exists = _clickstack_query(args, "EXISTS TABLE default.otel_traces")
     if not exists or exists[0].get("result") != 1:
         raise SmokeFailure("ClickStack default.otel_traces table is missing")
 
     count = _clickstack_query(
-        args.clickstack_query_url,
+        args,
         "SELECT count() AS count FROM default.otel_traces",
     )
     if not count or "count" not in count[0]:
@@ -199,14 +209,22 @@ def _check_clickstack(args: argparse.Namespace) -> None:
     print(f"ClickStack default.otel_traces rows: {count[0]['count']}")
 
 
-def _clickstack_query(query_url: str, query: str) -> list[dict[str, Any]]:
+def _clickstack_query(args: argparse.Namespace, query: str) -> list[dict[str, Any]]:
     response = httpx.post(
-        query_url.rstrip("/"),
+        args.clickstack_query_url.rstrip("/"),
         content=f"{query} FORMAT JSONEachRow".encode("utf-8"),
+        auth=_clickstack_auth(args),
         timeout=20,
     )
     response.raise_for_status()
     return [json.loads(line) for line in response.text.splitlines() if line.strip()]
+
+
+def _clickstack_auth(args: argparse.Namespace) -> tuple[str, str] | None:
+    user = args.clickstack_query_user
+    if user is None:
+        return None
+    return (user, args.clickstack_query_password)
 
 
 async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:

--- a/packages/phlo-mcp/tests/smoke_stack.py
+++ b/packages/phlo-mcp/tests/smoke_stack.py
@@ -1,0 +1,292 @@
+"""Live smoke test for phlo-mcp against phlo-api, Dagster, and ClickStack.
+
+This script is intentionally not part of the default unit test path. It expects
+real local services and exercises the MCP stdio transport against a live
+``phlo-api`` instance.
+
+Examples:
+    uv run python packages/phlo-mcp/tests/smoke_stack.py
+    uv run python packages/phlo-mcp/tests/smoke_stack.py --run-id abc-123 --require-run-spans
+    uv run python packages/phlo-mcp/tests/smoke_stack.py --asset-key silver/orders
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import anyio
+import httpx
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+_DEFAULT_API_BASE_URL = "http://127.0.0.1:4000"
+_DEFAULT_DAGSTER_URL = "http://127.0.0.1:3000/graphql"
+_DEFAULT_CLICKSTACK_QUERY_URL = "http://127.0.0.1:8123"
+_SMOKE_RUN_ID = "phlo-mcp-smoke-no-such-run"
+
+
+class SmokeFailure(RuntimeError):
+    """Raised when a smoke check fails."""
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[3]
+
+    if args.start_stack:
+        _start_stack(repo_root)
+
+    try:
+        _wait_for_json(f"{args.api_base_url}/health", timeout_seconds=args.timeout_seconds)
+        _check_phlo_api(args)
+        _check_clickstack(args)
+        anyio.run(_check_mcp_stdio, args, repo_root)
+    except SmokeFailure as exc:
+        print(f"SMOKE FAILED: {exc}", file=sys.stderr)
+        return 1
+
+    print("SMOKE PASSED: phlo-mcp, phlo-api, Dagster, and ClickStack paths are reachable")
+    return 0
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--api-base-url",
+        default=os.environ.get("PHLO_MCP_SMOKE_API_BASE_URL", _DEFAULT_API_BASE_URL),
+        help="Base URL for the live phlo-api instance",
+    )
+    parser.add_argument(
+        "--dagster-url",
+        default=os.environ.get("PHLO_MCP_SMOKE_DAGSTER_URL", _DEFAULT_DAGSTER_URL),
+        help="Dagster GraphQL URL reachable by phlo-api",
+    )
+    parser.add_argument(
+        "--clickstack-query-url",
+        default=os.environ.get(
+            "PHLO_MCP_SMOKE_CLICKSTACK_QUERY_URL", _DEFAULT_CLICKSTACK_QUERY_URL
+        ),
+        help="ClickStack ClickHouse HTTP query URL reachable from this host",
+    )
+    parser.add_argument(
+        "--api-token",
+        default=os.environ.get("PHLO_MCP_SMOKE_API_TOKEN"),
+        help="Optional bearer token for protected phlo-api instances",
+    )
+    parser.add_argument(
+        "--run-id",
+        default=os.environ.get("PHLO_MCP_SMOKE_RUN_ID", _SMOKE_RUN_ID),
+        help="Run id to query through the MCP trace-span tool",
+    )
+    parser.add_argument(
+        "--asset-key",
+        default=os.environ.get("PHLO_MCP_SMOKE_ASSET_KEY"),
+        help="Optional slash-delimited asset key to query for materialization history",
+    )
+    parser.add_argument(
+        "--require-run-spans",
+        action="store_true",
+        default=_truthy_env("PHLO_MCP_SMOKE_REQUIRE_RUN_SPANS"),
+        help="Fail unless --run-id returns at least one trace span",
+    )
+    parser.add_argument(
+        "--require-materialization",
+        action="store_true",
+        default=_truthy_env("PHLO_MCP_SMOKE_REQUIRE_MATERIALIZATION"),
+        help="Fail unless --asset-key returns at least one materialization event",
+    )
+    parser.add_argument(
+        "--start-stack",
+        action="store_true",
+        default=_truthy_env("PHLO_MCP_SMOKE_START_STACK"),
+        help="Run phlo service init/start before checking endpoints",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=float(os.environ.get("PHLO_MCP_SMOKE_TIMEOUT_SECONDS", "180")),
+        help="How long to wait for live endpoints",
+    )
+    return parser.parse_args(argv)
+
+
+def _truthy_env(name: str) -> bool:
+    return os.environ.get(name, "").lower() in {"1", "true", "yes", "on"}
+
+
+def _start_stack(repo_root: Path) -> None:
+    _run(["phlo", "services", "init", "--profile", "api", "--profile", "observability"], repo_root)
+    _run(
+        [
+            "phlo",
+            "services",
+            "start",
+            "--profile",
+            "api",
+            "--profile",
+            "observability",
+            "--service",
+            "dagster,clickstack,phlo-api",
+            "--native",
+        ],
+        repo_root,
+    )
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    result = subprocess.run(command, cwd=cwd, text=True, capture_output=True, timeout=600)
+    if result.returncode != 0:
+        raise SmokeFailure(
+            f"{' '.join(command)} failed with exit {result.returncode}\n{result.stderr}"
+        )
+
+
+def _wait_for_json(url: str, *, timeout_seconds: float) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            response = httpx.get(url, timeout=5)
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:  # noqa: BLE001
+            last_error = exc
+            time.sleep(2)
+    raise SmokeFailure(f"{url} did not become ready: {last_error}")
+
+
+def _get_json(url: str, *, params: dict[str, str] | None = None) -> dict[str, Any] | list[Any]:
+    response = httpx.get(url, params=params, timeout=20)
+    response.raise_for_status()
+    payload = response.json()
+    if isinstance(payload, dict) and payload.get("error"):
+        raise SmokeFailure(f"{url} returned error: {payload['error']}")
+    return payload
+
+
+def _check_phlo_api(args: argparse.Namespace) -> None:
+    health = _get_json(f"{args.api_base_url}/api/observability/health")
+    if not isinstance(health, dict) or "overall_status" not in health:
+        raise SmokeFailure("phlo-api observability health response was malformed")
+
+    dagster = _get_json(
+        f"{args.api_base_url}/api/dagster/connection",
+        params={"dagster_url": args.dagster_url},
+    )
+    if not isinstance(dagster, dict) or dagster.get("connected") is not True:
+        raise SmokeFailure(f"Dagster is not connected through phlo-api: {dagster}")
+
+
+def _check_clickstack(args: argparse.Namespace) -> None:
+    exists = _clickstack_query(args.clickstack_query_url, "EXISTS TABLE default.otel_traces")
+    if not exists or exists[0].get("result") != 1:
+        raise SmokeFailure("ClickStack default.otel_traces table is missing")
+
+    count = _clickstack_query(
+        args.clickstack_query_url,
+        "SELECT count() AS count FROM default.otel_traces",
+    )
+    if not count or "count" not in count[0]:
+        raise SmokeFailure("ClickStack otel_traces count query returned an unexpected payload")
+    print(f"ClickStack default.otel_traces rows: {count[0]['count']}")
+
+
+def _clickstack_query(query_url: str, query: str) -> list[dict[str, Any]]:
+    response = httpx.post(
+        query_url.rstrip("/"),
+        content=f"{query} FORMAT JSONEachRow".encode("utf-8"),
+        timeout=20,
+    )
+    response.raise_for_status()
+    return [json.loads(line) for line in response.text.splitlines() if line.strip()]
+
+
+async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:
+    command_args = [
+        "run",
+        "--package",
+        "phlo-mcp",
+        "phlo-mcp",
+        "--api-base-url",
+        args.api_base_url,
+    ]
+    if args.api_token:
+        command_args.extend(["--api-token", args.api_token])
+
+    params = StdioServerParameters(command="uv", args=command_args, cwd=repo_root)
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = await session.list_tools()
+            names = {tool.name for tool in tools.tools}
+            expected = {
+                "get_platform_health",
+                "get_dashboard_links",
+                "get_run_trace_spans",
+                "get_materialization_history",
+            }
+            missing = sorted(expected - names)
+            if missing:
+                raise SmokeFailure(f"MCP server is missing expected tools: {missing}")
+
+            await _call_tool_json(session, "get_platform_health", {})
+            await _call_tool_json(session, "get_dashboard_links", {})
+            spans = await _call_tool_json(session, "get_run_trace_spans", {"run_id": args.run_id})
+            span_rows = spans.get("spans") if isinstance(spans, dict) else None
+            if not isinstance(span_rows, list):
+                raise SmokeFailure(f"get_run_trace_spans returned unexpected payload: {spans}")
+            if args.require_run_spans and not span_rows:
+                raise SmokeFailure(f"run {args.run_id!r} returned no trace spans")
+
+            if args.asset_key:
+                history = await _call_tool_json(
+                    session,
+                    "get_materialization_history",
+                    {"asset_key_path": args.asset_key},
+                )
+                events = history.get("events") if isinstance(history, dict) else None
+                if not isinstance(events, list):
+                    raise SmokeFailure(
+                        f"get_materialization_history returned unexpected payload: {history}"
+                    )
+                if args.require_materialization and not events:
+                    raise SmokeFailure(f"asset {args.asset_key!r} returned no materializations")
+
+
+async def _call_tool_json(
+    session: ClientSession,
+    name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any] | list[Any]:
+    result = await session.call_tool(name, arguments)
+    if result.isError:
+        raise SmokeFailure(f"MCP tool {name} returned an error: {result.content}")
+    if not result.content:
+        raise SmokeFailure(f"MCP tool {name} returned no content")
+    content = result.content[0]
+    text = getattr(content, "text", None)
+    if not isinstance(text, str):
+        raise SmokeFailure(f"MCP tool {name} returned non-text content: {content}")
+    payload = json.loads(text)
+    if isinstance(payload, dict) and payload.get("payload", {}).get("error"):
+        raise SmokeFailure(f"MCP tool {name} returned upstream error: {payload}")
+    if isinstance(payload, dict):
+        spans = payload.get("spans")
+        if isinstance(spans, dict) and spans.get("error"):
+            raise SmokeFailure(f"MCP tool {name} returned upstream error: {payload}")
+        events = payload.get("events")
+        if isinstance(events, dict) and events.get("error"):
+            raise SmokeFailure(f"MCP tool {name} returned upstream error: {payload}")
+    return payload
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/phlo-mcp/tests/smoke_stack.py
+++ b/packages/phlo-mcp/tests/smoke_stack.py
@@ -1,4 +1,4 @@
-"""Live smoke test for phlo-mcp against phlo-api, Dagster, and ClickStack.
+"""Live smoke test for phlo-mcp against phlo-api capability routes.
 
 This script is intentionally not part of the default unit test path. It expects
 real local services and exercises the MCP stdio transport against a live
@@ -29,18 +29,26 @@ from mcp.client.stdio import stdio_client
 
 _DEFAULT_API_BASE_URL = "http://127.0.0.1:4000"
 _DEFAULT_DAGSTER_URL = "http://127.0.0.1:3000/graphql"
-_DEFAULT_CLICKSTACK_QUERY_URL = "http://127.0.0.1:8123"
 _SMOKE_RUN_ID = "phlo-mcp-smoke-no-such-run"
 _SMOKE_ASSET_KEY = "mcp_smoke_asset"
 _SMOKE_ASSET_FILENAME = "mcp_smoke_asset.py"
 _SMOKE_ASSET_SOURCE = '''"""Generated asset used by packages/phlo-mcp/tests/smoke_stack.py."""
 
-import dagster as dg
+from phlo.capabilities import AssetSpec, MaterializeResult, RunSpec, register_asset
 
 
-@dg.asset(group_name="smoke")
-def mcp_smoke_asset() -> int:
-    return 1
+def _run(runtime):
+    return [MaterializeResult(metadata={"rows": 1})]
+
+
+register_asset(
+    AssetSpec(
+        key="mcp_smoke_asset",
+        group="smoke",
+        description="MCP smoke asset",
+        run=RunSpec(fn=_run),
+    )
+)
 '''
 
 
@@ -62,13 +70,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         _wait_for_json(f"{args.api_base_url}/health", timeout_seconds=args.timeout_seconds)
         _check_phlo_api(args)
-        _check_clickstack(args)
         anyio.run(_check_mcp_stdio, args, repo_root)
     except SmokeFailure as exc:
         print(f"SMOKE FAILED: {exc}", file=sys.stderr)
         return 1
 
-    print("SMOKE PASSED: phlo-mcp, phlo-api, Dagster, and ClickStack paths are reachable")
+    print("SMOKE PASSED: phlo-mcp, phlo-api, and configured capability paths are reachable")
     return 0
 
 
@@ -83,23 +90,6 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         "--dagster-url",
         default=os.environ.get("PHLO_MCP_SMOKE_DAGSTER_URL", _DEFAULT_DAGSTER_URL),
         help="Dagster GraphQL URL reachable by phlo-api",
-    )
-    parser.add_argument(
-        "--clickstack-query-url",
-        default=os.environ.get(
-            "PHLO_MCP_SMOKE_CLICKSTACK_QUERY_URL", _DEFAULT_CLICKSTACK_QUERY_URL
-        ),
-        help="ClickStack ClickHouse HTTP query URL reachable from this host",
-    )
-    parser.add_argument(
-        "--clickstack-query-user",
-        default=os.environ.get("PHLO_MCP_SMOKE_CLICKSTACK_QUERY_USER"),
-        help="Optional ClickStack ClickHouse HTTP query user",
-    )
-    parser.add_argument(
-        "--clickstack-query-password",
-        default=os.environ.get("PHLO_MCP_SMOKE_CLICKSTACK_QUERY_PASSWORD", ""),
-        help="Optional ClickStack ClickHouse HTTP query password",
     )
     parser.add_argument(
         "--api-token",
@@ -192,6 +182,8 @@ def _start_stack(project_root: Path) -> None:
                 "services",
                 "init",
                 "--profile",
+                "orchestration",
+                "--profile",
                 "api",
                 "--profile",
                 "observability",
@@ -206,11 +198,11 @@ def _start_stack(project_root: Path) -> None:
             "services",
             "start",
             "--profile",
+            "orchestration",
+            "--profile",
             "api",
             "--profile",
             "observability",
-            "--service",
-            "dagster,clickstack,phlo-api",
             "--native",
         ],
         project_root,
@@ -295,38 +287,6 @@ def _check_phlo_api(args: argparse.Namespace) -> None:
     )
     if not isinstance(filtered_spans, list):
         raise SmokeFailure(f"filtered trace endpoint returned unexpected payload: {filtered_spans}")
-
-
-def _check_clickstack(args: argparse.Namespace) -> None:
-    exists = _clickstack_query(args, "EXISTS TABLE default.otel_traces")
-    if not exists or exists[0].get("result") != 1:
-        raise SmokeFailure("ClickStack default.otel_traces table is missing")
-
-    count = _clickstack_query(
-        args,
-        "SELECT count() AS count FROM default.otel_traces",
-    )
-    if not count or "count" not in count[0]:
-        raise SmokeFailure("ClickStack otel_traces count query returned an unexpected payload")
-    print(f"ClickStack default.otel_traces rows: {count[0]['count']}")
-
-
-def _clickstack_query(args: argparse.Namespace, query: str) -> list[dict[str, Any]]:
-    response = httpx.post(
-        args.clickstack_query_url.rstrip("/"),
-        content=f"{query} FORMAT JSONEachRow".encode("utf-8"),
-        auth=_clickstack_auth(args),
-        timeout=20,
-    )
-    response.raise_for_status()
-    return [json.loads(line) for line in response.text.splitlines() if line.strip()]
-
-
-def _clickstack_auth(args: argparse.Namespace) -> tuple[str, str] | None:
-    user = args.clickstack_query_user
-    if user is None:
-        return None
-    return (user, args.clickstack_query_password)
 
 
 async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:

--- a/packages/phlo-mcp/tests/smoke_stack.py
+++ b/packages/phlo-mcp/tests/smoke_stack.py
@@ -5,7 +5,7 @@ real local services and exercises the MCP stdio transport against a live
 ``phlo-api`` instance.
 
 Examples:
-    uv run python packages/phlo-mcp/tests/smoke_stack.py
+    uv run python packages/phlo-mcp/tests/smoke_stack.py --start-stack
     uv run python packages/phlo-mcp/tests/smoke_stack.py --run-id abc-123 --require-run-spans
     uv run python packages/phlo-mcp/tests/smoke_stack.py --asset-key silver/orders
 """
@@ -31,6 +31,17 @@ _DEFAULT_API_BASE_URL = "http://127.0.0.1:4000"
 _DEFAULT_DAGSTER_URL = "http://127.0.0.1:3000/graphql"
 _DEFAULT_CLICKSTACK_QUERY_URL = "http://127.0.0.1:8123"
 _SMOKE_RUN_ID = "phlo-mcp-smoke-no-such-run"
+_SMOKE_ASSET_KEY = "mcp_smoke_asset"
+_SMOKE_ASSET_FILENAME = "mcp_smoke_asset.py"
+_SMOKE_ASSET_SOURCE = '''"""Generated asset used by packages/phlo-mcp/tests/smoke_stack.py."""
+
+import dagster as dg
+
+
+@dg.asset(group_name="smoke")
+def mcp_smoke_asset() -> int:
+    return 1
+'''
 
 
 class SmokeFailure(RuntimeError):
@@ -40,9 +51,13 @@ class SmokeFailure(RuntimeError):
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     repo_root = Path(__file__).resolve().parents[3]
+    project_root = _project_root(args, repo_root)
 
     if args.start_stack:
-        _start_stack(repo_root)
+        _seed_smoke_asset(project_root)
+        if not args.asset_key:
+            args.asset_key = _SMOKE_ASSET_KEY
+        _start_stack(project_root)
 
     try:
         _wait_for_json(f"{args.api_base_url}/health", timeout_seconds=args.timeout_seconds)
@@ -92,6 +107,18 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         help="Optional bearer token for protected phlo-api instances",
     )
     parser.add_argument(
+        "--enable-write-tools",
+        action="store_true",
+        default=_truthy_env("PHLO_MCP_SMOKE_ENABLE_WRITE_TOOLS"),
+        help="Enable guarded MCP write-tool registration during the smoke",
+    )
+    parser.add_argument(
+        "--exercise-write-tools",
+        action="store_true",
+        default=_truthy_env("PHLO_MCP_SMOKE_EXERCISE_WRITE_TOOLS"),
+        help="Call guarded write tools in dry-run mode; requires live phlo-api write endpoints",
+    )
+    parser.add_argument(
         "--run-id",
         default=os.environ.get("PHLO_MCP_SMOKE_RUN_ID", _SMOKE_RUN_ID),
         help="Run id to query through the MCP trace-span tool",
@@ -120,6 +147,14 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         help="Run phlo service init/start before checking endpoints",
     )
     parser.add_argument(
+        "--project-root",
+        default=os.environ.get("PHLO_MCP_SMOKE_PROJECT_ROOT"),
+        help=(
+            "Project directory used with --start-stack; defaults to "
+            ".phlo/mcp-smoke-project under the repo"
+        ),
+    )
+    parser.add_argument(
         "--timeout-seconds",
         type=float,
         default=float(os.environ.get("PHLO_MCP_SMOKE_TIMEOUT_SECONDS", "180")),
@@ -132,8 +167,37 @@ def _truthy_env(name: str) -> bool:
     return os.environ.get(name, "").lower() in {"1", "true", "yes", "on"}
 
 
-def _start_stack(repo_root: Path) -> None:
-    _run(["phlo", "services", "init", "--profile", "api", "--profile", "observability"], repo_root)
+def _project_root(args: argparse.Namespace, repo_root: Path) -> Path:
+    if args.project_root:
+        return Path(args.project_root).expanduser().resolve()
+    return repo_root / ".phlo" / "mcp-smoke-project"
+
+
+def _seed_smoke_asset(project_root: Path) -> None:
+    workflows_dir = project_root / "workflows"
+    workflows_dir.mkdir(parents=True, exist_ok=True)
+    asset_path = workflows_dir / _SMOKE_ASSET_FILENAME
+    asset_path.write_text(_SMOKE_ASSET_SOURCE, encoding="utf-8")
+
+
+def _start_stack(project_root: Path) -> None:
+    project_root.mkdir(parents=True, exist_ok=True)
+    phlo_dir = project_root / ".phlo"
+    compose_file = phlo_dir / "docker-compose.yml"
+    if not compose_file.exists():
+        _run(
+            [
+                "phlo",
+                "services",
+                "init",
+                "--profile",
+                "api",
+                "--profile",
+                "observability",
+                "--force",
+            ],
+            project_root,
+        )
     _run(
         [
             "phlo",
@@ -147,7 +211,7 @@ def _start_stack(repo_root: Path) -> None:
             "dagster,clickstack,phlo-api",
             "--native",
         ],
-        repo_root,
+        project_root,
     )
 
 
@@ -173,8 +237,19 @@ def _wait_for_json(url: str, *, timeout_seconds: float) -> dict[str, Any]:
     raise SmokeFailure(f"{url} did not become ready: {last_error}")
 
 
-def _get_json(url: str, *, params: dict[str, str] | None = None) -> dict[str, Any] | list[Any]:
-    response = httpx.get(url, params=params, timeout=20)
+def _api_headers(args: argparse.Namespace) -> dict[str, str]:
+    if args.api_token:
+        return {"Authorization": f"Bearer {args.api_token}"}
+    return {}
+
+
+def _get_json(
+    args: argparse.Namespace,
+    url: str,
+    *,
+    params: dict[str, str] | None = None,
+) -> dict[str, Any] | list[Any]:
+    response = httpx.get(url, params=params, headers=_api_headers(args), timeout=20)
     response.raise_for_status()
     payload = response.json()
     if isinstance(payload, dict) and payload.get("error"):
@@ -183,16 +258,25 @@ def _get_json(url: str, *, params: dict[str, str] | None = None) -> dict[str, An
 
 
 def _check_phlo_api(args: argparse.Namespace) -> None:
-    health = _get_json(f"{args.api_base_url}/api/observability/health")
+    health = _get_json(args, f"{args.api_base_url}/api/observability/health")
     if not isinstance(health, dict) or "overall_status" not in health:
         raise SmokeFailure("phlo-api observability health response was malformed")
 
     dagster = _get_json(
+        args,
         f"{args.api_base_url}/api/dagster/connection",
         params={"dagster_url": args.dagster_url},
     )
     if not isinstance(dagster, dict) or dagster.get("connected") is not True:
         raise SmokeFailure(f"Dagster is not connected through phlo-api: {dagster}")
+
+    filtered_spans = _get_json(
+        args,
+        f"{args.api_base_url}/api/observability/traces",
+        params={"run_id": args.run_id, "limit": "25"},
+    )
+    if not isinstance(filtered_spans, list):
+        raise SmokeFailure(f"filtered trace endpoint returned unexpected payload: {filtered_spans}")
 
 
 def _check_clickstack(args: argparse.Namespace) -> None:
@@ -238,6 +322,8 @@ async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:
     ]
     if args.api_token:
         command_args.extend(["--api-token", args.api_token])
+    if args.enable_write_tools:
+        command_args.append("--enable-write-tools")
 
     params = StdioServerParameters(command="uv", args=command_args, cwd=repo_root)
     async with stdio_client(params) as (read, write):
@@ -249,11 +335,27 @@ async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:
                 "get_platform_health",
                 "get_dashboard_links",
                 "get_run_trace_spans",
+                "get_trace_spans",
+                "render_trace_spans_tree",
                 "get_materialization_history",
             }
             missing = sorted(expected - names)
             if missing:
                 raise SmokeFailure(f"MCP server is missing expected tools: {missing}")
+            write_tools = {"materialize_asset", "retry_failed_run", "get_dagster_run_status"}
+            registered_write_tools = names & write_tools
+            if args.enable_write_tools and args.api_token:
+                missing_write_tools = sorted(write_tools - names)
+                if missing_write_tools:
+                    raise SmokeFailure(
+                        f"MCP server is missing enabled write tools: {missing_write_tools}"
+                    )
+            elif registered_write_tools:
+                raise SmokeFailure(
+                    f"MCP server registered write tools without opt-in auth: {registered_write_tools}"
+                )
+
+            await _check_mcp_resources(session)
 
             await _call_tool_json(session, "get_platform_health", {})
             await _call_tool_json(session, "get_dashboard_links", {})
@@ -263,6 +365,27 @@ async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:
                 raise SmokeFailure(f"get_run_trace_spans returned unexpected payload: {spans}")
             if args.require_run_spans and not span_rows:
                 raise SmokeFailure(f"run {args.run_id!r} returned no trace spans")
+
+            filtered_spans = await _call_tool_json(
+                session,
+                "get_trace_spans",
+                {"run_id": args.run_id, "limit": 25},
+            )
+            filtered_span_rows = (
+                filtered_spans.get("spans") if isinstance(filtered_spans, dict) else None
+            )
+            if not isinstance(filtered_span_rows, list):
+                raise SmokeFailure(f"get_trace_spans returned unexpected payload: {filtered_spans}")
+            if args.require_run_spans and not filtered_span_rows:
+                raise SmokeFailure(f"filtered trace query for {args.run_id!r} returned no spans")
+
+            tree = await _call_tool_json(
+                session,
+                "render_trace_spans_tree",
+                {"run_id": args.run_id, "limit": 25},
+            )
+            if not isinstance(tree, dict) or not isinstance(tree.get("tree"), str):
+                raise SmokeFailure(f"render_trace_spans_tree returned unexpected payload: {tree}")
 
             if args.asset_key:
                 history = await _call_tool_json(
@@ -277,6 +400,77 @@ async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:
                     )
                 if args.require_materialization and not events:
                     raise SmokeFailure(f"asset {args.asset_key!r} returned no materializations")
+
+                if args.exercise_write_tools:
+                    if not args.enable_write_tools or not args.api_token:
+                        raise SmokeFailure(
+                            "--exercise-write-tools requires --enable-write-tools and --api-token"
+                        )
+                    materialize = await _call_tool_json(
+                        session,
+                        "materialize_asset",
+                        {"asset_key_path": args.asset_key, "dry_run": True},
+                    )
+                    audit = (
+                        materialize.get("audit_context") if isinstance(materialize, dict) else None
+                    )
+                    if not isinstance(audit, dict) or audit.get("dry_run") is not True:
+                        raise SmokeFailure(
+                            f"materialize_asset returned unexpected audit context: {materialize}"
+                        )
+
+
+async def _check_mcp_resources(session: ClientSession) -> None:
+    resources = await session.list_resources()
+    resource_uris = {str(resource.uri) for resource in resources.resources}
+    expected_resources = {
+        "phlo://runtime/config",
+        "phlo://runtime/services",
+        "phlo://runtime/plugins",
+        "phlo://runtime/assets",
+        "phlo://runtime/contracts",
+        "phlo://runtime/dashboards",
+    }
+    missing_resources = sorted(expected_resources - resource_uris)
+    if missing_resources:
+        raise SmokeFailure(f"MCP server is missing expected resources: {missing_resources}")
+
+    templates = await session.list_resource_templates()
+    template_uris = {template.uriTemplate for template in templates.resourceTemplates}
+    expected_templates = {
+        "phlo://docs/packages/{package_name}",
+        "phlo://runtime/services/{service_name}",
+        "phlo://runtime/assets/{asset_key_path}",
+        "phlo://runtime/schemas/{asset_key_path}",
+        "phlo://runtime/contracts/{table_name}",
+    }
+    missing_templates = sorted(expected_templates - template_uris)
+    if missing_templates:
+        raise SmokeFailure(
+            f"MCP server is missing expected resource templates: {missing_templates}"
+        )
+
+    await _read_resource_json(session, "phlo://runtime/config")
+    services = await _read_resource_json(session, "phlo://runtime/services")
+    if not isinstance(services, list):
+        raise SmokeFailure(f"phlo://runtime/services returned unexpected payload: {services}")
+    docs = await session.read_resource("phlo://docs/packages/phlo-mcp")
+    text = getattr(docs.contents[0], "text", "") if docs.contents else ""
+    if "# phlo-mcp" not in text:
+        raise SmokeFailure("phlo://docs/packages/phlo-mcp did not return package docs")
+
+
+async def _read_resource_json(session: ClientSession, uri: str) -> dict[str, Any] | list[Any]:
+    result = await session.read_resource(uri)
+    if not result.contents:
+        raise SmokeFailure(f"MCP resource {uri} returned no content")
+    text = getattr(result.contents[0], "text", None)
+    if not isinstance(text, str):
+        raise SmokeFailure(f"MCP resource {uri} returned non-text content: {result.contents[0]}")
+    payload = json.loads(text)
+    if isinstance(payload, dict) and payload.get("error"):
+        raise SmokeFailure(f"MCP resource {uri} returned upstream error: {payload}")
+    return payload
 
 
 async def _call_tool_json(

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -458,6 +458,33 @@ def test_run_analysis_helpers_render_materialization_view() -> None:
     assert "service.version=1.2.3" in span_tree
 
 
+def test_render_span_tree_renders_orphaned_filtered_spans() -> None:
+    from phlo_mcp.run_analysis import render_span_tree
+
+    tree = render_span_tree(
+        "filtered traces",
+        [
+            {
+                "timestamp": "2026-01-01T00:00:01Z",
+                "trace_id": "abc123",
+                "span_id": "child",
+                "parent_span_id": "missing-parent",
+                "span_name": "write_output",
+                "service_name": "dagster",
+                "span_kind": "INTERNAL",
+                "status_code": "STATUS_CODE_ERROR",
+                "duration_ms": 3.0,
+                "span_attributes": {"phlo.stage": "materialize"},
+                "resource_attributes": {"service.name": "dagster"},
+            }
+        ],
+    )
+
+    assert "trace abc123" in tree
+    assert "write_output [internal error]" in tree
+    assert "stage=materialize" in tree
+
+
 def test_render_run_trace_tree_uses_most_recent_logs_with_limit() -> None:
     entries = [
         {

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -1,0 +1,125 @@
+"""Tests for phlo-mcp package surfaces."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from phlo_mcp.api_client import PhloApiClient
+from phlo_mcp.cli import parse_args
+from phlo_mcp.config import McpConfig
+from phlo_mcp.server import create_server
+from phlo_mcp.tracing import render_trace_tree
+
+
+class _FakeResponse:
+    def __init__(self, payload):  # noqa: ANN001
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self):  # noqa: ANN201
+        return self._payload
+
+
+def test_api_client_wraps_observability_routes(monkeypatch) -> None:
+    seen_urls: list[str] = []
+
+    def fake_get(url: str, params=None, timeout=10.0):  # noqa: ANN001
+        seen_urls.append(url)
+        if url.endswith("/health"):
+            return _FakeResponse({"overall_status": "healthy"})
+        if url.endswith("/services"):
+            return _FakeResponse([{"name": "observability", "status": "unknown"}])
+        if url.endswith("/alerts"):
+            assert params == {"limit": 3}
+            return _FakeResponse([{"title": "No alerts"}])
+        if url.endswith("/dashboards"):
+            return _FakeResponse([{"title": "ClickStack", "url": "http://example.test"}])
+        if url.endswith("/links/logs"):
+            return _FakeResponse({"url": "http://logs.test"})
+        if url.endswith("/links/metrics"):
+            return _FakeResponse({"url": "http://metrics.test"})
+        raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr("phlo_mcp.api_client.httpx.get", fake_get)
+    client = PhloApiClient(McpConfig(api_base_url="http://example.test"))
+
+    assert client.get_platform_health()["overall_status"] == "healthy"
+    assert client.get_service_status()[0]["name"] == "observability"
+    assert client.get_recent_alerts(limit=3)[0]["title"] == "No alerts"
+    assert client.get_dashboard_links()[0]["title"] == "ClickStack"
+    assert client.get_logs_query_link()["url"] == "http://logs.test"
+    assert client.get_metrics_query_link()["url"] == "http://metrics.test"
+    assert seen_urls[0] == "http://example.test/api/observability/health"
+
+
+def test_create_server_registers_expected_tools() -> None:
+    server = create_server(McpConfig())
+
+    tool_names = [tool.name for tool in server._tool_manager.list_tools()]
+
+    assert tool_names == [
+        "get_platform_health",
+        "get_service_status",
+        "get_recent_alerts",
+        "get_dashboard_links",
+        "get_logs_query_link",
+        "get_metrics_query_link",
+    ]
+
+
+def test_parse_args_overrides_env(monkeypatch) -> None:
+    monkeypatch.setenv("PHLO_MCP_API_BASE_URL", "http://env.test:4000")
+    monkeypatch.setenv("PHLO_MCP_TRANSPORT", "stdio")
+    monkeypatch.setenv("PHLO_MCP_PORT", "8000")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "phlo-mcp",
+            "--transport",
+            "streamable-http",
+            "--api-base-url",
+            "http://cli.test:4100",
+            "--port",
+            "9000",
+        ],
+    )
+
+    config = parse_args()
+
+    assert config.transport == "streamable-http"
+    assert config.api_base_url == "http://cli.test:4100"
+    assert config.port == 9000
+
+
+def test_render_trace_tree_formats_tree(tmp_path: Path) -> None:
+    trace_file = tmp_path / "trace.jsonl"
+    spans = [
+        {
+            "name": "mcp.request",
+            "context": {"trace_id": "a" * 32, "span_id": "1" * 16, "parent_id": None},
+            "start_time_ns": 0,
+            "end_time_ns": 4_000_000,
+            "attributes": {},
+            "status": {"code": "UNSET", "description": None},
+        },
+        {
+            "name": "mcp.tool.execute",
+            "context": {"trace_id": "a" * 32, "span_id": "2" * 16, "parent_id": "1" * 16},
+            "start_time_ns": 1_000_000,
+            "end_time_ns": 3_000_000,
+            "attributes": {"mcp.tool.name": "get_platform_health"},
+            "status": {"code": "UNSET", "description": None},
+        },
+    ]
+    trace_file.write_text("\n".join(json.dumps(span) for span in spans), encoding="utf-8")
+
+    rendered = render_trace_tree(trace_file)
+
+    assert "Trace aaaaaaaa" in rendered
+    assert "mcp.request 4.0ms" in rendered
+    assert "mcp.tool.execute 2.0ms [tool=get_platform_health]" in rendered

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -375,6 +375,15 @@ def test_parse_args_overrides_env(monkeypatch) -> None:
     assert config.port == 9000
 
 
+def test_parse_args_preserves_zero_port(monkeypatch) -> None:
+    monkeypatch.setenv("PHLO_MCP_PORT", "8000")
+    monkeypatch.setattr(sys, "argv", ["phlo-mcp", "--port", "0"])
+
+    config = parse_args()
+
+    assert config.port == 0
+
+
 def test_config_from_env_reads_write_tool_gate(monkeypatch) -> None:
     monkeypatch.setenv("PHLO_MCP_ENABLE_WRITE_TOOLS", "true")
 

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from phlo_mcp.api_client import PhloApiClient
 from phlo_mcp.cli import parse_args
-from phlo_mcp.config import McpConfig
+from phlo_mcp.config import McpConfig, config_from_env
 from phlo_mcp.run_analysis import (
     render_run_trace_tree as render_run_trace_tree_text,
     summarize_run_logs,
@@ -35,6 +35,22 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     def fake_get(url: str, params=None, headers=None, timeout=10.0):  # noqa: ANN001
         seen_urls.append(url)
         seen_headers.append(headers or {})
+        if url.endswith("/api/config"):
+            return _FakeResponse({"name": "demo"})
+        if url.endswith("/api/plugins"):
+            return _FakeResponse({"services": ["phlo-api"]})
+        if url.endswith("/api/services"):
+            return _FakeResponse([{"name": "dagster", "profile": "orchestration"}])
+        if url.endswith("/api/services/dagster"):
+            return _FakeResponse({"name": "dagster", "depends_on": []})
+        if url.endswith("/api/dagster/assets"):
+            return _FakeResponse([{"key_path": "silver/orders"}])
+        if url.endswith("/api/dagster/assets/silver/orders"):
+            return _FakeResponse({"key_path": "silver/orders", "columns": [{"name": "id"}]})
+        if url.endswith("/api/contracts"):
+            return _FakeResponse([{"table": "silver.orders"}])
+        if url.endswith("/api/contracts/silver.orders"):
+            return _FakeResponse({"table": "silver.orders"})
         if url.endswith("/health"):
             return _FakeResponse({"overall_status": "healthy"})
         if url.endswith("/services"):
@@ -88,6 +104,30 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
                     }
                 ]
             )
+        if url.endswith("/api/observability/traces"):
+            assert params == {
+                "limit": 25,
+                "asset_key": "silver/orders",
+                "service_name": "dagster",
+                "status_code": "STATUS_CODE_ERROR",
+            }
+            return _FakeResponse(
+                [
+                    {
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "trace_id": "abc123",
+                        "span_id": "root",
+                        "parent_span_id": None,
+                        "span_name": "materialize_orders",
+                        "service_name": "dagster",
+                        "span_kind": "INTERNAL",
+                        "duration_ms": 12.5,
+                        "status_code": "STATUS_CODE_ERROR",
+                        "span_attributes": {"phlo.asset_key": "silver/orders"},
+                        "resource_attributes": {"service.name": "dagster"},
+                    }
+                ]
+            )
         if "/api/dagster/assets/" in url and url.endswith("/history"):
             return _FakeResponse([{"run_id": "run-123", "timestamp": "2026-01-01T00:00:00Z"}])
         if url.endswith("/links/logs"):
@@ -99,17 +139,72 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     monkeypatch.setattr("phlo_mcp.api_client.httpx.get", fake_get)
     client = PhloApiClient(McpConfig(api_base_url="http://example.test"))
 
+    assert client.get_config()["name"] == "demo"
+    assert client.get_plugins()["services"] == ["phlo-api"]
+    assert client.get_services()[0]["name"] == "dagster"
+    assert client.get_service_info("dagster")["name"] == "dagster"
+    assert client.get_assets()[0]["key_path"] == "silver/orders"
+    assert client.get_asset_details("silver/orders")["columns"][0]["name"] == "id"
+    assert client.get_contracts()[0]["table"] == "silver.orders"
+    assert client.get_contract("silver.orders")["table"] == "silver.orders"
     assert client.get_platform_health()["overall_status"] == "healthy"
     assert client.get_service_status()[0]["name"] == "observability"
     assert client.get_recent_alerts(limit=3)[0]["title"] == "No alerts"
     assert client.get_dashboard_links()[0]["title"] == "ClickStack"
     assert client.get_run_logs("run-123")["entries"][0]["metadata"]["trace_id"] == "abc123"
     assert client.get_run_trace_spans("run-123")[0]["span_id"] == "root"
+    assert (
+        client.get_trace_spans(
+            asset_key="silver/orders",
+            service_name="dagster",
+            status_code="STATUS_CODE_ERROR",
+            limit=25,
+        )[0]["status_code"]
+        == "STATUS_CODE_ERROR"
+    )
     assert client.get_materialization_history("silver/orders")[0]["run_id"] == "run-123"
     assert client.get_logs_query_link()["url"] == "http://logs.test"
     assert client.get_metrics_query_link()["url"] == "http://metrics.test"
-    assert seen_urls[0] == "http://example.test/api/observability/health"
+    assert "http://example.test/api/observability/health" in seen_urls
     assert seen_headers[0] == {}
+
+
+def test_create_server_registers_resources() -> None:
+    server = create_server(McpConfig())
+
+    resource_uris = sorted(str(uri) for uri in server._resource_manager._resources)
+    template_uris = sorted(
+        template.uri_template for template in server._resource_manager._templates.values()
+    )
+
+    assert resource_uris == [
+        "phlo://runtime/assets",
+        "phlo://runtime/config",
+        "phlo://runtime/contracts",
+        "phlo://runtime/dashboards",
+        "phlo://runtime/plugins",
+        "phlo://runtime/services",
+    ]
+    assert template_uris == [
+        "phlo://docs/packages/{package_name}",
+        "phlo://runtime/assets/{asset_key_path}",
+        "phlo://runtime/contracts/{table_name}",
+        "phlo://runtime/schemas/{asset_key_path}",
+        "phlo://runtime/services/{service_name}",
+    ]
+
+
+def test_package_docs_resource_reads_local_docs() -> None:
+    server = create_server(McpConfig())
+    template = next(
+        template
+        for template in server._resource_manager._templates.values()
+        if template.uri_template == "phlo://docs/packages/{package_name}"
+    )
+
+    rendered = template.fn("phlo-mcp")
+
+    assert "# phlo-mcp" in rendered
 
 
 def test_api_client_adds_bearer_token_header(monkeypatch) -> None:
@@ -124,6 +219,45 @@ def test_api_client_adds_bearer_token_header(monkeypatch) -> None:
 
     assert client.get_platform_health()["overall_status"] == "healthy"
     assert captured["headers"] == {"Authorization": "Bearer secret"}
+
+
+def test_api_client_wraps_operational_routes(monkeypatch) -> None:
+    seen_posts: list[dict[str, object]] = []
+    seen_gets: list[str] = []
+
+    def fake_post(url: str, json=None, headers=None, timeout=30.0):  # noqa: ANN001
+        seen_posts.append({"url": url, "json": json, "headers": headers or {}, "timeout": timeout})
+        return _FakeResponse({"queued": True, "dry_run": json["dry_run"]})
+
+    def fake_get(url: str, params=None, headers=None, timeout=10.0):  # noqa: ANN001
+        seen_gets.append(url)
+        return _FakeResponse({"run_id": "run-123", "status": "STARTED"})
+
+    monkeypatch.setattr("phlo_mcp.api_client.httpx.post", fake_post)
+    monkeypatch.setattr("phlo_mcp.api_client.httpx.get", fake_get)
+    client = PhloApiClient(McpConfig(api_base_url="http://example.test", api_token="secret"))
+
+    assert client.materialize_asset("silver/orders", dry_run=True, partition_key="2026-04-26") == {
+        "queued": True,
+        "dry_run": True,
+    }
+    assert client.retry_run("run-123", dry_run=False) == {"queued": True, "dry_run": False}
+    assert client.get_run_status("run-123")["status"] == "STARTED"
+    assert seen_posts == [
+        {
+            "url": "http://example.test/api/dagster/assets/silver/orders/materialize",
+            "json": {"dry_run": True, "partition_key": "2026-04-26"},
+            "headers": {"Authorization": "Bearer secret"},
+            "timeout": 30.0,
+        },
+        {
+            "url": "http://example.test/api/dagster/runs/run-123/retry",
+            "json": {"dry_run": False},
+            "headers": {"Authorization": "Bearer secret"},
+            "timeout": 30.0,
+        },
+    ]
+    assert seen_gets == ["http://example.test/api/dagster/runs/run-123/status"]
 
 
 def test_create_server_registers_expected_tools() -> None:
@@ -141,11 +275,73 @@ def test_create_server_registers_expected_tools() -> None:
         "get_materialization_history",
         "get_run_logs",
         "get_run_trace_spans",
+        "get_trace_spans",
+        "render_trace_spans_tree",
         "inspect_materialization",
         "get_asset_materialization_trace",
         "render_materialization_trace_tree",
         "render_run_trace_tree",
     ]
+
+
+def test_create_server_hides_write_tools_by_default() -> None:
+    server = create_server(McpConfig(api_token="secret"))
+
+    tool_names = [tool.name for tool in server._tool_manager.list_tools()]
+
+    assert "materialize_asset" not in tool_names
+    assert "retry_failed_run" not in tool_names
+    assert "get_dagster_run_status" not in tool_names
+
+
+def test_create_server_registers_write_tools_only_with_auth() -> None:
+    unauthenticated = create_server(McpConfig(enable_write_tools=True))
+    authenticated = create_server(McpConfig(api_token="secret", enable_write_tools=True))
+
+    unauthenticated_tool_names = [tool.name for tool in unauthenticated._tool_manager.list_tools()]
+    authenticated_tool_names = [tool.name for tool in authenticated._tool_manager.list_tools()]
+
+    assert "materialize_asset" not in unauthenticated_tool_names
+    assert "retry_failed_run" not in unauthenticated_tool_names
+    assert "get_dagster_run_status" not in unauthenticated_tool_names
+    assert authenticated_tool_names[-3:] == [
+        "materialize_asset",
+        "retry_failed_run",
+        "get_dagster_run_status",
+    ]
+
+
+def test_write_tool_returns_audit_context_without_token(monkeypatch) -> None:
+    def fake_materialize_asset(
+        self,  # noqa: ANN001
+        asset_key_path: str,
+        *,
+        dry_run: bool = True,
+        partition_key: str | None = None,
+    ) -> dict[str, object]:
+        return {
+            "asset_key_path": asset_key_path,
+            "dry_run": dry_run,
+            "partition_key": partition_key,
+            "queued": False,
+        }
+
+    monkeypatch.setattr(PhloApiClient, "materialize_asset", fake_materialize_asset)
+    server = create_server(McpConfig(api_token="secret-token", enable_write_tools=True))
+    tool = next(
+        tool for tool in server._tool_manager.list_tools() if tool.name == "materialize_asset"
+    )
+
+    result = tool.fn("silver/orders", dry_run=True, partition_key="2026-04-26")
+
+    assert result["audit_context"] == {
+        "operation": "materialize_asset",
+        "target": {"asset_key_path": "silver/orders", "partition_key": "2026-04-26"},
+        "dry_run": True,
+        "authenticated": True,
+        "api_base_url": "http://127.0.0.1:4000",
+    }
+    assert "secret-token" not in json.dumps(result)
 
 
 def test_parse_args_overrides_env(monkeypatch) -> None:
@@ -164,6 +360,7 @@ def test_parse_args_overrides_env(monkeypatch) -> None:
             "http://cli.test:4100",
             "--api-token",
             "cli-token",
+            "--enable-write-tools",
             "--port",
             "9000",
         ],
@@ -174,7 +371,16 @@ def test_parse_args_overrides_env(monkeypatch) -> None:
     assert config.transport == "streamable-http"
     assert config.api_base_url == "http://cli.test:4100"
     assert config.api_token == "cli-token"
+    assert config.enable_write_tools is True
     assert config.port == 9000
+
+
+def test_config_from_env_reads_write_tool_gate(monkeypatch) -> None:
+    monkeypatch.setenv("PHLO_MCP_ENABLE_WRITE_TOOLS", "true")
+
+    config = config_from_env()
+
+    assert config.enable_write_tools is True
 
 
 def test_run_analysis_helpers_render_materialization_view() -> None:

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -9,6 +9,10 @@ from pathlib import Path
 from phlo_mcp.api_client import PhloApiClient
 from phlo_mcp.cli import parse_args
 from phlo_mcp.config import McpConfig
+from phlo_mcp.run_analysis import (
+    render_run_trace_tree as render_run_trace_tree_text,
+    summarize_run_logs,
+)
 from phlo_mcp.server import create_server
 from phlo_mcp.tracing import render_trace_tree
 
@@ -38,6 +42,52 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
             return _FakeResponse([{"title": "No alerts"}])
         if url.endswith("/dashboards"):
             return _FakeResponse([{"title": "ClickStack", "url": "http://example.test"}])
+        if "/api/loki/runs/" in url:
+            return _FakeResponse(
+                {
+                    "entries": [
+                        {
+                            "timestamp": "2026-01-01T00:00:00Z",
+                            "level": "info",
+                            "message": "materialization started",
+                            "metadata": {
+                                "service": "dagster",
+                                "asset_key": "silver/orders",
+                                "trace_id": "abc123",
+                            },
+                        }
+                    ],
+                    "has_more": False,
+                }
+            )
+        if "/api/observability/traces/runs/" in url:
+            return _FakeResponse(
+                [
+                    {
+                        "timestamp": "2026-01-01T00:00:00Z",
+                        "trace_id": "abc123",
+                        "span_id": "root",
+                        "parent_span_id": None,
+                        "span_name": "materialize_orders",
+                        "service_name": "dagster",
+                        "span_kind": "INTERNAL",
+                        "duration_ms": 12.5,
+                        "status_code": "STATUS_CODE_OK",
+                        "span_attributes": {
+                            "phlo.run_id": "run-123",
+                            "phlo.asset_key": "silver/orders",
+                            "phlo.stage": "materialize",
+                            "phlo.operation": "write",
+                        },
+                        "resource_attributes": {
+                            "service.name": "dagster",
+                            "service.version": "1.2.3",
+                        },
+                    }
+                ]
+            )
+        if "/api/dagster/assets/" in url and url.endswith("/history"):
+            return _FakeResponse([{"run_id": "run-123", "timestamp": "2026-01-01T00:00:00Z"}])
         if url.endswith("/links/logs"):
             return _FakeResponse({"url": "http://logs.test"})
         if url.endswith("/links/metrics"):
@@ -51,6 +101,9 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     assert client.get_service_status()[0]["name"] == "observability"
     assert client.get_recent_alerts(limit=3)[0]["title"] == "No alerts"
     assert client.get_dashboard_links()[0]["title"] == "ClickStack"
+    assert client.get_run_logs("run-123")["entries"][0]["metadata"]["trace_id"] == "abc123"
+    assert client.get_run_trace_spans("run-123")[0]["span_id"] == "root"
+    assert client.get_materialization_history("silver/orders")[0]["run_id"] == "run-123"
     assert client.get_logs_query_link()["url"] == "http://logs.test"
     assert client.get_metrics_query_link()["url"] == "http://metrics.test"
     assert seen_urls[0] == "http://example.test/api/observability/health"
@@ -68,6 +121,13 @@ def test_create_server_registers_expected_tools() -> None:
         "get_dashboard_links",
         "get_logs_query_link",
         "get_metrics_query_link",
+        "get_materialization_history",
+        "get_run_logs",
+        "get_run_trace_spans",
+        "inspect_materialization",
+        "get_asset_materialization_trace",
+        "render_materialization_trace_tree",
+        "render_run_trace_tree",
     ]
 
 
@@ -94,6 +154,102 @@ def test_parse_args_overrides_env(monkeypatch) -> None:
     assert config.transport == "streamable-http"
     assert config.api_base_url == "http://cli.test:4100"
     assert config.port == 9000
+
+
+def test_run_analysis_helpers_render_materialization_view() -> None:
+    entries = [
+        {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "level": "info",
+            "message": "materialization started",
+            "metadata": {"service": "dagster", "function": "step", "trace_id": "abc123"},
+        },
+        {
+            "timestamp": "2026-01-01T00:00:01Z",
+            "level": "info",
+            "message": "materialization completed",
+            "metadata": {"service": "dagster", "function": "step", "trace_id": "abc123"},
+        },
+    ]
+    spans = [
+        {
+            "timestamp": "2026-01-01T00:00:00Z",
+            "trace_id": "abc123",
+            "span_id": "root",
+            "parent_span_id": None,
+            "span_name": "materialize_orders",
+            "service_name": "dagster",
+            "span_kind": "INTERNAL",
+            "status_code": "STATUS_CODE_OK",
+            "duration_ms": 12.5,
+            "span_attributes": {
+                "phlo.asset_key": "silver/orders",
+                "phlo.stage": "materialize",
+                "phlo.operation": "write",
+            },
+            "resource_attributes": {"service.name": "dagster", "service.version": "1.2.3"},
+        },
+        {
+            "timestamp": "2026-01-01T00:00:01Z",
+            "trace_id": "abc123",
+            "span_id": "child",
+            "parent_span_id": "root",
+            "span_name": "write_output",
+            "service_name": "dagster",
+            "span_kind": "INTERNAL",
+            "status_code": "STATUS_CODE_OK",
+            "duration_ms": 3.0,
+            "span_attributes": {"phlo.stage": "materialize"},
+            "resource_attributes": {"service.name": "dagster"},
+        },
+    ]
+
+    summary = summarize_run_logs("run-123", entries)
+    tree = render_run_trace_tree_text("run-123", entries)
+    from phlo_mcp.run_analysis import render_span_tree
+
+    span_tree = render_span_tree("run-123", spans)
+
+    assert summary["trace_ids"] == ["abc123"]
+    assert summary["entry_count"] == 2
+    assert "Run run-123" in tree
+    assert "trace abc123" in tree
+    assert "materialization started" in tree
+    assert "materialize_orders [internal ok]" in span_tree
+    assert "write_output [internal ok]" in span_tree
+    assert "asset=silver/orders" in span_tree
+    assert "stage=materialize" in span_tree
+    assert "service.version=1.2.3" in span_tree
+
+
+def test_render_run_trace_tree_uses_most_recent_logs_with_limit() -> None:
+    entries = [
+        {
+            "timestamp": "2026-01-01T00:00:03Z",
+            "level": "error",
+            "message": "latest failure",
+            "metadata": {"service": "dagster"},
+        },
+        {
+            "timestamp": "2026-01-01T00:00:02Z",
+            "level": "warn",
+            "message": "latest warning",
+            "metadata": {"service": "dagster"},
+        },
+        {
+            "timestamp": "2026-01-01T00:00:01Z",
+            "level": "info",
+            "message": "older info",
+            "metadata": {"service": "dagster"},
+        },
+    ]
+
+    tree = render_run_trace_tree_text("run-123", entries, limit=2)
+
+    assert "latest failure" in tree
+    assert "latest warning" in tree
+    assert "older info" not in tree
+    assert tree.index("latest warning") < tree.index("latest failure")
 
 
 def test_render_trace_tree_formats_tree(tmp_path: Path) -> None:

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -30,9 +30,11 @@ class _FakeResponse:
 
 def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     seen_urls: list[str] = []
+    seen_headers: list[dict[str, str]] = []
 
-    def fake_get(url: str, params=None, timeout=10.0):  # noqa: ANN001
+    def fake_get(url: str, params=None, headers=None, timeout=10.0):  # noqa: ANN001
         seen_urls.append(url)
+        seen_headers.append(headers or {})
         if url.endswith("/health"):
             return _FakeResponse({"overall_status": "healthy"})
         if url.endswith("/services"):
@@ -107,6 +109,21 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     assert client.get_logs_query_link()["url"] == "http://logs.test"
     assert client.get_metrics_query_link()["url"] == "http://metrics.test"
     assert seen_urls[0] == "http://example.test/api/observability/health"
+    assert seen_headers[0] == {}
+
+
+def test_api_client_adds_bearer_token_header(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_get(url: str, params=None, headers=None, timeout=10.0):  # noqa: ANN001
+        captured["headers"] = headers
+        return _FakeResponse({"overall_status": "healthy"})
+
+    monkeypatch.setattr("phlo_mcp.api_client.httpx.get", fake_get)
+    client = PhloApiClient(McpConfig(api_base_url="http://example.test", api_token="secret"))
+
+    assert client.get_platform_health()["overall_status"] == "healthy"
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
 
 
 def test_create_server_registers_expected_tools() -> None:
@@ -133,6 +150,7 @@ def test_create_server_registers_expected_tools() -> None:
 
 def test_parse_args_overrides_env(monkeypatch) -> None:
     monkeypatch.setenv("PHLO_MCP_API_BASE_URL", "http://env.test:4000")
+    monkeypatch.setenv("PHLO_MCP_API_TOKEN", "env-token")
     monkeypatch.setenv("PHLO_MCP_TRANSPORT", "stdio")
     monkeypatch.setenv("PHLO_MCP_PORT", "8000")
     monkeypatch.setattr(
@@ -144,6 +162,8 @@ def test_parse_args_overrides_env(monkeypatch) -> None:
             "streamable-http",
             "--api-base-url",
             "http://cli.test:4100",
+            "--api-token",
+            "cli-token",
             "--port",
             "9000",
         ],
@@ -153,6 +173,7 @@ def test_parse_args_overrides_env(monkeypatch) -> None:
 
     assert config.transport == "streamable-http"
     assert config.api_base_url == "http://cli.test:4100"
+    assert config.api_token == "cli-token"
     assert config.port == 9000
 
 

--- a/packages/phlo-mcp/tests/test_stack_smoke.py
+++ b/packages/phlo-mcp/tests/test_stack_smoke.py
@@ -1,0 +1,27 @@
+"""Pytest wrapper for the live phlo-mcp stack smoke script."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_live_stack_smoke_script() -> None:
+    if os.environ.get("PHLO_MCP_STACK_SMOKE", "").lower() not in {"1", "true", "yes", "on"}:
+        pytest.skip("set PHLO_MCP_STACK_SMOKE=1 to run the live stack smoke test")
+
+    script = Path(__file__).with_name("smoke_stack.py")
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        text=True,
+        capture_output=True,
+        timeout=600,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/packages/phlo-mcp/tests/test_stack_smoke.py
+++ b/packages/phlo-mcp/tests/test_stack_smoke.py
@@ -27,7 +27,10 @@ def test_smoke_stack_seeds_durable_asset(tmp_path: Path) -> None:
 
     asset_path = tmp_path / "workflows" / smoke_stack._SMOKE_ASSET_FILENAME
     assert asset_path.exists()
-    assert f"def {smoke_stack._SMOKE_ASSET_KEY}()" in asset_path.read_text(encoding="utf-8")
+    asset_source = asset_path.read_text(encoding="utf-8")
+    assert "AssetSpec(" in asset_source
+    assert f'key="{smoke_stack._SMOKE_ASSET_KEY}"' in asset_source
+    assert "import dagster" not in asset_source
 
 
 def test_smoke_stack_project_root_argument() -> None:

--- a/packages/phlo-mcp/tests/test_stack_smoke.py
+++ b/packages/phlo-mcp/tests/test_stack_smoke.py
@@ -37,6 +37,28 @@ def test_smoke_stack_project_root_argument() -> None:
     assert args.project_root == "/tmp/phlo-mcp-smoke"
 
 
+def test_smoke_stack_env_avoids_default_port_conflicts(monkeypatch) -> None:
+    monkeypatch.delenv("MINIO_API_PORT", raising=False)
+    monkeypatch.delenv("MINIO_CONSOLE_PORT", raising=False)
+    monkeypatch.delenv("CLICKSTACK_NATIVE_PORT", raising=False)
+
+    env = smoke_stack._smoke_stack_env()
+
+    assert env["MINIO_API_PORT"] == "19000"
+    assert env["MINIO_CONSOLE_PORT"] == "19001"
+    assert env["CLICKSTACK_NATIVE_PORT"] == "19002"
+
+
+def test_smoke_stack_env_respects_user_port_overrides(monkeypatch) -> None:
+    monkeypatch.setenv("MINIO_API_PORT", "29000")
+    monkeypatch.setenv("CLICKSTACK_NATIVE_PORT", "29002")
+
+    env = smoke_stack._smoke_stack_env()
+
+    assert env["MINIO_API_PORT"] == "29000"
+    assert env["CLICKSTACK_NATIVE_PORT"] == "29002"
+
+
 def test_live_stack_smoke_script() -> None:
     if os.environ.get("PHLO_MCP_STACK_SMOKE", "").lower() not in {"1", "true", "yes", "on"}:
         pytest.skip("set PHLO_MCP_STACK_SMOKE=1 to run the live stack smoke test")

--- a/packages/phlo-mcp/tests/test_stack_smoke.py
+++ b/packages/phlo-mcp/tests/test_stack_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
 import subprocess
 import sys
@@ -9,7 +10,31 @@ from pathlib import Path
 
 import pytest
 
+_SMOKE_STACK_PATH = Path(__file__).with_name("smoke_stack.py")
+_SMOKE_STACK_SPEC = importlib.util.spec_from_file_location(
+    "phlo_mcp_smoke_stack", _SMOKE_STACK_PATH
+)
+assert _SMOKE_STACK_SPEC is not None
+assert _SMOKE_STACK_SPEC.loader is not None
+smoke_stack = importlib.util.module_from_spec(_SMOKE_STACK_SPEC)
+_SMOKE_STACK_SPEC.loader.exec_module(smoke_stack)
+
 pytestmark = pytest.mark.integration
+
+
+def test_smoke_stack_seeds_durable_asset(tmp_path: Path) -> None:
+    smoke_stack._seed_smoke_asset(tmp_path)
+
+    asset_path = tmp_path / "workflows" / smoke_stack._SMOKE_ASSET_FILENAME
+    assert asset_path.exists()
+    assert f"def {smoke_stack._SMOKE_ASSET_KEY}()" in asset_path.read_text(encoding="utf-8")
+
+
+def test_smoke_stack_project_root_argument() -> None:
+    args = smoke_stack._parse_args(["--start-stack", "--project-root", "/tmp/phlo-mcp-smoke"])
+
+    assert args.start_stack is True
+    assert args.project_root == "/tmp/phlo-mcp-smoke"
 
 
 def test_live_stack_smoke_script() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "phlo-hasura>=0.1.0",
     "phlo-lineage>=0.1.0",
     "phlo-loki>=0.1.0",
+    "phlo-mcp>=0.1.0",
     "phlo-minio>=0.1.0",
     "phlo-sling>=0.1.0",
     "phlo-nessie>=0.1.0",
@@ -205,6 +206,7 @@ extra-paths = [
     "packages/phlo-iceberg/src",
     "packages/phlo-lineage/src",
     "packages/phlo-loki/src",
+    "packages/phlo-mcp/src",
     "packages/phlo-otel/src",
     "packages/phlo-minio/src",
     "packages/phlo-nessie/src",
@@ -274,6 +276,9 @@ workspace = true
 workspace = true
 
 [tool.uv.sources.phlo-loki]
+workspace = true
+
+[tool.uv.sources.phlo-mcp]
 workspace = true
 
 [tool.uv.sources.phlo-minio]

--- a/src/phlo/capabilities/__init__.py
+++ b/src/phlo/capabilities/__init__.py
@@ -102,6 +102,7 @@ from phlo.capabilities.interfaces import (
     SchemaMigrator,
     TableStore,
     TraceSpan,
+    TraceSpanFilter,
 )
 from phlo.capabilities.maintenance import (
     DefaultMaintenanceReadModel,
@@ -231,6 +232,7 @@ __all__ = [
     "PartitionSpec",
     "Principal",
     "TraceSpan",
+    "TraceSpanFilter",
     "PublishTargetSpec",
     "QueryEngine",
     "QualityBackendSpec",

--- a/src/phlo/capabilities/__init__.py
+++ b/src/phlo/capabilities/__init__.py
@@ -101,6 +101,7 @@ from phlo.capabilities.interfaces import (
     SchemaExtractor,
     SchemaMigrator,
     TableStore,
+    TraceSpan,
 )
 from phlo.capabilities.maintenance import (
     DefaultMaintenanceReadModel,
@@ -229,6 +230,7 @@ __all__ = [
     "ObservabilityBackendSpec",
     "PartitionSpec",
     "Principal",
+    "TraceSpan",
     "PublishTargetSpec",
     "QueryEngine",
     "QualityBackendSpec",

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -437,6 +437,21 @@ class TraceSpan:
     resource_attributes: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class TraceSpanFilter:
+    """Filter set for observability trace span queries."""
+
+    run_id: str | None = None
+    asset_key: str | None = None
+    job_name: str | None = None
+    service_name: str | None = None
+    span_name: str | None = None
+    status_code: str | None = None
+    start_time: str | None = None
+    end_time: str | None = None
+    limit: int = 500
+
+
 @runtime_checkable
 class ObservabilityBackend(Protocol):
     """Protocol for swappable observability backends (metrics, logs, dashboards)."""
@@ -471,6 +486,10 @@ class ObservabilityBackend(Protocol):
 
     def run_trace_spans(self, run_id: str, limit: int = 500) -> list[TraceSpan]:
         """Return OTEL spans correlated to a run id when supported."""
+        ...
+
+    def trace_spans(self, filters: TraceSpanFilter) -> list[TraceSpan]:
+        """Return OTEL spans matching a bounded filter set when supported."""
         ...
 
 

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -420,6 +420,23 @@ class DashboardLink:
     category: str | None = None
 
 
+@dataclass(frozen=True)
+class TraceSpan:
+    """Trace span row from an observability backend."""
+
+    timestamp: str
+    trace_id: str
+    span_id: str
+    parent_span_id: str | None = None
+    span_name: str = ""
+    service_name: str | None = None
+    span_kind: str | None = None
+    duration_ms: float | None = None
+    status_code: str | None = None
+    span_attributes: dict[str, Any] = field(default_factory=dict)
+    resource_attributes: dict[str, Any] = field(default_factory=dict)
+
+
 @runtime_checkable
 class ObservabilityBackend(Protocol):
     """Protocol for swappable observability backends (metrics, logs, dashboards)."""
@@ -450,6 +467,10 @@ class ObservabilityBackend(Protocol):
 
     def metrics_query_link(self, metric: str | None = None) -> str | None:
         """Return a link to query metrics, optionally filtered by metric."""
+        ...
+
+    def run_trace_spans(self, run_id: str, limit: int = 500) -> list[TraceSpan]:
+        """Return OTEL spans correlated to a run id when supported."""
         ...
 
 

--- a/src/phlo/capabilities/observability.py
+++ b/src/phlo/capabilities/observability.py
@@ -14,6 +14,7 @@ from phlo.capabilities.interfaces import (
     PlatformHealthSummary,
     PlatformMetricsSummary,
     ServiceStatus,
+    TraceSpan,
 )
 from phlo.capabilities.maintenance import DefaultMaintenanceReadModel
 from phlo.capabilities.registry import (
@@ -201,6 +202,14 @@ class DefaultObservabilityBackend:
         if metric:
             return f"{prometheus_url}{query_path}?g0.expr={metric}"
         return f"{prometheus_url}{query_path}"
+
+    def run_trace_spans(self, run_id: str, limit: int = 500) -> list[TraceSpan]:
+        """Return no trace spans by default.
+
+        Backend-specific packages such as phlo-clickstack can replace the default
+        observability backend with one that supports span queries.
+        """
+        return []
 
     def _resolve_clickstack_url(self) -> str | None:
         return _resolve_service_base_url(

--- a/src/phlo/capabilities/observability.py
+++ b/src/phlo/capabilities/observability.py
@@ -15,6 +15,7 @@ from phlo.capabilities.interfaces import (
     PlatformMetricsSummary,
     ServiceStatus,
     TraceSpan,
+    TraceSpanFilter,
 )
 from phlo.capabilities.maintenance import DefaultMaintenanceReadModel
 from phlo.capabilities.registry import (
@@ -209,6 +210,12 @@ class DefaultObservabilityBackend:
         Backend-specific packages such as phlo-clickstack can replace the default
         observability backend with one that supports span queries.
         """
+        return []
+
+    def trace_spans(self, filters: TraceSpanFilter) -> list[TraceSpan]:
+        """Return no filtered trace spans by default."""
+        if filters.run_id:
+            return self.run_trace_spans(filters.run_id, limit=filters.limit)
         return []
 
     def _resolve_clickstack_url(self) -> str | None:

--- a/uv.lock
+++ b/uv.lock
@@ -3885,7 +3885,6 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "opentelemetry-sdk" },
-    { name = "phlo" },
     { name = "phlo-api" },
 ]
 
@@ -3900,7 +3899,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0" },
-    { name = "phlo", editable = "." },
     { name = "phlo-api", editable = "packages/phlo-api" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -36,6 +36,7 @@ members = [
     "phlo-iceberg",
     "phlo-lineage",
     "phlo-loki",
+    "phlo-mcp",
     "phlo-minio",
     "phlo-nessie",
     "phlo-oauth2-proxy",
@@ -979,6 +980,65 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+]
+
+[[package]]
 name = "daff"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1883,6 +1943,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2218,6 +2287,37 @@ wheels = [
 [package.optional-dependencies]
 msgpack = [
     { name = "msgpack" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "python-dotenv" },
+    { name = "typer" },
 ]
 
 [[package]]
@@ -3181,6 +3281,7 @@ dev = [
     { name = "phlo-iceberg" },
     { name = "phlo-lineage" },
     { name = "phlo-loki" },
+    { name = "phlo-mcp" },
     { name = "phlo-minio" },
     { name = "phlo-nessie" },
     { name = "phlo-observatory" },
@@ -3268,6 +3369,7 @@ dev = [
     { name = "phlo-iceberg", editable = "packages/phlo-iceberg" },
     { name = "phlo-lineage", editable = "packages/phlo-lineage" },
     { name = "phlo-loki", editable = "packages/phlo-loki" },
+    { name = "phlo-mcp", editable = "packages/phlo-mcp" },
     { name = "phlo-minio", editable = "packages/phlo-minio" },
     { name = "phlo-nessie", editable = "packages/phlo-nessie" },
     { name = "phlo-observatory", editable = "packages/phlo-observatory" },
@@ -3774,6 +3876,36 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]
 provides-extras = ["dev", "observatory"]
+
+[[package]]
+name = "phlo-mcp"
+version = "0.1.0"
+source = { editable = "packages/phlo-mcp" }
+dependencies = [
+    { name = "httpx" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "opentelemetry-sdk" },
+    { name = "phlo" },
+    { name = "phlo-api" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.38.0" },
+    { name = "phlo", editable = "." },
+    { name = "phlo-api", editable = "packages/phlo-api" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-minio"
@@ -4799,6 +4931,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pymdown-extensions"
 version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4979,6 +5125,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]
@@ -5466,6 +5621,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "simplejson"
 version = "3.20.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5654,6 +5818,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/67/701f86b28d63b2086de47c942eccf8ca2208b3be69715a1119a4e384415a/sqlparse-0.5.4.tar.gz", hash = "sha256:4396a7d3cf1cd679c1be976cf3dc6e0a51d0111e87787e7a8d780e7d5a998f9e", size = 120112, upload-time = "2025-11-28T07:10:18.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/70/001ee337f7aa888fb2e3f5fd7592a6afc5283adb1ed44ce8df5764070f22/sqlparse-0.5.4-py3-none-any.whl", hash = "sha256:99a9f0314977b76d776a0fcb8554de91b9bb8a18560631d6bc48721d07023dcb", size = 45933, upload-time = "2025-11-28T07:10:19.73Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
 
 [[package]]
@@ -5902,6 +6079,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2b/e8/66e25efcc18542d58706ce4e50415710593721aae26e794ab1dec34fb66f/typeguard-4.5.1.tar.gz", hash = "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274", size = 80121, upload-time = "2026-02-19T16:09:03.392Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl", hash = "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40", size = 36745, upload-time = "2026-02-19T16:09:01.6Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/b8/9ebb531b6c2d377af08ac6746a5df3425b21853a5d2260876919b58a2a4a/typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480", size = 119849, upload-time = "2026-04-22T17:45:34.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/d1/9484b497e0a0410b901c12b8251c3e746e1e863f7d28419ffe06f7892fda/typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8", size = 55977, upload-time = "2026-04-22T17:45:33.055Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3885,6 +3885,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "opentelemetry-sdk" },
+    { name = "phlo" },
     { name = "phlo-api" },
 ]
 
@@ -3899,6 +3900,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.38.0" },
+    { name = "phlo", editable = "." },
     { name = "phlo-api", editable = "packages/phlo-api" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },


### PR DESCRIPTION
## Summary

This adds a first-class `phlo-mcp` package that exposes Phlo observability and operator workflows over MCP, then extends it with run-level and materialization-level inspection tools backed by Dagster history, Loki logs, and ClickStack trace spans.

## What Changed

- add the new `phlo-mcp` package, CLI, config, tracing utilities, workspace wiring, and package/docs navigation
- expose core observability MCP tools for platform health, service status, alerts, dashboards, and deep links via `phlo-api`
- add run and asset inspection MCP tools for materialization history, correlated run logs, OTEL run spans, and rendered trace trees
- add an observability backend capability contract for run trace spans and wire `phlo-clickstack` in as a resource provider that queries `otel_traces`
- extend `phlo-api` observability and Loki responses so MCP clients can consume richer trace and log correlation metadata
- fix log trace tree rendering so limited views use the most recent Loki entries in chronological order
- update package docs and README examples for the new MCP workflows

## Testing

- `uv run pytest packages/phlo-mcp/tests/test_phlo_mcp.py`
- `uv run pytest packages/phlo-api/tests/test_observability_api.py packages/phlo-clickstack/tests/test_observability_backend.py`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/phlohouse/phlo/pull/468" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
