### PR TITLE
chore(release): prepare 0.8.1b1 beta

### DIFF
--- a/packages/phlo-dagster/pyproject.toml
+++ b/packages/phlo-dagster/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Dagster service plugin for Phlo"
 name = "phlo-dagster"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1b1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/src/phlo_dagster/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "authorize_daemon_run",
     "create_daemon_principal",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.1b1"

--- a/packages/phlo-dlt/pyproject.toml
+++ b/packages/phlo-dlt/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 description = "DLT ingestion engine capability plugin for Phlo"
 name = "phlo-dlt"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1b1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-pandera/pyproject.toml
+++ b/packages/phlo-pandera/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Quality checks and schema utilities for Phlo"
 name = "phlo-pandera"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1b1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-pandera/src/phlo_pandera/__init__.py
+++ b/packages/phlo-pandera/src/phlo_pandera/__init__.py
@@ -167,4 +167,4 @@ __all__ = [
     "dbt_check_name",
 ]
 
-__version__ = "0.2.3"
+__version__ = "0.3.1b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,14 @@ dev = [
     "phlo-alloy>=0.1.0",
     "phlo-api>=0.1.0",
     "phlo-core-plugins>=0.1.0",
-    "phlo-dagster>=0.1.0",
+    "phlo-dagster>=0.3.1b1",
     "phlo-delta>=0.1.0",
     "pytest>=8.4.2",
     "pytest-cov>=6.0",
     "sqlfluff>=3.5.0",
     "phlo-clickstack>=0.1.0",
     "phlo-clickhouse>=0.1.0",
-    "phlo-dlt>=0.1.0",
+    "phlo-dlt>=0.3.1b1",
     "phlo-iceberg>=0.1.0",
     "phlo-dbt>=0.1.0",
     "phlo-grafana>=0.1.0",
@@ -30,7 +30,7 @@ dev = [
     "phlo-observatory-example>=0.1.0",
     "phlo-openmetadata>=0.1.0",
     "phlo-otel>=0.1.0",
-    "phlo-pandera>=0.1.0",
+    "phlo-pandera>=0.3.1b1",
     "phlo-pgweb>=0.1.0",
     "phlo-postgres>=0.1.0",
     "phlo-postgrest>=0.1.0",
@@ -88,7 +88,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.8.0"
+version = "0.8.1b1"
 
 [project.entry-points."phlo.plugins.quality"]
 
@@ -98,7 +98,7 @@ version = "0.8.0"
 
 [project.optional-dependencies]
 core-services = [
-    "phlo-dagster>=0.1.0",
+    "phlo-dagster>=0.3.1b1",
     "phlo-postgres>=0.1.0",
     "phlo-minio>=0.1.0",
     "phlo-nessie>=0.1.0",
@@ -107,10 +107,10 @@ core-services = [
 defaults = [
     "phlo-core-plugins>=0.1.0",
     "phlo-iceberg>=0.1.0",
-    "phlo-dlt>=0.1.0",
+    "phlo-dlt>=0.3.1b1",
     "phlo-dbt>=0.1.0",
-    "phlo-pandera>=0.1.0",
-    "phlo-dagster>=0.1.0",
+    "phlo-pandera>=0.3.1b1",
+    "phlo-dagster>=0.3.1b1",
     "phlo-postgres>=0.1.0",
     "phlo-minio>=0.1.0",
     "phlo-nessie>=0.1.0",

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.8.0"
+__version__ = "0.8.1b1"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -307,4 +307,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.8.1b1"

--- a/uv.lock
+++ b/uv.lock
@@ -3215,7 +3215,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.8.0"
+version = "0.8.1b1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3585,7 +3585,7 @@ provides-extras = ["dev", "quality"]
 
 [[package]]
 name = "phlo-dagster"
-version = "0.3.0"
+version = "0.3.1b1"
 source = { editable = "packages/phlo-dagster" }
 dependencies = [
     { name = "dagster-graphql" },
@@ -3697,7 +3697,7 @@ provides-extras = ["dev", "minio"]
 
 [[package]]
 name = "phlo-dlt"
-version = "0.3.0"
+version = "0.3.1b1"
 source = { editable = "packages/phlo-dlt" }
 dependencies = [
     { name = "dlt" },
@@ -4116,7 +4116,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-pandera"
-version = "0.3.0"
+version = "0.3.1b1"
 source = { editable = "packages/phlo-pandera" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- bump phlo to 0.8.1b1
- bump beta package artifacts for phlo-dagster, phlo-dlt, and phlo-pandera
- tighten phlo extras so phlo[defaults] resolves the beta package set with --pre
- refresh uv.lock

## Verification
- uv lock
- uv build --out-dir /tmp/phlo-beta-dist-root
- uv build packages/phlo-dagster --out-dir /tmp/phlo-beta-dist-dagster
- uv build packages/phlo-dlt --out-dir /tmp/phlo-beta-dist-dlt
- uv build packages/phlo-pandera --out-dir /tmp/phlo-beta-dist-pandera
- uv run ruff check pyproject.toml packages/phlo-dagster/pyproject.toml packages/phlo-dagster/src/phlo_dagster/__init__.py packages/phlo-dlt/pyproject.toml packages/phlo-pandera/pyproject.toml packages/phlo-pandera/src/phlo_pandera/__init__.py src/phlo/cli/__init__.py src/phlo/plugins/__init__.py
- uv run pytest packages/phlo-dagster/tests/test_integration_dagster.py packages/phlo-pandera/tests/test_schema_extractor.py tests/test_public_api_exports.py -q
- local wheel install: uv pip install --python /tmp/phlo-beta-local-install/bin/python --pre --find-links ... phlo[defaults]==0.8.1b1