### PR TITLE
ci: filter published PyPI artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: pypi
+    concurrency:
+      group: pypi-publish-${{ github.repository }}
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,57 @@ jobs:
 
       - name: Publish to PyPI
         if: inputs.dry_run != 'true'
-        run: uv publish dist/* --token "$PYPI_API_TOKEN" --check-url https://pypi.org/simple/
+        run: |
+          python <<'PY'
+          from __future__ import annotations
+
+          import re
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          def canonical_name(name: str) -> str:
+              return re.sub(r"[-_.]+", "-", name).lower()
+
+          def project_name(filename: str) -> str:
+              if filename.endswith(".whl"):
+                  return filename.split("-", 2)[0]
+              for suffix in (".tar.gz", ".zip"):
+                  if filename.endswith(suffix):
+                      return filename[: -len(suffix)].rsplit("-", 1)[0]
+              raise ValueError(f"Unsupported artifact filename: {filename}")
+
+          cache: dict[str, str] = {}
+          for artifact in sorted(Path("dist").glob("*")):
+              if not artifact.is_file() or not artifact.name.endswith((".whl", ".tar.gz", ".zip")):
+                  continue
+              package = canonical_name(project_name(artifact.name))
+              if package not in cache:
+                  try:
+                      with urllib.request.urlopen(
+                          f"https://pypi.org/simple/{package}/", timeout=30
+                      ) as response:
+                          cache[package] = response.read().decode("utf-8", "replace")
+                  except urllib.error.HTTPError as exc:
+                      if exc.code == 404:
+                          cache[package] = ""
+                      else:
+                          raise
+              if artifact.name in cache[package]:
+                  artifact.unlink()
+                  print(f"Skipping existing PyPI artifact: {artifact}")
+              else:
+                  print(f"Will publish: {artifact}")
+          PY
+
+          mapfile -d '' artifacts < <(
+            find dist \( -name '*.whl' -o -name '*.tar.gz' \) -print0
+          )
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No unpublished artifacts to publish."
+            exit 0
+          fi
+          uv publish "${artifacts[@]}" --token "$PYPI_API_TOKEN"
         env:
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,10 +135,65 @@ jobs:
             uv build --directory "$pkg" --out-dir "$package_dist"
           done
 
-      - uses: iamgp/ReleaseX@65c40c6bb71f99ce60cbc607e2f611711895b802
-        with:
-          command: release publish --skip-published
+      - name: Remove already-published artifacts
+        run: |
+          python <<'PY'
+          from __future__ import annotations
+
+          import re
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          def canonical_name(name: str) -> str:
+              return re.sub(r"[-_.]+", "-", name).lower()
+
+          def project_name(filename: str) -> str:
+              if filename.endswith(".whl"):
+                  return filename.split("-", 2)[0]
+              for suffix in (".tar.gz", ".zip"):
+                  if filename.endswith(suffix):
+                      return filename[: -len(suffix)].rsplit("-", 1)[0]
+              raise ValueError(f"Unsupported artifact filename: {filename}")
+
+          artifacts = sorted(
+              [
+                  *Path("dist").glob("*"),
+                  *Path("packages").glob("*/dist/*"),
+              ]
+          )
+          cache: dict[str, str] = {}
+          for artifact in artifacts:
+              if not artifact.is_file() or not artifact.name.endswith((".whl", ".tar.gz", ".zip")):
+                  continue
+              package = canonical_name(project_name(artifact.name))
+              if package not in cache:
+                  try:
+                      with urllib.request.urlopen(
+                          f"https://pypi.org/simple/{package}/", timeout=30
+                      ) as response:
+                          cache[package] = response.read().decode("utf-8", "replace")
+                  except urllib.error.HTTPError as exc:
+                      if exc.code == 404:
+                          cache[package] = ""
+                      else:
+                          raise
+              if artifact.name in cache[package]:
+                  artifact.unlink()
+                  print(f"Skipping existing PyPI artifact: {artifact}")
+              else:
+                  print(f"Will publish: {artifact}")
+          PY
+
+      - name: Publish packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-          UV_PUBLISH_CHECK_URL: https://pypi.org/simple/
+        run: |
+          mapfile -d '' artifacts < <(
+            find dist packages -type f \( -path 'dist/*' -o -path 'packages/*/dist/*' \) \( -name '*.whl' -o -name '*.tar.gz' \) -print0
+          )
+          if [ "${#artifacts[@]}" -eq 0 ]; then
+            echo "No unpublished artifacts to publish."
+            exit 0
+          fi
+          uv publish "${artifacts[@]}" --token "$PYPI_API_TOKEN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: pypi
+    concurrency:
+      group: pypi-publish-${{ github.repository }}
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary
- filter artifacts already present on PyPI before publishing
- replace ReleaseX publish in the release workflow with direct `uv publish` over unpublished artifacts
- apply the same filename-based filter to the manual PyPI publish workflow

## Why
`uv publish --check-url` fails when a rebuilt local wheel has a different hash from an already-uploaded file. Filtering by existing filename first makes reruns/recovery idempotent.

## Verification
- pre-commit hooks during commit, including yaml, yamllint, and zizmor