### PR TITLE
fix: smooth workshop inspection commands

### DIFF
--- a/packages/phlo-dagster/pyproject.toml
+++ b/packages/phlo-dagster/pyproject.toml
@@ -9,13 +9,14 @@ requires = [
 dependencies = [
     "phlo>=0.1.0",
     "dagster-graphql>=1.12.1",
+    "psycopg2-binary>=2.9.11",
     "pyyaml>=6.0.1",
     "requests>=2.32.5",
 ]
 description = "Dagster service plugin for Phlo"
 name = "phlo-dagster"
 requires-python = ">=3.11"
-version = "0.3.1b2"
+version = "0.3.1b3"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/src/phlo_dagster/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "authorize_daemon_run",
     "create_daemon_principal",
 ]
-__version__ = "0.3.1b2"
+__version__ = "0.3.1b3"

--- a/packages/phlo-dagster/src/phlo_dagster/cli_logs.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_logs.py
@@ -32,14 +32,18 @@ Example:
 
 """
 
+import json
 import os
 import re
 from datetime import datetime, timedelta, timezone
 
 import click
+import psycopg2
+import psycopg2.extras
 import requests as http_requests
 from rich.console import Console
 
+from phlo.config.network import resolve_host
 from phlo.logging import get_logger
 from phlo_dagster.cli_logs_display import _display_logs, _tail_logs
 from phlo_dagster.settings import get_settings
@@ -293,10 +297,11 @@ def _get_logs(filters: dict) -> list[dict]:
             return logs_list
 
         except Exception:
-            logger.warning(
-                "dagster_logs_graphql_query_failed",
-                exc_info=True,
-            )
+            postgres_logs = _get_logs_from_postgres(filters)
+            if postgres_logs:
+                logger.debug("dagster_logs_graphql_failed_postgres_fallback_used")
+                return postgres_logs
+            logger.warning("dagster_logs_graphql_query_failed", exc_info=True)
             return []
 
     except Exception:
@@ -304,7 +309,123 @@ def _get_logs(filters: dict) -> list[dict]:
             "dagster_logs_graphql_client_unavailable",
             exc_info=True,
         )
+        postgres_logs = _get_logs_from_postgres(filters)
+        if postgres_logs:
+            logger.debug("dagster_logs_graphql_client_unavailable_postgres_fallback_used")
+        return postgres_logs
+
+
+def _get_logs_from_postgres(filters: dict) -> list[dict]:
+    """Retrieve Dagster event logs directly from Dagster's Postgres storage."""
+    try:
+        host, port = resolve_host(
+            os.getenv("POSTGRES_HOST", "postgres"),
+            int(os.getenv("POSTGRES_PORT", "5432")),
+            port_env_var="POSTGRES_PORT",
+        )
+        conn = psycopg2.connect(
+            host=host,
+            port=port,
+            database=os.getenv("POSTGRES_DB", "phlo"),
+            user=os.getenv("POSTGRES_USER", "phlo"),
+            password=os.getenv("POSTGRES_PASSWORD", "phlo"),
+        )
+    except Exception:
+        logger.warning("dagster_logs_postgres_connect_failed", exc_info=True)
         return []
+
+    where = ["TRUE"]
+    params: list[object] = []
+    if filters.get("asset"):
+        asset = str(filters["asset"]).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        where.append("asset_key ILIKE %s ESCAPE '\\'")
+        params.append(f"%{asset}%")
+    if filters.get("run_id"):
+        where.append("run_id = %s")
+        params.append(filters["run_id"])
+    if filters.get("start_time"):
+        where.append("timestamp >= %s")
+        params.append(filters["start_time"])
+
+    params.append(int(filters.get("limit", 100)))
+    try:
+        with conn, conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+            cur.execute(
+                f"""
+                SELECT run_id, dagster_event_type, timestamp, event, step_key
+                FROM event_logs
+                WHERE {" AND ".join(where)}
+                ORDER BY id DESC
+                LIMIT %s
+                """,
+                params,
+            )
+            rows = cur.fetchall()
+    except Exception:
+        logger.warning("dagster_logs_postgres_query_failed", exc_info=True)
+        return []
+    finally:
+        conn.close()
+
+    logs_list: list[dict] = []
+    for row in rows:
+        entry = _event_log_row_to_entry(row)
+        if not entry:
+            continue
+        if filters.get("job") and entry.get("job_name") != filters["job"]:
+            continue
+        if filters.get("level") and entry.get("level") != filters["level"]:
+            continue
+        logs_list.append(entry)
+    logs_list.reverse()
+    return logs_list
+
+
+def _event_log_row_to_entry(row) -> dict | None:
+    raw_event = row.get("event")
+    payload: dict = {}
+    if isinstance(raw_event, str) and raw_event:
+        try:
+            payload = json.loads(raw_event)
+        except json.JSONDecodeError:
+            payload = {}
+
+    dagster_event = payload.get("dagster_event") or {}
+    logging_tags = dagster_event.get("logging_tags") or {}
+    event_type = row.get("dagster_event_type") or dagster_event.get("event_type_value") or ""
+    message = (
+        payload.get("user_message")
+        or dagster_event.get("message")
+        or payload.get("message")
+        or event_type
+    )
+    timestamp = row.get("timestamp")
+    if isinstance(timestamp, datetime):
+        timestamp_value = timestamp.replace(tzinfo=timezone.utc).isoformat()
+    else:
+        timestamp_value = str(timestamp) if timestamp is not None else ""
+
+    return {
+        "timestamp": timestamp_value,
+        "level": _level_from_event_payload(payload, event_type),
+        "message": str(message or ""),
+        "event_type": str(event_type),
+        "run_id": str(row.get("run_id") or payload.get("run_id") or ""),
+        "job_name": str(logging_tags.get("job_name") or payload.get("pipeline_name") or ""),
+        "run_status": "",
+    }
+
+
+def _level_from_event_payload(payload: dict, event_type: str) -> str:
+    level = payload.get("level")
+    if isinstance(level, int):
+        if level >= 40:
+            return "ERROR"
+        if level >= 30:
+            return "WARNING"
+        if level >= 20:
+            return "INFO"
+    return _get_log_level(event_type)
 
 
 def _build_logs_query(filters: dict) -> str:

--- a/packages/phlo-dagster/tests/test_cli_logs.py
+++ b/packages/phlo-dagster/tests/test_cli_logs.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from click.testing import CliRunner
 
 from phlo_dagster.cli_logs import (
+    _event_log_row_to_entry,
     _get_log_level,
     _parse_since,
     logs,
@@ -33,6 +34,30 @@ class TestLogLevelMapping:
         """Map DEBUG event type."""
         assert _get_log_level("LOG_MESSAGE") == "DEBUG"
         assert _get_log_level("STEP_INPUT") == "DEBUG"
+
+
+def test_event_log_row_to_entry_parses_dagster_event_payload() -> None:
+    row = {
+        "run_id": "run-123",
+        "dagster_event_type": "ASSET_MATERIALIZATION",
+        "timestamp": datetime(2026, 2, 1, 10, 0, tzinfo=timezone.utc),
+        "event": (
+            '{"level": 20, "user_message": "Materialized value dlt_orders.", '
+            '"dagster_event": {"logging_tags": {"job_name": "__ASSET_JOB"}}}'
+        ),
+    }
+
+    entry = _event_log_row_to_entry(row)
+
+    assert entry == {
+        "timestamp": "2026-02-01T10:00:00+00:00",
+        "level": "INFO",
+        "message": "Materialized value dlt_orders.",
+        "event_type": "ASSET_MATERIALIZATION",
+        "run_id": "run-123",
+        "job_name": "__ASSET_JOB",
+        "run_status": "",
+    }
 
 
 class TestTimeParsing:

--- a/packages/phlo-lineage/pyproject.toml
+++ b/packages/phlo-lineage/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Lineage tracking and visualization for Phlo"
 name = "phlo-lineage"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1b1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-lineage/src/phlo_lineage/cli_lineage.py
+++ b/packages/phlo-lineage/src/phlo_lineage/cli_lineage.py
@@ -56,6 +56,7 @@ import click
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
 
 from phlo_lineage import get_lineage_graph
 
@@ -107,6 +108,18 @@ def _resolve_asset_name(graph, asset_name: str) -> tuple[str | None, list[str]]:
     normalized = asset_name.replace("/", ".")
     if normalized in graph.assets:
         return normalized, [normalized]
+
+    if asset_name.startswith("dlt_"):
+        raw_table = asset_name.removeprefix("dlt_")
+        dlt_matches = [
+            name
+            for name in graph.assets.keys()
+            if name == raw_table or name.split(".")[-1] == raw_table
+        ]
+        if len(dlt_matches) == 1:
+            return dlt_matches[0], dlt_matches
+        if dlt_matches:
+            return None, dlt_matches
 
     query_segments = [seg for seg in re.split(r"[./]", asset_name) if seg]
     matches: list[str] = []
@@ -236,7 +249,7 @@ def show_lineage(asset_name: str, direction: str, depth: Optional[int]) -> None:
     if depth:
         title += f" (depth ≤ {depth})"
 
-    console.print(Panel(tree, title=title, expand=False))
+    console.print(Panel(Text(tree), title=title, expand=False))
 
 
 @lineage_group.command(name="export")

--- a/packages/phlo-lineage/tests/test_cli_lineage.py
+++ b/packages/phlo-lineage/tests/test_cli_lineage.py
@@ -1,0 +1,36 @@
+from phlo_lineage.cli_lineage import _resolve_asset_name
+from phlo_lineage.cli_lineage import show_lineage
+from phlo_lineage.graph import LineageGraph
+from click.testing import CliRunner
+
+
+def test_resolve_asset_name_maps_dlt_asset_to_raw_table_node() -> None:
+    graph = LineageGraph()
+    graph.add_asset("raw.orders")
+
+    resolved_name, matches = _resolve_asset_name(graph, "dlt_orders")
+
+    assert resolved_name == "raw.orders"
+    assert matches == ["raw.orders"]
+
+
+def test_resolve_asset_name_keeps_ambiguous_dlt_table_matches_unresolved() -> None:
+    graph = LineageGraph()
+    graph.add_asset("raw.orders")
+    graph.add_asset("archive.orders")
+
+    resolved_name, matches = _resolve_asset_name(graph, "dlt_orders")
+
+    assert resolved_name is None
+    assert sorted(matches) == ["archive.orders", "raw.orders"]
+
+
+def test_show_lineage_renders_direction_labels(monkeypatch) -> None:
+    graph = LineageGraph()
+    graph.add_edge("raw.orders", "stg_orders")
+    monkeypatch.setattr("phlo_lineage.cli_lineage.get_lineage_graph", lambda: graph)
+
+    result = CliRunner().invoke(show_lineage, ["dlt_orders", "--direction", "both"])
+
+    assert result.exit_code == 0
+    assert "[downstream]" in result.output

--- a/packages/phlo-nessie/pyproject.toml
+++ b/packages/phlo-nessie/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Nessie service plugin for Phlo"
 name = "phlo-nessie"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1b1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-nessie/src/phlo_nessie/__init__.py
+++ b/packages/phlo-nessie/src/phlo_nessie/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "NessieSettings",
     "get_settings",
 ]
-__version__ = "0.2.4"
+__version__ = "0.3.1b1"

--- a/packages/phlo-nessie/src/phlo_nessie/cli_catalog.py
+++ b/packages/phlo-nessie/src/phlo_nessie/cli_catalog.py
@@ -237,12 +237,13 @@ def describe(table_name: str, ref: str) -> None:
                 part_table.add_row(str(part_field.source_id), str(part_field.transform))
             console.print(part_table)
 
-        if table.properties():
+        properties = _value_or_call(table.properties)
+        if properties:
             console.print("\n[bold]Properties:[/bold]")
             prop_table = Table()
             prop_table.add_column("Key", style="cyan")
             prop_table.add_column("Value", style="green")
-            for key, value in sorted(table.properties().items()):
+            for key, value in sorted(properties.items()):
                 prop_table.add_row(key, value)
             console.print(prop_table)
         logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dev = [
     "phlo-alloy>=0.1.0",
     "phlo-api>=0.1.0",
     "phlo-core-plugins>=0.1.0",
-    "phlo-dagster>=0.3.1b2",
+    "phlo-dagster>=0.3.1b3",
     "phlo-delta>=0.1.0",
     "pytest>=8.4.2",
     "pytest-cov>=6.0",
@@ -20,12 +20,12 @@ dev = [
     "phlo-dbt>=0.1.0",
     "phlo-grafana>=0.1.0",
     "phlo-hasura>=0.1.0",
-    "phlo-lineage>=0.1.0",
+    "phlo-lineage>=0.3.1b1",
     "phlo-loki>=0.1.0",
     "phlo-mcp>=0.1.0",
     "phlo-minio>=0.3.1b1",
     "phlo-sling>=0.1.0",
-    "phlo-nessie>=0.1.0",
+    "phlo-nessie>=0.3.1b1",
     "phlo-observatory>=0.1.0",
     "phlo-observatory-example>=0.1.0",
     "phlo-openmetadata>=0.1.0",
@@ -88,7 +88,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.8.1b3"
+version = "0.8.1b4"
 
 [project.entry-points."phlo.plugins.quality"]
 
@@ -98,10 +98,10 @@ version = "0.8.1b3"
 
 [project.optional-dependencies]
 core-services = [
-    "phlo-dagster>=0.3.1b2",
+    "phlo-dagster>=0.3.1b3",
     "phlo-postgres>=0.1.0",
     "phlo-minio>=0.3.1b1",
-    "phlo-nessie>=0.1.0",
+    "phlo-nessie>=0.3.1b1",
     "phlo-trino>=0.1.0",
 ]
 defaults = [
@@ -110,10 +110,10 @@ defaults = [
     "phlo-dlt>=0.3.1b1",
     "phlo-dbt>=0.1.0",
     "phlo-pandera>=0.3.1b1",
-    "phlo-dagster>=0.3.1b2",
+    "phlo-dagster>=0.3.1b3",
     "phlo-postgres>=0.1.0",
     "phlo-minio>=0.3.1b1",
-    "phlo-nessie>=0.1.0",
+    "phlo-nessie>=0.3.1b1",
     "phlo-trino>=0.1.0",
 ]
 openmetadata = ["phlo-openmetadata>=0.1.0"]

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.8.1b3"
+__version__ = "0.8.1b4"

--- a/src/phlo/metrics.py
+++ b/src/phlo/metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
@@ -27,8 +28,8 @@ class MetricsBackendSettings(BaseConfig):
 
     postgres_host: str = Field(default="postgres", description="PostgreSQL host")
     postgres_port: int = Field(default=5432, description="PostgreSQL port")
-    postgres_user: str = Field(description="PostgreSQL username")
-    postgres_password: str = Field(description="PostgreSQL password")
+    postgres_user: str = Field(default="phlo", description="PostgreSQL username")
+    postgres_password: str = Field(default="phlo", description="PostgreSQL password")
     postgres_db: str = Field(default="phlo", description="PostgreSQL database name")
     nessie_host: str = Field(default="nessie", description="Nessie host")
     nessie_port: int = Field(default=19120, description="Nessie port")
@@ -202,7 +203,8 @@ class MetricsCollector:
             )
 
         try:
-            iceberg_metrics = self._get_iceberg_table_stats(asset_name)
+            iceberg_table_name = self._resolve_asset_table_name_from_postgres(asset_name)
+            iceberg_metrics = self._get_iceberg_table_stats(iceberg_table_name)
             metrics.data_growth_bytes = iceberg_metrics.get("total_bytes", 0)
         except Exception:
             logger.warning("asset_iceberg_stats_failed", asset_name=asset_name, exc_info=True)
@@ -357,21 +359,34 @@ class MetricsCollector:
                     """
                     SELECT
                         r.run_id,
-                        COALESCE(r.start_time, r.create_timestamp) AS start_time,
-                        COALESCE(r.end_time, r.update_timestamp) AS end_time,
+                        CASE
+                            WHEN r.start_time IS NOT NULL THEN to_timestamp(r.start_time)
+                            ELSE r.create_timestamp
+                        END AS start_time,
+                        CASE
+                            WHEN r.end_time IS NOT NULL THEN to_timestamp(r.end_time)
+                            ELSE r.update_timestamp
+                        END AS end_time,
                         r.status
-                    FROM dagster_runs AS r
-                    LEFT JOIN run_tags AS t ON t.run_id = r.run_id
+                    FROM runs AS r
                     WHERE r.pipeline_name = %s
-                       OR (
-                           t.key = 'dagster/asset_selection'
-                           AND t.value ILIKE %s ESCAPE '\\'
+                       OR EXISTS (
+                           SELECT 1
+                           FROM run_tags AS t
+                           WHERE t.run_id = r.run_id
+                             AND t.key = 'dagster/asset_selection'
+                             AND t.value ILIKE %s ESCAPE '\\'
                        )
-                    GROUP BY r.run_id, start_time, end_time, r.status
+                       OR EXISTS (
+                           SELECT 1
+                           FROM event_logs AS e
+                           WHERE e.run_id = r.run_id
+                             AND e.asset_key ILIKE %s ESCAPE '\\'
+                       )
                     ORDER BY start_time DESC
                     LIMIT %s
                     """,
-                    (asset_name, f"%{escaped_asset_name}%", limit),
+                    (asset_name, f"%{escaped_asset_name}%", f"%{escaped_asset_name}%", limit),
                 )
                 rows = cur.fetchall()
         except PsycopgError as exc:
@@ -398,6 +413,72 @@ class MetricsCollector:
             )
         return runs
 
+    def _resolve_asset_table_name_from_postgres(self, asset_name: str) -> str:
+        """Resolve a Dagster asset key to its physical table when metadata records it."""
+        try:
+            conn = psycopg2.connect(
+                host=self.settings.postgres_host,
+                port=self.settings.postgres_port,
+                database=self.settings.postgres_db,
+                user=self.settings.postgres_user,
+                password=self.settings.postgres_password,
+            )
+        except PsycopgError as exc:
+            raise MetricsDependencyError("Postgres unavailable for asset table lookup") from exc
+
+        try:
+            escaped_asset_name = (
+                asset_name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            )
+            with conn, conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT event
+                    FROM event_logs
+                    WHERE dagster_event_type = 'ASSET_MATERIALIZATION'
+                      AND asset_key ILIKE %s ESCAPE '\\'
+                    ORDER BY timestamp DESC
+                    LIMIT 20
+                    """,
+                    (f"%{escaped_asset_name}%",),
+                )
+                rows = cur.fetchall()
+        except PsycopgError as exc:
+            raise MetricsDependencyError("Failed querying asset materialization metadata") from exc
+        finally:
+            conn.close()
+
+        for row in rows:
+            table_name = self._extract_materialized_table_name(row.get("event"))
+            if table_name:
+                return table_name
+
+        return asset_name
+
+    def _extract_materialized_table_name(self, raw_event: Any) -> str | None:
+        if not isinstance(raw_event, str) or not raw_event:
+            return None
+        try:
+            event = json.loads(raw_event)
+        except json.JSONDecodeError:
+            return None
+
+        entries = (
+            event.get("dagster_event", {})
+            .get("event_specific_data", {})
+            .get("materialization", {})
+            .get("metadata_entries", [])
+        )
+        if not isinstance(entries, list):
+            return None
+        for entry in entries:
+            if entry.get("label") != "table_name":
+                continue
+            text = entry.get("entry_data", {}).get("text")
+            if isinstance(text, str) and text:
+                return text
+        return None
+
     def _get_iceberg_table_stats(self, table_name: str) -> dict[str, Any]:
         """Get table statistics from Iceberg."""
         query_engine = self._load_query_engine()
@@ -423,7 +504,7 @@ class MetricsCollector:
                 f"Failed querying Iceberg table stats for {table_name}"
             ) from exc
 
-        if not isinstance(row, list) or len(row) != 1 or not isinstance(row[0], tuple):
+        if not isinstance(row, list) or len(row) != 1 or not isinstance(row[0], (list, tuple)):
             raise MetricsMalformedResponseError(
                 f"Unexpected Iceberg table stats shape for {table_name}: {row!r}"
             )

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -307,4 +307,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.8.1b3"
+__version__ = "0.8.1b4"

--- a/tests/test_metrics_runtime.py
+++ b/tests/test_metrics_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
 import pytest
@@ -124,6 +125,58 @@ def test_get_asset_runs_from_postgres_success(monkeypatch: pytest.MonkeyPatch) -
     assert runs[0].duration_seconds == 300.0
     assert FakeCursor.last_params is not None
     assert FakeCursor.last_params[1] == r"%dlt\_users%"
+    assert FakeCursor.last_params[2] == r"%dlt\_users%"
+
+
+def test_resolve_asset_table_name_from_materialization_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event = {
+        "dagster_event": {
+            "event_specific_data": {
+                "materialization": {
+                    "metadata_entries": [
+                        {
+                            "label": "table_name",
+                            "entry_data": {"text": "raw.orders"},
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    class FakeCursor:
+        def execute(self, _query, _params):
+            return None
+
+        def fetchall(self):
+            return [{"event": json.dumps(event)}]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeConnection:
+        def cursor(self, **_kwargs):
+            return FakeCursor()
+
+        def close(self):
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr("phlo.metrics.psycopg2.connect", lambda **_kwargs: FakeConnection())
+
+    collector = MetricsCollector()
+
+    assert collector._resolve_asset_table_name_from_postgres("dlt_orders") == "raw.orders"
 
 
 def test_get_iceberg_table_stats_dependency_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -3215,7 +3215,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.8.1b3"
+version = "0.8.1b4"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3585,11 +3585,12 @@ provides-extras = ["dev", "quality"]
 
 [[package]]
 name = "phlo-dagster"
-version = "0.3.1b2"
+version = "0.3.1b3"
 source = { editable = "packages/phlo-dagster" }
 dependencies = [
     { name = "dagster-graphql" },
     { name = "phlo" },
+    { name = "psycopg2-binary" },
     { name = "pyyaml" },
     { name = "requests" },
 ]
@@ -3620,6 +3621,7 @@ requires-dist = [
     { name = "phlo-iceberg", marker = "extra == 'iceberg'", editable = "packages/phlo-iceberg" },
     { name = "phlo-nessie", marker = "extra == 'nessie'", editable = "packages/phlo-nessie" },
     { name = "phlo-observatory", marker = "extra == 'observatory'", editable = "packages/phlo-observatory" },
+    { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "requests", specifier = ">=2.32.5" },
@@ -3817,7 +3819,7 @@ provides-extras = ["dev", "minio", "nessie"]
 
 [[package]]
 name = "phlo-lineage"
-version = "0.3.0"
+version = "0.3.1b1"
 source = { editable = "packages/phlo-lineage" }
 dependencies = [
     { name = "click" },
@@ -3933,7 +3935,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-nessie"
-version = "0.3.0"
+version = "0.3.1b1"
 source = { editable = "packages/phlo-nessie" }
 dependencies = [
     { name = "marshmallow" },


### PR DESCRIPTION
## Summary
- publish b4 prerelease versions for root, Dagster, Lineage, and Nessie so the workshop installs the fixed packages
- make catalog describe tolerate PyIceberg property/method API differences
- make metrics use Dagster's current runs/event_logs storage and resolve DLT assets to physical Iceberg table metadata
- make lineage resolve dlt_<table> workshop asset names to raw table lineage nodes and render direction labels literally
- add quiet Postgres event-log fallback for phlo logs when Dagster GraphQL rejects the old event query

## Verification
- uv run ruff check src/phlo/metrics.py packages/phlo-dagster/src/phlo_dagster/cli_logs.py packages/phlo-dagster/tests/test_cli_logs.py packages/phlo-lineage/src/phlo_lineage/cli_lineage.py packages/phlo-lineage/tests/test_cli_lineage.py tests/test_metrics_runtime.py packages/phlo-nessie/src/phlo_nessie/cli_catalog.py packages/phlo-nessie/tests/test_cli_catalog.py
- uv run pytest tests/test_metrics_runtime.py -m integration
- uv run pytest packages/phlo-nessie/tests/test_cli_catalog.py packages/phlo-dagster/tests/test_cli_logs.py packages/phlo-lineage/tests/test_cli_lineage.py packages/phlo-dagster/tests/test_runtime_image_contract.py
- uv build root + phlo-dagster + phlo-lineage + phlo-nessie and inspected wheel metadata
- local workshop b3 project with editable b4 packages: phlo catalog describe raw.orders, phlo lineage show dlt_orders --direction both --depth 2, phlo metrics asset dlt_orders --runs 20, phlo logs --limit 3