### PR TITLE
fix: polish CLI feedback and runtime readiness

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1167,10 +1167,10 @@ Materialize Dagster assets.
 phlo materialize ASSET_NAME [OPTIONS]
 ```
 
-When running through Docker, Phlo waits for the Dagster runtime to finish startup and
-local package installation before executing the materialization. If the run fails, normal
-terminal output stays concise; use `phlo logs --level ERROR --limit 20` for the structured
-failure details.
+When running through Docker or Podman, Phlo waits for the Dagster runtime to finish
+startup and local package installation before executing the materialization. If the run
+fails, normal terminal output stays concise; use `phlo logs --level ERROR --limit 20`
+for the structured failure details.
 
 **Options**:
 
@@ -1461,9 +1461,9 @@ Backfill partitioned assets over a date range.
 phlo backfill [ASSET_NAME] [OPTIONS]
 ```
 
-Backfills use the same Docker runtime readiness checks as `phlo materialize`, so a freshly
-started Dagster container does not race local package installation before partition work
-begins.
+Backfills use the same container runtime readiness checks as `phlo materialize`, so a
+freshly started Dagster container does not race local package installation before
+partition work begins.
 
 **Arguments**:
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1022,11 +1022,11 @@ phlo init [PROJECT_NAME] [OPTIONS]
 
 - `minimal`: Minimal project structure (no transforms)
 - `basic`: dbt-ready project (requires `phlo-dbt`)
-- `csv-batch`: Local CSV batch pipeline
-- `api-ingestion`: REST API ingestion pipeline
+- `csv-batch`: Local CSV batch pipeline with partition-aware sample event keys
+- `api-ingestion`: REST API ingestion pipeline with partition-aware sample event keys
 - `dbt-medallion`: Bronze/silver/gold dbt project
 - `sling-replication`: Sling replication starter
-- `observability-demo`: Pipeline with telemetry wiring
+- `observability-demo`: Pipeline with telemetry wiring and partition-aware sample event keys
 
 #### List templates
 
@@ -1166,6 +1166,11 @@ Materialize Dagster assets.
 ```bash
 phlo materialize ASSET_NAME [OPTIONS]
 ```
+
+When running through Docker, Phlo waits for the Dagster runtime to finish startup and
+local package installation before executing the materialization. If the run fails, normal
+terminal output stays concise; use `phlo logs --level ERROR --limit 20` for the structured
+failure details.
 
 **Options**:
 
@@ -1405,6 +1410,10 @@ Query and filter structured logs from Dagster runs.
 phlo logs [OPTIONS]
 ```
 
+Error-level filters search a wider run-event window and prefer richer Dagster event-log
+details when available, so nested materialization failures show the actionable root cause
+rather than only the top-level Dagster wrapper.
+
 **Options**:
 
 ```bash
@@ -1451,6 +1460,10 @@ Backfill partitioned assets over a date range.
 ```bash
 phlo backfill [ASSET_NAME] [OPTIONS]
 ```
+
+Backfills use the same Docker runtime readiness checks as `phlo materialize`, so a freshly
+started Dagster container does not race local package installation before partition work
+begins.
 
 **Arguments**:
 

--- a/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
@@ -11,7 +11,7 @@ Features:
     - Dry-run mode for previewing operations
     - Rate limiting with delay between executions
     - Progress tracking with Rich UI
-    - Docker container execution
+    - Container backend execution
 
 State Management:
     Backfill state is persisted to `.phlo/backfill_state.json` to enable
@@ -19,7 +19,7 @@ State Management:
     partitions, and remaining work.
 
 Execution:
-    Backfills run via Docker exec into the Dagster container, enabling
+    Backfills run via the selected container backend into the Dagster container, enabling
     access to the full Dagster environment while maintaining isolation
     from the host system.
 
@@ -48,6 +48,10 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
+from phlo.cli.infrastructure.container_backend import (
+    ContainerBackend,
+    select_project_container_backend,
+)
 from phlo.cli.infrastructure.utils import get_project_name
 from phlo.cli.output import service_unavailable_error
 from phlo.logging import get_logger
@@ -329,10 +333,13 @@ def _validate_partition_dates(dates: list[str]) -> None:
 
 
 def _build_materialize_command(
-    asset_name: str, partition_date: str, container_name: str | None = None
+    asset_name: str,
+    partition_date: str,
+    container_name: str | None = None,
+    backend: ContainerBackend | None = None,
 ) -> list[str]:
     """
-    Build the docker exec command for materializing an asset.
+    Build the container exec command for materializing an asset.
 
     Args:
         asset_name: Name of the asset to materialize
@@ -348,27 +355,27 @@ def _build_materialize_command(
         project_name = get_project_name()
         container_name = find_dagster_container(project_name)
     host_platform = platform.system()
+    selected_backend = backend or select_project_container_backend()
 
-    return [
-        "docker",
-        "exec",
-        "-e",
-        f"PHLO_HOST_PLATFORM={host_platform}",
-        "-e",
-        "PHLO_PROJECT_PATH=/app",
-        "-w",
-        "/app",
-        container_name,
-        "dagster",
-        "asset",
-        "materialize",
-        "-m",
-        "phlo_dagster.framework.definitions",
-        "--select",
-        asset_name,
-        "--partition",
-        partition_date,
-    ]
+    return selected_backend.container_exec_cmd(
+        container_name=container_name,
+        env={
+            "PHLO_HOST_PLATFORM": host_platform,
+            "PHLO_PROJECT_PATH": "/app",
+        },
+        workdir="/app",
+        command=[
+            "dagster",
+            "asset",
+            "materialize",
+            "-m",
+            "phlo_dagster.framework.definitions",
+            "--select",
+            asset_name,
+            "--partition",
+            partition_date,
+        ],
+    )
 
 
 def _run_backfill(
@@ -410,8 +417,9 @@ def _run_backfill(
         delay=delay,
     )
     try:
+        backend = select_project_container_backend()
         container_name = find_dagster_container(get_project_name())
-        wait_for_dagster_runtime(container_name)
+        wait_for_dagster_runtime(container_name, backend=backend)
     except FileNotFoundError as exc:
         logger.error(
             "dagster_backfill_service_unavailable",
@@ -446,6 +454,7 @@ def _run_backfill(
                     date,
                     delay if i > 0 else 0,
                     container_name,
+                    backend,
                 ): date
                 for i, date in enumerate(remaining)
             }
@@ -562,6 +571,7 @@ def _materialize_partition(
     partition_date: str,
     delay: float = 0.0,
     container_name: str | None = None,
+    backend: ContainerBackend | None = None,
 ) -> tuple[bool, str]:
     """
     Materialize a single partition.
@@ -580,7 +590,12 @@ def _materialize_partition(
     if delay > 0:
         time.sleep(delay)
 
-    cmd = _build_materialize_command(asset_name, partition_date, container_name=container_name)
+    cmd = _build_materialize_command(
+        asset_name,
+        partition_date,
+        container_name=container_name,
+        backend=backend,
+    )
     logger.debug(
         "dagster_backfill_partition_materialize_started",
         asset_name=asset_name,
@@ -620,7 +635,7 @@ def _materialize_partition(
             asset_name=asset_name,
             partition_date=partition_date,
         )
-        return False, "Docker not found or container not running"
+        return False, "Container backend not found or container not running"
     except Exception as e:
         logger.error(
             "dagster_backfill_partition_materialize_failed",

--- a/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
@@ -49,6 +49,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from phlo.cli.infrastructure.utils import get_project_name
+from phlo.cli.output import service_unavailable_error
 from phlo.logging import get_logger
 from phlo_dagster.cli_materialize import wait_for_dagster_runtime
 from phlo_dagster.containers import find_dagster_container
@@ -411,6 +412,14 @@ def _run_backfill(
     try:
         container_name = find_dagster_container(get_project_name())
         wait_for_dagster_runtime(container_name)
+    except FileNotFoundError as exc:
+        logger.error(
+            "dagster_backfill_service_unavailable",
+            asset_name=asset_name,
+            error=str(exc),
+            exc_info=True,
+        )
+        raise service_unavailable_error("dagster") from exc
     except RuntimeError as exc:
         logger.error(
             "dagster_backfill_service_unavailable",

--- a/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
@@ -50,6 +50,7 @@ from rich.table import Table
 
 from phlo.cli.infrastructure.utils import get_project_name
 from phlo.logging import get_logger
+from phlo_dagster.cli_materialize import wait_for_dagster_runtime
 from phlo_dagster.containers import find_dagster_container
 
 console = Console()
@@ -57,7 +58,7 @@ logger = get_logger(__name__)
 BACKFILL_STATE_FILE = Path(".phlo/backfill_state.json")
 
 
-@click.command()
+@click.command(help="Run asset materialization across a date range with parallel execution.")
 @click.argument("asset_name", required=False)
 @click.option(
     "--start-date",
@@ -407,6 +408,17 @@ def _run_backfill(
         parallel=parallel,
         delay=delay,
     )
+    try:
+        container_name = find_dagster_container(get_project_name())
+        wait_for_dagster_runtime(container_name)
+    except RuntimeError as exc:
+        logger.error(
+            "dagster_backfill_service_unavailable",
+            asset_name=asset_name,
+            error=str(exc),
+            exc_info=True,
+        )
+        raise click.ClickException(str(exc)) from exc
 
     # Use ThreadPoolExecutor for parallel execution
     with Progress(
@@ -424,6 +436,7 @@ def _run_backfill(
                     asset_name,
                     date,
                     delay if i > 0 else 0,
+                    container_name,
                 ): date
                 for i, date in enumerate(remaining)
             }
@@ -539,6 +552,7 @@ def _materialize_partition(
     asset_name: str,
     partition_date: str,
     delay: float = 0.0,
+    container_name: str | None = None,
 ) -> tuple[bool, str]:
     """
     Materialize a single partition.
@@ -557,7 +571,7 @@ def _materialize_partition(
     if delay > 0:
         time.sleep(delay)
 
-    cmd = _build_materialize_command(asset_name, partition_date)
+    cmd = _build_materialize_command(asset_name, partition_date, container_name=container_name)
     logger.debug(
         "dagster_backfill_partition_materialize_started",
         asset_name=asset_name,

--- a/packages/phlo-dagster/src/phlo_dagster/cli_logs.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_logs.py
@@ -57,7 +57,7 @@ def _project_env() -> dict[str, str]:
     return load_project_env()
 
 
-@click.command()
+@click.command(help="Access and filter Dagster run logs.")
 @click.option(
     "--asset",
     type=str,
@@ -119,32 +119,24 @@ def logs(
     limit: int,
     output_json: bool,
 ):
-    """Access and filter Dagster run logs from CLI.
-
-    Supports multiple filtering options:
-    - By asset name: --asset dlt_orders
-    - By job name: --job orders_pipeline
-    - By log level: --level ERROR
-    - By time range: --since 1h (last hour)
-    - By specific run: --run-id abc123
-    - Tail mode: --follow (real-time updates)
+    """Access and filter Dagster run logs.
 
     Args:
-        asset: Filter by asset name.
-        job: Filter by job name.
-        level: Filter by log level (DEBUG, INFO, WARNING, ERROR).
-        since: Time filter (e.g., 1h, 30m, 2d).
-        run_id: Filter by specific run ID.
-        follow: If True, tail logs in real-time.
-        full: If True, don't truncate long messages.
-        limit: Number of logs to retrieve (default: 100).
-        output_json: If True, output as JSON.
+        asset: Optional asset name filter.
+        job: Optional job name filter.
+        level: Optional log level filter.
+        since: Optional relative time window.
+        run_id: Optional Dagster run identifier.
+        follow: If True, follow new log output.
+        full: If True, do not truncate long messages.
+        limit: Maximum number of log rows to display.
+        output_json: If True, emit JSON for scripting.
 
     Returns:
         None
 
     Raises:
-        No explicit exceptions raised. Logs warnings on query failures.
+        ClickException: If incompatible options are provided.
 
     """
     if follow and output_json:
@@ -247,6 +239,12 @@ def _get_logs(filters: dict) -> list[dict]:
         List of log dictionaries
 
     """
+    if filters.get("level"):
+        postgres_logs = _get_logs_from_postgres(filters)
+        if postgres_logs:
+            logger.debug("dagster_logs_level_filter_postgres_used")
+            return postgres_logs
+
     try:
         env = _project_env()
         settings = get_settings()
@@ -365,7 +363,12 @@ def _get_logs_from_postgres(filters: dict) -> list[dict]:
         where.append("timestamp >= %s")
         params.append(filters["start_time"])
 
-    params.append(int(filters.get("limit", 100)))
+    requested_limit = int(filters.get("limit", 100))
+    query_limit = requested_limit
+    if filters.get("level"):
+        query_limit = max(requested_limit * 20, 200)
+
+    params.append(query_limit)
     try:
         with conn, conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
             cur.execute(
@@ -395,6 +398,8 @@ def _get_logs_from_postgres(filters: dict) -> list[dict]:
         if filters.get("level") and entry.get("level") != filters["level"]:
             continue
         logs_list.append(entry)
+        if len(logs_list) >= requested_limit:
+            break
     logs_list.reverse()
     return logs_list
 
@@ -411,8 +416,10 @@ def _event_log_row_to_entry(row) -> dict | None:
     dagster_event = payload.get("dagster_event") or {}
     logging_tags = dagster_event.get("logging_tags") or {}
     event_type = row.get("dagster_event_type") or dagster_event.get("event_type_value") or ""
+    error_message = _extract_error_message(dagster_event)
     message = (
-        payload.get("user_message")
+        error_message
+        or payload.get("user_message")
         or dagster_event.get("message")
         or payload.get("message")
         or event_type
@@ -432,6 +439,51 @@ def _event_log_row_to_entry(row) -> dict | None:
         "job_name": str(logging_tags.get("job_name") or payload.get("pipeline_name") or ""),
         "run_status": "",
     }
+
+
+def _extract_error_message(dagster_event: dict) -> str | None:
+    """Extract the most specific useful error message from a Dagster event payload."""
+    event_data = dagster_event.get("event_specific_data")
+    candidates: list[dict] = []
+    if isinstance(event_data, dict):
+        if isinstance(event_data.get("error"), dict):
+            candidates.append(event_data["error"])
+        first_failure = event_data.get("first_step_failure_event")
+        if isinstance(first_failure, dict):
+            first_failure_data = first_failure.get("event_specific_data")
+            if isinstance(first_failure_data, dict) and isinstance(
+                first_failure_data.get("error"), dict
+            ):
+                candidates.append(first_failure_data["error"])
+
+    messages: list[str] = []
+    for candidate in candidates:
+        current: dict | None = candidate
+        while isinstance(current, dict):
+            message = current.get("message")
+            if isinstance(message, str) and message.strip():
+                messages.append(message.strip())
+            next_cause = current.get("cause")
+            current = next_cause if isinstance(next_cause, dict) else None
+
+    if not messages:
+        return None
+
+    return _clean_error_message(messages[-1])
+
+
+def _clean_error_message(message: str) -> str:
+    """Return the first readable sentence from a nested framework error."""
+    lines = [line.strip() for line in message.splitlines() if line.strip()]
+    if not lines:
+        return message.strip()
+    if lines[0].startswith(("dlt.", "dagster.")):
+        _, _, detail = lines[0].partition(":")
+        if detail.strip():
+            return detail.strip()
+        if len(lines) >= 2:
+            return lines[1]
+    return lines[0]
 
 
 def _level_from_event_payload(payload: dict, event_type: str) -> str:
@@ -460,6 +512,8 @@ def _build_logs_query(filters: dict) -> str:
     # Simplified query structure - in production would be more comprehensive
     limit = int(filters.get("limit", 100))
     event_limit = max(limit, 1)
+    if filters.get("level"):
+        event_limit = max(event_limit * 20, 200)
     query = """
     {
         runsOrError(limit: %d) {

--- a/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
@@ -1,9 +1,9 @@
-"""Materialize command for Dagster assets via Docker.
+"""Materialize command for Dagster assets via the configured container backend.
 
 This module implements the `phlo materialize` CLI command, providing a
-convenient interface for materializing Dagster assets through Docker
-container execution. It handles environment setup and passes through
-to Dagster's asset materialization CLI.
+convenient interface for materializing Dagster assets through Docker or
+Podman container execution. It handles environment setup and passes
+through to Dagster's asset materialization CLI.
 
 Features:
     - Single asset or asset selection expression materialization
@@ -20,9 +20,9 @@ Environment Variables:
     - PHLO_AUTO_REFRESH_CONTRACTS: Enable schema contract refresh
     - PHLO_CONTRACT_REFRESH_SELECTION: Assets to refresh contracts for
 
-Docker Integration:
-    The command uses `docker exec` to run Dagster CLI commands within
-the running Dagster container. This ensures:
+Container Integration:
+    The command uses the selected project container backend to run Dagster
+CLI commands within the running Dagster container. This ensures:
     - Access to configured resources (Trino, MinIO, etc.)
     - Consistent Python environment
     - Proper logging context
@@ -49,6 +49,10 @@ from typing import Optional
 
 import click
 
+from phlo.cli.infrastructure.container_backend import (
+    ContainerBackend,
+    select_project_container_backend,
+)
 from phlo.cli.infrastructure.utils import get_project_name
 from phlo.cli.output import command_failed_error, service_unavailable_error
 from phlo_dagster.containers import find_dagster_container
@@ -64,20 +68,25 @@ def _summarize_process_output(lines: list[str]) -> str | None:
     return None
 
 
-def wait_for_dagster_runtime(container_name: str, timeout_seconds: float = 600.0) -> None:
+def wait_for_dagster_runtime(
+    container_name: str,
+    timeout_seconds: float = 600.0,
+    backend: ContainerBackend | None = None,
+) -> None:
     """Wait until the Dagster container has finished entrypoint setup."""
+    selected_backend = backend or select_project_container_backend()
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         result = subprocess.run(
-            [
-                "docker",
-                "exec",
-                container_name,
-                "sh",
-                "-lc",
-                "test -f /tmp/phlo-dagster-ready "
-                "|| python -c 'import phlo_dagster.framework.definitions'",
-            ],
+            selected_backend.container_exec_cmd(
+                container_name=container_name,
+                command=[
+                    "sh",
+                    "-lc",
+                    "test -f /tmp/phlo-dagster-ready "
+                    "|| python -c 'import phlo_dagster.framework.definitions'",
+                ],
+            ),
             check=False,
             capture_output=True,
             text=True,
@@ -92,7 +101,7 @@ def wait_for_dagster_runtime(container_name: str, timeout_seconds: float = 600.0
     )
 
 
-@click.command(help="Materialize Dagster assets via Docker.")
+@click.command(help="Materialize Dagster assets via the configured container backend.")
 @click.argument("asset_name", required=False)
 @click.option("-p", "--partition", help="Partition date (YYYY-MM-DD)")
 @click.option("--select", help="Asset selector expression")
@@ -109,7 +118,7 @@ def materialize(
     no_contract_refresh: bool,
     dry_run: bool,
 ) -> None:
-    """Materialize Dagster assets via Docker.
+    """Materialize Dagster assets via the configured container backend.
 
     Args:
         asset_name: Name of the asset to materialize.
@@ -122,7 +131,7 @@ def materialize(
         None
 
     Raises:
-        SystemExit: On command failure or Docker not found.
+        SystemExit: On command failure or container backend not found.
 
     """
     if not asset_name and not select:
@@ -145,31 +154,29 @@ def materialize(
 
     try:
         host_platform = platform.system()
+        backend = select_project_container_backend()
 
         if not dry_run:
             container_name = find_dagster_container(project_name)
-            wait_for_dagster_runtime(container_name)
+            wait_for_dagster_runtime(container_name, backend=backend)
 
-        cmd = [
-            "docker",
-            "exec",
-            "-e",
-            f"PHLO_HOST_PLATFORM={host_platform}",
-            "-e",
-            "PHLO_PROJECT_PATH=/app",
-            "-e",
-            f"PHLO_AUTO_REFRESH_CONTRACTS={'0' if no_contract_refresh else '1'}",
-            "-e",
-            f"PHLO_CONTRACT_REFRESH_SELECTION={effective_selection}",
-            "-w",
-            "/app",
-            container_name,
-            "dagster",
-            "asset",
-            "materialize",
-            "-m",
-            "phlo_dagster.framework.definitions",
-        ]
+        cmd = backend.container_exec_cmd(
+            container_name=container_name,
+            env={
+                "PHLO_HOST_PLATFORM": host_platform,
+                "PHLO_PROJECT_PATH": "/app",
+                "PHLO_AUTO_REFRESH_CONTRACTS": "0" if no_contract_refresh else "1",
+                "PHLO_CONTRACT_REFRESH_SELECTION": effective_selection,
+            },
+            workdir="/app",
+            command=[
+                "dagster",
+                "asset",
+                "materialize",
+                "-m",
+                "phlo_dagster.framework.definitions",
+            ],
+        )
 
         cmd.extend(["--select", effective_selection])
 

--- a/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
@@ -64,7 +64,35 @@ def _summarize_process_output(lines: list[str]) -> str | None:
     return None
 
 
-@click.command()
+def wait_for_dagster_runtime(container_name: str, timeout_seconds: float = 600.0) -> None:
+    """Wait until the Dagster container has finished entrypoint setup."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_name,
+                "sh",
+                "-lc",
+                "test -f /tmp/phlo-dagster-ready "
+                "|| python -c 'import phlo_dagster.framework.definitions'",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(1)
+
+    raise RuntimeError(
+        "Dagster container is still finishing runtime setup. "
+        "Inspect startup logs with: phlo services logs --tail 120 dagster"
+    )
+
+
+@click.command(help="Materialize Dagster assets via Docker.")
 @click.argument("asset_name", required=False)
 @click.option("-p", "--partition", help="Partition date (YYYY-MM-DD)")
 @click.option("--select", help="Asset selector expression")
@@ -120,6 +148,7 @@ def materialize(
 
         if not dry_run:
             container_name = find_dagster_container(project_name)
+            wait_for_dagster_runtime(container_name)
 
         cmd = [
             "docker",
@@ -232,6 +261,20 @@ def materialize(
             exc_info=True,
         )
         raise service_unavailable_error(container_name) from None
+    except RuntimeError as exc:
+        logger.error(
+            "dagster_materialize_service_unavailable",
+            asset_name=effective_selection,
+            partition=partition,
+            select=select,
+            no_contract_refresh=no_contract_refresh,
+            dry_run=dry_run,
+            project_name=project_name,
+            duration_seconds=round(time.perf_counter() - started_at, 3),
+            error=str(exc),
+            exc_info=True,
+        )
+        raise service_unavailable_error("dagster") from exc
     except click.ClickException:
         raise
     except Exception as exc:

--- a/packages/phlo-dagster/src/phlo_dagster/containers.py
+++ b/packages/phlo-dagster/src/phlo_dagster/containers.py
@@ -1,7 +1,7 @@
-"""Docker container discovery for Dagster services.
+"""Container discovery for Dagster services.
 
 This module provides utilities for finding and managing Dagster-related
-Docker containers within a Docker Compose environment. It handles
+containers within a compose environment. It handles
 candidate container name generation and resolution across different
 naming conventions.
 

--- a/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
+++ b/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
@@ -80,5 +80,7 @@ except ImportError:
     pass
 EOF
 
+touch /tmp/phlo-dagster-ready
+
 # Execute the main command
 exec "$@"

--- a/packages/phlo-dagster/tests/test_cli_backfill.py
+++ b/packages/phlo-dagster/tests/test_cli_backfill.py
@@ -242,6 +242,31 @@ class TestBackfillCLI:
             "mock-container",
         )
 
+    @patch("phlo_dagster.cli_backfill.find_dagster_container", return_value="mock-container")
+    @patch("phlo_dagster.cli_backfill.get_project_name", return_value="mock-project")
+    @patch(
+        "phlo_dagster.cli_backfill.wait_for_dagster_runtime",
+        side_effect=FileNotFoundError("docker"),
+    )
+    def test_backfill_missing_docker_is_actionable(
+        self,
+        mock_wait,
+        mock_project,
+        mock_container,
+    ):
+        """Missing Docker during readiness checks should not show a traceback."""
+        runner = CliRunner()
+        result = runner.invoke(
+            backfill,
+            ["dlt_events", "--partitions", "2024-01-01"],
+        )
+
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        assert "Error: dagster is not available" in result.output
+        assert "Make sure the dagster service is running." in result.output
+        assert "Run: phlo services start" in result.output
+
     def test_resume_without_state(self):
         """Reject resume without state file."""
         runner = CliRunner()

--- a/packages/phlo-dagster/tests/test_cli_backfill.py
+++ b/packages/phlo-dagster/tests/test_cli_backfill.py
@@ -2,7 +2,7 @@
 
 import json
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from click.testing import CliRunner
 
@@ -234,12 +234,13 @@ class TestBackfillCLI:
 
         _run_backfill("dlt_events", ["2024-01-01"], parallel=1)
 
-        mock_wait.assert_called_once_with("mock-container")
+        mock_wait.assert_called_once_with("mock-container", backend=ANY)
         mock_materialize.assert_called_once_with(
             "dlt_events",
             "2024-01-01",
             0,
             "mock-container",
+            ANY,
         )
 
     @patch("phlo_dagster.cli_backfill.find_dagster_container", return_value="mock-container")

--- a/packages/phlo-dagster/tests/test_cli_backfill.py
+++ b/packages/phlo-dagster/tests/test_cli_backfill.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 
 from phlo_dagster.cli_backfill import (
     _generate_partition_dates,
+    _run_backfill,
     _validate_partition_dates,
     backfill,
 )
@@ -214,6 +215,32 @@ class TestBackfillCLI:
         )
         assert result.exit_code == 1
         assert "Parallel must be >= 1" in result.output
+
+    @patch("phlo_dagster.cli_backfill.find_dagster_container", return_value="mock-container")
+    @patch("phlo_dagster.cli_backfill.get_project_name", return_value="mock-project")
+    @patch("phlo_dagster.cli_backfill.wait_for_dagster_runtime")
+    @patch("phlo_dagster.cli_backfill._materialize_partition", return_value=(True, "ok"))
+    def test_backfill_waits_for_runtime_before_partitions(
+        self,
+        mock_materialize,
+        mock_wait,
+        mock_project,
+        mock_container,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Wait for Dagster setup before partition docker exec calls."""
+        monkeypatch.chdir(tmp_path)
+
+        _run_backfill("dlt_events", ["2024-01-01"], parallel=1)
+
+        mock_wait.assert_called_once_with("mock-container")
+        mock_materialize.assert_called_once_with(
+            "dlt_events",
+            "2024-01-01",
+            0,
+            "mock-container",
+        )
 
     def test_resume_without_state(self):
         """Reject resume without state file."""

--- a/packages/phlo-dagster/tests/test_cli_logs.py
+++ b/packages/phlo-dagster/tests/test_cli_logs.py
@@ -1,6 +1,7 @@
 """Tests for the phlo logs CLI command."""
 
 from datetime import datetime, timedelta, timezone
+import json
 
 from click.testing import CliRunner
 
@@ -14,6 +15,17 @@ from phlo_dagster.cli_logs import (
     logs,
 )
 from phlo_dagster.cli_logs_display import _is_json
+
+
+def test_logs_help_is_user_facing() -> None:
+    result = CliRunner().invoke(logs, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Access and filter Dagster run logs." in result.output
+    assert "Args:" not in result.output
+    assert "Returns:" not in result.output
+    assert "Raises:" not in result.output
+    assert "output_json" not in result.output
 
 
 class TestLogLevelMapping:
@@ -61,6 +73,41 @@ def test_event_log_row_to_entry_parses_dagster_event_payload() -> None:
         "job_name": "__ASSET_JOB",
         "run_status": "",
     }
+
+
+def test_event_log_row_to_entry_surfaces_nested_failure_cause() -> None:
+    row = {
+        "run_id": "run-123",
+        "dagster_event_type": "STEP_FAILURE",
+        "timestamp": None,
+        "event": json.dumps(
+            {
+                "dagster_event": {
+                    "event_specific_data": {
+                        "error": {
+                            "message": "Exceeded max_retries of 3",
+                            "cause": {
+                                "message": (
+                                    "dlt.extract.exceptions.ResourceNameMissing: "
+                                    "Resource name is missing.\nIf you create a resource directly "
+                                    "from data pass `name`."
+                                ),
+                                "cause": None,
+                            },
+                        }
+                    },
+                    "logging_tags": {"job_name": "__ASSET_JOB"},
+                }
+            }
+        ),
+        "step_key": "dlt_events",
+    }
+
+    entry = _event_log_row_to_entry(row)
+
+    assert entry is not None
+    assert entry["level"] == "ERROR"
+    assert entry["message"] == "Resource name is missing."
 
 
 class TestTimeParsing:
@@ -215,6 +262,13 @@ def test_build_logs_query_matches_current_dagster_runs_schema() -> None:
     assert "ExecutionStepSuccessEvent" in query
 
 
+def test_build_logs_query_expands_event_window_for_level_filters() -> None:
+    query = _build_logs_query({"limit": 20, "level": "ERROR"})
+
+    assert "runsOrError(limit: 20)" in query
+    assert "eventConnection(limit: 400)" in query
+
+
 def test_get_logs_parses_current_dagster_graphql_shape(monkeypatch) -> None:
     """GraphQL parser should read runsOrError.results[].eventConnection.events."""
     from phlo_dagster import cli_logs as logs_module
@@ -262,6 +316,35 @@ def test_get_logs_parses_current_dagster_graphql_shape(monkeypatch) -> None:
             "run_status": "SUCCESS",
         }
     ]
+
+
+def test_get_logs_prefers_postgres_for_level_filters(monkeypatch) -> None:
+    from phlo_dagster import cli_logs as logs_module
+
+    monkeypatch.setattr(
+        logs_module,
+        "_get_logs_from_postgres",
+        lambda _filters: [
+            {
+                "timestamp": "",
+                "level": "ERROR",
+                "message": "root cause",
+                "event_type": "STEP_FAILURE",
+                "run_id": "run-1",
+                "job_name": "__ASSET_JOB",
+                "run_status": "",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        logs_module.http_requests,
+        "post",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("skip GraphQL")),
+    )
+
+    result = _get_logs({"limit": 20, "level": "ERROR"})
+
+    assert result[0]["message"] == "root cause"
 
 
 def test_get_logs_from_postgres_uses_project_env(monkeypatch) -> None:
@@ -313,6 +396,73 @@ def test_get_logs_from_postgres_uses_project_env(monkeypatch) -> None:
         "user": "user",
         "password": "secret",
     }
+
+
+def test_get_logs_from_postgres_expands_level_filter_window(monkeypatch) -> None:
+    """ERROR lookups should not miss failures just outside the latest display limit."""
+    from phlo_dagster import cli_logs as logs_module
+
+    captured: dict[str, object] = {}
+
+    class FakeCursor:
+        def __enter__(self) -> "FakeCursor":
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def execute(self, _query, params) -> None:
+            captured["params"] = params
+
+        def fetchall(self) -> list[dict]:
+            return [
+                {
+                    "run_id": "run-1",
+                    "dagster_event_type": "STEP_SUCCESS",
+                    "timestamp": None,
+                    "event": "{}",
+                    "step_key": "dlt_events",
+                },
+                {
+                    "run_id": "run-1",
+                    "dagster_event_type": "STEP_FAILURE",
+                    "timestamp": None,
+                    "event": '{"level": 40, "user_message": "failed"}',
+                    "step_key": "dlt_events",
+                },
+            ]
+
+    class FakeConnection:
+        def __enter__(self) -> "FakeConnection":
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def cursor(self, *_args, **_kwargs) -> FakeCursor:
+            return FakeCursor()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        logs_module,
+        "_project_env",
+        lambda: {
+            "POSTGRES_HOST": "localhost",
+            "POSTGRES_PORT": "15432",
+            "POSTGRES_DB": "phlo",
+            "POSTGRES_USER": "phlo",
+            "POSTGRES_PASSWORD": "phlo",
+        },
+    )
+    monkeypatch.setattr(logs_module.psycopg2, "connect", lambda **_kwargs: FakeConnection())
+
+    result = _get_logs_from_postgres({"limit": 1, "level": "ERROR"})
+
+    assert captured["params"][-1] == 200
+    assert len(result) == 1
+    assert result[0]["level"] == "ERROR"
 
 
 class TestLogsPerformance:

--- a/packages/phlo-dagster/tests/test_cli_materialize.py
+++ b/packages/phlo-dagster/tests/test_cli_materialize.py
@@ -5,7 +5,64 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 
-from phlo_dagster.cli_materialize import materialize
+from phlo_dagster.cli_materialize import materialize, wait_for_dagster_runtime
+
+
+def test_materialize_help_is_user_facing() -> None:
+    result = CliRunner().invoke(materialize, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Materialize Dagster assets via Docker." in result.output
+    assert "Args:" not in result.output
+    assert "Returns:" not in result.output
+    assert "Raises:" not in result.output
+
+
+def test_wait_for_dagster_runtime_uses_ready_marker(monkeypatch) -> None:
+    calls = []
+
+    def fake_run(cmd, check, capture_output, text):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr("phlo_dagster.cli_materialize.subprocess.run", fake_run)
+
+    wait_for_dagster_runtime("dagster-1", timeout_seconds=0.1)
+
+    assert calls == [
+        [
+            "docker",
+            "exec",
+            "dagster-1",
+            "sh",
+            "-lc",
+            "test -f /tmp/phlo-dagster-ready "
+            "|| python -c 'import phlo_dagster.framework.definitions'",
+        ]
+    ]
+
+
+def test_wait_for_dagster_runtime_times_out(monkeypatch) -> None:
+    def fake_run(cmd, check, capture_output, text):
+        class Result:
+            returncode = 1
+
+        return Result()
+
+    monkeypatch.setattr("phlo_dagster.cli_materialize.subprocess.run", fake_run)
+    monkeypatch.setattr("phlo_dagster.cli_materialize.time.sleep", lambda seconds: None)
+
+    try:
+        wait_for_dagster_runtime("dagster-1", timeout_seconds=0)
+    except RuntimeError as exc:
+        assert "still finishing runtime setup" in str(exc)
+        assert "phlo services logs --tail 120 dagster" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError")
 
 
 @patch("phlo_dagster.cli_materialize.find_dagster_container", return_value="mock-container")
@@ -73,6 +130,7 @@ def test_materialize_failure_hides_raw_process_output(
         return FakeProcess()
 
     monkeypatch.setattr("phlo_dagster.cli_materialize.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("phlo_dagster.cli_materialize.wait_for_dagster_runtime", lambda _: None)
 
     result = CliRunner().invoke(materialize, ["dlt_orders"])
 
@@ -82,3 +140,20 @@ def test_materialize_failure_hides_raw_process_output(
     assert "Exit code: 2" in result.output
     assert "Last output: User-facing failure" in result.output
     assert "Run: phlo logs --level ERROR --limit 20" in result.output
+
+
+@patch(
+    "phlo_dagster.cli_materialize.find_dagster_container",
+    side_effect=RuntimeError("Could not find running dagster container"),
+)
+@patch("phlo_dagster.cli_materialize.get_project_name", return_value="mock-project")
+def test_materialize_missing_dagster_container_is_actionable(mock_project, mock_container) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(materialize, ["dlt_orders"])
+
+    assert result.exit_code != 0
+    assert "Traceback" not in result.output
+    assert "Error: dagster is not available" in result.output
+    assert "Make sure the dagster service is running." in result.output
+    assert "Run: phlo services start" in result.output

--- a/packages/phlo-dagster/tests/test_cli_materialize.py
+++ b/packages/phlo-dagster/tests/test_cli_materialize.py
@@ -8,11 +8,25 @@ from click.testing import CliRunner
 from phlo_dagster.cli_materialize import materialize, wait_for_dagster_runtime
 
 
+class FakePodmanBackend:
+    name = "podman"
+
+    def container_exec_cmd(self, *, container_name, command, env=None, workdir=None):
+        cmd = ["podman", "exec"]
+        for key, value in (env or {}).items():
+            cmd.extend(["-e", f"{key}={value}"])
+        if workdir:
+            cmd.extend(["-w", workdir])
+        cmd.append(container_name)
+        cmd.extend(command)
+        return cmd
+
+
 def test_materialize_help_is_user_facing() -> None:
     result = CliRunner().invoke(materialize, ["--help"])
 
     assert result.exit_code == 0
-    assert "Materialize Dagster assets via Docker." in result.output
+    assert "Materialize Dagster assets via the configured container backend." in result.output
     assert "Args:" not in result.output
     assert "Returns:" not in result.output
     assert "Raises:" not in result.output
@@ -44,6 +58,24 @@ def test_wait_for_dagster_runtime_uses_ready_marker(monkeypatch) -> None:
             "|| python -c 'import phlo_dagster.framework.definitions'",
         ]
     ]
+
+
+def test_wait_for_dagster_runtime_uses_selected_backend(monkeypatch) -> None:
+    calls = []
+
+    def fake_run(cmd, check, capture_output, text):
+        calls.append(cmd)
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setattr("phlo_dagster.cli_materialize.subprocess.run", fake_run)
+
+    wait_for_dagster_runtime("dagster-1", timeout_seconds=0.1, backend=FakePodmanBackend())
+
+    assert calls[0][:3] == ["podman", "exec", "dagster-1"]
 
 
 def test_wait_for_dagster_runtime_times_out(monkeypatch) -> None:
@@ -130,7 +162,10 @@ def test_materialize_failure_hides_raw_process_output(
         return FakeProcess()
 
     monkeypatch.setattr("phlo_dagster.cli_materialize.subprocess.Popen", fake_popen)
-    monkeypatch.setattr("phlo_dagster.cli_materialize.wait_for_dagster_runtime", lambda _: None)
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.wait_for_dagster_runtime",
+        lambda *args, **kwargs: None,
+    )
 
     result = CliRunner().invoke(materialize, ["dlt_orders"])
 
@@ -157,3 +192,22 @@ def test_materialize_missing_dagster_container_is_actionable(mock_project, mock_
     assert "Error: dagster is not available" in result.output
     assert "Make sure the dagster service is running." in result.output
     assert "Run: phlo services start" in result.output
+
+
+@patch("phlo_dagster.cli_materialize.find_dagster_container", return_value="mock-container")
+@patch("phlo_dagster.cli_materialize.get_project_name", return_value="mock-project")
+def test_materialize_dry_run_uses_configured_container_backend(
+    mock_project,
+    mock_container,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.select_project_container_backend",
+        lambda: FakePodmanBackend(),
+    )
+
+    result = CliRunner().invoke(materialize, ["dlt_orders", "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "podman exec" in result.output
+    assert "docker exec" not in result.output

--- a/packages/phlo-dbt/src/phlo_dbt/cli_plugin.py
+++ b/packages/phlo-dbt/src/phlo_dbt/cli_plugin.py
@@ -29,6 +29,7 @@ import click
 from phlo.cli.commands.services.utils import ensure_phlo_dir
 from phlo.cli.infrastructure.compose import compose_base_cmd
 from phlo.cli.infrastructure.utils import get_project_name
+from phlo.cli.output import user_error
 from phlo.logging import get_logger
 from phlo.plugins.base import CliCommandPlugin, PluginMetadata
 from phlo_dbt.cli_publishing import publishing
@@ -132,8 +133,12 @@ def _run_dbt_in_container(
     exec_service_name = _resolve_exec_service_name()
 
     if not (project_dir / "dbt_project.yml").exists():
-        click.echo(f"No dbt project found at {project_dir}", err=True)
-        sys.exit(1)
+        raise user_error(
+            "no dbt project found",
+            missing=project_dir / "dbt_project.yml",
+            details=["Create or copy a dbt project under workflows/transforms/dbt."],
+            run="phlo workflow create --help",
+        )
 
     phlo_dir = ensure_phlo_dir()
     compose_cmd = compose_base_cmd(phlo_dir=phlo_dir, project_name=get_project_name())
@@ -209,8 +214,12 @@ def _run_dbt_local(subcommand: str, target: str, select_expr: str | None = None)
     profiles_dir = settings.dbt_profiles_path
 
     if not (project_dir / "dbt_project.yml").exists():
-        click.echo(f"No dbt project found at {project_dir}", err=True)
-        sys.exit(1)
+        raise user_error(
+            "no dbt project found",
+            missing=project_dir / "dbt_project.yml",
+            details=["Create or copy a dbt project under workflows/transforms/dbt."],
+            run="phlo workflow create --help",
+        )
 
     ensure_dbt_profile(profiles_dir, target=target)
 

--- a/packages/phlo-dbt/tests/test_dbt_cli_plugin.py
+++ b/packages/phlo-dbt/tests/test_dbt_cli_plugin.py
@@ -141,6 +141,25 @@ def test_dbt_run_local_uses_host_dbt(monkeypatch, tmp_path) -> None:
     assert imported_manifests == [project_dir / "target" / "manifest.json"]
 
 
+def test_dbt_run_missing_project_is_actionable(monkeypatch, tmp_path) -> None:
+    project_dir = tmp_path / "workflows" / "transforms" / "dbt"
+    profiles_dir = project_dir / "profiles"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        dbt_settings,
+        "get_settings",
+        lambda: SimpleNamespace(dbt_project_path=project_dir, dbt_profiles_path=profiles_dir),
+    )
+
+    result = CliRunner().invoke(dbt_group, ["run", "--local"])
+
+    assert result.exit_code != 0
+    assert "Error: no dbt project found" in result.output
+    assert f"Missing: {project_dir / 'dbt_project.yml'}" in result.output
+    assert "Create or copy a dbt project under workflows/transforms/dbt." in result.output
+    assert "Run: phlo workflow create --help" in result.output
+
+
 def test_dbt_run_container_requires_exec_service(monkeypatch, tmp_path) -> None:
     project_dir = tmp_path / "workflows" / "transforms" / "dbt"
     profiles_dir = project_dir / "profiles"

--- a/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
+++ b/packages/phlo-dlt/src/phlo_dlt/cli_workflow.py
@@ -99,7 +99,8 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
     "--type",
     "workflow_type",
     type=click.Choice(["ingestion"]),
-    prompt="Workflow type",
+    default="ingestion",
+    show_default=True,
     help="Type of workflow to create (ingestion only)",
 )
 @click.option("--domain", prompt="Domain name", help="Domain name (e.g., weather, stripe, github)")
@@ -112,12 +113,11 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
 @click.option(
     "--cron",
     default="0 */1 * * *",
-    prompt="Cron schedule",
+    show_default=True,
     help="Cron schedule expression",
 )
 @click.option(
     "--api-base-url",
-    prompt="API base URL (optional)",
     default="",
     help="REST API base URL",
 )

--- a/packages/phlo-dlt/src/phlo_dlt/scaffold.py
+++ b/packages/phlo-dlt/src/phlo_dlt/scaffold.py
@@ -262,6 +262,8 @@ from pandera.typing import Series
 from {schema_base_module} import {schema_base_name}
 
 class {schema_class}({schema_base_name}):
+    """Raw {domain} {schema_class} records."""
+
 {schema_fields}
 
     class Config:
@@ -272,12 +274,15 @@ class {schema_class}({schema_base_name}):
 
 def _render_schema_class_block(
     *,
+    domain: str,
     schema_class: str,
     schema_base_name: str,
     schema_fields: str,
 ) -> str:
     """Render one schema class block for an existing schema module."""
     return f"""class {schema_class}({schema_base_name}):
+    \"\"\"Raw {domain} {schema_class} records.\"\"\"
+
 {schema_fields}
 
     class Config:
@@ -302,6 +307,16 @@ def _append_missing_imports(path: Path, import_lines: str) -> None:
             insert_at = index + 1
     lines.insert(insert_at, insertion)
     path.write_text("".join(lines))
+
+
+def _schema_runtime_imports(schema_base_module: str, schema_base_name: str) -> str:
+    """Return imports required by generated schema fields and base classes."""
+    return "\n".join(
+        [
+            "from pandera.typing import Series",
+            f"from {schema_base_module} import {schema_base_name}",
+        ]
+    )
 
 
 def _append_schema_class(path: Path, schema_class: str, class_block: str) -> None:
@@ -547,11 +562,13 @@ def create_ingestion_workflow(
     )
 
     if schema_file.exists():
-        _append_missing_imports(schema_file, type_imports)
+        schema_imports = _schema_runtime_imports(schema_base_module, schema_base_name)
+        _append_missing_imports(schema_file, f"{schema_imports}\n{type_imports}".strip())
         _append_schema_class(
             schema_file,
             schema_class,
             _render_schema_class_block(
+                domain=domain,
                 schema_class=schema_class,
                 schema_base_name=schema_base_name,
                 schema_fields=schema_fields,

--- a/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_validate.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 
 
 @click.command()
-@click.argument("schema_file", type=click.Path(exists=True))
+@click.argument("schema_file", type=click.Path(dir_okay=False))
 @click.option(
     "--check-constraints",
     is_flag=True,
@@ -65,10 +65,16 @@ def validate_schema(
         ```
 
     """
+    schema_path = Path(schema_file)
+    if not schema_path.exists():
+        raise click.ClickException(
+            f"Schema file not found: {schema_path}\n\nRun: phlo workflow create"
+        )
+
     console.print(f"\n[bold blue]🔍 Validating Schema[/bold blue]: {schema_file}\n")
 
     # Load the module
-    schema_module = _load_module_from_file(Path(schema_file))
+    schema_module = _load_module_from_file(schema_path)
     if schema_module is None:
         console.print("[red]✗ Failed to load schema file[/red]")
         raise click.Abort()

--- a/packages/phlo-pandera/src/phlo_pandera/plugin.py
+++ b/packages/phlo-pandera/src/phlo_pandera/plugin.py
@@ -228,6 +228,8 @@ from pandera.typing import Series
 from phlo_pandera.schemas import PhloSchema
 
 {type_imports}class {schema_class}(PhloSchema):
+    """Raw {domain} {schema_class} records."""
+
 {schema_fields}
 
     class Config:

--- a/packages/phlo-pandera/tests/test_cli_validate_schema.py
+++ b/packages/phlo-pandera/tests/test_cli_validate_schema.py
@@ -13,3 +13,13 @@ def test_validate_schema_rejects_files_without_schema_classes(tmp_path) -> None:
 
     assert result.exit_code != 0
     assert "No Pandera DataFrameModel classes found" in result.output
+
+
+def test_validate_schema_missing_file_is_actionable(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(validate_schema, ["workflows/schemas/missing.py"])
+
+    assert result.exit_code != 0
+    assert "Schema file not found: workflows/schemas/missing.py" in result.output
+    assert "Run: phlo workflow create" in result.output

--- a/packages/phlo-postgres/src/phlo_postgres/cli.py
+++ b/packages/phlo-postgres/src/phlo_postgres/cli.py
@@ -24,13 +24,18 @@ from subprocess import TimeoutExpired
 import click
 
 from phlo.cli.commands.services.utils import (
-    ensure_phlo_dir,
+    ensure_compose_project,
     require_container_backend as _require_selected_container_backend,
 )
 from phlo.cli.infrastructure.command import CommandError, run_command
 from phlo.cli.infrastructure.compose import compose_base_cmd
 from phlo.cli.infrastructure.utils import get_project_name
-from phlo.cli.output import empty_file_error, exclusive_options_error, file_read_error
+from phlo.cli.output import (
+    command_failed_error,
+    empty_file_error,
+    exclusive_options_error,
+    file_read_error,
+)
 from phlo.cli.output import missing_query_error
 from phlo_postgres.settings import get_settings
 
@@ -95,7 +100,7 @@ def _postgres_exec_base(*, tty: bool) -> list[str]:
         >>> # Returns: ['docker', 'compose', '-p', 'phlo', '-f', '...', 'exec', '-t', 'postgres']
 
     """
-    phlo_dir = ensure_phlo_dir()
+    phlo_dir = ensure_compose_project()
     project_name = get_project_name()
     cmd = compose_base_cmd(phlo_dir=phlo_dir, project_name=project_name)
     cmd.append("exec")
@@ -246,7 +251,12 @@ def postgres_query(
         )
     except CommandError as exc:
         stderr = exc.stderr.strip()
-        raise click.ClickException(stderr or str(exc)) from exc
+        raise command_failed_error(
+            "psql",
+            exit_code=exc.returncode,
+            details=[stderr] if stderr else ["PostgreSQL did not complete the query."],
+            run="phlo services status postgres",
+        ) from exc
     except TimeoutExpired as exc:
         raise click.ClickException(f"Query timed out after {timeout_seconds} seconds.") from exc
 
@@ -304,7 +314,12 @@ def postgres_dump(
         )
     except CommandError as exc:
         stderr = exc.stderr.strip()
-        raise click.ClickException(stderr or str(exc)) from exc
+        raise command_failed_error(
+            "pg_dump",
+            exit_code=exc.returncode,
+            details=[stderr] if stderr else ["PostgreSQL did not create the dump."],
+            run="phlo services status postgres",
+        ) from exc
     except TimeoutExpired as exc:
         raise click.ClickException(f"Dump timed out after {timeout_seconds} seconds.") from exc
 

--- a/packages/phlo-postgres/tests/test_postgres_cli.py
+++ b/packages/phlo-postgres/tests/test_postgres_cli.py
@@ -42,7 +42,9 @@ def test_postgres_query_runs_psql(monkeypatch) -> None:
         ]
         return CompletedProcess(cmd, 0, stdout="1\n", stderr="")
 
-    monkeypatch.setattr("phlo_postgres.cli.ensure_phlo_dir", lambda: Path("/tmp/project/.phlo"))
+    monkeypatch.setattr(
+        "phlo_postgres.cli.ensure_compose_project", lambda: Path("/tmp/project/.phlo")
+    )
     monkeypatch.setattr("phlo_postgres.cli.get_project_name", lambda: "demo")
     monkeypatch.setattr(
         "phlo_postgres.cli.compose_base_cmd",
@@ -56,6 +58,20 @@ def test_postgres_query_runs_psql(monkeypatch) -> None:
     assert result.output == "1\n"
 
 
+def test_postgres_query_requires_initialized_services(monkeypatch, tmp_path) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(postgres_group, ["query", "SELECT 1"])
+
+    assert result.exit_code != 0
+    assert "Error: Phlo services have not been initialized" in result.output
+    assert "Missing: .phlo/docker-compose.yml" in result.output
+    assert "Run: phlo services init" in result.output
+    assert "couldn't find env file" not in result.output
+
+
 def test_postgres_dump_writes_gzip_file(monkeypatch, tmp_path) -> None:
     output_file = tmp_path / "backup.sql.gz"
 
@@ -65,7 +81,9 @@ def test_postgres_dump_writes_gzip_file(monkeypatch, tmp_path) -> None:
         assert cmd[-4:] == ["pg_dump", "-U", "phlo", "phlo"]
         return CompletedProcess(cmd, 0, stdout="CREATE TABLE test ();", stderr="")
 
-    monkeypatch.setattr("phlo_postgres.cli.ensure_phlo_dir", lambda: Path("/tmp/project/.phlo"))
+    monkeypatch.setattr(
+        "phlo_postgres.cli.ensure_compose_project", lambda: Path("/tmp/project/.phlo")
+    )
     monkeypatch.setattr("phlo_postgres.cli.get_project_name", lambda: "demo")
     monkeypatch.setattr(
         "phlo_postgres.cli.compose_base_cmd",
@@ -86,7 +104,9 @@ def test_postgres_restore_reads_file(monkeypatch, tmp_path) -> None:
     input_file.write_text("SELECT 1;", encoding="utf-8")
     captured: list[tuple[list[str], str]] = []
 
-    monkeypatch.setattr("phlo_postgres.cli.ensure_phlo_dir", lambda: Path("/tmp/project/.phlo"))
+    monkeypatch.setattr(
+        "phlo_postgres.cli.ensure_compose_project", lambda: Path("/tmp/project/.phlo")
+    )
     monkeypatch.setattr("phlo_postgres.cli.get_project_name", lambda: "demo")
     monkeypatch.setattr(
         "phlo_postgres.cli.compose_base_cmd",
@@ -136,7 +156,9 @@ def test_postgres_vacuum_runs_vacuumdb(monkeypatch) -> None:
         assert cmd[-5:] == ["vacuumdb", "-U", "phlo", "-z", "phlo"]
         return CompletedProcess(cmd, 0, stdout="VACUUM\n", stderr="")
 
-    monkeypatch.setattr("phlo_postgres.cli.ensure_phlo_dir", lambda: Path("/tmp/project/.phlo"))
+    monkeypatch.setattr(
+        "phlo_postgres.cli.ensure_compose_project", lambda: Path("/tmp/project/.phlo")
+    )
     monkeypatch.setattr("phlo_postgres.cli.get_project_name", lambda: "demo")
     monkeypatch.setattr(
         "phlo_postgres.cli.compose_base_cmd",
@@ -153,7 +175,9 @@ def test_postgres_vacuum_runs_vacuumdb(monkeypatch) -> None:
 def test_postgres_shell_passthrough(monkeypatch) -> None:
     captured: list[list[str]] = []
 
-    monkeypatch.setattr("phlo_postgres.cli.ensure_phlo_dir", lambda: Path("/tmp/project/.phlo"))
+    monkeypatch.setattr(
+        "phlo_postgres.cli.ensure_compose_project", lambda: Path("/tmp/project/.phlo")
+    )
     monkeypatch.setattr("phlo_postgres.cli.get_project_name", lambda: "demo")
     monkeypatch.setattr(
         "phlo_postgres.cli.compose_base_cmd",
@@ -197,7 +221,9 @@ def test_postgres_query_timeout(monkeypatch) -> None:
             return CompletedProcess(cmd, 0, stdout="", stderr="")
         raise TimeoutExpired(cmd=cmd, timeout=30)
 
-    monkeypatch.setattr("phlo_postgres.cli.ensure_phlo_dir", lambda: Path("/tmp/project/.phlo"))
+    monkeypatch.setattr(
+        "phlo_postgres.cli.ensure_compose_project", lambda: Path("/tmp/project/.phlo")
+    )
     monkeypatch.setattr("phlo_postgres.cli.get_project_name", lambda: "demo")
     monkeypatch.setattr(
         "phlo_postgres.cli.compose_base_cmd",

--- a/packages/phlo-trino/src/phlo_trino/cli.py
+++ b/packages/phlo-trino/src/phlo_trino/cli.py
@@ -28,13 +28,18 @@ from subprocess import TimeoutExpired
 import click
 
 from phlo.cli.commands.services.utils import (
-    ensure_phlo_dir,
+    ensure_compose_project,
     require_container_backend as _require_selected_container_backend,
 )
 from phlo.cli.infrastructure.command import CommandError, run_command
 from phlo.cli.infrastructure.compose import compose_base_cmd
 from phlo.cli.infrastructure.utils import get_project_name
-from phlo.cli.output import empty_file_error, exclusive_options_error, file_read_error
+from phlo.cli.output import (
+    command_failed_error,
+    empty_file_error,
+    exclusive_options_error,
+    file_read_error,
+)
 from phlo.cli.output import missing_query_error
 
 
@@ -62,7 +67,7 @@ def _require_container_backend() -> None:
 
 def _trino_exec_base(*, tty: bool) -> list[str]:
     """Build the docker compose exec command for the Trino container."""
-    phlo_dir = ensure_phlo_dir()
+    phlo_dir = ensure_compose_project()
     project_name = get_project_name()
     cmd = compose_base_cmd(phlo_dir=phlo_dir, project_name=project_name)
     cmd.append("exec")
@@ -133,7 +138,12 @@ def trino_query(
         )
     except CommandError as exc:
         stderr = exc.stderr.strip()
-        raise click.ClickException(stderr or str(exc)) from exc
+        raise command_failed_error(
+            "trino",
+            exit_code=exc.returncode,
+            details=[stderr] if stderr else ["The Trino service did not complete the query."],
+            run="phlo services status trino",
+        ) from exc
     except TimeoutExpired as exc:
         raise click.ClickException(f"Query timed out after {timeout_seconds} seconds.") from exc
 

--- a/packages/phlo-trino/tests/test_trino_cli.py
+++ b/packages/phlo-trino/tests/test_trino_cli.py
@@ -139,6 +139,24 @@ def test_trino_query_rejects_missing_input(monkeypatch) -> None:
     assert 'Run: phlo trino query "SELECT 1"' in result.output
 
 
+def test_trino_query_requires_initialized_services(monkeypatch, tmp_path) -> None:
+    """Query command should hide raw compose errors before services are initialized."""
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setitem(
+        trino_query.callback.__globals__, "_require_container_backend", lambda: None
+    )
+
+    result = CliRunner().invoke(trino_group, ["query", "SELECT 1"])
+
+    assert result.exit_code != 0
+    assert "Error: Phlo services have not been initialized" in result.output
+    assert "Missing: .phlo/docker-compose.yml" in result.output
+    assert "Run: phlo services init" in result.output
+    assert "couldn't find env file" not in result.output
+
+
 def test_trino_query_surfaces_timeout(monkeypatch) -> None:
     """Query command should surface timeouts as click exceptions."""
 

--- a/src/phlo/cli/commands/services/exec.py
+++ b/src/phlo/cli/commands/services/exec.py
@@ -14,7 +14,11 @@ from phlo.logging import get_logger
 logger = get_logger(__name__)
 
 
-@click.command("exec", context_settings={"ignore_unknown_options": True})
+@click.command(
+    "exec",
+    context_settings={"ignore_unknown_options": True},
+    help="Run a command inside a running Phlo service container.",
+)
 @click.argument("service_name")
 @click.argument("command", nargs=-1, type=click.UNPROCESSED)
 @click.option("--tty/--no-tty", default=False, show_default=True, help="Allocate a TTY.")

--- a/src/phlo/cli/commands/services/list.py
+++ b/src/phlo/cli/commands/services/list.py
@@ -169,6 +169,25 @@ def list_cmd(show_all: bool, output_json: bool, backend_name: str | None):
         click.echo(json.dumps(payload, indent=2))
         return
 
+    # Separate services by type
+    package_services = [s for s in available_services.values() if not s.core]
+    visible_services = [
+        svc
+        for svc in sorted(package_services, key=lambda x: x.name)
+        if show_all
+        or not svc.profile
+        or svc.default
+        or svc.name in enabled_services
+        or svc.name in running_containers
+    ]
+    name_width = max(
+        [
+            18,
+            *(len(svc.name) for svc in visible_services),
+            *(len(name) for name in disabled_services),
+        ]
+    )
+
     # Helper to format service line
     def format_service_line(svc, custom_status=None):
         """Format a service line with status, ports, and description."""
@@ -198,29 +217,18 @@ def list_cmd(show_all: bool, output_json: bool, backend_name: str | None):
             suffix = custom_status
 
         # Format: "  ✓ service-name    Running    :3000   Description [extra]"
-        name_col = f"{svc.name:<18}"
+        name_col = f"{svc.name:<{name_width}}"
         status_col = f"{status:<10}"
         ports_col = f"{ports:<7}"
         desc_with_suffix = f"{svc.description} {suffix}".strip()
 
         return f"  {status_marker} {name_col} {status_col} {ports_col} {desc_with_suffix}"
 
-    # Separate services by type
-    package_services = [s for s in available_services.values() if not s.core]
-
     # Display package services
     if package_services or disabled_services:
         click.echo("\nPackage Services (installed):")
         displayed = set()
-        for svc in sorted(package_services, key=lambda x: x.name):
-            if (
-                not show_all
-                and svc.profile
-                and not svc.default
-                and svc.name not in enabled_services
-                and svc.name not in running_containers
-            ):
-                continue
+        for svc in visible_services:
             click.echo(format_service_line(svc))
             displayed.add(svc.name)
 

--- a/src/phlo/cli/commands/services/logs.py
+++ b/src/phlo/cli/commands/services/logs.py
@@ -11,7 +11,7 @@ from phlo.logging import get_logger
 logger = get_logger(__name__)
 
 
-@click.command("logs")
+@click.command("logs", help="View logs from Phlo infrastructure services.")
 @click.argument("service", required=False)
 @click.option("-f", "--follow", is_flag=True, help="Follow log output")
 @click.option("-n", "--tail", default=100, help="Number of lines to show")

--- a/src/phlo/cli/commands/services/restart.py
+++ b/src/phlo/cli/commands/services/restart.py
@@ -19,7 +19,7 @@ from phlo.logging import get_logger
 logger = get_logger(__name__)
 
 
-@click.command("restart")
+@click.command("restart", help="Restart Phlo infrastructure services.")
 @click.option("--build", is_flag=True, help="Build images before starting")
 @click.option(
     "--profile",
@@ -50,15 +50,15 @@ def restart_cmd(
     dev: bool,
     backend_name: str | None,
 ):
-    """Restart Phlo infrastructure services (stop + start).
+    """Restart Phlo infrastructure services.
 
     Combines stop and start in a single command for convenience.
 
     Examples:
-        phlo services restart                          # Restart all services
-        phlo services restart --profile observability  # Restart profile services only
-        phlo services restart --service postgres       # Restart specific service
-        phlo services restart --build                  # Rebuild before starting
+        phlo services restart
+        phlo services restart --profile observability
+        phlo services restart --service postgres
+        phlo services restart --build
     """
     require_container_backend(backend_name)
     if dev:

--- a/src/phlo/cli/commands/services/start.py
+++ b/src/phlo/cli/commands/services/start.py
@@ -282,7 +282,7 @@ def _preflight_required_env_vars(
     )
 
 
-@click.command("start")
+@click.command("start", help="Start Phlo infrastructure services.")
 @click.option(
     "-d",
     "--detach/--no-detach",
@@ -330,7 +330,7 @@ def start_cmd(
         phlo services start --build
         phlo services start --profile observability
         phlo services start --service postgres
-        phlo services start --native  # Run Observatory/phlo-api as subprocesses
+        phlo services start --native
     """
     phlo_dir = ensure_phlo_dir()
     compose_file = phlo_dir / "docker-compose.yml"

--- a/src/phlo/cli/commands/services/status.py
+++ b/src/phlo/cli/commands/services/status.py
@@ -3,7 +3,7 @@
 import click
 
 from phlo.cli.commands.services.common import run_compose
-from phlo.cli.commands.services.utils import ensure_phlo_dir, require_container_backend
+from phlo.cli.commands.services.utils import ensure_compose_project, require_container_backend
 from phlo.cli.infrastructure.compose import compose_base_cmd
 from phlo.cli.infrastructure.utils import get_project_name
 from phlo.logging import get_logger
@@ -26,7 +26,7 @@ def status_cmd(backend_name: str | None):
         phlo services status
     """
     require_container_backend(backend_name)
-    phlo_dir = ensure_phlo_dir()
+    phlo_dir = ensure_compose_project()
     project_name = get_project_name()
     logger.info(
         "services_status_requested",
@@ -39,9 +39,9 @@ def status_cmd(backend_name: str | None):
         project_name=project_name,
         backend_name=backend_name,
     )
-    cmd.extend(["ps", "--format", "table {{.Name}}\t{{.Status}}\t{{.Ports}}"])
+    cmd.extend(["ps", "--format", "table {{.Service}}\t{{.Status}}\t{{.Ports}}"])
 
-    result = run_compose(cmd, check=False, capture_output=False)
+    result = run_compose(cmd, check=False, capture_output=True)
     if result.returncode != 0:
         logger.warning(
             "services_status_failed",
@@ -49,4 +49,10 @@ def status_cmd(backend_name: str | None):
             returncode=result.returncode,
         )
         raise click.ClickException("No services running or error checking status.")
+    if result.stdout:
+        click.echo(result.stdout, nl=False)
+    lines = [line for line in (result.stdout or "").splitlines() if line.strip()]
+    if len(lines) <= 1:
+        click.echo("\nNo services are running.")
+        click.echo("Run: phlo services start")
     logger.info("services_status_succeeded", project_name=project_name)

--- a/src/phlo/cli/commands/services/stop.py
+++ b/src/phlo/cli/commands/services/stop.py
@@ -37,7 +37,7 @@ def _remaining_project_containers(project_name: str, backend_name: str | None) -
         return []
 
 
-@click.command("stop")
+@click.command("stop", help="Stop Phlo infrastructure services.")
 @click.option("-v", "--volumes", is_flag=True, help="Remove volumes (deletes data)")
 @click.option(
     "--native",

--- a/src/phlo/cli/commands/services/utils.py
+++ b/src/phlo/cli/commands/services/utils.py
@@ -15,7 +15,7 @@ import click
 
 from phlo.cli.infrastructure.command import run_command
 from phlo.cli.infrastructure.container_backend import select_project_container_backend
-from phlo.cli.output import missing_phlo_project_error
+from phlo.cli.output import missing_compose_file_error, missing_phlo_project_error, user_error
 from phlo.infrastructure.containers import resolve_container_name as _resolve_container_name
 from phlo.logging import get_logger
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
@@ -79,6 +79,23 @@ def ensure_phlo_dir() -> Path:
     if not phlo_dir.exists():
         raise missing_phlo_project_error()
 
+    return phlo_dir
+
+
+def ensure_compose_project() -> Path:
+    """Ensure generated service configuration exists before compose-backed commands run."""
+    phlo_dir = ensure_phlo_dir()
+    compose_file = phlo_dir / "docker-compose.yml"
+    env_file = phlo_dir / ".env"
+
+    if not compose_file.exists():
+        raise missing_compose_file_error(".phlo/docker-compose.yml")
+    if not env_file.exists():
+        raise user_error(
+            "Phlo services have not been initialized",
+            missing=".phlo/.env",
+            run="phlo services init",
+        )
     return phlo_dir
 
 

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -80,7 +80,8 @@ def _validate_schema_file(path: str) -> None:
     "--type",
     "workflow_type",
     type=click.Choice(["ingestion"]),
-    prompt="Workflow type",
+    default="ingestion",
+    show_default=True,
     help="Type of workflow to create (ingestion only)",
 )
 @click.option("--domain", prompt="Domain name", help="Domain name (e.g., weather, stripe, github)")
@@ -98,7 +99,6 @@ def _validate_schema_file(path: str) -> None:
 )
 @click.option(
     "--api-base-url",
-    prompt="API base URL (optional)",
     default="",
     help="REST API base URL",
 )
@@ -171,10 +171,17 @@ def create_workflow_cmd(
 
 
 @workflow_group.command("check")
-@click.argument("workflow_file", type=click.Path(exists=True, dir_okay=False))
+@click.argument("workflow_file", type=click.Path(dir_okay=False))
 def check_workflow_cmd(workflow_file: str) -> None:
     """Validate a workflow and its inferred schema before materialization."""
     workflow_path = Path(workflow_file)
+    if not workflow_path.exists():
+        raise user_error(
+            "workflow file not found",
+            missing=str(workflow_path),
+            run="phlo workflow create",
+        )
+
     schema_path = _infer_schema_path(workflow_path)
 
     _validate_workflow_file(str(workflow_path))

--- a/src/phlo/cli/infrastructure/container_backend.py
+++ b/src/phlo/cli/infrastructure/container_backend.py
@@ -38,6 +38,16 @@ class ContainerBackend(Protocol):
     def list_project_containers(self, project_name: str) -> list[ContainerInfo]:
         """Return containers for a compose project."""
 
+    def container_exec_cmd(
+        self,
+        *,
+        container_name: str,
+        command: list[str],
+        env: dict[str, str] | None = None,
+        workdir: str | None = None,
+    ) -> list[str]:
+        """Return command tokens for executing a process inside a running container."""
+
 
 def _compose_base_cmd(
     *,
@@ -195,6 +205,23 @@ class DockerBackend:
             )
         return containers
 
+    def container_exec_cmd(
+        self,
+        *,
+        container_name: str,
+        command: list[str],
+        env: dict[str, str] | None = None,
+        workdir: str | None = None,
+    ) -> list[str]:
+        cmd = ["docker", "exec"]
+        for key, value in (env or {}).items():
+            cmd.extend(["-e", f"{key}={value}"])
+        if workdir:
+            cmd.extend(["-w", workdir])
+        cmd.append(container_name)
+        cmd.extend(command)
+        return cmd
+
 
 class PodmanBackend:
     name = "podman"
@@ -283,6 +310,23 @@ class PodmanBackend:
             labels=labels,
             ports=_format_podman_ports(info.get("Ports")),
         )
+
+    def container_exec_cmd(
+        self,
+        *,
+        container_name: str,
+        command: list[str],
+        env: dict[str, str] | None = None,
+        workdir: str | None = None,
+    ) -> list[str]:
+        cmd = ["podman", "exec"]
+        for key, value in (env or {}).items():
+            cmd.extend(["-e", f"{key}={value}"])
+        if workdir:
+            cmd.extend(["-w", workdir])
+        cmd.append(container_name)
+        cmd.extend(command)
+        return cmd
 
 
 def select_container_backend(

--- a/src/phlo/cli/templates/builtin.py
+++ b/src/phlo/cli/templates/builtin.py
@@ -257,6 +257,9 @@ import pandera.pandas as pa
 
 
 class EventsSchema(pa.DataFrameModel):
+    '''CSV demo event records.'''
+
+    event_id: str
     id: int
     name: str
     value: int
@@ -268,15 +271,25 @@ class EventsSchema(pa.DataFrameModel):
 
 from pathlib import Path
 
+import dlt
 import pandas as pd
 import phlo
 
 from workflows.schemas.csv import EventsSchema
 
 
-@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="csv")
-def csv_events():
-    return pd.read_csv(Path("data/events.csv"))
+@phlo.ingestion(
+    table_name="events",
+    unique_key="event_id",
+    validation_schema=EventsSchema,
+    group="csv",
+    freshness_hours=(1, 24),
+)
+def csv_events(partition_date: str) -> object:
+    events = pd.read_csv(Path("data/events.csv"))
+    events["event_id"] = events["id"].astype(str) + "-" + partition_date
+    rows = events.to_dict(orient="records")
+    return dlt.resource(rows, name="events")
 """,
         )
 
@@ -309,6 +322,9 @@ import pandera.pandas as pa
 
 
 class EventsSchema(pa.DataFrameModel):
+    '''API demo event records.'''
+
+    event_id: str
     id: int
     name: str
 """,
@@ -319,13 +335,23 @@ class EventsSchema(pa.DataFrameModel):
 
 import pandas as pd
 import phlo
+import dlt
 
 from workflows.schemas.api import EventsSchema
 
 
-@phlo.ingestion(table_name="events", unique_key="id", validation_schema=EventsSchema, group="api")
-def api_events():
-    return pd.DataFrame([{"id": 1, "name": "sample"}])
+@phlo.ingestion(
+    table_name="events",
+    unique_key="event_id",
+    validation_schema=EventsSchema,
+    group="api",
+    freshness_hours=(1, 24),
+)
+def api_events(partition_date: str) -> object:
+    events = pd.DataFrame([{"id": 1, "name": "sample"}])
+    events["event_id"] = events["id"].astype(str) + "-" + partition_date
+    rows = events.to_dict(orient="records")
+    return dlt.resource(rows, name="events")
 """,
         )
 
@@ -400,6 +426,7 @@ class ObservabilityDemoTemplate:
 
 import logging
 
+import dlt
 import pandas as pd
 import phlo
 
@@ -410,12 +437,16 @@ logger = logging.getLogger(__name__)
 
 @phlo.ingestion(
     table_name="observability_events",
-    unique_key="id",
+    unique_key="event_id",
     validation_schema=EventsSchema,
     group="observability",
+    freshness_hours=(1, 24),
 )
-def observability_events():
+def observability_events(partition_date: str) -> object:
     logger.info("loading observability demo events")
-    return pd.DataFrame([{"id": 1, "name": "traceable", "value": 1}])
+    events = pd.DataFrame([{"id": 1, "name": "traceable", "value": 1}])
+    events["event_id"] = events["id"].astype(str) + "-" + partition_date
+    rows = events.to_dict(orient="records")
+    return dlt.resource(rows, name="observability_events")
 """,
         )

--- a/tests/test_cli_init_templates.py
+++ b/tests/test_cli_init_templates.py
@@ -105,8 +105,16 @@ def test_csv_batch_template_generates_runnable_files(tmp_path) -> None:
     workflow_text = workflow_file.read_text()
     assert "import phlo" in workflow_text
     assert "@phlo.ingestion(" in workflow_text
+    assert 'unique_key="event_id"' in workflow_text
+    assert 'events["event_id"]' in workflow_text
+    assert "freshness_hours=(1, 24)" in workflow_text
+    assert "partition_date: str" in workflow_text
+    assert "dlt.resource" in workflow_text
+    assert 'name="events"' in workflow_text
     assert "phlo_ingestion" not in workflow_text
-    assert (project_dir / "workflows" / "schemas" / "csv.py").exists()
+    schema_text = (project_dir / "workflows" / "schemas" / "csv.py").read_text()
+    assert "CSV demo event records." in schema_text
+    assert "event_id: str" in schema_text
     _assert_python_files_parse(project_dir)
     _assert_generated_module_imports(project_dir, "workflows.ingestion.csv.events")
 
@@ -161,7 +169,15 @@ def test_api_ingestion_template_generates_runnable_files(tmp_path) -> None:
 
     assert result.exit_code == 0, result.output
     assert (project_dir / "workflows" / "ingestion" / "api" / "events.py").exists()
-    assert (project_dir / "workflows" / "schemas" / "api.py").exists()
+    workflow_text = (project_dir / "workflows" / "ingestion" / "api" / "events.py").read_text()
+    schema_text = (project_dir / "workflows" / "schemas" / "api.py").read_text()
+    assert 'unique_key="event_id"' in workflow_text
+    assert 'events["event_id"]' in workflow_text
+    assert "freshness_hours=(1, 24)" in workflow_text
+    assert "partition_date: str" in workflow_text
+    assert "dlt.resource" in workflow_text
+    assert "API demo event records." in schema_text
+    assert "event_id: str" in schema_text
     _assert_python_files_parse(project_dir)
     _assert_generated_module_imports(project_dir, "workflows.ingestion.api.events")
 

--- a/tests/test_cli_services_help.py
+++ b/tests/test_cli_services_help.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from phlo.cli.commands.services.exec import exec_cmd
+from phlo.cli.commands.services.logs import logs_cmd
+from phlo.cli.commands.services.restart import restart_cmd
+from phlo.cli.commands.services.start import start_cmd
+from phlo.cli.commands.services.stop import stop_cmd
+
+
+def test_docker_lifecycle_help_is_user_facing() -> None:
+    commands = [start_cmd, stop_cmd, restart_cmd, logs_cmd, exec_cmd]
+
+    for command in commands:
+        result = CliRunner().invoke(command, ["--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "Examples:" not in result.output
+        assert "Args:" not in result.output
+        assert "Returns:" not in result.output

--- a/tests/test_cli_services_list.py
+++ b/tests/test_cli_services_list.py
@@ -197,3 +197,39 @@ def test_services_list_handles_backend_status_failures(
     result = CliRunner().invoke(list_module.list_cmd, ["--json"])
     assert result.exit_code == 0
     assert result.output.strip() == "[]"
+
+
+def test_services_list_aligns_long_service_names(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    from phlo.cli.commands.services import list as list_module
+
+    class ServiceFakeDiscovery(FakeDiscovery):
+        def discover(self) -> dict[str, ServiceDefinition]:
+            return {
+                "postgres": ServiceDefinition(
+                    name="postgres",
+                    description="Postgres",
+                    category="metadata",
+                ),
+                "postgres-volume-setup": ServiceDefinition(
+                    name="postgres-volume-setup",
+                    description="Volume setup",
+                    category="metadata",
+                ),
+            }
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(list_module, "ServiceDiscovery", ServiceFakeDiscovery)
+    monkeypatch.setattr(list_module, "get_project_name", lambda: "demo")
+    monkeypatch.setattr(
+        list_module,
+        "select_project_container_backend",
+        lambda **_kwargs: (_ for _ in ()).throw(ValueError("no backend")),
+    )
+
+    result = CliRunner().invoke(list_module.list_cmd, [])
+
+    assert result.exit_code == 0
+    lines = result.output.splitlines()
+    postgres_line = next(line for line in lines if " postgres " in line)
+    setup_line = next(line for line in lines if " postgres-volume-setup " in line)
+    assert postgres_line.index("Stopped") == setup_line.index("Stopped")

--- a/tests/test_cli_services_status.py
+++ b/tests/test_cli_services_status.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from subprocess import CompletedProcess
+
+from click.testing import CliRunner
+
+from phlo.cli.commands.services import status as status_module
+
+
+def test_services_status_empty_compose_output_has_next_step(monkeypatch, tmp_path) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(status_module, "require_container_backend", lambda _backend=None: None)
+    monkeypatch.setattr(status_module, "ensure_compose_project", lambda: phlo_dir)
+    monkeypatch.setattr(status_module, "get_project_name", lambda: "demo")
+    monkeypatch.setattr(
+        status_module,
+        "compose_base_cmd",
+        lambda **_kwargs: ["docker", "compose", "-p", "demo"],
+    )
+    monkeypatch.setattr(
+        status_module,
+        "run_compose",
+        lambda cmd, **_kwargs: CompletedProcess(cmd, 0, stdout="SERVICE   STATUS    PORTS\n"),
+    )
+
+    result = CliRunner().invoke(status_module.status_cmd)
+
+    assert result.exit_code == 0
+    assert "SERVICE   STATUS    PORTS" in result.output
+    assert "No services are running." in result.output
+    assert "Run: phlo services start" in result.output
+
+
+def test_services_status_uses_service_names(monkeypatch, tmp_path) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(status_module, "require_container_backend", lambda _backend=None: None)
+    monkeypatch.setattr(status_module, "ensure_compose_project", lambda: phlo_dir)
+    monkeypatch.setattr(status_module, "get_project_name", lambda: "demo")
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_compose_base_cmd(**_kwargs) -> list[str]:
+        return ["docker-compose", "-p", "demo"]
+
+    def fake_run_compose(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return CompletedProcess(
+            cmd,
+            0,
+            stdout="SERVICE    STATUS                    PORTS\npostgres   Up 1 second (healthy)    0.0.0.0:5432->5432/tcp\n",
+        )
+
+    monkeypatch.setattr(status_module, "compose_base_cmd", fake_compose_base_cmd)
+    monkeypatch.setattr(status_module, "run_compose", fake_run_compose)
+
+    result = CliRunner().invoke(status_module.status_cmd)
+
+    assert result.exit_code == 0
+    assert any("{{.Service}}" in part for part in captured["cmd"])
+    assert "postgres" in result.output
+    assert "demo-postgres-1" not in result.output
+
+
+def test_services_status_requires_initialized_project(monkeypatch, tmp_path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(status_module, "require_container_backend", lambda _backend=None: None)
+
+    result = CliRunner().invoke(status_module.status_cmd)
+
+    assert result.exit_code == 1
+    assert "Phlo services have not been initialized" in result.output
+    assert "Missing: .phlo/" in result.output
+    assert "Run: phlo services init" in result.output

--- a/tests/test_cli_workflow.py
+++ b/tests/test_cli_workflow.py
@@ -66,6 +66,44 @@ def test_workflow_create_uses_cron_default_noninteractively(monkeypatch) -> None
     assert calls["cron"] == "0 */1 * * *"
 
 
+def test_workflow_create_defaults_ingestion_noninteractively(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_create_ingestion_workflow(**kwargs):
+        calls.update(kwargs)
+        return [
+            "workflows/schemas/weather.py",
+            "workflows/ingestion/weather/observations.py",
+            "tests/test_weather_observations.py",
+        ]
+
+    monkeypatch.setattr(
+        "phlo_dlt.scaffold.create_ingestion_workflow",
+        fake_create_ingestion_workflow,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "workflow",
+            "create",
+            "--domain",
+            "weather",
+            "--table",
+            "observations",
+            "--unique-key",
+            "station_id",
+            "--field",
+            "station_id:str",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["domain"] == "weather"
+    assert calls["api_base_url"] is None
+    assert "Workflow type" not in result.output
+
+
 def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
     """Passes CLI options to ingestion scaffold creation."""
     calls = {}
@@ -313,6 +351,20 @@ def test_workflow_check_delegates_to_existing_validators(monkeypatch, tmp_path) 
     assert ("workflow", str(workflow_file)) in calls
     assert ("schema", str(schema_file)) in calls
     assert "phlo materialize dlt_observations" in result.output
+
+
+def test_workflow_check_missing_file_is_actionable(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    result = CliRunner().invoke(
+        cli,
+        ["workflow", "check", "workflows/ingestion/weather/missing.py"],
+    )
+
+    assert result.exit_code == 1
+    assert "Error: workflow file not found" in result.output
+    assert "Missing: workflows/ingestion/weather/missing.py" in result.output
+    assert "Run: phlo workflow create" in result.output
 
 
 def test_workflow_check_rejects_files_without_ingestion_workflow(tmp_path, monkeypatch) -> None:

--- a/tests/test_container_backend.py
+++ b/tests/test_container_backend.py
@@ -74,6 +74,28 @@ def test_docker_backend_compose_base_cmd_supports_standalone_compose(
     ]
 
 
+def test_docker_backend_container_exec_cmd_builds_docker_exec() -> None:
+    cmd = DockerBackend().container_exec_cmd(
+        container_name="demo-dagster-1",
+        env={"PHLO_PROJECT_PATH": "/app"},
+        workdir="/app",
+        command=["dagster", "asset", "materialize"],
+    )
+
+    assert cmd == [
+        "docker",
+        "exec",
+        "-e",
+        "PHLO_PROJECT_PATH=/app",
+        "-w",
+        "/app",
+        "demo-dagster-1",
+        "dagster",
+        "asset",
+        "materialize",
+    ]
+
+
 def test_podman_backend_compose_base_cmd_uses_podman(tmp_path: Path) -> None:
     phlo_dir = tmp_path / ".phlo"
     phlo_dir.mkdir()
@@ -87,6 +109,28 @@ def test_podman_backend_compose_base_cmd_uses_podman(tmp_path: Path) -> None:
 
     assert cmd[:2] == ["podman", "compose"]
     assert str(phlo_dir / "docker-compose.yml") in cmd
+
+
+def test_podman_backend_container_exec_cmd_builds_podman_exec() -> None:
+    cmd = PodmanBackend().container_exec_cmd(
+        container_name="demo_dagster_1",
+        env={"PHLO_PROJECT_PATH": "/app"},
+        workdir="/app",
+        command=["dagster", "asset", "materialize"],
+    )
+
+    assert cmd == [
+        "podman",
+        "exec",
+        "-e",
+        "PHLO_PROJECT_PATH=/app",
+        "-w",
+        "/app",
+        "demo_dagster_1",
+        "dagster",
+        "asset",
+        "materialize",
+    ]
 
 
 def test_podman_backend_lists_containers_with_podman_compose_labels(

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -238,6 +238,43 @@ def test_scaffold_appends_schema_class_for_existing_domain(
     assert "class RawCustomers(PhloSchema):" in schema_text
 
 
+def test_scaffold_appends_required_imports_to_existing_template_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Generated workflows remain importable when init templates already created a schema."""
+    monkeypatch.setattr(
+        scaffold_module,
+        "_resolve_schema_base_import",
+        lambda: ("phlo_pandera.schemas", "PhloSchema"),
+    )
+    monkeypatch.chdir(tmp_path)
+    schema_dir = tmp_path / "workflows" / "schemas"
+    schema_dir.mkdir(parents=True)
+    (tmp_path / "workflows" / "ingestion").mkdir(parents=True)
+    schema_file = schema_dir / "api.py"
+    schema_file.write_text(
+        "from __future__ import annotations\n\n"
+        "import pandera.pandas as pa\n\n\n"
+        "class EventsSchema(pa.DataFrameModel):\n"
+        "    id: int\n"
+    )
+
+    create_ingestion_workflow(
+        domain="api",
+        table_name="purchases",
+        unique_key="id",
+        api_base_url="https://example.test/api",
+        fields=["id:int", "amount:float", "customer_id:str"],
+    )
+
+    schema_text = schema_file.read_text()
+    assert "from pandera.typing import Series" in schema_text
+    assert "from phlo_pandera.schemas import PhloSchema" in schema_text
+    assert "class RawPurchases(PhloSchema):" in schema_text
+    assert '"""Raw api RawPurchases records."""' in schema_text
+
+
 def test_scaffold_uses_normalized_table_identifier(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- polish user-facing CLI errors/output across services, workflow checks, dbt, Trino, Postgres, materialize, backfill, and logs
- keep structured logging behind the scenes while surfacing concise actionable terminal feedback
- add Dagster runtime readiness checks so `materialize` and `backfill` do not race dev-mode package installation
- make generated CSV/API/observability templates materialize partitioned sample data correctly with partition-aware event keys
- preserve maintainer docstrings while using explicit Click help text for clean terminal help

## Real usage exercised

Used local packages via `uv run --project /Users/garethprice/Developer/phlo phlo ...` in unique projects under `/Users/garethprice/Developer/phlo-tests/`.

- generated and checked `csv-batch` and `api-ingestion` projects
- initialized Docker services and started Dagster/Postgres dependency stacks
- materialized `dlt_events` partitions through Docker-backed Dagster
- ran backfills for multiple partitions
- queried Iceberg data through Trino to verify rows landed per partition
- inspected MinIO object storage for Iceberg parquet/metadata files
- reran an existing partition to verify idempotent merge behavior

## Verification

- `uv run ruff check .`
- `bash -n packages/phlo-dagster/src/phlo_dagster/entrypoint.sh`
- `uv run pytest -q` (`2226 passed, 2 skipped, 448 deselected`)
- focused post-format check: `uv run pytest packages/phlo-postgres/tests/test_postgres_cli.py packages/phlo-trino/tests/test_trino_cli.py tests/test_cli_init_templates.py tests/test_cli_services_list.py -q`
