### PR TITLE
ci: skip existing PyPI artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Publish to PyPI
         if: inputs.dry_run != 'true'
-        run: uv publish dist/* --token "$PYPI_API_TOKEN"
+        run: uv publish dist/* --token "$PYPI_API_TOKEN" --check-url https://pypi.org/simple/
         env:
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,3 +141,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          UV_PUBLISH_CHECK_URL: https://pypi.org/simple/


### PR DESCRIPTION
## Summary
- pass PyPI simple index check URL to ReleaseX/uv publish so recovery reruns can skip already-uploaded files
- add the same check URL to the manual package publish workflow

## Verification
- pre-commit hooks during commit, including yaml, yamllint, and zizmor
- beta PyPI install verified separately with `uv pip install --prerelease allow phlo[defaults]==0.8.1b1`