### PR TITLE
feat: polish workflow authoring path

### DIFF
--- a/docs/guides/developer-workflow.md
+++ b/docs/guides/developer-workflow.md
@@ -37,6 +37,9 @@ phlo services start
 - define transforms with dbt
 - keep schemas under `workflows/schemas/`
 
+For the full command-by-command authoring loop with `phlo workflow check`, see
+[Workflow Development](workflow-development.md#authoring-loop).
+
 ### 4. Run the pipeline
 
 ```bash

--- a/docs/guides/workflow-development.md
+++ b/docs/guides/workflow-development.md
@@ -6,6 +6,23 @@ This guide walks you through creating a complete data pipeline from scratch. We'
 
 ---
 
+## Authoring Loop
+
+Use this loop when creating a new ingestion workflow:
+
+```bash
+phlo workflow create --type ingestion --domain weather --table observations --unique-key station_id
+phlo workflow check workflows/ingestion/weather/observations.py
+phlo services restart dagster
+phlo materialize dlt_observations
+phlo status
+```
+
+`phlo workflow check` validates the workflow file and the inferred schema file before you
+restart Dagster or materialize the asset.
+
+---
+
 ## Table of Contents
 
 1. [Pipeline Overview](#pipeline-overview)

--- a/docs/guides/workflow-development.md
+++ b/docs/guides/workflow-development.md
@@ -13,7 +13,7 @@ Use this loop when creating a new ingestion workflow:
 ```bash
 phlo workflow create --type ingestion --domain weather --table observations --unique-key station_id
 phlo workflow check workflows/ingestion/weather/observations.py
-phlo services restart dagster
+phlo services restart --service dagster
 phlo materialize dlt_observations
 phlo status
 ```

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1092,6 +1092,14 @@ workflows/
     └── github.py
 ```
 
+### phlo workflow check
+
+Validate a workflow file and its inferred schema file.
+
+```bash
+phlo workflow check workflows/ingestion/weather/observations.py
+```
+
 ## Asset Commands
 
 ### phlo materialize

--- a/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
+++ b/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
@@ -88,10 +88,10 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
     click.echo(f"  4. Validate workflow: phlo validate-workflow {workflow_file}")
     if test_file:
         click.echo(f"  5. Run generated tests: uv run pytest {test_file} -q")
-        click.echo("  6. Restart Dagster: phlo services restart dagster")
+        click.echo("  6. Restart Dagster: phlo services restart --service dagster")
         click.echo(f"  7. Materialize: phlo materialize dlt_{table}")
     else:
-        click.echo("  5. Restart Dagster: phlo services restart dagster")
+        click.echo("  5. Restart Dagster: phlo services restart --service dagster")
         click.echo(f"  6. Materialize: phlo materialize dlt_{table}")
 
 

--- a/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
+++ b/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
@@ -75,6 +75,26 @@ def workflow_group() -> None:
     """
 
 
+def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
+    """Print the next commands for a generated ingestion workflow."""
+    schema_file = files[0]
+    workflow_file = files[1]
+    test_file = files[2] if len(files) > 2 else None
+
+    click.echo("\nNext steps:")
+    click.echo(f"  1. Review schema: {schema_file}")
+    click.echo(f"  2. Review workflow: {workflow_file}")
+    click.echo(f"  3. Validate schema: phlo schema validate {schema_file}")
+    click.echo(f"  4. Validate workflow: phlo validate-workflow {workflow_file}")
+    if test_file:
+        click.echo(f"  5. Run generated tests: uv run pytest {test_file} -q")
+        click.echo("  6. Restart Dagster: phlo services restart dagster")
+        click.echo(f"  7. Materialize: phlo materialize dlt_{table}")
+    else:
+        click.echo("  5. Restart Dagster: phlo services restart dagster")
+        click.echo(f"  6. Materialize: phlo materialize dlt_{table}")
+
+
 @workflow_group.command("create")
 @click.option(
     "--type",
@@ -189,12 +209,7 @@ def create_workflow_cmd(
             for file_path in files:
                 click.echo(f"  - {file_path}")
 
-            click.echo("\nNext steps:")
-            click.echo(f"  1. Edit schema: {files[0]}")
-            click.echo(f"  2. Configure API: {files[1]}")
-            click.echo("  3. Restart Dagster: docker restart dagster-webserver")
-            click.echo(f"  4. Test: phlo test {domain}")
-            click.echo(f"  5. Materialize: phlo materialize dlt_{table}")
+            _print_ingestion_next_steps(files, table=table)
             logger.info(
                 "dlt_workflow_create_succeeded",
                 workflow_type=workflow_type,

--- a/packages/phlo-pandera/src/phlo_pandera/cli_schema_utils.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_schema_utils.py
@@ -52,6 +52,30 @@ def format_table(title: str, columns: list[str], rows: list[tuple]) -> Table:
     return table
 
 
+def validate_schema_file(schema_path: Path) -> None:
+    """Validate basic schema file syntax and structure."""
+    if not schema_path.exists():
+        raise FileNotFoundError(f"Schema file not found: {schema_path}")
+
+    content = schema_path.read_text()
+    checks = {
+        "Has imports": "import" in content.lower(),
+        "Has class definition": "class " in content,
+        "Has docstring": '"""' in content or "'''" in content,
+        "Valid Python": True,
+    }
+
+    try:
+        compile(content, str(schema_path), "exec")
+    except SyntaxError as exc:
+        checks["Valid Python"] = False
+        raise ValueError(f"Syntax error in {schema_path}: {exc}") from exc
+
+    failed = [name for name, passed in checks.items() if not passed]
+    if failed:
+        raise ValueError(f"Schema validation failed for {schema_path}: {', '.join(failed)}")
+
+
 def discover_pandera_schemas(
     search_paths: Optional[list[str]] = None,
 ) -> dict[str, type]:

--- a/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
@@ -364,7 +364,7 @@ def _validate_workflow_file(
     Args:
         file_path: Path to the workflow file.
         fix: Whether to auto-fix issues.
-        require_workflow: Whether at least one @phlo_ingestion workflow is required.
+        require_workflow: Whether at least one ingestion workflow is required.
 
     Returns:
         True if file is valid, False otherwise.
@@ -379,11 +379,11 @@ def _validate_workflow_file(
         console.print("  [red]✗ Failed to load module[/red]")
         return False
 
-    # Find all functions decorated with @phlo_ingestion
+    # Find all functions decorated with a Phlo ingestion decorator.
     phlo_ingestion_funcs = _find_phlo_ingestion_functions(module)
 
     if not phlo_ingestion_funcs:
-        message = "No @phlo_ingestion decorated workflow found"
+        message = "No @phlo.ingestion decorated workflow found"
         if require_workflow:
             console.print(f"  [red]✗ {message}[/red]")
             return False
@@ -403,7 +403,7 @@ def _validate_workflow_file(
 
 
 def _find_phlo_ingestion_functions(module: Any) -> List[Tuple[str, Any, dict]]:
-    """Find all functions decorated with @phlo_ingestion.
+    """Find all functions decorated with a Phlo ingestion decorator.
 
     Args:
         module: Python module object to search.
@@ -445,13 +445,33 @@ def _find_phlo_ingestion_functions(module: Any) -> List[Tuple[str, Any, dict]]:
 
 
 def _is_phlo_ingestion_decorator(decorator: ast.expr) -> bool:
-    """Return whether an AST decorator is phlo_ingestion."""
+    """Return whether an AST decorator is a supported ingestion decorator."""
     target = decorator.func if isinstance(decorator, ast.Call) else decorator
     if isinstance(target, ast.Name):
         return target.id == "phlo_ingestion"
     if isinstance(target, ast.Attribute):
-        return target.attr == "phlo_ingestion"
+        return _dotted_name(target) in {"phlo.ingestion", "phlo.ingestion.phlo_ingestion"} or (
+            target.attr == "phlo_ingestion"
+        )
     return False
+
+
+def _dotted_name(node: ast.expr) -> str | None:
+    """Return a dotted name for simple attribute expressions."""
+    parts: list[str] = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _line_has_ingestion_decorator(line: str) -> bool:
+    """Return whether a source line starts a supported ingestion decorator."""
+    stripped = line.strip()
+    return stripped.startswith("@phlo.ingestion") or stripped.startswith("@phlo_ingestion")
 
 
 def _extract_decorator_params(func: Any) -> dict:
@@ -461,11 +481,11 @@ def _extract_decorator_params(func: Any) -> dict:
         func: Decorated function object.
 
     Returns:
-        Dictionary of parameters if this is a @phlo_ingestion function,
+        Dictionary of parameters if this is an ingestion function,
         otherwise empty dict.
 
     """
-    # The @phlo_ingestion decorator doesn't expose params directly,
+    # The ingestion decorator doesn't expose params directly,
     # so we'll mark functions that look like ingestion functions
     if hasattr(func, "__qualname__") and "wrapper" in func.__qualname__:
         # This is likely a decorated function; we can't extract params
@@ -507,7 +527,7 @@ def _validate_workflow_function(
         source = file_path.read_text()
         lines = source.split("\n")
 
-        # Find the @phlo_ingestion decorator for this function
+        # Find the ingestion decorator for this function.
         deco_match = None
         func_line_idx = None
 
@@ -519,9 +539,9 @@ def _validate_workflow_function(
         if func_line_idx is None:
             warnings.append("Could not locate function in source code")
         else:
-            # Search backwards for @phlo_ingestion decorator
+            # Search backwards for the decorator block.
             for i in range(func_line_idx - 1, max(0, func_line_idx - 20), -1):
-                if "@phlo_ingestion" in lines[i]:
+                if _line_has_ingestion_decorator(lines[i]):
                     # Extract decorator block
                     deco_lines = []
                     bracket_count = 0
@@ -592,7 +612,7 @@ def _validate_workflow_function(
 def _validate_decorator_params(
     deco_text: str, func_line_idx: int, issues: List[str], warnings: List[str]
 ) -> None:
-    """Validate @phlo_ingestion decorator parameters.
+    """Validate ingestion decorator parameters.
 
     Args:
         deco_text: The decorator text.

--- a/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
@@ -240,7 +240,7 @@ def _validate_single_schema(
 
 
 @click.command()
-@click.argument("asset_file", type=click.Path(exists=True))
+@click.argument("asset_file", type=click.Path())
 @click.option(
     "--fix",
     is_flag=True,
@@ -277,6 +277,9 @@ def validate_workflow(asset_file: str, fix: bool):
     console.print("\n[bold blue]🔍 Validating Workflow[/bold blue]\n")
 
     path = Path(asset_file)
+    if not path.exists():
+        _print_validation_failure(str(path), "file does not exist")
+        raise click.ClickException(f"Workflow file not found: {path}")
 
     # Handle directory input
     if path.is_dir():
@@ -306,6 +309,13 @@ def validate_workflow(asset_file: str, fix: bool):
         else:
             console.print("\n[bold yellow]⚠ Issues found (see above)[/bold yellow]")
             sys.exit(1)
+
+
+def _print_validation_failure(path: str, message: str) -> None:
+    """Print consistent workflow validation failure context."""
+    click.echo(f"Validation failed for {path}", err=True)
+    click.echo(f"Reason: {message}", err=True)
+    click.echo(f"Rerun: phlo validate-workflow {path}", err=True)
 
 
 def _validate_workflow_file(file_path: Path, fix: bool = False) -> bool:

--- a/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
@@ -4,6 +4,7 @@ Validate Command
 Validates Pandera schemas and Phlo configurations.
 """
 
+import ast
 import importlib.util
 import sys
 from pathlib import Path
@@ -413,23 +414,23 @@ def _find_phlo_ingestion_functions(module: Any) -> List[Tuple[str, Any, dict]]:
     """
     results = []
 
-    # Try to find functions with decorator by inspecting module source
+    # Try to find functions with actual decorators by inspecting module source.
     try:
         import inspect
 
         source = inspect.getsource(module)
-        # Look for @phlo_ingestion decorators in source
-        if "@phlo_ingestion" in source:
-            for name in dir(module):
-                obj = getattr(module, name)
-                if callable(obj) and not name.startswith("_"):
-                    # Check if this function is defined in the module
-                    try:
-                        if inspect.getfile(obj) == inspect.getfile(module):
-                            results.append((name, obj, {"found_in_source": True}))
-                    except (TypeError, OSError):
-                        pass
-    except (OSError, TypeError):
+        tree = ast.parse(source)
+        decorated_names = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and any(_is_phlo_ingestion_decorator(decorator) for decorator in node.decorator_list)
+        }
+        for name in sorted(decorated_names):
+            obj = getattr(module, name, None)
+            if callable(obj):
+                results.append((name, obj, {"found_in_source": True}))
+    except (OSError, SyntaxError, TypeError):
         logger.warning("validate_workflow_source_unavailable")
         # Module might not have source (e.g., built-in), fall back to __wrapped__ check
         for name in dir(module):
@@ -441,6 +442,16 @@ def _find_phlo_ingestion_functions(module: Any) -> List[Tuple[str, Any, dict]]:
                         results.append((name, obj, decorator_params))
 
     return results
+
+
+def _is_phlo_ingestion_decorator(decorator: ast.expr) -> bool:
+    """Return whether an AST decorator is phlo_ingestion."""
+    target = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if isinstance(target, ast.Name):
+        return target.id == "phlo_ingestion"
+    if isinstance(target, ast.Attribute):
+        return target.attr == "phlo_ingestion"
+    return False
 
 
 def _extract_decorator_params(func: Any) -> dict:

--- a/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
@@ -109,7 +109,12 @@ def _load_module_from_file(file_path: Path) -> Any:
         Loaded module object, or None if loading fails.
 
     """
+    import_root = _project_import_root(file_path)
+    import_root_str = str(import_root)
+    inserted_import_root = import_root_str not in sys.path
     try:
+        if inserted_import_root:
+            sys.path.insert(0, import_root_str)
         spec = importlib.util.spec_from_file_location("schema_module", file_path)
         if spec and spec.loader:
             module = importlib.util.module_from_spec(spec)
@@ -123,6 +128,22 @@ def _load_module_from_file(file_path: Path) -> Any:
         )
         console.print(f"[red]Error loading module: {e}[/red]")
         return None
+    finally:
+        if inserted_import_root:
+            sys.path.remove(import_root_str)
+
+
+def _project_import_root(file_path: Path) -> Path:
+    """Return the project root needed for workflow-local imports."""
+    path = file_path.resolve()
+    parts = path.parts
+    if "workflows" not in parts:
+        return Path.cwd().resolve()
+
+    workflows_index = parts.index("workflows")
+    if workflows_index == 0:
+        return Path.cwd().resolve()
+    return Path(*parts[:workflows_index])
 
 
 def _find_pandera_schemas(module: Any) -> List[Any]:

--- a/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
@@ -339,22 +339,31 @@ def _print_validation_failure(path: str, message: str) -> None:
     click.echo(f"Rerun: phlo validate-workflow {path}", err=True)
 
 
-def validate_workflow_file(file_path: Path, fix: bool = False) -> None:
+def validate_workflow_file(
+    file_path: Path,
+    fix: bool = False,
+    require_workflow: bool = False,
+) -> None:
     """Validate one workflow file and raise on failure."""
     if not file_path.exists():
         _print_validation_failure(str(file_path), "file does not exist")
         raise click.ClickException(f"Workflow file not found: {file_path}")
 
-    if not _validate_workflow_file(file_path, fix=fix):
+    if not _validate_workflow_file(file_path, fix=fix, require_workflow=require_workflow):
         raise click.ClickException(f"Workflow validation failed: {file_path}")
 
 
-def _validate_workflow_file(file_path: Path, fix: bool = False) -> bool:
+def _validate_workflow_file(
+    file_path: Path,
+    fix: bool = False,
+    require_workflow: bool = False,
+) -> bool:
     """Validate a single workflow file.
 
     Args:
         file_path: Path to the workflow file.
         fix: Whether to auto-fix issues.
+        require_workflow: Whether at least one @phlo_ingestion workflow is required.
 
     Returns:
         True if file is valid, False otherwise.
@@ -373,7 +382,11 @@ def _validate_workflow_file(file_path: Path, fix: bool = False) -> bool:
     phlo_ingestion_funcs = _find_phlo_ingestion_functions(module)
 
     if not phlo_ingestion_funcs:
-        console.print("  [yellow]⚠ No @phlo_ingestion decorated functions found[/yellow]")
+        message = "No @phlo_ingestion decorated workflow found"
+        if require_workflow:
+            console.print(f"  [red]✗ {message}[/red]")
+            return False
+        console.print(f"  [yellow]⚠ {message}[/yellow]")
         return True
 
     console.print(f"  [green]✓[/green] Found {len(phlo_ingestion_funcs)} workflow(s)\n")

--- a/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
@@ -318,6 +318,16 @@ def _print_validation_failure(path: str, message: str) -> None:
     click.echo(f"Rerun: phlo validate-workflow {path}", err=True)
 
 
+def validate_workflow_file(file_path: Path, fix: bool = False) -> None:
+    """Validate one workflow file and raise on failure."""
+    if not file_path.exists():
+        _print_validation_failure(str(file_path), "file does not exist")
+        raise click.ClickException(f"Workflow file not found: {file_path}")
+
+    if not _validate_workflow_file(file_path, fix=fix):
+        raise click.ClickException(f"Workflow validation failed: {file_path}")
+
+
 def _validate_workflow_file(file_path: Path, fix: bool = False) -> bool:
     """Validate a single workflow file.
 

--- a/packages/phlo-pandera/tests/test_cli_validate_workflow.py
+++ b/packages/phlo-pandera/tests/test_cli_validate_workflow.py
@@ -21,6 +21,15 @@ from phlo_pandera.cli_validate import (
 )
 
 
+def test_validate_workflow_missing_file_prints_rerun_hint() -> None:
+    """Shows a rerun command when the workflow path is missing."""
+    result = CliRunner().invoke(validate_workflow, ["workflows/ingestion/missing.py"])
+
+    assert result.exit_code != 0
+    assert "workflows/ingestion/missing.py" in result.output
+    assert "phlo validate-workflow workflows/ingestion/missing.py" in result.output
+
+
 class TestValidateCronField:
     """Tests for cron field validation."""
 

--- a/packages/phlo-pandera/tests/test_cli_validate_workflow.py
+++ b/packages/phlo-pandera/tests/test_cli_validate_workflow.py
@@ -7,12 +7,14 @@ Tests the workflow validation CLI command, including:
 - Directory and file handling
 """
 
+import ast
 import tempfile
 from pathlib import Path
 
 from click.testing import CliRunner
 
 from phlo_pandera.cli_validate import (
+    _is_phlo_ingestion_decorator,
     _is_valid_cron_field,
     _is_valid_field_name,
     _is_valid_table_name,
@@ -67,6 +69,23 @@ def events(partition_date: str) -> None:
 
     assert result.exit_code == 0
     assert "Workflow is valid" in result.output
+
+
+def test_validate_workflow_recognizes_preferred_phlo_ingestion_decorator() -> None:
+    """Recognizes @phlo.ingestion while keeping @phlo_ingestion supported."""
+    source = """
+@phlo.ingestion(table_name="events")
+def preferred(): pass
+
+@phlo_ingestion(table_name="events")
+def legacy(): pass
+"""
+    tree = ast.parse(source)
+    decorators = [
+        node.decorator_list[0] for node in ast.walk(tree) if isinstance(node, ast.FunctionDef)
+    ]
+
+    assert all(_is_phlo_ingestion_decorator(decorator) for decorator in decorators)
 
 
 class TestValidateCronField:

--- a/packages/phlo-pandera/tests/test_cli_validate_workflow.py
+++ b/packages/phlo-pandera/tests/test_cli_validate_workflow.py
@@ -30,6 +30,45 @@ def test_validate_workflow_missing_file_prints_rerun_hint() -> None:
     assert "phlo validate-workflow workflows/ingestion/missing.py" in result.output
 
 
+def test_validate_workflow_resolves_project_workflow_imports(monkeypatch, tmp_path) -> None:
+    """Loads workflow files that import project-local schemas."""
+    workflow_file = tmp_path / "workflows" / "ingestion" / "demo" / "events.py"
+    schema_file = tmp_path / "workflows" / "schemas" / "demo.py"
+    workflow_file.parent.mkdir(parents=True)
+    schema_file.parent.mkdir(parents=True)
+    schema_file.write_text("class RawEvents: pass\n")
+    workflow_file.write_text(
+        """
+from workflows.schemas.demo import RawEvents
+
+
+def phlo_ingestion(**kwargs):
+    def decorator(func):
+        return func
+
+    return decorator
+
+
+@phlo_ingestion(
+    table_name="events",
+    unique_key="id",
+    validation_schema=RawEvents,
+    group="demo",
+    cron="0 */1 * * *",
+    freshness_hours=(1, 24),
+)
+def events(partition_date: str) -> None:
+    return None
+"""
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(validate_workflow, [str(workflow_file)])
+
+    assert result.exit_code == 0
+    assert "Workflow is valid" in result.output
+
+
 class TestValidateCronField:
     """Tests for cron field validation."""
 

--- a/src/phlo/__init__.py
+++ b/src/phlo/__init__.py
@@ -51,7 +51,7 @@ Example:
     import phlo
 
     # Access ingestion decorator
-    @phlo.ingestion.phlo_ingestion(source="api", table_name="events")
+    @phlo.ingestion(source="api", table_name="events")
     def load_events():
         return fetch_events()
 

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 import click
 
@@ -36,6 +37,39 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
         click.echo("  5. Restart Dagster: phlo services restart dagster")
         click.echo(f"  6. Materialize: phlo materialize dlt_{table}")
         click.echo(f"  7. Inspect status: phlo status --select dlt_{table}")
+
+
+def _infer_schema_path(workflow_path: Path) -> Path | None:
+    """Infer a domain schema path from a workflow path."""
+    parts = workflow_path.parts
+    if "workflows" not in parts or "ingestion" not in parts:
+        return None
+    workflows_index = parts.index("workflows")
+    ingestion_index = parts.index("ingestion")
+    if ingestion_index + 1 >= len(parts):
+        return None
+    domain = parts[ingestion_index + 1]
+    root = Path(*parts[:workflows_index]) if workflows_index > 0 else Path()
+    return root / "workflows" / "schemas" / f"{domain}.py"
+
+
+def _asset_key_from_workflow_path(workflow_path: Path) -> str:
+    """Infer the DLT asset key from a workflow file path."""
+    return f"dlt_{workflow_path.stem}"
+
+
+def _validate_workflow_file(path: str) -> None:
+    """Validate a workflow file using the existing Pandera validator."""
+    from phlo_pandera.cli_validate import validate_workflow_file
+
+    validate_workflow_file(Path(path))
+
+
+def _validate_schema_file(path: str) -> None:
+    """Validate a schema file using the existing schema validator."""
+    from phlo_pandera.cli_schema_utils import validate_schema_file
+
+    validate_schema_file(Path(path))
 
 
 @workflow_group.command("create")
@@ -124,3 +158,23 @@ def create_workflow_cmd(
         )
         click.echo(f"Error creating workflow: {exc}", err=True)
         sys.exit(1)
+
+
+@workflow_group.command("check")
+@click.argument("workflow_file", type=click.Path(exists=True, dir_okay=False))
+def check_workflow_cmd(workflow_file: str) -> None:
+    """Validate a workflow and its inferred schema before materialization."""
+    workflow_path = Path(workflow_file)
+    schema_path = _infer_schema_path(workflow_path)
+
+    _validate_workflow_file(str(workflow_path))
+    click.echo(f"Workflow valid: {workflow_path}")
+
+    if schema_path and schema_path.exists():
+        _validate_schema_file(str(schema_path))
+        click.echo(f"Schema valid: {schema_path}")
+    elif schema_path:
+        raise click.ClickException(f"Inferred schema file not found: {schema_path}")
+
+    asset_key = _asset_key_from_workflow_path(workflow_path)
+    click.echo(f"Next: phlo materialize {asset_key}")

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -16,6 +16,28 @@ def workflow_group() -> None:
     """Manage workflows."""
 
 
+def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
+    """Print the next commands for a generated ingestion workflow."""
+    schema_file = files[0]
+    workflow_file = files[1]
+    test_file = files[2] if len(files) > 2 else None
+
+    click.echo("\nNext steps:")
+    click.echo(f"  1. Review schema: {schema_file}")
+    click.echo(f"  2. Review workflow: {workflow_file}")
+    click.echo(f"  3. Validate schema: phlo schema validate {schema_file}")
+    click.echo(f"  4. Validate workflow: phlo validate-workflow {workflow_file}")
+    if test_file:
+        click.echo(f"  5. Run generated tests: uv run pytest {test_file} -q")
+        click.echo("  6. Restart Dagster: phlo services restart dagster")
+        click.echo(f"  7. Materialize: phlo materialize dlt_{table}")
+        click.echo(f"  8. Inspect status: phlo status --select dlt_{table}")
+    else:
+        click.echo("  5. Restart Dagster: phlo services restart dagster")
+        click.echo(f"  6. Materialize: phlo materialize dlt_{table}")
+        click.echo(f"  7. Inspect status: phlo status --select dlt_{table}")
+
+
 @workflow_group.command("create")
 @click.option(
     "--type",
@@ -85,12 +107,7 @@ def create_workflow_cmd(
             for file_path in files:
                 click.echo(f"  - {file_path}")
 
-            click.echo("\nNext steps:")
-            click.echo(f"  1. Edit schema: {files[0]}")
-            click.echo(f"  2. Configure API: {files[1]}")
-            click.echo("  3. Restart Dagster: phlo services restart dagster")
-            click.echo(f"  4. Test: phlo test {domain}")
-            click.echo(f"  5. Materialize: phlo materialize dlt_{table}")
+            _print_ingestion_next_steps(files, table=table)
             logger.info(
                 "workflow_create_succeeded",
                 workflow_type=workflow_type,

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -30,13 +30,13 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
     click.echo(f"  4. Validate workflow: phlo validate-workflow {workflow_file}")
     if test_file:
         click.echo(f"  5. Run generated tests: uv run pytest {test_file} -q")
-        click.echo("  6. Restart Dagster: phlo services restart dagster")
+        click.echo("  6. Restart Dagster: phlo services restart --service dagster")
         click.echo(f"  7. Materialize: phlo materialize dlt_{table}")
-        click.echo(f"  8. Inspect status: phlo status --select dlt_{table}")
+        click.echo("  8. Inspect status: phlo status")
     else:
-        click.echo("  5. Restart Dagster: phlo services restart dagster")
+        click.echo("  5. Restart Dagster: phlo services restart --service dagster")
         click.echo(f"  6. Materialize: phlo materialize dlt_{table}")
-        click.echo(f"  7. Inspect status: phlo status --select dlt_{table}")
+        click.echo("  7. Inspect status: phlo status")
 
 
 def _infer_schema_path(workflow_path: Path) -> Path | None:
@@ -62,14 +62,19 @@ def _validate_workflow_file(path: str) -> None:
     """Validate a workflow file using the existing Pandera validator."""
     from phlo_pandera.cli_validate import validate_workflow_file
 
-    validate_workflow_file(Path(path))
+    validate_workflow_file(Path(path), require_workflow=True)
 
 
 def _validate_schema_file(path: str) -> None:
     """Validate a schema file using the existing schema validator."""
     from phlo_pandera.cli_schema_utils import validate_schema_file
 
-    validate_schema_file(Path(path))
+    try:
+        validate_schema_file(Path(path))
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        raise click.ClickException(f"Schema validation failed for {path}: {exc}") from exc
 
 
 @workflow_group.command("create")
@@ -171,7 +176,14 @@ def check_workflow_cmd(workflow_file: str) -> None:
     click.echo(f"Workflow valid: {workflow_path}")
 
     if schema_path and schema_path.exists():
-        _validate_schema_file(str(schema_path))
+        try:
+            _validate_schema_file(str(schema_path))
+        except click.ClickException:
+            raise
+        except Exception as exc:
+            raise click.ClickException(
+                f"Schema validation failed for {schema_path}: {exc}"
+            ) from exc
         click.echo(f"Schema valid: {schema_path}")
     elif schema_path:
         raise click.ClickException(f"Inferred schema file not found: {schema_path}")

--- a/src/phlo/ingestion.py
+++ b/src/phlo/ingestion.py
@@ -19,9 +19,8 @@ Note:
 Example:
     ```python
     import phlo
-    from phlo.ingestion import phlo_ingestion
 
-    @phlo_ingestion(
+    @phlo.ingestion(
         source="github",
         table_name="events",
         group_name="raw"
@@ -46,6 +45,10 @@ Raises:
 
 from __future__ import annotations
 
+import sys
+from types import ModuleType
+from typing import Any
+
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
@@ -57,5 +60,15 @@ except ModuleNotFoundError as exc:  # pragma: no cover - exercised via optional 
     raise ModuleNotFoundError(
         "phlo.ingestion requires phlo-dlt. Install phlo[defaults] or phlo-dlt."
     ) from exc
+
+
+class _CallableIngestionModule(ModuleType):
+    """Module type that lets ``phlo.ingestion(...)`` call the decorator."""
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return phlo_ingestion(*args, **kwargs)
+
+
+sys.modules[__name__].__class__ = _CallableIngestionModule
 
 __all__ = ["get_ingestion_assets", "phlo_ingestion"]

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -239,6 +239,37 @@ def test_workflow_create_reports_scaffold_failures(monkeypatch) -> None:
     assert "Error creating workflow: schema field is invalid" in result.output
 
 
+def test_workflow_check_delegates_to_existing_validators(monkeypatch, tmp_path) -> None:
+    """Checks the workflow and inferred schema before materialization."""
+    workflow_file = tmp_path / "workflows" / "ingestion" / "weather" / "observations.py"
+    schema_file = tmp_path / "workflows" / "schemas" / "weather.py"
+    workflow_file.parent.mkdir(parents=True)
+    schema_file.parent.mkdir(parents=True)
+    workflow_file.write_text("import phlo\n")
+    schema_file.write_text("class WeatherSchema: pass\n")
+    monkeypatch.chdir(tmp_path)
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_validate_schema(path: str) -> None:
+        calls.append(("schema", path))
+
+    def fake_validate_workflow(path: str) -> None:
+        calls.append(("workflow", path))
+
+    monkeypatch.setattr("phlo.cli.commands.workflow._validate_schema_file", fake_validate_schema)
+    monkeypatch.setattr(
+        "phlo.cli.commands.workflow._validate_workflow_file", fake_validate_workflow
+    )
+
+    result = CliRunner().invoke(cli, ["workflow", "check", str(workflow_file)])
+
+    assert result.exit_code == 0
+    assert ("workflow", str(workflow_file)) in calls
+    assert ("schema", str(schema_file)) in calls
+    assert "phlo materialize dlt_observations" in result.output
+
+
 def test_init_with_absolute_path_uses_directory_name_for_project_metadata(tmp_path: Path) -> None:
     """Uses directory basename, not full absolute path, for project name.
 

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -290,6 +290,40 @@ def test_workflow_check_rejects_files_without_ingestion_workflow(tmp_path, monke
     assert "phlo materialize" not in result.output
 
 
+def test_workflow_check_rejects_commented_ingestion_decorator(tmp_path, monkeypatch) -> None:
+    """Does not treat decorator-looking comments as workflows."""
+    workflow_file = tmp_path / "workflows" / "ingestion" / "weather" / "notes.py"
+    schema_file = tmp_path / "workflows" / "schemas" / "weather.py"
+    workflow_file.parent.mkdir(parents=True)
+    schema_file.parent.mkdir(parents=True)
+    workflow_file.write_text(
+        """
+DECORATOR_TEXT = "@phlo_ingestion(table_name='notes')"
+
+# @phlo_ingestion(
+#     table_name="notes",
+#     unique_key="id",
+#     validation_schema=None,
+#     group="weather",
+#     cron="0 */1 * * *",
+#     freshness_hours=(1, 24),
+# )
+def helper(partition_date: str) -> None:
+    return None
+"""
+    )
+    schema_file.write_text(
+        '"""Weather schema."""\n\nimport pandera as pa\n\nclass WeatherSchema: pass\n'
+    )
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["workflow", "check", str(workflow_file)])
+
+    assert result.exit_code != 0
+    assert "No @phlo_ingestion decorated workflow found" in result.output
+    assert "phlo materialize" not in result.output
+
+
 def test_workflow_check_wraps_schema_validation_failures(monkeypatch, tmp_path) -> None:
     """Reports schema validation errors as Click failures."""
     workflow_file = tmp_path / "workflows" / "ingestion" / "weather" / "observations.py"

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -197,9 +197,12 @@ def test_workflow_create_prints_runnable_next_steps(monkeypatch, tmp_path) -> No
     assert result.exit_code == 0
     assert "phlo schema validate workflows/schemas/weather.py" in result.output
     assert "phlo validate-workflow workflows/ingestion/weather/observations.py" in result.output
-    assert "phlo services restart dagster" in result.output
+    assert "phlo services restart --service dagster" in result.output
     assert "phlo materialize dlt_observations" in result.output
+    assert "phlo status" in result.output
+    assert "phlo status --select" not in result.output
     assert "phlo test weather" not in result.output
+    assert "phlo services restart dagster" not in result.output
     assert "docker restart" not in result.output
 
 
@@ -268,6 +271,52 @@ def test_workflow_check_delegates_to_existing_validators(monkeypatch, tmp_path) 
     assert ("workflow", str(workflow_file)) in calls
     assert ("schema", str(schema_file)) in calls
     assert "phlo materialize dlt_observations" in result.output
+
+
+def test_workflow_check_rejects_files_without_ingestion_workflow(tmp_path, monkeypatch) -> None:
+    """Fails strict checks when a file has no Phlo ingestion asset."""
+    workflow_file = tmp_path / "workflows" / "ingestion" / "weather" / "notes.py"
+    schema_file = tmp_path / "workflows" / "schemas" / "weather.py"
+    workflow_file.parent.mkdir(parents=True)
+    schema_file.parent.mkdir(parents=True)
+    workflow_file.write_text("VALUE = 1\n")
+    schema_file.write_text('"""Weather schema."""\n\nclass WeatherSchema: pass\n')
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(cli, ["workflow", "check", str(workflow_file)])
+
+    assert result.exit_code != 0
+    assert "No @phlo_ingestion decorated workflow found" in result.output
+    assert "phlo materialize" not in result.output
+
+
+def test_workflow_check_wraps_schema_validation_failures(monkeypatch, tmp_path) -> None:
+    """Reports schema validation errors as Click failures."""
+    workflow_file = tmp_path / "workflows" / "ingestion" / "weather" / "observations.py"
+    schema_file = tmp_path / "workflows" / "schemas" / "weather.py"
+    workflow_file.parent.mkdir(parents=True)
+    schema_file.parent.mkdir(parents=True)
+    workflow_file.write_text("import phlo\n")
+    schema_file.write_text("not valid python")
+    monkeypatch.chdir(tmp_path)
+
+    def fake_validate_workflow(path: str) -> None:
+        return None
+
+    def fake_validate_schema(path: str) -> None:
+        raise ValueError("schema syntax exploded")
+
+    monkeypatch.setattr(
+        "phlo.cli.commands.workflow._validate_workflow_file", fake_validate_workflow
+    )
+    monkeypatch.setattr("phlo.cli.commands.workflow._validate_schema_file", fake_validate_schema)
+
+    result = CliRunner().invoke(cli, ["workflow", "check", str(workflow_file)])
+
+    assert result.exit_code != 0
+    assert "Schema validation failed" in result.output
+    assert "schema syntax exploded" in result.output
+    assert "Traceback" not in result.output
 
 
 def test_init_with_absolute_path_uses_directory_name_for_project_metadata(tmp_path: Path) -> None:

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -7,6 +7,18 @@ from click.testing import CliRunner
 from phlo.cli.main import cli
 
 
+def test_authoring_commands_remain_discoverable() -> None:
+    """Keeps the authoring path commands visible from root help."""
+    result = CliRunner().invoke(cli, ["--help"])
+
+    assert result.exit_code == 0
+    assert "workflow" in result.output
+    assert "schema" in result.output
+    assert "validate-workflow" in result.output
+    assert "materialize" in result.output
+    assert "status" in result.output
+
+
 def test_workflow_group_help_lists_create() -> None:
     """Shows the scaffold command in workflow group help output."""
     runner = CliRunner()

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -286,7 +286,7 @@ def test_workflow_check_rejects_files_without_ingestion_workflow(tmp_path, monke
     result = CliRunner().invoke(cli, ["workflow", "check", str(workflow_file)])
 
     assert result.exit_code != 0
-    assert "No @phlo_ingestion decorated workflow found" in result.output
+    assert "No @phlo.ingestion decorated workflow found" in result.output
     assert "phlo materialize" not in result.output
 
 
@@ -298,9 +298,9 @@ def test_workflow_check_rejects_commented_ingestion_decorator(tmp_path, monkeypa
     schema_file.parent.mkdir(parents=True)
     workflow_file.write_text(
         """
-DECORATOR_TEXT = "@phlo_ingestion(table_name='notes')"
+DECORATOR_TEXT = "@phlo.ingestion(table_name='notes')"
 
-# @phlo_ingestion(
+# @phlo.ingestion(
 #     table_name="notes",
 #     unique_key="id",
 #     validation_schema=None,
@@ -320,7 +320,7 @@ def helper(partition_date: str) -> None:
     result = CliRunner().invoke(cli, ["workflow", "check", str(workflow_file)])
 
     assert result.exit_code != 0
-    assert "No @phlo_ingestion decorated workflow found" in result.output
+    assert "No @phlo.ingestion decorated workflow found" in result.output
     assert "phlo materialize" not in result.output
 
 

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -155,7 +155,52 @@ def test_workflow_create_converts_blank_api_base_url_to_none(monkeypatch) -> Non
     assert result.exit_code == 0
     assert calls["api_base_url"] is None
     assert calls["fields"] == ["event_id:string!", "clicked_at:datetime?"]
-    assert "Edit schema: workflows/schemas/events.py" in result.output
+    assert "Review schema: workflows/schemas/events.py" in result.output
+
+
+def test_workflow_create_prints_runnable_next_steps(monkeypatch, tmp_path) -> None:
+    """Prints next steps that exist in the current CLI surface."""
+    monkeypatch.chdir(tmp_path)
+
+    def fake_create_ingestion_workflow(**kwargs):
+        return [
+            "workflows/schemas/weather.py",
+            "workflows/ingestion/weather/observations.py",
+            "tests/test_weather_observations.py",
+        ]
+
+    monkeypatch.setattr(
+        "phlo_dlt.scaffold.create_ingestion_workflow",
+        fake_create_ingestion_workflow,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "workflow",
+            "create",
+            "--type",
+            "ingestion",
+            "--domain",
+            "weather",
+            "--table",
+            "observations",
+            "--unique-key",
+            "station_id",
+            "--cron",
+            "0 */1 * * *",
+            "--api-base-url",
+            "https://example.test",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "phlo schema validate workflows/schemas/weather.py" in result.output
+    assert "phlo validate-workflow workflows/ingestion/weather/observations.py" in result.output
+    assert "phlo services restart dagster" in result.output
+    assert "phlo materialize dlt_observations" in result.output
+    assert "phlo test weather" not in result.output
+    assert "docker restart" not in result.output
 
 
 def test_workflow_create_reports_scaffold_failures(monkeypatch) -> None:

--- a/tests/test_public_api_exports.py
+++ b/tests/test_public_api_exports.py
@@ -13,6 +13,25 @@ import pytest
 pytestmark = pytest.mark.core_regression
 
 
+def test_phlo_ingestion_module_is_callable_decorator_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """phlo.ingestion should be the preferred callable decorator alias."""
+    import phlo
+
+    calls: list[dict[str, str]] = []
+
+    def fake_phlo_ingestion(**kwargs: str) -> str:
+        calls.append(kwargs)
+        return "decorator"
+
+    monkeypatch.setattr(phlo.ingestion, "phlo_ingestion", fake_phlo_ingestion)
+
+    assert callable(phlo.ingestion)
+    assert phlo.ingestion(table_name="events") == "decorator"
+    assert calls == [{"table_name": "events"}]
+
+
 def test_quality_module_import_does_not_load_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     """Importing phlo.quality should define no provider-backed exports eagerly."""
     import phlo.plugins.discovery as discovery


### PR DESCRIPTION
## What this changes

Workflow authoring has a guided validation path for scaffolded and hand-written ingestion workflows.

`phlo workflow check` validates an ingestion workflow, validates the inferred schema, and prints the materialization command for the resulting asset. `phlo workflow create` prints the concrete follow-up commands needed to review, validate, test, restart services, materialize, and inspect the new workflow.

Generated and documented examples use the public Phlo decorator API:

```python
import phlo

@phlo.ingestion(
    table_name="observations",
    unique_key="id",
    validation_schema=ObservationsSchema,
    group="weather",
)
def observations(partition_date: str):
    ...
```

## Example: creating a workflow

```text
Creating ingestion workflow for weather.observations...

Created files:
  - workflows/schemas/weather.py
  - workflows/ingestion/weather/observations.py
  - tests/workflows/ingestion/weather/test_observations.py

Next steps:
  1. Review schema: workflows/schemas/weather.py
  2. Review workflow: workflows/ingestion/weather/observations.py
  3. Validate schema: phlo schema validate workflows/schemas/weather.py
  4. Validate workflow: phlo validate-workflow workflows/ingestion/weather/observations.py
  5. Run generated tests: uv run pytest tests/workflows/ingestion/weather/test_observations.py -q
  6. Restart Dagster: phlo services restart --service dagster
  7. Materialize: phlo materialize dlt_observations
  8. Inspect status: phlo status
```

## Example: checking a workflow before materialization

```bash
phlo workflow check workflows/ingestion/weather/observations.py
```

Successful output points at both the workflow and inferred schema, then gives the materialization command:

```text
observations.py
  ✓ Found 1 workflow(s)
  Function: observations
    ✓ No issues found
Workflow valid: workflows/ingestion/weather/observations.py
Schema valid: workflows/schemas/weather.py
Next: phlo materialize dlt_observations
```

A file without an ingestion workflow fails clearly:

```text
notes.py
  ✗ No @phlo.ingestion decorated workflow found
```

## Validation behavior

- Uses Python AST inspection for decorator detection.
- Accepts Phlo ingestion decorators without matching comments or string literals.
- Infers schema paths from workflow domains, for example `workflows/ingestion/weather/observations.py` -> `workflows/schemas/weather.py`.
- Emits the inferred Dagster/DLT asset key, for example `dlt_observations`.

## Reviewer notes

Review the boundary between scaffolded files, schema inference, and AST decorator detection. The authoring path should guide users from a workflow file to a valid materialization command without false positives from commented examples.

## Verification

- `uv run ruff check src/phlo/ingestion.py src/phlo/__init__.py packages/phlo-pandera/src/phlo_pandera/cli_validate.py tests/test_cli_workflow.py packages/phlo-pandera/tests/test_cli_validate_workflow.py tests/test_public_api_exports.py`
- `uv run pytest tests/test_public_api_exports.py tests/test_cli_workflow.py packages/phlo-pandera/tests/test_cli_validate_workflow.py`