### PR TITLE
fix: prepare seamless workshop beta

### DIFF
--- a/docs/blog/data-engineering-fundamentals/01-what-is-data-engineering.md
+++ b/docs/blog/data-engineering-fundamentals/01-what-is-data-engineering.md
@@ -62,7 +62,7 @@ First, make sure the CLI is installed in your environment:
 ```bash
 uv venv
 source .venv/bin/activate
-uv pip install "phlo[defaults]" phlo-otel phlo-clickstack phlo-lineage
+uv pip install "phlo[defaults]" phlo-otel phlo-clickstack phlo-lineage pytest
 ```
 
 The command should return something like this:

--- a/docs/blog/data-engineering-fundamentals/README.md
+++ b/docs/blog/data-engineering-fundamentals/README.md
@@ -37,10 +37,10 @@ Run this once before following any command snippets:
 ```bash
 uv venv
 source .venv/bin/activate
-uv pip install "phlo[defaults]" phlo-otel phlo-clickstack phlo-lineage
+uv pip install "phlo[defaults]" phlo-otel phlo-clickstack phlo-lineage pytest
 ```
 
-Then run the blog commands from your working project directory (for example `~/dev/phlo-examples/blog`).
+Then run the blog commands from your working project directory (for example `/path/to/your/project`).
 
 ## Posts
 

--- a/packages/phlo-dagster/pyproject.toml
+++ b/packages/phlo-dagster/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Dagster service plugin for Phlo"
 name = "phlo-dagster"
 requires-python = ">=3.11"
-version = "0.3.1b1"
+version = "0.3.1b2"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/src/phlo_dagster/Dockerfile
+++ b/packages/phlo-dagster/src/phlo_dagster/Dockerfile
@@ -13,9 +13,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install phlo from PyPI (or specific version if provided)
 RUN if [ -n "$PHLO_VERSION" ]; then \
-        uv pip install --system "phlo[defaults]==$PHLO_VERSION" dagster-postgres; \
+        uv pip install --system --no-deps --prerelease explicit "phlo==$PHLO_VERSION"; \
+        PHLO_PRERELEASE_REQUIREMENTS="$(python -c 'import importlib.metadata as md, re; print(" ".join(req.split(";")[0].strip() for req in (md.metadata("phlo").get_all("Requires-Dist") or []) if "extra == '\''defaults'\''" in req and re.search(r"(a|b|rc|dev)[0-9]+", req)))')"; \
+        uv pip install --system --prerelease explicit "phlo[defaults]==$PHLO_VERSION" $PHLO_PRERELEASE_REQUIREMENTS dagster-postgres "psycopg[binary]"; \
     else \
-        uv pip install --system "phlo[defaults]" dagster-postgres; \
+        uv pip install --system "phlo[defaults]" dagster-postgres "psycopg[binary]"; \
     fi
 
 # Keep entrypoint outside /opt/dagster so dev volume mounts never hide it.

--- a/packages/phlo-dagster/src/phlo_dagster/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "authorize_daemon_run",
     "create_daemon_principal",
 ]
-__version__ = "0.3.1b1"
+__version__ = "0.3.1b2"

--- a/packages/phlo-dagster/tests/test_runtime_image_contract.py
+++ b/packages/phlo-dagster/tests/test_runtime_image_contract.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from importlib import resources
+
+
+def test_dagster_runtime_image_installs_prerelease_phlo_with_postgres_driver() -> None:
+    dockerfile = resources.files("phlo_dagster").joinpath("Dockerfile").read_text()
+
+    assert (
+        'uv pip install --system --no-deps --prerelease explicit "phlo==$PHLO_VERSION"'
+        in dockerfile
+    )
+    assert "PHLO_PRERELEASE_REQUIREMENTS" in dockerfile
+    assert (
+        'uv pip install --system --prerelease explicit "phlo[defaults]==$PHLO_VERSION"'
+        in dockerfile
+    )
+    assert 'dagster-postgres "psycopg[binary]"' in dockerfile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dev = [
     "phlo-alloy>=0.1.0",
     "phlo-api>=0.1.0",
     "phlo-core-plugins>=0.1.0",
-    "phlo-dagster>=0.3.1b1",
+    "phlo-dagster>=0.3.1b2",
     "phlo-delta>=0.1.0",
     "pytest>=8.4.2",
     "pytest-cov>=6.0",
@@ -88,7 +88,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.8.1b1"
+version = "0.8.1b2"
 
 [project.entry-points."phlo.plugins.quality"]
 
@@ -98,7 +98,7 @@ version = "0.8.1b1"
 
 [project.optional-dependencies]
 core-services = [
-    "phlo-dagster>=0.3.1b1",
+    "phlo-dagster>=0.3.1b2",
     "phlo-postgres>=0.1.0",
     "phlo-minio>=0.1.0",
     "phlo-nessie>=0.1.0",
@@ -110,7 +110,7 @@ defaults = [
     "phlo-dlt>=0.3.1b1",
     "phlo-dbt>=0.1.0",
     "phlo-pandera>=0.3.1b1",
-    "phlo-dagster>=0.3.1b1",
+    "phlo-dagster>=0.3.1b2",
     "phlo-postgres>=0.1.0",
     "phlo-minio>=0.1.0",
     "phlo-nessie>=0.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3215,7 +3215,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.8.1b1"
+version = "0.8.1b2"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3585,7 +3585,7 @@ provides-extras = ["dev", "quality"]
 
 [[package]]
 name = "phlo-dagster"
-version = "0.3.1b1"
+version = "0.3.1b2"
 source = { editable = "packages/phlo-dagster" }
 dependencies = [
     { name = "dagster-graphql" },


### PR DESCRIPTION
## Summary
- prepare phlo 0.8.1b2 and phlo-dagster 0.3.1b2 beta versions
- fix Dagster runtime image install for pinned prerelease Phlo without allowing unrelated prerelease dependencies
- install the psycopg driver required by dagster-postgres and document pytest in the workshop setup

## Verification
- uv run pytest packages/phlo-dagster/tests/test_runtime_image_contract.py tests/test_cli_services_init.py -q
- uv build --wheel --out-dir /tmp/phlo-b2-dist .
- uv build --wheel --out-dir /tmp/phlo-b2-dist packages/phlo-dagster
- inspected built wheel metadata for phlo-dagster>=0.3.1b2 and bundled Dockerfile contents
- reran workshop through dlt_orders materialization in /Users/garethprice/Developer/phlo-blog-20260503-160057 with sandbox-applied equivalent Dockerfile fixes