### PR TITLE
feat: add project template gallery

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -17,6 +17,20 @@ A simple glucose data ingestion pipeline that:
 - 10 minutes
 - Text editor
 
+### Choose a starter template
+
+List available project templates:
+
+```bash
+phlo init --list-templates
+```
+
+For a local file-backed first pipeline, use:
+
+```bash
+phlo init my-project --template csv-batch
+```
+
 ## Step 1: Clone and Setup (2 minutes)
 
 ```bash

--- a/docs/guides/workflow-development.md
+++ b/docs/guides/workflow-development.md
@@ -87,6 +87,20 @@ Before starting, make sure you have:
 
 ---
 
+## Choosing a Template
+
+| Template | Use when |
+| --- | --- |
+| `minimal` | You want an empty Phlo project. |
+| `basic` | You want a dbt-ready project. |
+| `csv-batch` | You want the smallest local pipeline with no network calls. |
+| `api-ingestion` | You want a REST-style ingestion starting point. |
+| `dbt-medallion` | You want bronze/silver/gold transform structure. |
+| `sling-replication` | You want to start with Sling replication. |
+| `observability-demo` | You want a tiny pipeline wired for telemetry. |
+
+---
+
 ## Step 1: Define Your Data Schema
 
 First, let's define what our data looks like.

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1014,13 +1014,31 @@ phlo init [PROJECT_NAME] [OPTIONS]
 
 ```bash
 --template TEMPLATE      # Project template (default: basic)
+--list-templates         # List available project templates and exit
 --force                  # Initialize in non-empty directory
 ```
 
 **Templates**:
 
-- `basic`: Ingestion + dbt transforms (requires `phlo-dbt`)
 - `minimal`: Minimal project structure (no transforms)
+- `basic`: Ingestion + dbt transforms (requires `phlo-dbt`)
+- `csv-batch`: Local CSV batch pipeline
+- `api-ingestion`: REST API ingestion pipeline
+- `dbt-medallion`: Bronze/silver/gold dbt project
+- `sling-replication`: Sling replication starter
+- `observability-demo`: Pipeline with telemetry wiring
+
+#### List templates
+
+```bash
+phlo init --list-templates
+```
+
+#### Create from a template
+
+```bash
+phlo init my-project --template csv-batch
+```
 
 **Example**:
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1013,7 +1013,7 @@ phlo init [PROJECT_NAME] [OPTIONS]
 **Options**:
 
 ```bash
---template TEMPLATE      # Project template (default: basic)
+--template TEMPLATE      # Project template (default: minimal)
 --list-templates         # List available project templates and exit
 --force                  # Initialize in non-empty directory
 ```
@@ -1021,7 +1021,7 @@ phlo init [PROJECT_NAME] [OPTIONS]
 **Templates**:
 
 - `minimal`: Minimal project structure (no transforms)
-- `basic`: Ingestion + dbt transforms (requires `phlo-dbt`)
+- `basic`: dbt-ready project (requires `phlo-dbt`)
 - `csv-batch`: Local CSV batch pipeline
 - `api-ingestion`: REST API ingestion pipeline
 - `dbt-medallion`: Bronze/silver/gold dbt project
@@ -1040,6 +1040,12 @@ phlo init --list-templates
 phlo init my-project --template csv-batch
 ```
 
+#### Create the default minimal project
+
+```bash
+phlo init my-project
+```
+
 **Example**:
 
 ```bash
@@ -1055,7 +1061,7 @@ my-lakehouse/
 ├── workflows/
 │   ├── ingestion/
 │   ├── schemas/
-│   └── transforms/       # basic template only
+│   └── transforms/       # dbt templates only
 │       └── dbt/
 ├── tests/
 └── phlo.yaml

--- a/src/phlo/cli/_init_discovery_guard.py
+++ b/src/phlo/cli/_init_discovery_guard.py
@@ -5,10 +5,22 @@ from __future__ import annotations
 import os
 import sys
 
+_GLOBAL_FLAGS_WITHOUT_VALUES = {"--help", "-h", "--version"}
+
+
+def _root_command_name(argv: list[str]) -> str | None:
+    for token in argv[1:]:
+        if token in _GLOBAL_FLAGS_WITHOUT_VALUES:
+            return None
+        if token.startswith("-"):
+            continue
+        return token
+    return None
+
 
 def is_init_command_invocation(argv: list[str] | None = None) -> bool:
     args = sys.argv if argv is None else argv
-    return "init" in args[1:]
+    return _root_command_name(args) == "init"
 
 
 if is_init_command_invocation():

--- a/src/phlo/cli/_init_discovery_guard.py
+++ b/src/phlo/cli/_init_discovery_guard.py
@@ -1,0 +1,15 @@
+"""Disable eager plugin discovery for built-in init invocations."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def is_init_command_invocation(argv: list[str] | None = None) -> bool:
+    args = sys.argv if argv is None else argv
+    return "init" in args[1:]
+
+
+if is_init_command_invocation():
+    os.environ.setdefault("PHLO_NO_AUTO_DISCOVER", "1")

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -179,6 +179,34 @@ def test(
         sys.exit(1)
 
 
+def _display_created_structure(project_dir: Path, selected_template) -> None:
+    click.echo("Created structure:")
+    click.echo(f"  {project_dir}/")
+    click.echo("  ├── phlo.yaml            # Project configuration")
+    click.echo("  ├── pyproject.toml       # Project dependencies")
+    click.echo("  ├── .env.example         # Local secrets template")
+    click.echo("  ├── .gitignore")
+    click.echo("  ├── README.md")
+    click.echo("  ├── workflows/           # Workflow definitions")
+    click.echo("  └── tests/               # Workflow tests")
+    common_paths = {
+        "phlo.yaml",
+        "pyproject.toml",
+        ".env.example",
+        ".gitignore",
+        "README.md",
+        "workflows/__init__.py",
+        "tests/__init__.py",
+    }
+    extra_paths = tuple(
+        path for path in selected_template.metadata.generated_paths if path not in common_paths
+    )
+    if extra_paths:
+        click.echo("  Template additions:")
+        for path in extra_paths:
+            click.echo(f"    - {path}")
+
+
 @cli.command("init")
 @click.argument("project_name", required=False)
 @click.option(
@@ -232,17 +260,7 @@ def init(project_name: str | None, template: str, force: bool, list_templates: b
         selected_template = _create_project_structure(project_dir, project_metadata_name, template)
 
         click.echo(f"\nSuccessfully initialized Phlo project: {project_dir}\n")
-        click.echo("Created structure:")
-        click.echo(f"  {project_dir}/")
-        click.echo("  ├── phlo.yaml            # Project configuration with infrastructure")
-        click.echo("  ├── pyproject.toml       # Project dependencies")
-        click.echo("  ├── .env.example         # Local secrets template (copy to .phlo/.env.local)")
-        click.echo("  ├── .sqlfluff            # SQL linting configuration for dbt models")
-        click.echo("  ├── workflows/           # Your workflow definitions")
-        click.echo("  │   ├── ingestion/       # Data ingestion workflows")
-        click.echo("  │   ├── schemas/         # Pandera validation schemas")
-        click.echo("  │   └── transforms/dbt/  # dbt transformation models")
-        click.echo("  └── tests/               # Workflow tests")
+        _display_created_structure(project_dir, selected_template)
 
         click.echo("\nNext steps:")
         step_number = 1

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -14,6 +14,7 @@ import click
 
 import phlo.cli._warning_filters  # noqa: F401
 from phlo.cli.commands.doctor import doctor_cmd
+from phlo.cli.templates import TemplateRenderContext, get_template
 from phlo.logging import get_logger, setup_logging
 
 logger = get_logger(__name__, service="phlo-cli")
@@ -259,150 +260,10 @@ def _create_project_structure(project_dir: Path, project_name: str, template: st
         project_name: Name of the project
         template: Template type ("basic" or "minimal")
     """
-    # Create directories
-    project_dir.mkdir(parents=True, exist_ok=True)
-
-    # Create workflows structure
-    workflows_dir = project_dir / "workflows"
-    workflows_dir.mkdir(exist_ok=True)
-    (workflows_dir / "__init__.py").write_text('"""User workflows."""\n')
-
-    (workflows_dir / "ingestion").mkdir(exist_ok=True)
-    (workflows_dir / "ingestion" / "__init__.py").write_text('"""Ingestion workflows."""\n')
-
-    (workflows_dir / "schemas").mkdir(exist_ok=True)
-    (workflows_dir / "schemas" / "__init__.py").write_text('"""Pandera validation schemas."""\n')
-
-    # Create workflows/transforms/dbt structure if basic template
-    if template == "basic":
-        transforms_dir = project_dir / "workflows" / "transforms" / "dbt"
-        transforms_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            from phlo_dbt.scaffold import write_dbt_scaffold
-        except ImportError as exc:
-            raise RuntimeError(
-                "phlo-dbt is required for the basic template. "
-                "Install phlo-dbt or use --template minimal."
-            ) from exc
-
-        write_dbt_scaffold(project_name, transforms_dir, project_dir)
-
-        # Create models directory
-        (transforms_dir / "models").mkdir(exist_ok=True)
-        (transforms_dir / "models" / ".gitkeep").write_text("")
-
-    # Create tests directory
-    tests_dir = project_dir / "tests"
-    tests_dir.mkdir(exist_ok=True)
-    (tests_dir / "__init__.py").write_text("")
-
-    # Create pyproject.toml
-    pyproject_content = f"""[project]
-name = "{project_name}"
-version = "0.1.0"
-description = "Phlo data workflows"
-requires-python = ">=3.11"
-dependencies = [
-    "phlo",
-]
-
-[dependency-groups]
-dev = [
-    "pytest>=8.0",
-    "ruff",
-]
-
-[tool.ruff]
-line-length = 100
-target-version = "py311"
-
-[tool.ruff.lint]
-select = ["E", "F", "I"]
-"""
-    (project_dir / "pyproject.toml").write_text(pyproject_content)
-
-    # Create .env.example (secrets template)
-    env_example_content = _build_env_example_content()
-    (project_dir / ".env.example").write_text(env_example_content)
-
-    # Create .gitignore
-    gitignore_content = """.env
-.env.local
-.phlo/
-__pycache__/
-*.py[cod]
-*$py.class
-*.so
-.Python
-.venv/
-venv/
-*.egg-info/
-dist/
-build/
-.pytest_cache/
-.coverage
-htmlcov/
-.ruff_cache/
-"""
-    (project_dir / ".gitignore").write_text(gitignore_content)
-
-    # Create README.md
-    readme_content = f"""# {project_name}
-
-Phlo data workflows for {project_name}.
-
-## Getting Started
-
-1. **Install dependencies:**
-   ```bash
-   pip install -e .
-   ```
-
-2. **Create your first workflow:**
-   ```bash
-   phlo workflow create
-   ```
-
-3. **Start Dagster UI:**
-   ```bash
-   phlo dev
-   ```
-
-4. **Access the UI:**
-   Open http://localhost:3000 in your browser
-
-## Project Structure
-
-```
-{project_name}/
-├── workflows/          # Your workflow definitions
-│   ├── ingestion/     # Data ingestion workflows
-│   ├── schemas/       # Pandera validation schemas
-│   └── transforms/dbt/ # dbt transformation models
-└── tests/            # Workflow tests
-```
-
-## Documentation
-
-- [Phlo Documentation](https://github.com/iamgp/phlo)
-- [Workflow Development Guide](https://github.com/iamgp/phlo/blob/main/docs/guides/workflow-development.md)
-
-## Commands
-
-- `phlo dev` - Start Dagster development server
-- `phlo workflow create` - Scaffold new workflow
-- `phlo test` - Run tests
-"""
-    (project_dir / "README.md").write_text(readme_content)
-
-    # Create phlo.yaml with infrastructure configuration
-    from phlo.cli.commands.services.utils import PHLO_CONFIG_TEMPLATE
-
-    phlo_config_content = PHLO_CONFIG_TEMPLATE.format(
-        name=project_name,
-        description=f"{project_name} data workflows",
+    selected_template = get_template(template)
+    selected_template.render(
+        TemplateRenderContext(project_dir=project_dir, project_name=project_name)
     )
-    (project_dir / "phlo.yaml").write_text(phlo_config_content)
 
 
 def _build_env_example_content() -> str:

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -16,6 +16,7 @@ import phlo.cli._warning_filters  # noqa: F401
 from phlo.cli.commands.doctor import doctor_cmd
 from phlo.cli.templates import TemplateRenderContext, get_template
 from phlo.cli.templates import list_templates as get_project_templates
+from phlo.cli.templates.registry import missing_required_packages
 from phlo.logging import get_logger, setup_logging
 
 logger = get_logger(__name__, service="phlo-cli")
@@ -249,6 +250,8 @@ def init(project_name: str | None, template: str, force: bool, list_templates: b
 
         click.echo("\nDocumentation: https://github.com/iamgp/phlo")
 
+    except click.ClickException:
+        raise
     except Exception as e:
         logger.exception("project_initialization_failed", project_dir=str(project_dir))
         click.echo(f"\nError initializing project: {e}", err=True)
@@ -268,6 +271,13 @@ def _create_project_structure(project_dir: Path, project_name: str, template: st
         template: Template type ("basic" or "minimal")
     """
     selected_template = get_template(template)
+    missing = missing_required_packages(selected_template)
+    if missing:
+        packages = " ".join(missing)
+        raise click.ClickException(
+            f"Template '{template}' requires missing package(s): {', '.join(missing)}. "
+            f"Install with: uv pip install {packages}"
+        )
     selected_template.render(
         TemplateRenderContext(project_dir=project_dir, project_name=project_name)
     )

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -178,7 +178,6 @@ def test(
 @click.argument("project_name", required=False)
 @click.option(
     "--template",
-    type=click.Choice(["basic", "minimal"]),
     default="basic",
     help="Project template to use",
 )

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -211,7 +211,8 @@ def _display_created_structure(project_dir: Path, selected_template) -> None:
 @click.argument("project_name", required=False)
 @click.option(
     "--template",
-    default="basic",
+    default="minimal",
+    show_default=True,
     help="Project template to use",
 )
 @click.option("--force", is_flag=True, help="Initialize in non-empty directory")
@@ -226,7 +227,7 @@ def init(project_name: str | None, template: str, force: bool, list_templates: b
     Examples:
         phlo init my-data-project          # Create new project directory
         phlo init . --force                # Initialize in current directory
-        phlo init weather-pipeline --template minimal
+        phlo init weather-pipeline --template csv-batch
     """
     if list_templates:
         for item in get_project_templates():
@@ -291,7 +292,7 @@ def _create_project_structure(project_dir: Path, project_name: str, template: st
     Args:
         project_dir: Path to project directory
         project_name: Name of the project
-        template: Template type ("basic" or "minimal")
+        template: Project template name.
     """
     try:
         selected_template = get_template(template)

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -271,7 +271,13 @@ def _create_project_structure(project_dir: Path, project_name: str, template: st
         project_name: Name of the project
         template: Template type ("basic" or "minimal")
     """
-    selected_template = get_template(template)
+    try:
+        selected_template = get_template(template)
+    except KeyError as exc:
+        available = ", ".join(item.metadata.name for item in get_project_templates())
+        raise click.ClickException(
+            f"Unknown template '{template}'. Available templates: {available}"
+        ) from exc
     missing = missing_required_packages(selected_template)
     if missing:
         packages = " ".join(missing)

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -225,7 +225,7 @@ def init(project_name: str | None, template: str, force: bool, list_templates: b
 
     # Create project structure
     try:
-        _create_project_structure(project_dir, project_metadata_name, template)
+        selected_template = _create_project_structure(project_dir, project_metadata_name, template)
 
         click.echo(f"\nSuccessfully initialized Phlo project: {project_dir}\n")
         click.echo("Created structure:")
@@ -241,12 +241,13 @@ def init(project_name: str | None, template: str, force: bool, list_templates: b
         click.echo("  └── tests/               # Workflow tests")
 
         click.echo("\nNext steps:")
+        step_number = 1
         if project_dir != Path.cwd():
-            click.echo(f"  1. cd {project_dir}")
-        click.echo("  2. pip install -e .              # Install Phlo and dependencies")
-        click.echo("  3. phlo services init            # Set up infrastructure (Docker)")
-        click.echo("  4. phlo workflow create          # Create your first workflow")
-        click.echo("  5. phlo dev                      # Start Dagster UI")
+            click.echo(f"  {step_number}. cd {project_dir}")
+            step_number += 1
+        for next_step in selected_template.metadata.next_steps:
+            click.echo(f"  {step_number}. {next_step}")
+            step_number += 1
 
         click.echo("\nDocumentation: https://github.com/iamgp/phlo")
 
@@ -281,6 +282,7 @@ def _create_project_structure(project_dir: Path, project_name: str, template: st
     selected_template.render(
         TemplateRenderContext(project_dir=project_dir, project_name=project_name)
     )
+    return selected_template
 
 
 def _build_env_example_content() -> str:

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -295,38 +295,6 @@ def _create_project_structure(project_dir: Path, project_name: str, template: st
     return selected_template
 
 
-def _build_env_example_content() -> str:
-    from phlo.plugins.discovery import ServiceDiscovery
-
-    lines = [
-        "# Phlo Local Secrets Template",
-        "# Copy to .phlo/.env.local after running `phlo services init`.",
-        "",
-    ]
-
-    discovery = ServiceDiscovery()
-    services = discovery.discover()
-    if not services:
-        lines.append(
-            "# No service plugins discovered; install service packages to populate secrets."
-        )
-        return "\n".join(lines) + "\n"
-
-    for service in sorted(services.values(), key=lambda s: s.name):
-        secrets = {key: cfg for key, cfg in service.env_vars.items() if cfg.get("secret") is True}
-        if not secrets:
-            continue
-        lines.append(f"# {service.name}")
-        for key in sorted(secrets.keys()):
-            desc = secrets[key].get("description")
-            if desc:
-                lines.append(f"# {desc}")
-            lines.append(f"{key}=")
-        lines.append("")
-
-    return "\n".join(lines).rstrip() + "\n"
-
-
 def main():
     """Main entry point for CLI."""
     cli()

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -12,7 +12,9 @@ from pathlib import Path
 
 import click
 
+import phlo.cli._init_discovery_guard  # noqa: F401
 import phlo.cli._warning_filters  # noqa: F401
+from phlo.cli._init_discovery_guard import is_init_command_invocation
 from phlo.cli.commands.doctor import doctor_cmd
 from phlo.cli.templates import TemplateRenderContext, get_template
 from phlo.cli.templates import list_templates as get_project_templates
@@ -35,6 +37,7 @@ def _is_doctor_invocation(argv: list[str]) -> bool:
 
 
 _DOCTOR_INVOCATION = _is_doctor_invocation(sys.argv)
+_INIT_INVOCATION = is_init_command_invocation(sys.argv)
 
 if not _DOCTOR_INVOCATION:
     from phlo.cli.commands.authz import authz_group
@@ -104,6 +107,7 @@ def _load_cli_plugin_commands() -> None:
 
 if not _DOCTOR_INVOCATION:
     _register_service_commands()
+if not _DOCTOR_INVOCATION and not _INIT_INVOCATION:
     _load_cli_plugin_commands()
 
 

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -15,6 +15,7 @@ import click
 import phlo.cli._warning_filters  # noqa: F401
 from phlo.cli.commands.doctor import doctor_cmd
 from phlo.cli.templates import TemplateRenderContext, get_template
+from phlo.cli.templates import list_templates as get_project_templates
 from phlo.logging import get_logger, setup_logging
 
 logger = get_logger(__name__, service="phlo-cli")
@@ -182,7 +183,8 @@ def test(
     help="Project template to use",
 )
 @click.option("--force", is_flag=True, help="Initialize in non-empty directory")
-def init(project_name: str | None, template: str, force: bool):
+@click.option("--list-templates", is_flag=True, help="List available project templates and exit.")
+def init(project_name: str | None, template: str, force: bool, list_templates: bool):
     """
     Initialize a new Phlo project.
 
@@ -194,6 +196,12 @@ def init(project_name: str | None, template: str, force: bool):
         phlo init . --force                # Initialize in current directory
         phlo init weather-pipeline --template minimal
     """
+    if list_templates:
+        for item in get_project_templates():
+            packages = ", ".join(item.metadata.required_packages)
+            click.echo(f"{item.metadata.name:<20} {item.metadata.description:<36} {packages}")
+        return
+
     click.echo("Phlo Project Initializer\n")
 
     # Determine project directory and metadata-safe project name

--- a/src/phlo/cli/templates/__init__.py
+++ b/src/phlo/cli/templates/__init__.py
@@ -1,0 +1,10 @@
+from phlo.cli.templates.models import ProjectTemplate, TemplateMetadata, TemplateRenderContext
+from phlo.cli.templates.registry import get_template, list_templates
+
+__all__ = [
+    "ProjectTemplate",
+    "TemplateMetadata",
+    "TemplateRenderContext",
+    "get_template",
+    "list_templates",
+]

--- a/src/phlo/cli/templates/builtin.py
+++ b/src/phlo/cli/templates/builtin.py
@@ -266,12 +266,12 @@ class EventsSchema(pa.DataFrameModel):
 from pathlib import Path
 
 import pandas as pd
-from phlo.ingestion import phlo_ingestion
+import phlo
 
 from workflows.schemas.csv import EventsSchema
 
 
-@phlo_ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="csv")
+@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="csv")
 def csv_events():
     return pd.read_csv(Path("data/events.csv"))
 """,
@@ -315,12 +315,12 @@ class EventsSchema(pa.DataFrameModel):
             """from __future__ import annotations
 
 import pandas as pd
-from phlo.ingestion import phlo_ingestion
+import phlo
 
 from workflows.schemas.api import EventsSchema
 
 
-@phlo_ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="api")
+@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="api")
 def api_events():
     return pd.DataFrame([{"id": 1, "name": "sample"}])
 """,
@@ -398,14 +398,14 @@ class ObservabilityDemoTemplate:
 import logging
 
 import pandas as pd
-from phlo.ingestion import phlo_ingestion
+import phlo
 
 from workflows.schemas.csv import EventsSchema
 
 logger = logging.getLogger(__name__)
 
 
-@phlo_ingestion(
+@phlo.ingestion(
     table_name="observability_events",
     unique_key="id",
     validation_schema=EventsSchema,

--- a/src/phlo/cli/templates/builtin.py
+++ b/src/phlo/cli/templates/builtin.py
@@ -301,3 +301,81 @@ def api_events():
     return pd.DataFrame([{"id": 1, "name": "sample"}])
 """,
         )
+
+
+class DbtMedallionTemplate:
+    metadata = TemplateMetadata(
+        name="dbt-medallion",
+        description="Bronze/silver/gold dbt project",
+        required_packages=("phlo", "phlo-dbt"),
+        generated_paths=("workflows/transforms/dbt/models/silver/stg_events.sql",),
+        next_steps=("dbt compile", "phlo services restart dagster"),
+    )
+
+    def render(self, context: TemplateRenderContext) -> None:
+        BasicTemplate().render(context)
+        base = context.project_dir / "workflows" / "transforms" / "dbt" / "models"
+        _write_text(base / "bronze" / "source_events.sql", "select 1 as id, 'sample' as name\n")
+        _write_text(
+            base / "silver" / "stg_events.sql",
+            "select id, name from {{ ref('source_events') }}\n",
+        )
+        _write_text(
+            base / "gold" / "dim_events.sql",
+            "select id, name from {{ ref('stg_events') }}\n",
+        )
+        _write_text(base / "sources.yml", "version: 2\nsources: []\n")
+
+
+class SlingReplicationTemplate:
+    metadata = TemplateMetadata(
+        name="sling-replication",
+        description="Sling replication starter",
+        required_packages=("phlo", "phlo-sling"),
+        generated_paths=("replication/sling.yaml",),
+        next_steps=("phlo sling --help",),
+    )
+
+    def render(self, context: TemplateRenderContext) -> None:
+        MinimalTemplate().render(context)
+        _write_text(
+            context.project_dir / "replication" / "sling.yaml",
+            """source: LOCAL
+target: POSTGRES
+streams:
+  file://data/events.csv:
+    object: public.events
+""",
+        )
+        _write_text(context.project_dir / "data" / "events.csv", "id,name\n1,alpha\n")
+
+
+class ObservabilityDemoTemplate:
+    metadata = TemplateMetadata(
+        name="observability-demo",
+        description="Pipeline with telemetry wiring",
+        required_packages=("phlo", "phlo-dlt", "phlo-pandera", "phlo-otel"),
+        generated_paths=("workflows/ingestion/observability/events.py",),
+        next_steps=("phlo services init", "phlo services start --profile observability"),
+    )
+
+    def render(self, context: TemplateRenderContext) -> None:
+        CsvBatchTemplate().render(context)
+        _write_text(
+            context.project_dir / "workflows" / "ingestion" / "observability" / "events.py",
+            """from __future__ import annotations
+
+import logging
+
+import pandas as pd
+import phlo
+
+logger = logging.getLogger(__name__)
+
+
+@phlo.ingestion(table_name="observability_events", unique_key="id", group="observability")
+def observability_events():
+    logger.info("loading observability demo events")
+    return pd.DataFrame([{"id": 1, "name": "traceable"}])
+""",
+        )

--- a/src/phlo/cli/templates/builtin.py
+++ b/src/phlo/cli/templates/builtin.py
@@ -42,16 +42,15 @@ def _build_env_example_content() -> str:
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _write_common_project_files(project_dir: Path, project_name: str) -> None:
-    _write_text(
-        project_dir / "pyproject.toml",
-        f"""[project]
+def _pyproject_toml(project_name: str, required_packages: tuple[str, ...]) -> str:
+    dependencies = "\n".join(f'    "{package}",' for package in required_packages)
+    return f"""[project]
 name = "{project_name}"
 version = "0.1.0"
 description = "Phlo data workflows"
 requires-python = ">=3.11"
 dependencies = [
-    "phlo",
+{dependencies}
 ]
 
 [dependency-groups]
@@ -66,9 +65,23 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
-""",
+"""
+
+
+def _write_pyproject_toml(
+    project_dir: Path, project_name: str, required_packages: tuple[str, ...]
+) -> None:
+    _write_text(project_dir / "pyproject.toml", _pyproject_toml(project_name, required_packages))
+
+
+def _write_common_project_files(
+    project_dir: Path, project_name: str, required_packages: tuple[str, ...]
+) -> None:
+    _write_text(
+        project_dir / ".env.example",
+        _build_env_example_content(),
     )
-    _write_text(project_dir / ".env.example", _build_env_example_content())
+    _write_pyproject_toml(project_dir, project_name, required_packages)
     _write_text(
         project_dir / ".gitignore",
         """.env
@@ -178,7 +191,9 @@ class MinimalTemplate:
             '"""Pandera validation schemas."""\n',
         )
         _write_text(context.project_dir / "tests" / "__init__.py", "")
-        _write_common_project_files(context.project_dir, context.project_name)
+        _write_common_project_files(
+            context.project_dir, context.project_name, self.metadata.required_packages
+        )
 
 
 class BasicTemplate:
@@ -196,6 +211,9 @@ class BasicTemplate:
 
     def render(self, context: TemplateRenderContext) -> None:
         MinimalTemplate().render(context)
+        _write_pyproject_toml(
+            context.project_dir, context.project_name, self.metadata.required_packages
+        )
         from phlo_dbt.scaffold import write_dbt_scaffold
 
         transforms_dir = context.project_dir / "workflows" / "transforms" / "dbt"
@@ -214,13 +232,16 @@ class CsvBatchTemplate:
             "workflows/schemas/csv.py",
         ),
         next_steps=(
-            "phlo workflow check workflows/ingestion/csv/events.py",
+            "phlo test",
             "phlo materialize dlt_events",
         ),
     )
 
     def render(self, context: TemplateRenderContext) -> None:
         MinimalTemplate().render(context)
+        _write_pyproject_toml(
+            context.project_dir, context.project_name, self.metadata.required_packages
+        )
         _write_text(
             context.project_dir / "data" / "events.csv",
             "id,name,value\n1,alpha,10\n2,beta,20\n",
@@ -245,12 +266,12 @@ class EventsSchema(pa.DataFrameModel):
 from pathlib import Path
 
 import pandas as pd
-import phlo
+from phlo.ingestion import phlo_ingestion
 
 from workflows.schemas.csv import EventsSchema
 
 
-@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="csv")
+@phlo_ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="csv")
 def csv_events():
     return pd.read_csv(Path("data/events.csv"))
 """,
@@ -267,13 +288,16 @@ class ApiIngestionTemplate:
             "workflows/schemas/api.py",
         ),
         next_steps=(
-            "phlo workflow check workflows/ingestion/api/events.py",
+            "phlo test",
             "phlo materialize dlt_events",
         ),
     )
 
     def render(self, context: TemplateRenderContext) -> None:
         MinimalTemplate().render(context)
+        _write_pyproject_toml(
+            context.project_dir, context.project_name, self.metadata.required_packages
+        )
         _write_text(
             context.project_dir / "workflows" / "schemas" / "api.py",
             """from __future__ import annotations
@@ -291,12 +315,12 @@ class EventsSchema(pa.DataFrameModel):
             """from __future__ import annotations
 
 import pandas as pd
-import phlo
+from phlo.ingestion import phlo_ingestion
 
 from workflows.schemas.api import EventsSchema
 
 
-@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="api")
+@phlo_ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="api")
 def api_events():
     return pd.DataFrame([{"id": 1, "name": "sample"}])
 """,
@@ -338,6 +362,9 @@ class SlingReplicationTemplate:
 
     def render(self, context: TemplateRenderContext) -> None:
         MinimalTemplate().render(context)
+        _write_pyproject_toml(
+            context.project_dir, context.project_name, self.metadata.required_packages
+        )
         _write_text(
             context.project_dir / "replication" / "sling.yaml",
             """source: LOCAL
@@ -361,6 +388,9 @@ class ObservabilityDemoTemplate:
 
     def render(self, context: TemplateRenderContext) -> None:
         CsvBatchTemplate().render(context)
+        _write_pyproject_toml(
+            context.project_dir, context.project_name, self.metadata.required_packages
+        )
         _write_text(
             context.project_dir / "workflows" / "ingestion" / "observability" / "events.py",
             """from __future__ import annotations
@@ -368,14 +398,21 @@ class ObservabilityDemoTemplate:
 import logging
 
 import pandas as pd
-import phlo
+from phlo.ingestion import phlo_ingestion
+
+from workflows.schemas.csv import EventsSchema
 
 logger = logging.getLogger(__name__)
 
 
-@phlo.ingestion(table_name="observability_events", unique_key="id", group="observability")
+@phlo_ingestion(
+    table_name="observability_events",
+    unique_key="id",
+    validation_schema=EventsSchema,
+    group="observability",
+)
 def observability_events():
     logger.info("loading observability demo events")
-    return pd.DataFrame([{"id": 1, "name": "traceable"}])
+    return pd.DataFrame([{"id": 1, "name": "traceable", "value": 1}])
 """,
         )

--- a/src/phlo/cli/templates/builtin.py
+++ b/src/phlo/cli/templates/builtin.py
@@ -201,3 +201,103 @@ class BasicTemplate:
         transforms_dir = context.project_dir / "workflows" / "transforms" / "dbt"
         write_dbt_scaffold(context.project_name, transforms_dir, context.project_dir)
         _write_text(transforms_dir / "models" / ".gitkeep", "")
+
+
+class CsvBatchTemplate:
+    metadata = TemplateMetadata(
+        name="csv-batch",
+        description="Local CSV batch pipeline",
+        required_packages=("phlo", "phlo-dlt", "phlo-pandera"),
+        generated_paths=(
+            "data/events.csv",
+            "workflows/ingestion/csv/events.py",
+            "workflows/schemas/csv.py",
+        ),
+        next_steps=(
+            "phlo workflow check workflows/ingestion/csv/events.py",
+            "phlo materialize dlt_events",
+        ),
+    )
+
+    def render(self, context: TemplateRenderContext) -> None:
+        MinimalTemplate().render(context)
+        _write_text(
+            context.project_dir / "data" / "events.csv",
+            "id,name,value\n1,alpha,10\n2,beta,20\n",
+        )
+        _write_text(
+            context.project_dir / "workflows" / "schemas" / "csv.py",
+            """from __future__ import annotations
+
+import pandera.pandas as pa
+
+
+class EventsSchema(pa.DataFrameModel):
+    id: int
+    name: str
+    value: int
+""",
+        )
+        _write_text(
+            context.project_dir / "workflows" / "ingestion" / "csv" / "events.py",
+            """from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import phlo
+
+from workflows.schemas.csv import EventsSchema
+
+
+@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="csv")
+def csv_events():
+    return pd.read_csv(Path("data/events.csv"))
+""",
+        )
+
+
+class ApiIngestionTemplate:
+    metadata = TemplateMetadata(
+        name="api-ingestion",
+        description="REST API ingestion pipeline",
+        required_packages=("phlo", "phlo-dlt", "phlo-pandera"),
+        generated_paths=(
+            "workflows/ingestion/api/events.py",
+            "workflows/schemas/api.py",
+        ),
+        next_steps=(
+            "phlo workflow check workflows/ingestion/api/events.py",
+            "phlo materialize dlt_events",
+        ),
+    )
+
+    def render(self, context: TemplateRenderContext) -> None:
+        MinimalTemplate().render(context)
+        _write_text(
+            context.project_dir / "workflows" / "schemas" / "api.py",
+            """from __future__ import annotations
+
+import pandera.pandas as pa
+
+
+class EventsSchema(pa.DataFrameModel):
+    id: int
+    name: str
+""",
+        )
+        _write_text(
+            context.project_dir / "workflows" / "ingestion" / "api" / "events.py",
+            """from __future__ import annotations
+
+import pandas as pd
+import phlo
+
+from workflows.schemas.api import EventsSchema
+
+
+@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="api")
+def api_events():
+    return pd.DataFrame([{"id": 1, "name": "sample"}])
+""",
+        )

--- a/src/phlo/cli/templates/builtin.py
+++ b/src/phlo/cli/templates/builtin.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from phlo.cli.templates.models import TemplateMetadata, TemplateRenderContext
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def _build_env_example_content() -> str:
+    from phlo.plugins.discovery import ServiceDiscovery
+
+    lines = [
+        "# Phlo Local Secrets Template",
+        "# Copy to .phlo/.env.local after running `phlo services init`.",
+        "",
+    ]
+
+    discovery = ServiceDiscovery()
+    services = discovery.discover()
+    if not services:
+        lines.append(
+            "# No service plugins discovered; install service packages to populate secrets."
+        )
+        return "\n".join(lines) + "\n"
+
+    for service in sorted(services.values(), key=lambda item: item.name):
+        secrets = {key: cfg for key, cfg in service.env_vars.items() if cfg.get("secret") is True}
+        if not secrets:
+            continue
+        lines.append(f"# {service.name}")
+        for key in sorted(secrets.keys()):
+            desc = secrets[key].get("description")
+            if desc:
+                lines.append(f"# {desc}")
+            lines.append(f"{key}=")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _write_common_project_files(project_dir: Path, project_name: str) -> None:
+    _write_text(
+        project_dir / "pyproject.toml",
+        f"""[project]
+name = "{project_name}"
+version = "0.1.0"
+description = "Phlo data workflows"
+requires-python = ">=3.11"
+dependencies = [
+    "phlo",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+    "ruff",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+""",
+    )
+    _write_text(project_dir / ".env.example", _build_env_example_content())
+    _write_text(
+        project_dir / ".gitignore",
+        """.env
+.env.local
+.phlo/
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.venv/
+venv/
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/
+.ruff_cache/
+""",
+    )
+    _write_text(
+        project_dir / "README.md",
+        f"""# {project_name}
+
+Phlo data workflows for {project_name}.
+
+## Getting Started
+
+1. **Install dependencies:**
+   ```bash
+   pip install -e .
+   ```
+
+2. **Create your first workflow:**
+   ```bash
+   phlo workflow create
+   ```
+
+3. **Start Dagster UI:**
+   ```bash
+   phlo dev
+   ```
+
+4. **Access the UI:**
+   Open http://localhost:3000 in your browser
+
+## Project Structure
+
+```
+{project_name}/
+├── workflows/          # Your workflow definitions
+│   ├── ingestion/     # Data ingestion workflows
+│   ├── schemas/       # Pandera validation schemas
+│   └── transforms/dbt/ # dbt transformation models
+└── tests/            # Workflow tests
+```
+
+## Documentation
+
+- [Phlo Documentation](https://github.com/iamgp/phlo)
+- [Workflow Development Guide](https://github.com/iamgp/phlo/blob/main/docs/guides/workflow-development.md)
+
+## Commands
+
+- `phlo dev` - Start Dagster development server
+- `phlo workflow create` - Scaffold new workflow
+- `phlo test` - Run tests
+""",
+    )
+
+    from phlo.cli.commands.services.utils import PHLO_CONFIG_TEMPLATE
+
+    _write_text(
+        project_dir / "phlo.yaml",
+        PHLO_CONFIG_TEMPLATE.format(
+            name=project_name,
+            description=f"{project_name} data workflows",
+        ),
+    )
+
+
+class MinimalTemplate:
+    metadata = TemplateMetadata(
+        name="minimal",
+        description="Empty Phlo project",
+        required_packages=("phlo",),
+        generated_paths=(
+            "phlo.yaml",
+            "pyproject.toml",
+            ".env.example",
+            ".gitignore",
+            "README.md",
+            "workflows/__init__.py",
+            "tests/__init__.py",
+        ),
+        next_steps=("phlo services init", "phlo workflow create"),
+    )
+
+    def render(self, context: TemplateRenderContext) -> None:
+        context.project_dir.mkdir(parents=True, exist_ok=True)
+        workflows_dir = context.project_dir / "workflows"
+        _write_text(workflows_dir / "__init__.py", '"""User workflows."""\n')
+        _write_text(workflows_dir / "ingestion" / "__init__.py", '"""Ingestion workflows."""\n')
+        _write_text(
+            workflows_dir / "schemas" / "__init__.py",
+            '"""Pandera validation schemas."""\n',
+        )
+        _write_text(context.project_dir / "tests" / "__init__.py", "")
+        _write_common_project_files(context.project_dir, context.project_name)
+
+
+class BasicTemplate:
+    metadata = TemplateMetadata(
+        name="basic",
+        description="dbt-ready Phlo project",
+        required_packages=("phlo", "phlo-dbt"),
+        generated_paths=(
+            "phlo.yaml",
+            "pyproject.toml",
+            "workflows/transforms/dbt/dbt_project.yml",
+        ),
+        next_steps=("phlo services init", "phlo workflow create"),
+    )
+
+    def render(self, context: TemplateRenderContext) -> None:
+        MinimalTemplate().render(context)
+        from phlo_dbt.scaffold import write_dbt_scaffold
+
+        transforms_dir = context.project_dir / "workflows" / "transforms" / "dbt"
+        write_dbt_scaffold(context.project_name, transforms_dir, context.project_dir)
+        _write_text(transforms_dir / "models" / ".gitkeep", "")

--- a/src/phlo/cli/templates/models.py
+++ b/src/phlo/cli/templates/models.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class TemplateMetadata:
+    name: str
+    description: str
+    required_packages: tuple[str, ...] = ()
+    generated_paths: tuple[str, ...] = ()
+    next_steps: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TemplateRenderContext:
+    project_dir: Path
+    project_name: str
+    force: bool = False
+
+
+class ProjectTemplate(Protocol):
+    metadata: TemplateMetadata
+
+    def render(self, context: TemplateRenderContext) -> None:
+        """Render template files into the project directory."""

--- a/src/phlo/cli/templates/registry.py
+++ b/src/phlo/cli/templates/registry.py
@@ -8,10 +8,21 @@ def _builtin_templates() -> tuple[ProjectTemplate, ...]:
         ApiIngestionTemplate,
         BasicTemplate,
         CsvBatchTemplate,
+        DbtMedallionTemplate,
         MinimalTemplate,
+        ObservabilityDemoTemplate,
+        SlingReplicationTemplate,
     )
 
-    return (MinimalTemplate(), BasicTemplate(), CsvBatchTemplate(), ApiIngestionTemplate())
+    return (
+        MinimalTemplate(),
+        BasicTemplate(),
+        CsvBatchTemplate(),
+        ApiIngestionTemplate(),
+        DbtMedallionTemplate(),
+        SlingReplicationTemplate(),
+        ObservabilityDemoTemplate(),
+    )
 
 
 def list_templates() -> tuple[ProjectTemplate, ...]:

--- a/src/phlo/cli/templates/registry.py
+++ b/src/phlo/cli/templates/registry.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
 
+import importlib.util
+
 from phlo.cli.templates.models import ProjectTemplate
+
+PACKAGE_IMPORTS = {
+    "phlo": "phlo",
+    "phlo-dbt": "phlo_dbt",
+    "phlo-dlt": "phlo_dlt",
+    "phlo-pandera": "phlo_pandera",
+    "phlo-sling": "phlo_sling",
+    "phlo-otel": "phlo_otel",
+}
 
 
 def _builtin_templates() -> tuple[ProjectTemplate, ...]:
@@ -34,3 +45,12 @@ def get_template(name: str) -> ProjectTemplate:
         if template.metadata.name == name:
             return template
     raise KeyError(name)
+
+
+def missing_required_packages(template: ProjectTemplate) -> tuple[str, ...]:
+    missing: list[str] = []
+    for package in template.metadata.required_packages:
+        import_name = PACKAGE_IMPORTS.get(package, package.replace("-", "_"))
+        if importlib.util.find_spec(import_name) is None:
+            missing.append(package)
+    return tuple(missing)

--- a/src/phlo/cli/templates/registry.py
+++ b/src/phlo/cli/templates/registry.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from phlo.cli.templates.models import ProjectTemplate
+
+
+def _builtin_templates() -> tuple[ProjectTemplate, ...]:
+    from phlo.cli.templates.builtin import BasicTemplate, MinimalTemplate
+
+    return (MinimalTemplate(), BasicTemplate())
+
+
+def list_templates() -> tuple[ProjectTemplate, ...]:
+    return tuple(sorted(_builtin_templates(), key=lambda template: template.metadata.name))
+
+
+def get_template(name: str) -> ProjectTemplate:
+    for template in list_templates():
+        if template.metadata.name == name:
+            return template
+    raise KeyError(name)

--- a/src/phlo/cli/templates/registry.py
+++ b/src/phlo/cli/templates/registry.py
@@ -4,9 +4,14 @@ from phlo.cli.templates.models import ProjectTemplate
 
 
 def _builtin_templates() -> tuple[ProjectTemplate, ...]:
-    from phlo.cli.templates.builtin import BasicTemplate, MinimalTemplate
+    from phlo.cli.templates.builtin import (
+        ApiIngestionTemplate,
+        BasicTemplate,
+        CsvBatchTemplate,
+        MinimalTemplate,
+    )
 
-    return (MinimalTemplate(), BasicTemplate())
+    return (MinimalTemplate(), BasicTemplate(), CsvBatchTemplate(), ApiIngestionTemplate())
 
 
 def list_templates() -> tuple[ProjectTemplate, ...]:

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -89,7 +89,12 @@ def test_csv_batch_template_generates_runnable_files(tmp_path) -> None:
 
     assert result.exit_code == 0, result.output
     assert (project_dir / "data" / "events.csv").exists()
-    assert (project_dir / "workflows" / "ingestion" / "csv" / "events.py").exists()
+    workflow_file = project_dir / "workflows" / "ingestion" / "csv" / "events.py"
+    assert workflow_file.exists()
+    workflow_text = workflow_file.read_text()
+    assert "import phlo" in workflow_text
+    assert "@phlo.ingestion(" in workflow_text
+    assert "phlo_ingestion" not in workflow_text
     assert (project_dir / "workflows" / "schemas" / "csv.py").exists()
     _assert_python_files_parse(project_dir)
     _assert_generated_module_imports(project_dir, "workflows.ingestion.csv.events")

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -1,5 +1,6 @@
 import ast
 import importlib
+import subprocess
 import sys
 import tomllib
 from collections.abc import Iterator
@@ -190,3 +191,27 @@ def test_unknown_template_prints_clean_error(tmp_path) -> None:
     assert "unknown-template" in result.output
     assert "Available templates:" in result.output
     assert "Traceback" not in result.output
+
+
+def test_unknown_template_real_command_has_no_plugin_traceback_noise(tmp_path) -> None:
+    result = subprocess.run(
+        [
+            "uv",
+            "run",
+            "phlo",
+            "init",
+            str(tmp_path / "demo"),
+            "--template",
+            "nope",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    assert "Unknown template 'nope'" in output
+    assert "Available templates:" in output
+    assert "plugin_load_failed" not in output
+    assert "Traceback" not in output

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -1,0 +1,15 @@
+import pytest
+
+from phlo.cli.templates.registry import get_template, list_templates
+
+
+def test_registry_contains_existing_templates() -> None:
+    names = [template.metadata.name for template in list_templates()]
+
+    assert "minimal" in names
+    assert "basic" in names
+
+
+def test_get_template_rejects_unknown_template() -> None:
+    with pytest.raises(KeyError, match="unknown-template"):
+        get_template("unknown-template")

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -1,3 +1,6 @@
+import ast
+from pathlib import Path
+
 import pytest
 from click.testing import CliRunner
 
@@ -41,3 +44,29 @@ def test_init_list_templates_outputs_metadata() -> None:
     assert "minimal" in result.output
     assert "basic" in result.output
     assert "dbt-ready Phlo project" in result.output
+
+
+def _assert_python_files_parse(project_dir: Path) -> None:
+    for path in project_dir.rglob("*.py"):
+        ast.parse(path.read_text(), filename=str(path))
+
+
+def test_csv_batch_template_generates_runnable_files(tmp_path) -> None:
+    project_dir = tmp_path / "csv-demo"
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "csv-batch"])
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "data" / "events.csv").exists()
+    assert (project_dir / "workflows" / "ingestion" / "csv" / "events.py").exists()
+    assert (project_dir / "workflows" / "schemas" / "csv.py").exists()
+    _assert_python_files_parse(project_dir)
+
+
+def test_api_ingestion_template_generates_runnable_files(tmp_path) -> None:
+    project_dir = tmp_path / "api-demo"
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "api-ingestion"])
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "workflows" / "ingestion" / "api" / "events.py").exists()
+    assert (project_dir / "workflows" / "schemas" / "api.py").exists()
+    _assert_python_files_parse(project_dir)

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from phlo.cli._init_discovery_guard import is_init_command_invocation
 from phlo.cli.main import cli
 from phlo.cli.templates.registry import get_template, list_templates
 
@@ -215,3 +216,31 @@ def test_unknown_template_real_command_has_no_plugin_traceback_noise(tmp_path) -
     assert "Available templates:" in output
     assert "plugin_load_failed" not in output
     assert "Traceback" not in output
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["phlo", "init", "demo"], True),
+        (["phlo", "--help", "init"], False),
+        (["phlo", "dbt", "run", "--select", "init"], False),
+    ],
+)
+def test_init_discovery_guard_only_matches_root_init_command(
+    argv: list[str], expected: bool
+) -> None:
+    assert is_init_command_invocation(argv) is expected
+
+
+def test_plugin_command_with_init_argument_is_registered() -> None:
+    result = subprocess.run(
+        ["uv", "run", "phlo", "dbt", "run", "--select", "init", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout + result.stderr
+
+    assert "No such command 'dbt'" not in output
+    assert "Usage:" in output
+    assert "dbt run" in output

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -32,3 +32,12 @@ def test_basic_template_generates_dbt_project(tmp_path) -> None:
 
     assert result.exit_code == 0, result.output
     assert (project_dir / "workflows" / "transforms" / "dbt" / "dbt_project.yml").exists()
+
+
+def test_init_list_templates_outputs_metadata() -> None:
+    result = CliRunner().invoke(cli, ["init", "--list-templates"])
+
+    assert result.exit_code == 0
+    assert "minimal" in result.output
+    assert "basic" in result.output
+    assert "dbt-ready Phlo project" in result.output

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -100,6 +100,9 @@ def test_csv_batch_template_prints_metadata_next_steps(tmp_path) -> None:
     result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "csv-batch"])
 
     assert result.exit_code == 0, result.output
+    assert ".sqlfluff" not in result.output
+    assert "workflows/transforms/dbt" not in result.output
+    assert "workflows/ingestion/csv/events.py" in result.output
     assert "phlo test" in result.output
     assert "phlo materialize dlt_events" in result.output
     assert "phlo workflow check" not in result.output

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -44,6 +44,17 @@ def test_basic_template_generates_dbt_project(tmp_path) -> None:
     assert (project_dir / "workflows" / "transforms" / "dbt" / "dbt_project.yml").exists()
 
 
+def test_init_defaults_to_minimal_template(tmp_path) -> None:
+    project_dir = tmp_path / "demo"
+    result = CliRunner().invoke(cli, ["init", str(project_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "phlo.yaml").exists()
+    assert (project_dir / "workflows" / "__init__.py").exists()
+    assert not (project_dir / "workflows" / "transforms" / "dbt" / "dbt_project.yml").exists()
+    assert _project_dependencies(project_dir) == ["phlo"]
+
+
 def test_init_list_templates_outputs_metadata() -> None:
     result = CliRunner().invoke(cli, ["init", "--list-templates"])
 

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -62,6 +62,26 @@ def test_csv_batch_template_generates_runnable_files(tmp_path) -> None:
     _assert_python_files_parse(project_dir)
 
 
+def test_csv_batch_template_prints_metadata_next_steps(tmp_path) -> None:
+    project_dir = tmp_path / "csv-demo"
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "csv-batch"])
+
+    assert result.exit_code == 0, result.output
+    assert "phlo workflow check workflows/ingestion/csv/events.py" in result.output
+    assert "phlo materialize dlt_events" in result.output
+    assert "phlo dev" not in result.output
+
+
+@pytest.mark.parametrize("template_name", ["minimal", "basic"])
+def test_existing_templates_print_metadata_next_steps(tmp_path, template_name: str) -> None:
+    project_dir = tmp_path / template_name
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", template_name])
+
+    assert result.exit_code == 0, result.output
+    assert "phlo services init" in result.output
+    assert "phlo workflow create" in result.output
+
+
 def test_api_ingestion_template_generates_runnable_files(tmp_path) -> None:
     project_dir = tmp_path / "api-demo"
     result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "api-ingestion"])

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -89,3 +89,18 @@ def test_gallery_templates_generate_expected_files(
     assert result.exit_code == 0, result.output
     assert (project_dir / expected_path).exists()
     _assert_python_files_parse(project_dir)
+
+
+def test_template_missing_package_prints_install_hint(monkeypatch, tmp_path) -> None:
+    def fake_find_spec(name: str):
+        return None if name == "phlo_sling" else object()
+
+    monkeypatch.setattr("phlo.cli.templates.registry.importlib.util.find_spec", fake_find_spec)
+
+    result = CliRunner().invoke(
+        cli, ["init", str(tmp_path / "demo"), "--template", "sling-replication"]
+    )
+
+    assert result.exit_code != 0
+    assert "phlo-sling" in result.output
+    assert "uv pip install" in result.output

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -1,4 +1,9 @@
 import ast
+import importlib
+import sys
+import tomllib
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -51,6 +56,31 @@ def _assert_python_files_parse(project_dir: Path) -> None:
         ast.parse(path.read_text(), filename=str(path))
 
 
+@contextmanager
+def _generated_project_import_path(project_dir: Path) -> Iterator[None]:
+    sys.path.insert(0, str(project_dir))
+    for module_name in list(sys.modules):
+        if module_name == "workflows" or module_name.startswith("workflows."):
+            sys.modules.pop(module_name)
+    try:
+        yield
+    finally:
+        sys.path.remove(str(project_dir))
+        for module_name in list(sys.modules):
+            if module_name == "workflows" or module_name.startswith("workflows."):
+                sys.modules.pop(module_name)
+
+
+def _assert_generated_module_imports(project_dir: Path, module_name: str) -> None:
+    with _generated_project_import_path(project_dir):
+        importlib.import_module(module_name)
+
+
+def _project_dependencies(project_dir: Path) -> list[str]:
+    pyproject = tomllib.loads((project_dir / "pyproject.toml").read_text())
+    return pyproject["project"]["dependencies"]
+
+
 def test_csv_batch_template_generates_runnable_files(tmp_path) -> None:
     project_dir = tmp_path / "csv-demo"
     result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "csv-batch"])
@@ -60,6 +90,7 @@ def test_csv_batch_template_generates_runnable_files(tmp_path) -> None:
     assert (project_dir / "workflows" / "ingestion" / "csv" / "events.py").exists()
     assert (project_dir / "workflows" / "schemas" / "csv.py").exists()
     _assert_python_files_parse(project_dir)
+    _assert_generated_module_imports(project_dir, "workflows.ingestion.csv.events")
 
 
 def test_csv_batch_template_prints_metadata_next_steps(tmp_path) -> None:
@@ -67,9 +98,30 @@ def test_csv_batch_template_prints_metadata_next_steps(tmp_path) -> None:
     result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "csv-batch"])
 
     assert result.exit_code == 0, result.output
-    assert "phlo workflow check workflows/ingestion/csv/events.py" in result.output
+    assert "phlo test" in result.output
     assert "phlo materialize dlt_events" in result.output
+    assert "phlo workflow check" not in result.output
     assert "phlo dev" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("template_name", "expected_dependencies"),
+    [
+        ("minimal", ["phlo"]),
+        ("basic", ["phlo", "phlo-dbt"]),
+        ("csv-batch", ["phlo", "phlo-dlt", "phlo-pandera"]),
+        ("api-ingestion", ["phlo", "phlo-dlt", "phlo-pandera"]),
+        ("observability-demo", ["phlo", "phlo-dlt", "phlo-pandera", "phlo-otel"]),
+    ],
+)
+def test_template_writes_required_packages_to_pyproject(
+    tmp_path, template_name: str, expected_dependencies: list[str]
+) -> None:
+    project_dir = tmp_path / template_name
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", template_name])
+
+    assert result.exit_code == 0, result.output
+    assert _project_dependencies(project_dir) == expected_dependencies
 
 
 @pytest.mark.parametrize("template_name", ["minimal", "basic"])
@@ -90,6 +142,7 @@ def test_api_ingestion_template_generates_runnable_files(tmp_path) -> None:
     assert (project_dir / "workflows" / "ingestion" / "api" / "events.py").exists()
     assert (project_dir / "workflows" / "schemas" / "api.py").exists()
     _assert_python_files_parse(project_dir)
+    _assert_generated_module_imports(project_dir, "workflows.ingestion.api.events")
 
 
 @pytest.mark.parametrize(
@@ -109,6 +162,8 @@ def test_gallery_templates_generate_expected_files(
     assert result.exit_code == 0, result.output
     assert (project_dir / expected_path).exists()
     _assert_python_files_parse(project_dir)
+    if template_name == "observability-demo":
+        _assert_generated_module_imports(project_dir, "workflows.ingestion.observability.events")
 
 
 def test_template_missing_package_prints_install_hint(monkeypatch, tmp_path) -> None:
@@ -124,3 +179,14 @@ def test_template_missing_package_prints_install_hint(monkeypatch, tmp_path) -> 
     assert result.exit_code != 0
     assert "phlo-sling" in result.output
     assert "uv pip install" in result.output
+
+
+def test_unknown_template_prints_clean_error(tmp_path) -> None:
+    result = CliRunner().invoke(
+        cli, ["init", str(tmp_path / "demo"), "--template", "unknown-template"]
+    )
+
+    assert result.exit_code != 0
+    assert "unknown-template" in result.output
+    assert "Available templates:" in result.output
+    assert "Traceback" not in result.output

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -70,3 +70,22 @@ def test_api_ingestion_template_generates_runnable_files(tmp_path) -> None:
     assert (project_dir / "workflows" / "ingestion" / "api" / "events.py").exists()
     assert (project_dir / "workflows" / "schemas" / "api.py").exists()
     _assert_python_files_parse(project_dir)
+
+
+@pytest.mark.parametrize(
+    ("template_name", "expected_path"),
+    [
+        ("dbt-medallion", "workflows/transforms/dbt/models/silver/stg_events.sql"),
+        ("sling-replication", "replication/sling.yaml"),
+        ("observability-demo", "workflows/ingestion/observability/events.py"),
+    ],
+)
+def test_gallery_templates_generate_expected_files(
+    tmp_path, template_name: str, expected_path: str
+) -> None:
+    project_dir = tmp_path / template_name
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", template_name])
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / expected_path).exists()
+    _assert_python_files_parse(project_dir)

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -1,5 +1,7 @@
 import pytest
+from click.testing import CliRunner
 
+from phlo.cli.main import cli
 from phlo.cli.templates.registry import get_template, list_templates
 
 
@@ -13,3 +15,20 @@ def test_registry_contains_existing_templates() -> None:
 def test_get_template_rejects_unknown_template() -> None:
     with pytest.raises(KeyError, match="unknown-template"):
         get_template("unknown-template")
+
+
+def test_minimal_template_generates_project(tmp_path) -> None:
+    project_dir = tmp_path / "demo"
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "minimal"])
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "phlo.yaml").exists()
+    assert (project_dir / "workflows" / "__init__.py").exists()
+
+
+def test_basic_template_generates_dbt_project(tmp_path) -> None:
+    project_dir = tmp_path / "demo"
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--template", "basic"])
+
+    assert result.exit_code == 0, result.output
+    assert (project_dir / "workflows" / "transforms" / "dbt" / "dbt_project.yml").exists()

--- a/tests/test_quickstart_smoke.py
+++ b/tests/test_quickstart_smoke.py
@@ -106,6 +106,7 @@ def test_documented_quickstart_bootstrap_path_reaches_services_start(
     from phlo.cli import main as main_module
     from phlo.cli.commands.services import init as init_module
     from phlo.cli.commands.services import start as start_module
+    from phlo.cli.templates import builtin as builtin_templates
 
     postgres = _service("postgres", default=True)
     prometheus = ServiceDefinition(
@@ -126,7 +127,7 @@ def test_documented_quickstart_bootstrap_path_reaches_services_start(
         return CompletedProcess(args=cmd, returncode=0)
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(main_module, "_build_env_example_content", lambda: "PHLO_SECRET=\n")
+    monkeypatch.setattr(builtin_templates, "_build_env_example_content", lambda: "PHLO_SECRET=\n")
     monkeypatch.setattr(init_module, "ServiceDiscovery", lambda: fake_discovery)
     monkeypatch.setattr(init_module, "ComposeGenerator", _SmokeComposer)
     monkeypatch.setattr(start_module, "ServiceDiscovery", lambda: fake_discovery)


### PR DESCRIPTION
## What this changes

`phlo init` provides a template gallery for common project shapes.

Users can list available templates, choose one by name, and get template-specific files, dependencies, generated paths, and next steps. The gallery covers empty projects, dbt projects, CSV ingestion, API ingestion, medallion dbt layout, Sling replication, and an observability demo.

## Default behavior

Plain `phlo init` uses the `minimal` template.

```bash
phlo init
```

That initializes the current directory with the smallest Phlo project shape:

```text
./
  .env.example
  .gitignore
  README.md
  phlo.yaml
  pyproject.toml
  workflows/__init__.py
  workflows/ingestion/__init__.py
  workflows/schemas/__init__.py
  tests/__init__.py
```

The default dependency list is intentionally small:

```toml
dependencies = [
    "phlo",
]
```

`phlo init my-project` creates the same minimal project in `./my-project`. dbt and ingestion examples are opt-in through explicit templates such as `--template basic` or `--template csv-batch`.

## Example: list templates

```bash
phlo init --list-templates
```

Example output shape:

```text
Available templates:

  minimal             Empty Phlo project
  basic               dbt-ready Phlo project
  csv-batch           Local CSV batch pipeline
  api-ingestion       REST API ingestion pipeline
  dbt-medallion       Bronze/silver/gold dbt project
  sling-replication   Sling replication starter
  observability-demo  Pipeline with telemetry wiring
```

## Example: create a CSV ingestion project

```bash
phlo init csv-demo --template csv-batch
```

Generated files include:

```text
csv-demo/
  data/events.csv
  phlo.yaml
  pyproject.toml
  workflows/__init__.py
  workflows/ingestion/csv/events.py
  workflows/schemas/csv.py
  tests/__init__.py
```

The generated workflow is readable and runnable:

```python
from __future__ import annotations

from pathlib import Path

import pandas as pd
import phlo

from workflows.schemas.csv import EventsSchema


@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="csv")
def csv_events():
    return pd.read_csv(Path("data/events.csv"))
```

The generated schema is intentionally small:

```python
import pandera.pandas as pa


class EventsSchema(pa.DataFrameModel):
    id: int
    name: str
    value: int
```

Template next steps include:

```text
phlo test
phlo materialize dlt_events
```

## Template details

`minimal`

- Empty Phlo project with `phlo.yaml`, `pyproject.toml`, `.env.example`, `.gitignore`, README, workflow package dirs, and test package dirs.
- Dependencies: `phlo`.
- Next steps: `phlo services init`, `phlo workflow create`.

`basic`

- dbt scaffold under `workflows/transforms/dbt/`.
- Dependencies: `phlo`, `phlo-dbt`.

`csv-batch`

- `data/events.csv`, a Pandera schema, and a local CSV ingestion workflow.
- Dependencies: `phlo`, `phlo-dlt`, `phlo-pandera`.

`api-ingestion`

- Pandera schema and a starter REST/API-style ingestion workflow returning sample data.
- Dependencies: `phlo`, `phlo-dlt`, `phlo-pandera`.

`dbt-medallion`

- Bronze/silver/gold dbt model folders and simple sample models:
  - `bronze/source_events.sql`
  - `silver/stg_events.sql`
  - `gold/dim_events.sql`
- Dependencies: `phlo`, `phlo-dbt`.

`sling-replication`

- `replication/sling.yaml` and sample local CSV data for a Sling starter.
- Dependencies: `phlo`, `phlo-sling`.

`observability-demo`

- CSV ingestion plus a logging-enabled ingestion workflow for observability-oriented demos.
- Dependencies: `phlo`, `phlo-dlt`, `phlo-pandera`, `phlo-otel`.
- Next steps include starting services with the observability profile.

## Error handling example

Unknown template errors are clean and actionable:

```bash
phlo init demo --template nope
```

```text
Unknown template 'nope'
Available templates: minimal, basic, csv-batch, api-ingestion, dbt-medallion, sling-replication, observability-demo
```

Init command discovery avoids plugin traceback noise while scaffolding projects.

## Reviewer notes

Review the generated project shape and first-run experience. Each template should parse as Python, import cleanly when its required packages are installed, write only the dependencies it needs, and print next steps that match the generated files.

## Verification

- `uv run ruff check src/phlo/cli/main.py tests/test_cli_init_templates.py`
- `uv run pytest tests/test_cli_init_templates.py -q`
- Subprocess regressions for unknown templates and plugin command args containing `init`