### PR TITLE
fix: unblock data engineering blog walkthrough

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
-          GITHUB_REF_NAME: ${{ github.ref }}
+          PUBLISH_GITHUB_REF: ${{ github.ref }}
         run: |
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             tag_input="$INPUT_TAG"
@@ -96,7 +96,7 @@ jobs:
             esac
             ref="refs/tags/$tag_input"
           else
-            ref="$GITHUB_REF_NAME"
+            ref="$PUBLISH_GITHUB_REF"
           fi
 
           case "$ref" in

--- a/docs/blog/data-engineering-fundamentals/02-build-your-first-phlo-project.md
+++ b/docs/blog/data-engineering-fundamentals/02-build-your-first-phlo-project.md
@@ -180,7 +180,7 @@ Example first-day checklist:
 2. Confirm .phlo directory and generated compose files.
 3. Confirm service inventory from phlo services list.
 4. Confirm at least one materialize dry-run works.
-5. Confirm schema and workflow validation commands run.
+5. Confirm the generated pytest file and materialization dry-run pass.
 ```
 
 ## Naming Conventions That Save Time Later

--- a/docs/blog/data-engineering-fundamentals/02-build-your-first-phlo-project.md
+++ b/docs/blog/data-engineering-fundamentals/02-build-your-first-phlo-project.md
@@ -223,7 +223,7 @@ Anti-pattern 1: "One global project for everything"
 Anti-pattern 2: "Skip validations until real data arrives"
 
 - Result: schema and workflow mistakes discovered too late.
-- Better: run `phlo validate-workflow` at scaffold time.
+- Better: run the generated pytest file and a dry-run materialization before loading data.
 
 Anti-pattern 3: "Ad hoc service starts"
 
@@ -331,7 +331,7 @@ When onboarding pain is low, platform adoption rises naturally.
 1. Run `phlo workflow create` and scaffold one ingestion workflow.
 2. Open generated schema and ingestion files.
 3. Replace placeholder fields with your own domain fields.
-4. Run `phlo validate-workflow <path-to-file>` on your new workflow.
+4. Run the generated pytest file and `phlo materialize <asset-name> --dry-run`.
 
 ## Common Issues
 

--- a/docs/blog/data-engineering-fundamentals/06-transformations-with-dbt.md
+++ b/docs/blog/data-engineering-fundamentals/06-transformations-with-dbt.md
@@ -6,16 +6,15 @@
 
 - Why dbt belongs between raw ingestion and serving layers
 - How Phlo discovers dbt projects in `workflows/transforms/dbt`
-- How to structure bronze, silver, and gold models
+- How to structure bronze and silver models
 - How to scaffold publishing config for marts
 
 ## Prerequisites
 
 - Ingestion assets landing data in Iceberg
-- dbt project scaffold under `workflows/transforms/dbt`
 - Trino service running
 
-The models below use an orders domain schema (`order_id`, `customer_id`, `total_amount`, `order_timestamp`) that is richer than the demo products data from Part 2. Adapt column names to match your own ingested data, or follow these examples as a standalone reference.
+The examples below continue from the Fake Store ingestion in Part 2. That source lands product-like fields in `raw.orders`: `id`, `title`, `price`, and `category`.
 
 ## Where dbt Fits
 
@@ -29,24 +28,74 @@ Model flow:
 graph LR
     A[raw.orders] --> B[bronze.stg_orders]
     B --> C[silver.fct_orders]
-    C --> D[gold.mrt_revenue_daily]
 ```
 
 
-## Example dbt Model
+## Create the dbt Project
+
+Phlo looks for dbt projects under `workflows/transforms/dbt`.
+
+```bash
+mkdir -p workflows/transforms/dbt/models/bronze workflows/transforms/dbt/models/silver workflows/transforms/dbt/profiles
+```
+
+Create `workflows/transforms/dbt/dbt_project.yml`:
+
+```yaml
+name: phlo_fundamentals
+version: "1.0"
+config-version: 2
+profile: phlo
+
+model-paths: ["models"]
+
+models:
+  phlo_fundamentals:
+    +materialized: table
+```
+
+Create `workflows/transforms/dbt/profiles/profiles.yml`:
+
+```yaml
+phlo:
+  target: dev
+  outputs:
+    dev:
+      type: trino
+      host: trino
+      port: 8080
+      user: phlo
+      catalog: iceberg
+      schema: raw
+      method: none
+      threads: 4
+```
+
+Create `workflows/transforms/dbt/models/sources.yml`:
+
+```yaml
+version: 2
+
+sources:
+  - name: raw
+    schema: raw
+    tables:
+      - name: orders
+```
+
+## Example dbt Models
 
 Bronze model (type cleanup and source normalisation):
 
 ```sql
 -- workflows/transforms/dbt/models/bronze/stg_orders.sql
 select
-  cast(order_id as varchar) as order_id,
-  cast(customer_id as varchar) as customer_id,
-  cast(order_timestamp as timestamp) as order_timestamp,
-  cast(total_amount as double) as total_amount,
-  cast(currency as varchar) as currency
+  cast(id as integer) as order_id,
+  cast(title as varchar) as title,
+  cast(price as double) as price,
+  cast(category as varchar) as category
 from {{ source('raw', 'orders') }}
-where order_id is not null
+where id is not null
 ```
 
 Silver model (business rules and entity logic):
@@ -55,29 +104,40 @@ Silver model (business rules and entity logic):
 -- workflows/transforms/dbt/models/silver/fct_orders.sql
 select
   order_id,
-  customer_id,
-  order_timestamp,
-  total_amount,
+  title,
+  price,
+  category,
   case
-    when total_amount >= 1000 then 'enterprise'
-    when total_amount >= 200 then 'mid_market'
-    else 'self_serve'
-  end as segment
+    when price >= 100 then 'premium'
+    when price >= 25 then 'standard'
+    else 'entry'
+  end as price_band
 from {{ ref('stg_orders') }}
 ```
 
-Gold model (reporting-ready mart):
+Add tests in `workflows/transforms/dbt/models/silver/schema.yml`:
 
-```sql
--- workflows/transforms/dbt/models/gold/mrt_revenue_daily.sql
-select
-  date_trunc('day', order_timestamp) as order_date,
-  segment,
-  count(*) as order_count,
-  sum(total_amount) as total_revenue,
-  avg(total_amount) as avg_order_value
-from {{ ref('fct_orders') }}
-group by 1, 2
+```yaml
+version: 2
+
+models:
+  - name: stg_orders
+    columns:
+      - name: order_id
+        tests:
+          - not_null
+          - unique
+  - name: fct_orders
+    columns:
+      - name: order_id
+        tests:
+          - not_null
+          - unique
+      - name: price_band
+        tests:
+          - accepted_values:
+              arguments:
+                values: ["premium", "standard", "entry"]
 ```
 
 
@@ -92,7 +152,7 @@ phlo dbt test --select stg_orders --select fct_orders
 Expected output from `dbt compile`:
 
 ```text
-Found 3 models, 4 tests, 1 source
+Found 2 models, 5 tests, 1 source
 Compiled successfully.
 ```
 
@@ -130,17 +190,13 @@ Example incremental pattern:
 
 select
   order_id,
-  customer_id,
-  order_timestamp,
-  total_amount,
-  case
-    when total_amount >= 1000 then 'enterprise'
-    when total_amount >= 200 then 'mid_market'
-    else 'self_serve'
-  end as segment
+  title,
+  price,
+  category,
+  price_band
 from {{ ref('stg_orders') }}
 {% if is_incremental() %}
-where order_timestamp > (select max(order_timestamp) from {{ this }})
+where order_id > (select max(order_id) from {{ this }})
 {% endif %}
 ```
 
@@ -169,13 +225,14 @@ models:
         tests:
           - not_null
           - unique
-      - name: total_amount
+      - name: price
         tests:
           - not_null
-      - name: segment
+      - name: price_band
         tests:
           - accepted_values:
-              values: ['enterprise', 'mid_market', 'self_serve']
+              arguments:
+                values: ['premium', 'standard', 'entry']
 ```
 
 Test tiers:
@@ -232,8 +289,7 @@ That sentence keeps modelling grounded in user value instead of internal style p
 1. dbt project placed outside `workflows/transforms/dbt` and not discovered.
 2. Model names drift from downstream expectations.
 3. Teams skip dbt tests and debug in dashboards.
-4. Gold models mix transformation and serving concerns.
-5. Publishing configs become stale after model rename.
+4. Publishing configs become stale after model rename.
 
 For failed commands and environment drift, use [Troubleshooting](../../operations/troubleshooting.md).
 
@@ -244,7 +300,7 @@ dbt gives a clean SQL boundary for transformation logic, while Phlo keeps discov
 ## Next Steps
 
 1. Continue to [Part 7](07-quality-checks-with-pandera-and-phlo-pandera.md) to enforce contracts and checks.
-2. Add model test coverage for every gold output used by stakeholders.
+2. Add model test coverage for every output used by stakeholders.
 
 ## See Also
 

--- a/docs/blog/data-engineering-fundamentals/06-transformations-with-dbt.md
+++ b/docs/blog/data-engineering-fundamentals/06-transformations-with-dbt.md
@@ -200,6 +200,10 @@ where order_id > (select max(order_id) from {{ this }})
 {% endif %}
 ```
 
+The `order_id > max(order_id)` predicate is only safe when `order_id` is strictly
+increasing. For most production sources, replace this with a timestamp watermark
+such as `updated_at > (select max(updated_at) from {{ this }})`.
+
 When to use incremental:
 
 - Source volume grows daily and full scans are slow

--- a/docs/blog/data-engineering-fundamentals/README.md
+++ b/docs/blog/data-engineering-fundamentals/README.md
@@ -40,7 +40,7 @@ source .venv/bin/activate
 uv pip install "phlo[defaults]" phlo-otel phlo-clickstack phlo-lineage
 ```
 
-Then run the blog commands from your working project directory (for example `/Users/garethprice/Developer/phlo-examples/blog`).
+Then run the blog commands from your working project directory (for example `~/dev/phlo-examples/blog`).
 
 ## Posts
 

--- a/docs/packages/phlo-dlt.md
+++ b/docs/packages/phlo-dlt.md
@@ -109,7 +109,7 @@ from phlo.contracts import Consumer, SLA
 | `consumers`         | `list[Consumer \| str]` | Optional downstream consumer metadata         |
 | `sla`               | `SLA`             | Optional freshness/quality contract metadata        |
 | `capabilities`      | `dict[str, str]`  | Optional capability provider overrides for the asset |
-| `validate`          | `bool`            | Run Pandera validation (default: True)            |
+| `validate`          | `bool`            | Run configured provider validation using `validation_schema` (default: True) |
 | `strict_validation` | `bool`            | Fail on validation errors (default: True)           |
 | `max_runtime_seconds`| `int`            | Maximum runtime before timeout (default: 300)       |
 | `max_retries`       | `int`             | Maximum retry attempts (default: 3)                 |

--- a/packages/phlo-dagster/src/phlo_dagster/Dockerfile
+++ b/packages/phlo-dagster/src/phlo_dagster/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install phlo from PyPI (or specific version if provided)
 RUN if [ -n "$PHLO_VERSION" ]; then \
-        uv pip install --system "phlo[defaults]==$PHLO_VERSION" "phlo-pandera==$PHLO_VERSION" dagster-postgres; \
+        uv pip install --system "phlo[defaults]==$PHLO_VERSION" dagster-postgres; \
     else \
-        uv pip install --system "phlo[defaults]" phlo-pandera dagster-postgres; \
+        uv pip install --system "phlo[defaults]" dagster-postgres; \
     fi
 
 # Keep entrypoint outside /opt/dagster so dev volume mounts never hide it.

--- a/packages/phlo-dagster/src/phlo_dagster/Dockerfile
+++ b/packages/phlo-dagster/src/phlo_dagster/Dockerfile
@@ -13,9 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install phlo from PyPI (or specific version if provided)
 RUN if [ -n "$PHLO_VERSION" ]; then \
-        uv pip install --system "phlo[defaults]==$PHLO_VERSION" dagster-postgres; \
+        uv pip install --system "phlo[defaults]==$PHLO_VERSION" "phlo-pandera==$PHLO_VERSION" dagster-postgres; \
     else \
-        uv pip install --system "phlo[defaults]" dagster-postgres; \
+        uv pip install --system "phlo[defaults]" phlo-pandera dagster-postgres; \
     fi
 
 # Keep entrypoint outside /opt/dagster so dev volume mounts never hide it.

--- a/packages/phlo-dagster/src/phlo_dagster/service.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/service.yaml
@@ -2,7 +2,6 @@ name: dagster
 description: Data orchestration platform for workflows and pipelines
 category: orchestration
 default: true
-profile: orchestration
 phlo_dev: true
 gitignore:
   - dagster/storage/

--- a/packages/phlo-dagster/tests/test_dagster_plugin.py
+++ b/packages/phlo-dagster/tests/test_dagster_plugin.py
@@ -10,4 +10,4 @@ def test_dagster_service_definition():
 
     assert service_definition["name"] == "dagster"
     assert service_definition["category"] == "orchestration"
-    assert service_definition["profile"] == "orchestration"
+    assert "profile" not in service_definition

--- a/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
+++ b/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
@@ -88,9 +88,11 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
         click.echo(f"  3. Run generated tests: uv run pytest {test_file} -q")
         click.echo("  4. Restart Dagster: phlo services restart --service dagster")
         click.echo(f"  5. Materialize: phlo materialize dlt_{table}")
+        click.echo("  6. Inspect status: phlo status")
     else:
         click.echo("  3. Restart Dagster: phlo services restart --service dagster")
         click.echo(f"  4. Materialize: phlo materialize dlt_{table}")
+        click.echo("  5. Inspect status: phlo status")
 
 
 @workflow_group.command("create")

--- a/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
+++ b/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
@@ -84,15 +84,13 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
     click.echo("\nNext steps:")
     click.echo(f"  1. Review schema: {schema_file}")
     click.echo(f"  2. Review workflow: {workflow_file}")
-    click.echo(f"  3. Validate schema: phlo schema validate {schema_file}")
-    click.echo(f"  4. Validate workflow: phlo validate-workflow {workflow_file}")
     if test_file:
-        click.echo(f"  5. Run generated tests: uv run pytest {test_file} -q")
-        click.echo("  6. Restart Dagster: phlo services restart --service dagster")
-        click.echo(f"  7. Materialize: phlo materialize dlt_{table}")
+        click.echo(f"  3. Run generated tests: uv run pytest {test_file} -q")
+        click.echo("  4. Restart Dagster: phlo services restart --service dagster")
+        click.echo(f"  5. Materialize: phlo materialize dlt_{table}")
     else:
-        click.echo("  5. Restart Dagster: phlo services restart --service dagster")
-        click.echo(f"  6. Materialize: phlo materialize dlt_{table}")
+        click.echo("  3. Restart Dagster: phlo services restart --service dagster")
+        click.echo(f"  4. Materialize: phlo materialize dlt_{table}")
 
 
 @workflow_group.command("create")

--- a/packages/phlo-dlt/src/phlo_dlt/pandera_checks.py
+++ b/packages/phlo-dlt/src/phlo_dlt/pandera_checks.py
@@ -39,18 +39,28 @@ import pandas as pd
 from phlo.capabilities.specs import CheckResult
 
 PANDERA_CONTRACT_CHECK_NAME = "pandera_contract"
+_PANDERA_INSTALL_HINT = (
+    "pandera is required for validation; install the quality provider "
+    "(for example, pip install phlo-pandera or pip install pandera)"
+)
 
 
 def _pandera_schema_errors() -> type[Exception]:
     """Return Pandera's lazy validation exception class."""
-    import pandera.errors
+    try:
+        import pandera.errors
+    except ModuleNotFoundError as exc:
+        raise ImportError(_PANDERA_INSTALL_HINT) from exc
 
     return pandera.errors.SchemaErrors
 
 
 def _pandas_datetime_engine() -> type[Any]:
     """Return Pandera's pandas datetime dtype marker."""
-    from pandera.engines import pandas_engine
+    try:
+        from pandera.engines import pandas_engine
+    except ModuleNotFoundError as exc:
+        raise ImportError(_PANDERA_INSTALL_HINT) from exc
 
     return pandas_engine.DateTime
 

--- a/packages/phlo-dlt/src/phlo_dlt/scaffold.py
+++ b/packages/phlo-dlt/src/phlo_dlt/scaffold.py
@@ -66,7 +66,7 @@ from importlib.metadata import entry_points
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 
 def _to_snake_case(name: str) -> str:
@@ -172,17 +172,15 @@ _MINIMAL_TEST_VALUES: dict[str, str] = {
 }
 
 
-def _resolve_schema_base_import() -> tuple[str, str]:
-    """Resolve the generated schema base class from the active quality provider."""
+def _load_quality_provider() -> Any | None:
+    """Load the active quality provider used for generated schemas."""
     try:
         from phlo.plugins.discovery import discover_plugins, get_quality_provider
 
         discover_plugins()
         provider = get_quality_provider("pandera")
         if provider is not None:
-            schema_base_import = provider.get_schema_base_import()
-            if schema_base_import is not None:
-                return schema_base_import
+            return provider
     except Exception:
         pass
 
@@ -191,14 +189,85 @@ def _resolve_schema_base_import() -> tuple[str, str]:
         for provider_entry in providers:
             if provider_entry.name != "pandera":
                 continue
-            provider = provider_entry.load()()
-            schema_base_import = provider.get_schema_base_import()
-            if schema_base_import is not None:
-                return schema_base_import
+            return provider_entry.load()()
     except Exception:
         pass
 
+    return None
+
+
+def _resolve_schema_base_import() -> tuple[str, str]:
+    """Resolve the generated schema base class from the active quality provider."""
+    provider = _load_quality_provider()
+    if provider is not None:
+        schema_base_import = provider.get_schema_base_import()
+        if schema_base_import is not None:
+            return schema_base_import
+
     return ("pandera.pandas", "DataFrameModel")
+
+
+def _render_schema_field(
+    provider: Any | None,
+    *,
+    name: str,
+    type_name: str,
+    nullable: bool,
+    description: str | None = None,
+) -> str:
+    """Render a generated schema field through the quality provider when available."""
+    if provider is not None and hasattr(provider, "render_schema_field"):
+        rendered = provider.render_schema_field(
+            name=name,
+            type_name=type_name,
+            nullable=nullable,
+            description=description,
+        )
+        if rendered is not None:
+            return rendered
+
+    description_arg = f'description="{description}", ' if description else ""
+    return f"    {name}: Series[{type_name}] = pa.Field({description_arg}nullable={nullable})"
+
+
+def _render_schema_module(
+    provider: Any | None,
+    *,
+    domain: str,
+    schema_class: str,
+    schema_base_module: str,
+    schema_base_name: str,
+    type_imports: str,
+    schema_fields: str,
+) -> str:
+    """Render a generated schema module through the quality provider when available."""
+    if provider is not None and hasattr(provider, "render_schema_module"):
+        rendered = provider.render_schema_module(
+            domain=domain,
+            schema_class=schema_class,
+            type_imports=type_imports,
+            schema_fields=schema_fields,
+        )
+        if rendered is not None:
+            return rendered
+
+    return f'''"""
+Pandera schemas for {domain} domain.
+
+Extend this schema with additional fields as you stabilize the source contract.
+"""
+
+import pandera as pa
+from pandera.typing import Series
+from {schema_base_module} import {schema_base_name}
+
+{type_imports}class {schema_class}({schema_base_name}):
+{schema_fields}
+
+    class Config:
+        strict = False
+        coerce = True
+'''
 
 
 def _minimal_test_value(type_name: str) -> str:
@@ -371,41 +440,44 @@ def create_ingestion_workflow(
     unique_key_normalized = _to_snake_case(unique_key)
     unique_key_field = field_by_name.get(unique_key_normalized)
     unique_key_type = unique_key_field.type_name if unique_key_field else "str"
-    unique_key_nullable = unique_key_field.nullable if unique_key_field else False
+    if unique_key_field and unique_key_field.nullable:
+        raise ValueError(f"Unique key '{unique_key_normalized}' cannot be nullable")
+    unique_key_nullable = False
+    schema_provider = _load_quality_provider()
     schema_base_module, schema_base_name = _resolve_schema_base_import()
 
     schema_fields_lines = [
-        (
-            f"    {unique_key_normalized}: Series[{unique_key_type}] = "
-            f'pa.Field(description="Unique key", nullable={unique_key_nullable})'
+        _render_schema_field(
+            schema_provider,
+            name=unique_key_normalized,
+            type_name=unique_key_type,
+            nullable=unique_key_nullable,
+            description="Unique key",
         )
     ]
     for field in field_specs:
         if field.name == unique_key_normalized:
             continue
         schema_fields_lines.append(
-            f"    {field.name}: Series[{field.type_name}] = pa.Field(nullable={field.nullable})"
+            _render_schema_field(
+                schema_provider,
+                name=field.name,
+                type_name=field.type_name,
+                nullable=field.nullable,
+            )
         )
 
     schema_fields = "\n".join(schema_fields_lines)
 
-    schema_content = f'''"""
-Pandera schemas for {domain} domain.
-
-Extend this schema with additional fields as you stabilize the source contract.
-"""
-
-import pandera as pa
-from pandera.typing import Series
-from {schema_base_module} import {schema_base_name}
-
-{type_imports}class {schema_class}({schema_base_name}):
-{schema_fields}
-
-    class Config:
-        strict = False
-        coerce = True
-'''
+    schema_content = _render_schema_module(
+        schema_provider,
+        domain=domain,
+        schema_class=schema_class,
+        schema_base_module=schema_base_module,
+        schema_base_name=schema_base_name,
+        type_imports=type_imports,
+        schema_fields=schema_fields,
+    )
 
     schema_file.write_text(schema_content)
 

--- a/packages/phlo-dlt/src/phlo_dlt/scaffold.py
+++ b/packages/phlo-dlt/src/phlo_dlt/scaffold.py
@@ -62,6 +62,7 @@ Example:
 
 from __future__ import annotations
 
+from importlib.metadata import entry_points
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -179,6 +180,18 @@ def _resolve_schema_base_import() -> tuple[str, str]:
         discover_plugins()
         provider = get_quality_provider("pandera")
         if provider is not None:
+            schema_base_import = provider.get_schema_base_import()
+            if schema_base_import is not None:
+                return schema_base_import
+    except Exception:
+        pass
+
+    try:
+        providers = entry_points(group="phlo.plugins.quality_providers")
+        for provider_entry in providers:
+            if provider_entry.name != "pandera":
+                continue
+            provider = provider_entry.load()()
             schema_base_import = provider.get_schema_base_import()
             if schema_base_import is not None:
                 return schema_base_import

--- a/packages/phlo-minio/src/phlo_minio/service.yaml
+++ b/packages/phlo-minio/src/phlo_minio/service.yaml
@@ -47,7 +47,7 @@ compose:
     - "${MINIO_API_PORT:-9000}:9000"
     - "${MINIO_CONSOLE_PORT:-9001}:9001"
   volumes:
-    - ./volumes/minio:/data
+    - minio-data:/data
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/ready"]
     interval: 10s

--- a/packages/phlo-nessie/src/phlo_nessie/cli_catalog.py
+++ b/packages/phlo-nessie/src/phlo_nessie/cli_catalog.py
@@ -40,6 +40,17 @@ def _value_or_call(value):
     return value() if callable(value) else value
 
 
+def _schema_field_display(field) -> tuple[str, str, str]:
+    """Return display-safe name, type, and required marker for PyIceberg fields."""
+    field_type = getattr(field, "field_type", getattr(field, "type", None))
+    required_flag = getattr(field, "required", None)
+    if required_flag is None and field_type is not None:
+        is_optional = getattr(field_type, "is_optional", False)
+        required_flag = not is_optional
+    required = "✓" if required_flag else ""
+    return str(field.name), str(field_type), required
+
+
 def _get_iceberg_catalog(ref: str = "main"):
     """Load the PyIceberg catalog for the specified Nessie reference.
 
@@ -213,8 +224,7 @@ def describe(table_name: str, ref: str) -> None:
         schema_table.add_column("Required", justify="center")
 
         for field in schema.fields:
-            required = "✓" if not field.type.is_optional else ""
-            schema_table.add_row(field.name, str(field.type), required)
+            schema_table.add_row(*_schema_field_display(field))
         console.print(schema_table)
 
         spec = table.spec()

--- a/packages/phlo-nessie/tests/test_cli_catalog.py
+++ b/packages/phlo-nessie/tests/test_cli_catalog.py
@@ -44,8 +44,21 @@ def test_schema_field_display_supports_current_pyiceberg_nested_field() -> None:
     assert cli_catalog._schema_field_display(field) == ("id", "long", "✓")
 
 
+def test_schema_field_display_supports_current_pyiceberg_optional_field() -> None:
+    field = SimpleNamespace(name="nickname", field_type="string", required=False)
+
+    assert cli_catalog._schema_field_display(field) == ("nickname", "string", "")
+
+
 def test_schema_field_display_supports_legacy_type_optional_marker() -> None:
     field_type = SimpleNamespace(is_optional=True)
     field = SimpleNamespace(name="name", type=field_type)
 
     assert cli_catalog._schema_field_display(field) == ("name", str(field_type), "")
+
+
+def test_schema_field_display_supports_legacy_type_required_marker() -> None:
+    field_type = SimpleNamespace(is_optional=False)
+    field = SimpleNamespace(name="name", type=field_type)
+
+    assert cli_catalog._schema_field_display(field) == ("name", str(field_type), "✓")

--- a/packages/phlo-nessie/tests/test_cli_catalog.py
+++ b/packages/phlo-nessie/tests/test_cli_catalog.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -35,3 +36,16 @@ def test_get_iceberg_catalog_raises_clear_error_when_backend_missing(monkeypatch
 def test_value_or_call_supports_property_and_method_values() -> None:
     assert cli_catalog._value_or_call(2) == 2
     assert cli_catalog._value_or_call(lambda: 2) == 2
+
+
+def test_schema_field_display_supports_current_pyiceberg_nested_field() -> None:
+    field = SimpleNamespace(name="id", field_type="long", required=True)
+
+    assert cli_catalog._schema_field_display(field) == ("id", "long", "✓")
+
+
+def test_schema_field_display_supports_legacy_type_optional_marker() -> None:
+    field_type = SimpleNamespace(is_optional=True)
+    field = SimpleNamespace(name="name", type=field_type)
+
+    assert cli_catalog._schema_field_display(field) == ("name", str(field_type), "")

--- a/packages/phlo-pandera/src/phlo_pandera/cli_schema_utils.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_schema_utils.py
@@ -1,5 +1,7 @@
 """Shared CLI utilities for schema commands."""
 
+import importlib
+from importlib import import_module
 import os
 import sys
 from pathlib import Path
@@ -94,7 +96,6 @@ def discover_pandera_schemas(
 
     """
     import inspect
-    from importlib import import_module
 
     from pandera.pandas import DataFrameModel
 
@@ -113,7 +114,9 @@ def discover_pandera_schemas(
         if import_root not in sys.path:
             sys.path.insert(0, import_root)
             added_import_root = True
+            importlib.invalidate_caches()
 
+        old_modules = dict(sys.modules)
         try:
             for py_file in path.glob("**/schemas/*.py"):
                 if py_file.name.startswith("_"):
@@ -149,6 +152,11 @@ def discover_pandera_schemas(
                     )
                     continue
         finally:
+            for module_name in set(sys.modules) - set(old_modules):
+                sys.modules.pop(module_name, None)
+            for module_name, module in old_modules.items():
+                if sys.modules.get(module_name) is not module:
+                    sys.modules[module_name] = module
             if added_import_root:
                 try:
                     sys.path.remove(import_root)

--- a/packages/phlo-pandera/src/phlo_pandera/plugin.py
+++ b/packages/phlo-pandera/src/phlo_pandera/plugin.py
@@ -196,6 +196,45 @@ class PanderaQualityProvider(QualityProviderPlugin):
         """Return the Phlo schema base class used by generated project schemas."""
         return ("phlo_pandera.schemas", "PhloSchema")
 
+    def render_schema_field(
+        self,
+        *,
+        name: str,
+        type_name: str,
+        nullable: bool,
+        description: str | None = None,
+    ) -> str:
+        """Render a Pandera schema field for generated project schemas."""
+        description_arg = f'description="{description}", ' if description else ""
+        return f"    {name}: Series[{type_name}] = pa.Field({description_arg}nullable={nullable})"
+
+    def render_schema_module(
+        self,
+        *,
+        domain: str,
+        schema_class: str,
+        type_imports: str,
+        schema_fields: str,
+    ) -> str:
+        """Render a Pandera-backed schema module for generated project schemas."""
+        return f'''"""
+Pandera schemas for {domain} domain.
+
+Extend this schema with additional fields as you stabilize the source contract.
+"""
+
+import pandera as pa
+from pandera.typing import Series
+from phlo_pandera.schemas import PhloSchema
+
+{type_imports}class {schema_class}(PhloSchema):
+{schema_fields}
+
+    class Config:
+        strict = False
+        coerce = True
+'''
+
     def get_reconciliation_checks(self) -> dict[str, type] | None:
         """Return reconciliation check classes.
 

--- a/packages/phlo-pandera/tests/test_schema_extractor.py
+++ b/packages/phlo-pandera/tests/test_schema_extractor.py
@@ -97,3 +97,4 @@ class TestPanderaSchemaExtractor:
         assert by_name["title"].dtype == "string"
         assert by_name["price"].dtype == "float64"
         assert by_name["price"].nullable is True
+        assert by_name["id"].nullable is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ defaults = [
     "phlo-iceberg>=0.1.0",
     "phlo-dlt>=0.1.0",
     "phlo-dbt>=0.1.0",
+    "phlo-pandera>=0.1.0",
     "phlo-dagster>=0.1.0",
     "phlo-postgres>=0.1.0",
     "phlo-minio>=0.1.0",

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -26,17 +26,15 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
     click.echo("\nNext steps:")
     click.echo(f"  1. Review schema: {schema_file}")
     click.echo(f"  2. Review workflow: {workflow_file}")
-    click.echo(f"  3. Validate schema: phlo schema validate {schema_file}")
-    click.echo(f"  4. Validate workflow: phlo validate-workflow {workflow_file}")
     if test_file:
-        click.echo(f"  5. Run generated tests: uv run pytest {test_file} -q")
-        click.echo("  6. Restart Dagster: phlo services restart --service dagster")
-        click.echo(f"  7. Materialize: phlo materialize dlt_{table}")
-        click.echo("  8. Inspect status: phlo status")
+        click.echo(f"  3. Run generated tests: uv run pytest {test_file} -q")
+        click.echo("  4. Restart Dagster: phlo services restart --service dagster")
+        click.echo(f"  5. Materialize: phlo materialize dlt_{table}")
+        click.echo("  6. Inspect status: phlo status")
     else:
-        click.echo("  5. Restart Dagster: phlo services restart --service dagster")
-        click.echo(f"  6. Materialize: phlo materialize dlt_{table}")
-        click.echo("  7. Inspect status: phlo status")
+        click.echo("  3. Restart Dagster: phlo services restart --service dagster")
+        click.echo(f"  4. Materialize: phlo materialize dlt_{table}")
+        click.echo("  5. Inspect status: phlo status")
 
 
 def _infer_schema_path(workflow_path: Path) -> Path | None:

--- a/src/phlo/plugins/base/quality_provider.py
+++ b/src/phlo/plugins/base/quality_provider.py
@@ -108,6 +108,40 @@ class QualityProviderPlugin(Plugin, ABC):
         """
         return None
 
+    def render_schema_field(
+        self,
+        *,
+        name: str,
+        type_name: str,
+        nullable: bool,
+        description: str | None = None,
+    ) -> str | None:
+        """Render one generated schema field for this quality provider.
+
+        Returns:
+            Python source for a class-level field declaration, or None when the
+            provider does not support schema scaffolding.
+
+        """
+        return None
+
+    def render_schema_module(
+        self,
+        *,
+        domain: str,
+        schema_class: str,
+        type_imports: str,
+        schema_fields: str,
+    ) -> str | None:
+        """Render a complete generated schema module for this quality provider.
+
+        Returns:
+            Python source for the schema module, or None when the provider does
+            not support schema scaffolding.
+
+        """
+        return None
+
     def get_reconciliation_checks(self) -> dict[str, type] | None:
         """Return reconciliation check classes.
 

--- a/src/phlo/plugins/compose/env.py
+++ b/src/phlo/plugins/compose/env.py
@@ -1,8 +1,17 @@
 """Render `.env` and `.env.local` content from discovered service definitions."""
 
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 from phlo.plugins.discovery import ServiceDefinition
+
+
+def _default_phlo_version() -> str:
+    """Return the installed Phlo version for repeatable service image builds."""
+    try:
+        return version("phlo")
+    except PackageNotFoundError:
+        return ""
 
 
 def normalize_env_value(value: Any) -> str:
@@ -107,6 +116,8 @@ def render_env(
                 continue
 
             default = var_config.get("default", "")
+            if var_name == "PHLO_VERSION" and not default:
+                default = _default_phlo_version()
             description = var_config.get("description", "")
             value = overrides.get(var_name, normalize_env_value(default))
 

--- a/tests/test_cli_services_init.py
+++ b/tests/test_cli_services_init.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 
 from phlo.cli.commands.services.utils import detect_phlo_source_path
 from phlo.cli.infrastructure.selection import select_services_to_install
+from phlo.plugins.compose.env import generate_env
 from phlo.plugins.compose.generator import ComposeGenerator
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
 from tests.helpers import FakeDiscovery, _service
@@ -156,6 +157,27 @@ def test_compose_generator_declares_named_volumes(tmp_path) -> None:
 
     data = yaml.safe_load(compose_yaml)
     assert data["volumes"] == {"postgres-data": {}}
+
+
+def test_generate_env_pins_phlo_version_for_service_builds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keeps repeated service builds on the installed Phlo version, not Docker's stale latest."""
+    monkeypatch.setattr("phlo.plugins.compose.env.version", lambda package: "9.8.7")
+    service = ServiceDefinition(
+        name="dagster",
+        description="dagster",
+        category="orchestration",
+        default=True,
+        env_vars={
+            "PHLO_VERSION": {
+                "default": "",
+                "description": "Phlo version to install",
+            }
+        },
+    )
+
+    env = generate_env([service])
+
+    assert "PHLO_VERSION=9.8.7" in env
 
 
 def test_compose_generator_resolves_source_path_dev_volumes(tmp_path) -> None:

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -197,6 +197,7 @@ def test_workflow_create_prints_runnable_next_steps(monkeypatch, tmp_path) -> No
     assert result.exit_code == 0
     assert "phlo services restart --service dagster" in result.output
     assert "phlo materialize dlt_observations" in result.output
+    assert "Inspect status: phlo status" in result.output
     assert "phlo schema validate workflows/schemas/weather.py" not in result.output
     assert "phlo validate-workflow workflows/ingestion/weather/observations.py" not in result.output
     assert "phlo status --select" not in result.output

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -195,11 +195,10 @@ def test_workflow_create_prints_runnable_next_steps(monkeypatch, tmp_path) -> No
     )
 
     assert result.exit_code == 0
-    assert "phlo schema validate workflows/schemas/weather.py" in result.output
-    assert "phlo validate-workflow workflows/ingestion/weather/observations.py" in result.output
     assert "phlo services restart --service dagster" in result.output
     assert "phlo materialize dlt_observations" in result.output
-    assert "phlo status" in result.output
+    assert "phlo schema validate workflows/schemas/weather.py" not in result.output
+    assert "phlo validate-workflow workflows/ingestion/weather/observations.py" not in result.output
     assert "phlo status --select" not in result.output
     assert "phlo test weather" not in result.output
     assert "phlo services restart dagster" not in result.output

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -44,6 +44,76 @@ def test_scaffold_schema_base_comes_from_quality_provider(monkeypatch: pytest.Mo
     assert _resolve_schema_base_import() == ("example_quality.schemas", "ExampleSchema")
 
 
+def test_scaffold_rejects_nullable_unique_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rejects merge keys that cannot reliably deduplicate downstream."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "workflows" / "schemas").mkdir(parents=True)
+    (tmp_path / "workflows" / "ingestion").mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="Unique key 'id' cannot be nullable"):
+        create_ingestion_workflow(
+            domain="commerce",
+            table_name="orders",
+            unique_key="id",
+            fields=["id:int?"],
+        )
+
+
+def test_scaffold_schema_rendering_comes_from_quality_provider(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lets quality providers own generated schema source rendering."""
+
+    class FakeQualityProvider:
+        def get_schema_base_import(self) -> tuple[str, str]:
+            return ("example_quality.schemas", "ExampleSchema")
+
+        def render_schema_field(
+            self,
+            *,
+            name: str,
+            type_name: str,
+            nullable: bool,
+            description: str | None = None,
+        ) -> str:
+            suffix = f"  # {description}" if description else ""
+            return f"    {name}: {type_name} = field(nullable={nullable}){suffix}"
+
+        def render_schema_module(
+            self,
+            *,
+            domain: str,
+            schema_class: str,
+            type_imports: str,
+            schema_fields: str,
+        ) -> str:
+            return (
+                f'"""Schema for {domain}."""\n\n'
+                "from example_quality import field\n\n\n"
+                f"class {schema_class}:\n"
+                f"{schema_fields}\n"
+            )
+
+    monkeypatch.setattr(scaffold_module, "_load_quality_provider", lambda: FakeQualityProvider())
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "workflows" / "schemas").mkdir(parents=True)
+    (tmp_path / "workflows" / "ingestion").mkdir(parents=True)
+
+    create_ingestion_workflow(
+        domain="commerce",
+        table_name="products",
+        unique_key="id",
+        fields=["id:int", "title:str"],
+    )
+
+    schema_text = (tmp_path / "workflows" / "schemas" / "commerce.py").read_text()
+    assert "from example_quality import field" in schema_text
+    assert "import pandera" not in schema_text
+    assert "id: int = field(nullable=False)  # Unique key" in schema_text
+
+
 def test_phlo_dlt_does_not_depend_on_pandera_packages() -> None:
     """Quality providers own Pandera dependencies; phlo-dlt only consumes capability metadata."""
     pyproject = tomllib.loads(Path("packages/phlo-dlt/pyproject.toml").read_text())

--- a/uv.lock
+++ b/uv.lock
@@ -3254,6 +3254,7 @@ defaults = [
     { name = "phlo-iceberg" },
     { name = "phlo-minio" },
     { name = "phlo-nessie" },
+    { name = "phlo-pandera" },
     { name = "phlo-postgres" },
     { name = "phlo-trino" },
 ]
@@ -3335,6 +3336,7 @@ requires-dist = [
     { name = "phlo-nessie", marker = "extra == 'core-services'", editable = "packages/phlo-nessie" },
     { name = "phlo-nessie", marker = "extra == 'defaults'", editable = "packages/phlo-nessie" },
     { name = "phlo-openmetadata", marker = "extra == 'openmetadata'", editable = "packages/phlo-openmetadata" },
+    { name = "phlo-pandera", marker = "extra == 'defaults'", editable = "packages/phlo-pandera" },
     { name = "phlo-postgres", marker = "extra == 'core-services'", editable = "packages/phlo-postgres" },
     { name = "phlo-postgres", marker = "extra == 'defaults'", editable = "packages/phlo-postgres" },
     { name = "phlo-trino", marker = "extra == 'core-services'", editable = "packages/phlo-trino" },


### PR DESCRIPTION
## Summary
- make the default generated service stack start without an orchestration profile and move MinIO to a named volume
- pin generated Dagster builds to the installed Phlo version and include the Pandera quality provider in the default/runtime path
- remove stale scaffold next-step commands, fix catalog describe for current PyIceberg fields, and add dbt project setup to the blog walkthrough

## Verification
- uv run pytest tests/test_cli_workflow.py tests/test_cli_services_init.py tests/test_scaffold.py packages/phlo-nessie/tests/test_cli_catalog.py -q
- uv run ruff check .
- generated a smoke project with phlo services init --no-dev --force and verified Dagster has no profile, MinIO uses minio-data, top-level volumes are declared, and PHLO_VERSION is populated
