### PR TITLE
fix: publish minio volume beta

### DIFF
--- a/packages/phlo-minio/README.md
+++ b/packages/phlo-minio/README.md
@@ -35,7 +35,7 @@ This package is **fully auto-configured**:
 | ----------------------- | ---------------------------------------------------- |
 | **Metrics Labels**      | Exposes MinIO metrics at `/minio/v2/metrics/cluster` |
 | **Prometheus Scraping** | Auto-scraped by Prometheus via Docker labels         |
-| **Volume Mounting**     | Persists data to `./volumes/minio`                   |
+| **Volume Mounting**     | Persists data to the `minio-data` Docker volume      |
 
 ### Metrics Labels
 

--- a/packages/phlo-minio/pyproject.toml
+++ b/packages/phlo-minio/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "MinIO service plugin for Phlo"
 name = "phlo-minio"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1b1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-minio/src/phlo_minio/__init__.py
+++ b/packages/phlo-minio/src/phlo_minio/__init__.py
@@ -29,4 +29,4 @@ from phlo_minio.plugin import MinioServicePlugin
 from phlo_minio.settings import MinioSettings, get_settings
 
 __all__ = ["MinioServicePlugin", "MinioSettings", "get_settings"]
-__version__ = "0.2.4"
+__version__ = "0.3.1b1"

--- a/packages/phlo-minio/tests/test_minio_plugin.py
+++ b/packages/phlo-minio/tests/test_minio_plugin.py
@@ -13,6 +13,16 @@ def test_minio_service_definition():
     assert service_definition["category"] == "core"
 
 
+def test_minio_service_uses_named_volume():
+    """MinIO should not bind-mount a local data directory."""
+
+    plugin = MinioServicePlugin()
+    volumes = plugin.service_definition["compose"]["volumes"]
+
+    assert "minio-data:/data" in volumes
+    assert all("./volumes/minio" not in volume for volume in volumes)
+
+
 def test_minio_resource_provider_exposes_object_store(monkeypatch) -> None:
     """MinIO should expose an object_store capability."""
     monkeypatch.setattr(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
     "phlo-lineage>=0.1.0",
     "phlo-loki>=0.1.0",
     "phlo-mcp>=0.1.0",
-    "phlo-minio>=0.1.0",
+    "phlo-minio>=0.3.1b1",
     "phlo-sling>=0.1.0",
     "phlo-nessie>=0.1.0",
     "phlo-observatory>=0.1.0",
@@ -88,7 +88,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.8.1b2"
+version = "0.8.1b3"
 
 [project.entry-points."phlo.plugins.quality"]
 
@@ -100,7 +100,7 @@ version = "0.8.1b2"
 core-services = [
     "phlo-dagster>=0.3.1b2",
     "phlo-postgres>=0.1.0",
-    "phlo-minio>=0.1.0",
+    "phlo-minio>=0.3.1b1",
     "phlo-nessie>=0.1.0",
     "phlo-trino>=0.1.0",
 ]
@@ -112,7 +112,7 @@ defaults = [
     "phlo-pandera>=0.3.1b1",
     "phlo-dagster>=0.3.1b2",
     "phlo-postgres>=0.1.0",
-    "phlo-minio>=0.1.0",
+    "phlo-minio>=0.3.1b1",
     "phlo-nessie>=0.1.0",
     "phlo-trino>=0.1.0",
 ]

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.8.1b1"
+__version__ = "0.8.1b3"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -307,4 +307,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.8.1b1"
+__version__ = "0.8.1b3"

--- a/uv.lock
+++ b/uv.lock
@@ -3215,7 +3215,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.8.1b2"
+version = "0.8.1b3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3909,7 +3909,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-minio"
-version = "0.3.0"
+version = "0.3.1b1"
 source = { editable = "packages/phlo-minio" }
 dependencies = [
     { name = "phlo" },


### PR DESCRIPTION
## Summary
- prepare phlo 0.8.1b3 and phlo-minio 0.3.1b1 for the next workshop beta
- publish the MinIO named-volume service definition so generated projects no longer bind-mount .phlo/volumes/minio
- align root/minio version constants and update MinIO docs
- add a regression test for the MinIO service volume contract

## Verification
- uv run pytest packages/phlo-minio/tests/test_minio_plugin.py packages/phlo-dagster/tests/test_runtime_image_contract.py tests/test_cli_services_init.py -q
- uv run ruff check packages/phlo-minio/tests/test_minio_plugin.py packages/phlo-minio/src/phlo_minio/__init__.py src/phlo/cli/__init__.py src/phlo/plugins/__init__.py
- git diff --check
- uv build --wheel --out-dir /tmp/phlo-b3-dist .
- uv build --wheel --out-dir /tmp/phlo-b3-dist packages/phlo-minio
- inspected b3 wheels for phlo-minio>=0.3.1b1 root metadata and minio-data:/data service.yaml

## Workshop note
Fresh b2 PyPI rerun reached service startup, then failed on Docker chown for generated .phlo/volumes/minio. This beta publishes the existing named-volume fix so the next run can continue without that local patch.