### PR TITLE
fix: smooth first workshop materialization

### DIFF
--- a/packages/phlo-iceberg/pyproject.toml
+++ b/packages/phlo-iceberg/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Iceberg table-store capability plugin for Phlo"
 name = "phlo-iceberg"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1b1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-iceberg/src/phlo_iceberg/catalog.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/catalog.py
@@ -40,6 +40,22 @@ from phlo_iceberg.settings import get_settings
 logger = get_logger(__name__)
 
 
+def _is_namespace_already_exists_error(exc: BaseException) -> bool:
+    """Return whether PyIceberg reported an idempotent namespace create conflict."""
+    try:
+        from pyiceberg.exceptions import NamespaceAlreadyExistsError
+    except Exception:
+        already_exists_types: tuple[type[BaseException], ...] = ()
+    else:
+        already_exists_types = (NamespaceAlreadyExistsError,)
+
+    if already_exists_types and isinstance(exc, already_exists_types):
+        return True
+
+    message = str(exc).lower()
+    return "namespace already exists" in message or "alreadyexistsexception" in message
+
+
 @lru_cache(maxsize=16)
 def get_catalog(ref: str = "main"):
     """Get a configured PyIceberg REST catalog instance (cached).
@@ -216,10 +232,17 @@ def create_namespace(namespace: str, ref: str = "main") -> None:
             namespace=namespace,
             ref=ref,
         )
-    except Exception:
-        # Namespace might already exist
+    except Exception as exc:
+        if _is_namespace_already_exists_error(exc):
+            logger.info(
+                "iceberg_catalog_create_namespace_exists",
+                namespace=namespace,
+                ref=ref,
+            )
+            return None
+
         logger.warning(
-            "iceberg_catalog_create_namespace_skipped",
+            "iceberg_catalog_create_namespace_failed",
             namespace=namespace,
             ref=ref,
             exc_info=True,

--- a/packages/phlo-iceberg/tests/test_iceberg.py
+++ b/packages/phlo-iceberg/tests/test_iceberg.py
@@ -16,6 +16,7 @@ from phlo_iceberg.tables import (
     ensure_table,
     get_table_schema,
 )
+from pyiceberg.exceptions import NamespaceAlreadyExistsError
 from pyiceberg.schema import Schema
 from pyiceberg.types import NestedField, StringType, TimestampType
 
@@ -128,6 +129,27 @@ class TestIcebergCatalogUnitTests:
         mock_catalog.create_namespace.side_effect = Exception("Namespace already exists")
         create_namespace("raw")  # Should not raise
         assert mock_catalog.create_namespace.call_count == 2
+
+    @patch("phlo_iceberg.catalog.logger")
+    @patch("phlo_iceberg.catalog.get_catalog")
+    def test_create_namespace_logs_existing_namespace_without_stack(
+        self, mock_get_catalog, mock_logger
+    ):
+        """Existing namespaces are an idempotent condition, not a warning."""
+        mock_catalog = MagicMock()
+        mock_get_catalog.return_value = mock_catalog
+        mock_catalog.create_namespace.side_effect = NamespaceAlreadyExistsError(
+            "Namespace already exists: raw"
+        )
+
+        create_namespace("raw")
+
+        mock_logger.info.assert_any_call(
+            "iceberg_catalog_create_namespace_exists",
+            namespace="raw",
+            ref="main",
+        )
+        mock_logger.warning.assert_not_called()
 
     def test_reset_catalog_cache_clears_cli_utils_cache(self):
         """reset_catalog_cache should clear the CLI-level catalog cache too."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dev = [
     "phlo-clickstack>=0.1.0",
     "phlo-clickhouse>=0.1.0",
     "phlo-dlt>=0.3.1b1",
-    "phlo-iceberg>=0.1.0",
+    "phlo-iceberg>=0.3.1b1",
     "phlo-dbt>=0.1.0",
     "phlo-grafana>=0.1.0",
     "phlo-hasura>=0.1.0",
@@ -88,7 +88,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.8.1b4"
+version = "0.8.1b5"
 
 [project.entry-points."phlo.plugins.quality"]
 
@@ -106,7 +106,7 @@ core-services = [
 ]
 defaults = [
     "phlo-core-plugins>=0.1.0",
-    "phlo-iceberg>=0.1.0",
+    "phlo-iceberg>=0.3.1b1",
     "phlo-dlt>=0.3.1b1",
     "phlo-dbt>=0.1.0",
     "phlo-pandera>=0.3.1b1",

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.8.1b4"
+__version__ = "0.8.1b5"

--- a/src/phlo/cli/commands/schema_migrate.py
+++ b/src/phlo/cli/commands/schema_migrate.py
@@ -312,6 +312,27 @@ def export_contract_for_table(
     return destination
 
 
+def _is_missing_table_error(exc: BaseException) -> bool:
+    """Return whether a schema refresh failed because the table is not available yet."""
+    try:
+        from pyiceberg.exceptions import NoSuchIdentifierError, NoSuchTableError
+    except Exception:
+        missing_error_types: tuple[type[BaseException], ...] = ()
+    else:
+        missing_error_types = (NoSuchIdentifierError, NoSuchTableError)
+
+    if missing_error_types and isinstance(exc, missing_error_types):
+        return True
+
+    exc_name = type(exc).__name__
+    message = str(exc).lower()
+    return (
+        exc_name in {"NoSuchIdentifierError", "NoSuchTableError"}
+        or "table does not exist" in message
+        or "missing namespace or invalid identifier" in message
+    )
+
+
 def refresh_contracts_for_selection(
     *,
     selection: str | None = None,
@@ -321,6 +342,7 @@ def refresh_contracts_for_selection(
     registry = get_capability_registry()
     candidate_tables: set[str] = set()
     selection_value = (selection or "").strip()
+    found_matching_dlt_asset = False
 
     if selection_value.startswith("dlt_"):
         candidate_tables.add(selection_value.removeprefix("dlt_"))
@@ -334,7 +356,11 @@ def refresh_contracts_for_selection(
             continue
         if selection_value and selection_value.startswith("dlt_") and asset.key != selection_value:
             continue
+        found_matching_dlt_asset = True
         candidate_tables.add(table_name)
+
+    if found_matching_dlt_asset and selection_value.startswith("dlt_"):
+        candidate_tables.discard(selection_value.removeprefix("dlt_"))
 
     refreshed_count = 0
     for table in sorted(candidate_tables):
@@ -355,7 +381,14 @@ def refresh_contracts_for_selection(
                 export_contract_for_table(table_name=candidate, force=force)
             except SystemExit:
                 raise
-            except Exception:
+            except Exception as exc:
+                if _is_missing_table_error(exc):
+                    logger.debug(
+                        "schema_contract_refresh_skipped_table_missing",
+                        table_name=candidate,
+                        selection=selection_value or None,
+                    )
+                    continue
                 logger.warning(
                     "schema_contract_refresh_failed",
                     table_name=candidate,

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -307,4 +307,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.8.1b4"
+__version__ = "0.8.1b5"

--- a/tests/test_cli_schema_migrate.py
+++ b/tests/test_cli_schema_migrate.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 import yaml
 from click.testing import CliRunner
+from pyiceberg.exceptions import NoSuchTableError
 
 from phlo.capabilities.specs import (
     FieldSpec,
@@ -622,3 +623,50 @@ def test_build_scaffold_payload_from_contract_rejects_table_mismatch(monkeypatch
             table_name="warehouse.customers",
             contract_path=Path(".phlo/contracts/warehouse__customers.json"),
         )
+
+
+def test_refresh_contracts_skips_missing_tables_without_warning(monkeypatch) -> None:
+    """First materialization can refresh before the Iceberg table exists."""
+
+    class FakeLogger:
+        def __init__(self) -> None:
+            self.debug_events: list[tuple[str, dict[str, object]]] = []
+            self.warning_events: list[tuple[str, dict[str, object]]] = []
+
+        def debug(self, event: str, **kwargs: object) -> None:
+            self.debug_events.append((event, kwargs))
+
+        def warning(self, event: str, **kwargs: object) -> None:
+            self.warning_events.append((event, kwargs))
+
+    class FakeAsset:
+        key = "dlt_orders"
+        kinds = {"dlt"}
+        metadata = {"table_name": "raw.orders"}
+
+    class FakeRegistry:
+        def list_assets(self) -> list[FakeAsset]:
+            return [FakeAsset()]
+
+    logger = FakeLogger()
+    calls: list[str] = []
+
+    def _missing_table(*, table_name: str, force: bool = True) -> Path:
+        calls.append(table_name)
+        raise NoSuchTableError(f"Table does not exist: {table_name}")
+
+    monkeypatch.setattr(schema_migrate_commands, "get_capability_registry", lambda: FakeRegistry())
+    monkeypatch.setattr(schema_migrate_commands, "export_contract_for_table", _missing_table)
+    monkeypatch.setattr(schema_migrate_commands, "logger", logger)
+
+    refreshed = schema_migrate_commands.refresh_contracts_for_selection(selection="dlt_orders")
+
+    assert refreshed == 0
+    assert calls == ["raw.orders"]
+    assert logger.warning_events == []
+    assert logger.debug_events == [
+        (
+            "schema_contract_refresh_skipped_table_missing",
+            {"table_name": "raw.orders", "selection": "dlt_orders"},
+        )
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -3215,7 +3215,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.8.1b4"
+version = "0.8.1b5"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3785,7 +3785,7 @@ provides-extras = ["dev", "postgres"]
 
 [[package]]
 name = "phlo-iceberg"
-version = "0.3.0"
+version = "0.3.1b1"
 source = { editable = "packages/phlo-iceberg" }
 dependencies = [
     { name = "pandera" },


### PR DESCRIPTION
## Summary
- skip expected missing-table contract refresh attempts before first materialization without warning stacks
- treat existing Iceberg namespaces as idempotent info instead of warning stacks
- release phlo 0.8.1b5 with phlo-iceberg 0.3.1b1 in defaults

## Verification
- uv run ruff check src/phlo/cli/commands/schema_migrate.py packages/phlo-iceberg/src/phlo_iceberg/catalog.py tests/test_cli_schema_migrate.py packages/phlo-iceberg/tests/test_iceberg.py
- uv run pytest tests/test_cli_schema_migrate.py packages/phlo-iceberg/tests/test_iceberg.py packages/phlo-iceberg/tests/test_schema_migrator.py
- uv build
- uv build --package phlo-iceberg
- inspected wheel metadata for phlo[defaults] -> phlo-iceberg>=0.3.1b1
