### PR TITLE
chore(release): phlo 0.8.3 + 21 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## [phlo 0.8.3 + 21 packages] - 2026-05-05
+
+### Fixed
+- phlo: harden service lifecycle and plugin boundaries (#484)
+- phlo: polish CLI output and structured logging (#486)
+- phlo: polish CLI feedback and runtime readiness (#487)
+- phlo: harden docker-backed service fixes (#492)
+- phlo-api: harden service lifecycle and plugin boundaries (#484)
+- phlo-api: harden docker-backed service fixes (#492)
+- phlo-clickhouse: polish CLI output and structured logging (#486)
+- phlo-clickstack: harden service lifecycle and plugin boundaries (#484)
+- phlo-clickstack: polish CLI output and structured logging (#486)
+- phlo-clickstack: harden docker-backed service fixes (#492)
+- phlo-dagster: harden service lifecycle and plugin boundaries (#484)
+- phlo-dagster: polish CLI output and structured logging (#486)
+- phlo-dagster: polish CLI feedback and runtime readiness (#487)
+- phlo-dbt: polish CLI output and structured logging (#486)
+- phlo-dbt: polish CLI feedback and runtime readiness (#487)
+- phlo-dlt: harden service lifecycle and plugin boundaries (#484)
+- phlo-dlt: polish CLI output and structured logging (#486)
+- phlo-dlt: polish CLI feedback and runtime readiness (#487)
+- phlo-grafana: harden service lifecycle and plugin boundaries (#484)
+- phlo-hasura: harden service lifecycle and plugin boundaries (#484)
+- phlo-hasura: polish CLI output and structured logging (#486)
+- phlo-lineage: polish CLI output and structured logging (#486)
+- phlo-loki: harden service lifecycle and plugin boundaries (#484)
+- phlo-minio: harden service lifecycle and plugin boundaries (#484)
+- phlo-minio: polish CLI output and structured logging (#486)
+- phlo-nessie: harden service lifecycle and plugin boundaries (#484)
+- phlo-nessie: polish CLI output and structured logging (#486)
+- phlo-observatory: harden service lifecycle and plugin boundaries (#484)
+- phlo-observatory: harden docker-backed service fixes (#492)
+- phlo-openmetadata: polish CLI output and structured logging (#486)
+- phlo-pandera: harden service lifecycle and plugin boundaries (#484)
+- phlo-pandera: polish CLI output and structured logging (#486)
+- phlo-pandera: polish CLI feedback and runtime readiness (#487)
+- phlo-postgres: polish CLI output and structured logging (#486)
+- phlo-postgres: polish CLI feedback and runtime readiness (#487)
+- phlo-postgrest: harden service lifecycle and plugin boundaries (#484)
+- phlo-postgrest: polish CLI output and structured logging (#486)
+- phlo-postgrest: harden docker-backed service fixes (#492)
+- phlo-prometheus: harden service lifecycle and plugin boundaries (#484)
+- phlo-sling: polish CLI output and structured logging (#486)
+- phlo-superset: harden service lifecycle and plugin boundaries (#484)
+- phlo-trino: harden service lifecycle and plugin boundaries (#484)
+- phlo-trino: polish CLI output and structured logging (#486)
+- phlo-trino: polish CLI feedback and runtime readiness (#487)
+
+### Contributors
+Thanks to our contributors for this release:
+- @iamgp (48 commits)
+
 ## [phlo 0.8.2 + 7 packages] - 2026-05-03
 
 ### Fixed

--- a/packages/phlo-api/pyproject.toml
+++ b/packages/phlo-api/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 description = "Phlo API - Backend service exposing Phlo internals to Observatory"
 name = "phlo-api"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-clickhouse/pyproject.toml
+++ b/packages/phlo-clickhouse/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "ClickHouse service and resource plugin for Phlo"
 name = "phlo-clickhouse"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-clickstack/pyproject.toml
+++ b/packages/phlo-clickstack/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "clickstack service plugin for Phlo"
 name = "phlo-clickstack"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/pyproject.toml
+++ b/packages/phlo-dagster/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Dagster service plugin for Phlo"
 name = "phlo-dagster"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.3.3"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/src/phlo_dagster/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "authorize_daemon_run",
     "create_daemon_principal",
 ]
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/packages/phlo-dbt/pyproject.toml
+++ b/packages/phlo-dbt/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "dbt integration capability plugin for Phlo"
 name = "phlo-dbt"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dlt/pyproject.toml
+++ b/packages/phlo-dlt/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 description = "DLT ingestion engine capability plugin for Phlo"
 name = "phlo-dlt"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.3.3"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-grafana/pyproject.toml
+++ b/packages/phlo-grafana/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "grafana service plugin for Phlo"
 name = "phlo-grafana"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-hasura/pyproject.toml
+++ b/packages/phlo-hasura/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "hasura service plugin for Phlo"
 name = "phlo-hasura"
 requires-python = ">=3.11"
-version = "0.2.5"
+version = "0.2.6"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-lineage/pyproject.toml
+++ b/packages/phlo-lineage/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Lineage tracking and visualization for Phlo"
 name = "phlo-lineage"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.3.3"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-loki/pyproject.toml
+++ b/packages/phlo-loki/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "loki service plugin for Phlo"
 name = "phlo-loki"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-minio/pyproject.toml
+++ b/packages/phlo-minio/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "MinIO service plugin for Phlo"
 name = "phlo-minio"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.3.3"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-nessie/pyproject.toml
+++ b/packages/phlo-nessie/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Nessie service plugin for Phlo"
 name = "phlo-nessie"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.3.3"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/pyproject.toml
+++ b/packages/phlo-observatory/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["phlo>=0.1.0"]
 description = "Phlo Observatory - Data platform UI (bundled with phlo core)"
 name = "phlo-observatory"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/src/phlo_observatory/__init__.py
+++ b/packages/phlo-observatory/src/phlo_observatory/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "get_settings",
     "get_settings_service",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/packages/phlo-openmetadata/pyproject.toml
+++ b/packages/phlo-openmetadata/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "OpenMetadata integration for Phlo"
 name = "phlo-openmetadata"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-pandera/pyproject.toml
+++ b/packages/phlo-pandera/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Quality checks and schema utilities for Phlo"
 name = "phlo-pandera"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.3.3"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-postgres/pyproject.toml
+++ b/packages/phlo-postgres/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Postgres service plugin for Phlo"
 name = "phlo-postgres"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-postgres/src/phlo_postgres/__init__.py
+++ b/packages/phlo-postgres/src/phlo_postgres/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "PostgresSettings",
     "get_settings",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/packages/phlo-postgrest/pyproject.toml
+++ b/packages/phlo-postgrest/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "postgrest service plugin for Phlo"
 name = "phlo-postgrest"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.2.5"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-prometheus/pyproject.toml
+++ b/packages/phlo-prometheus/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "prometheus service plugin for Phlo"
 name = "phlo-prometheus"
 requires-python = ">=3.11"
-version = "0.2.3"
+version = "0.2.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-sling/pyproject.toml
+++ b/packages/phlo-sling/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Sling replication ingestion provider for Phlo"
 name = "phlo-sling"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-superset/pyproject.toml
+++ b/packages/phlo-superset/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "superset service plugin for Phlo"
 name = "phlo-superset"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.2.5"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/pyproject.toml
+++ b/packages/phlo-trino/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Trino service plugin for Phlo"
 name = "phlo-trino"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.3.1"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/src/phlo_trino/__init__.py
+++ b/packages/phlo-trino/src/phlo_trino/__init__.py
@@ -32,4 +32,4 @@ __all__ = [
     "TrinoSettings",
     "get_settings",
 ]
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.8.2"
+version = "0.8.3"
 
 [project.entry-points."phlo.plugins.quality"]
 
@@ -289,13 +289,13 @@ workspace = true
 [tool.uv.sources.phlo-nessie]
 workspace = true
 
+[tool.uv.sources.phlo-oauth2-proxy]
+workspace = true
+
 [tool.uv.sources.phlo-observatory]
 workspace = true
 
 [tool.uv.sources.phlo-observatory-example]
-workspace = true
-
-[tool.uv.sources.phlo-oauth2-proxy]
 workspace = true
 
 [tool.uv.sources.phlo-openmetadata]

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -307,4 +307,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"

--- a/uv.lock
+++ b/uv.lock
@@ -2982,7 +2982,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3222,7 +3222,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-api"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-api" }
 dependencies = [
     { name = "anyio" },
@@ -3262,7 +3262,7 @@ provides-extras = ["dev", "lineage"]
 
 [[package]]
 name = "phlo-clickhouse"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-clickhouse" }
 dependencies = [
     { name = "clickhouse-connect" },
@@ -3298,7 +3298,7 @@ provides-extras = ["dbt", "dev"]
 
 [[package]]
 name = "phlo-clickstack"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-clickstack" }
 dependencies = [
     { name = "phlo" },
@@ -3352,7 +3352,7 @@ provides-extras = ["dev", "quality"]
 
 [[package]]
 name = "phlo-dagster"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "packages/phlo-dagster" }
 dependencies = [
     { name = "dagster-graphql" },
@@ -3398,7 +3398,7 @@ provides-extras = ["alerting", "dev", "iceberg", "nessie", "observatory"]
 
 [[package]]
 name = "phlo-dbt"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-dbt" }
 dependencies = [
     { name = "dbt-core" },
@@ -3466,7 +3466,7 @@ provides-extras = ["dev", "minio"]
 
 [[package]]
 name = "phlo-dlt"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "packages/phlo-dlt" }
 dependencies = [
     { name = "dlt" },
@@ -3498,7 +3498,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-grafana"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-grafana" }
 dependencies = [
     { name = "phlo" },
@@ -3522,7 +3522,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-hasura"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "packages/phlo-hasura" }
 dependencies = [
     { name = "phlo" },
@@ -3586,7 +3586,7 @@ provides-extras = ["dev", "minio", "nessie"]
 
 [[package]]
 name = "phlo-lineage"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "packages/phlo-lineage" }
 dependencies = [
     { name = "click" },
@@ -3620,7 +3620,7 @@ provides-extras = ["dev", "observatory"]
 
 [[package]]
 name = "phlo-loki"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-loki" }
 dependencies = [
     { name = "phlo" },
@@ -3678,7 +3678,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-minio"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "packages/phlo-minio" }
 dependencies = [
     { name = "phlo" },
@@ -3702,7 +3702,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-nessie"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "packages/phlo-nessie" }
 dependencies = [
     { name = "marshmallow" },
@@ -3768,7 +3768,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-observatory"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-observatory" }
 dependencies = [
     { name = "phlo" },
@@ -3809,7 +3809,7 @@ requires-dist = [
 
 [[package]]
 name = "phlo-openmetadata"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-openmetadata" }
 dependencies = [
     { name = "phlo" },
@@ -3885,7 +3885,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-pandera"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "packages/phlo-pandera" }
 dependencies = [
     { name = "click" },
@@ -3943,7 +3943,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-postgres"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-postgres" }
 dependencies = [
     { name = "phlo" },
@@ -3969,7 +3969,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-postgrest"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "packages/phlo-postgrest" }
 dependencies = [
     { name = "phlo" },
@@ -4003,7 +4003,7 @@ provides-extras = ["dbt", "dev", "postgres"]
 
 [[package]]
 name = "phlo-prometheus"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "packages/phlo-prometheus" }
 dependencies = [
     { name = "phlo" },
@@ -4051,7 +4051,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-sling"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-sling" }
 dependencies = [
     { name = "phlo" },
@@ -4077,7 +4077,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-superset"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "packages/phlo-superset" }
 dependencies = [
     { name = "phlo" },
@@ -4169,7 +4169,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-trino"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/phlo-trino" }
 dependencies = [
     { name = "phlo" },


### PR DESCRIPTION
## Release summary

## [phlo 0.8.3 + 21 packages] - 2026-05-05

### Fixed
- phlo: harden service lifecycle and plugin boundaries (#484)
- phlo: polish CLI output and structured logging (#486)
- phlo: polish CLI feedback and runtime readiness (#487)
- phlo: harden docker-backed service fixes (#492)
- phlo-api: harden service lifecycle and plugin boundaries (#484)
- phlo-api: harden docker-backed service fixes (#492)
- phlo-clickhouse: polish CLI output and structured logging (#486)
- phlo-clickstack: harden service lifecycle and plugin boundaries (#484)
- phlo-clickstack: polish CLI output and structured logging (#486)
- phlo-clickstack: harden docker-backed service fixes (#492)
- phlo-dagster: harden service lifecycle and plugin boundaries (#484)
- phlo-dagster: polish CLI output and structured logging (#486)
- phlo-dagster: polish CLI feedback and runtime readiness (#487)
- phlo-dbt: polish CLI output and structured logging (#486)
- phlo-dbt: polish CLI feedback and runtime readiness (#487)
- phlo-dlt: harden service lifecycle and plugin boundaries (#484)
- phlo-dlt: polish CLI output and structured logging (#486)
- phlo-dlt: polish CLI feedback and runtime readiness (#487)
- phlo-grafana: harden service lifecycle and plugin boundaries (#484)
- phlo-hasura: harden service lifecycle and plugin boundaries (#484)
- phlo-hasura: polish CLI output and structured logging (#486)
- phlo-lineage: polish CLI output and structured logging (#486)
- phlo-loki: harden service lifecycle and plugin boundaries (#484)
- phlo-minio: harden service lifecycle and plugin boundaries (#484)
- phlo-minio: polish CLI output and structured logging (#486)
- phlo-nessie: harden service lifecycle and plugin boundaries (#484)
- phlo-nessie: polish CLI output and structured logging (#486)
- phlo-observatory: harden service lifecycle and plugin boundaries (#484)
- phlo-observatory: harden docker-backed service fixes (#492)
- phlo-openmetadata: polish CLI output and structured logging (#486)
- phlo-pandera: harden service lifecycle and plugin boundaries (#484)
- phlo-pandera: polish CLI output and structured logging (#486)
- phlo-pandera: polish CLI feedback and runtime readiness (#487)
- phlo-postgres: polish CLI output and structured logging (#486)
- phlo-postgres: polish CLI feedback and runtime readiness (#487)
- phlo-postgrest: harden service lifecycle and plugin boundaries (#484)
- phlo-postgrest: polish CLI output and structured logging (#486)
- phlo-postgrest: harden docker-backed service fixes (#492)
- phlo-prometheus: harden service lifecycle and plugin boundaries (#484)
- phlo-sling: polish CLI output and structured logging (#486)
- phlo-superset: harden service lifecycle and plugin boundaries (#484)
- phlo-trino: harden service lifecycle and plugin boundaries (#484)
- phlo-trino: polish CLI output and structured logging (#486)
- phlo-trino: polish CLI feedback and runtime readiness (#487)

### Contributors
Thanks to our contributors for this release:
- @iamgp (48 commits)

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release