### PR TITLE
refactor: deepen services lifecycle planning

### DIFF
--- a/src/phlo/cli/commands/services/init.py
+++ b/src/phlo/cli/commands/services/init.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import click
 import yaml
 
+from phlo.cli.commands.services.planner import build_service_selection_plan
 from phlo.cli.commands.services.utils import (
     PHLO_CONFIG_FILE,
     PHLO_CONFIG_TEMPLATE,
@@ -213,13 +214,6 @@ def init_cmd(
     user_overrides = existing_config.get("services", {})
     env_overrides = _get_env_overrides(existing_config)
 
-    # Collect disabled services (those with enabled: false)
-    disabled_services = {
-        name
-        for name, cfg in user_overrides.items()
-        if isinstance(cfg, dict) and cfg.get("enabled") is False
-    }
-
     # Collect inline custom services (those with type: inline)
     inline_services = [
         ServiceDefinition.from_inline(name, cfg)
@@ -227,11 +221,9 @@ def init_cmd(
         if isinstance(cfg, dict) and cfg.get("type") == "inline"
     ]
 
-    # Get default services (excluding disabled) + requested profile services + inline services
-    default_services = discovery.get_default_services(disabled_services=disabled_services)
-    requested_profiles = {profile.strip() for profile in profiles if profile.strip()}
+    requested_profiles = tuple(dict.fromkeys(profile.strip() for profile in profiles if profile.strip()))
     available_profiles = discovery.get_available_profiles()
-    unknown_profiles = sorted(requested_profiles - available_profiles)
+    unknown_profiles = sorted(set(requested_profiles) - available_profiles)
     if unknown_profiles:
         click.echo(
             f"Error: Unknown profile(s): {', '.join(unknown_profiles)}. "
@@ -240,18 +232,14 @@ def init_cmd(
         )
         sys.exit(1)
 
-    profile_services = []
-    for profile in sorted(requested_profiles):
-        profile_services.extend(
-            [
-                service
-                for service in discovery.get_services_by_profile(profile)
-                if service.name not in disabled_services
-            ]
-        )
-
+    selection_plan = build_service_selection_plan(
+        services=all_services,
+        config=existing_config,
+        profiles=requested_profiles,
+        requested_names=[],
+    )
     deduped_services: dict[str, ServiceDefinition] = {}
-    for service in [*default_services, *profile_services, *inline_services]:
+    for service in [*selection_plan.selected_services, *inline_services]:
         deduped_services[service.name] = service
     services_to_install = _expand_selected_services(discovery, list(deduped_services.values()))
     _warn_secret_env_overrides(env_overrides, services_to_install)
@@ -305,6 +293,7 @@ def init_cmd(
     click.echo("Phlo infrastructure initialized.")
     click.echo("")
 
+    default_services = discovery.get_default_services(disabled_services=selection_plan.disabled_names)
     default_names = sorted([s.name for s in default_services])
     click.echo(f"Default services: {', '.join(default_names)}")
 

--- a/src/phlo/cli/commands/services/init.py
+++ b/src/phlo/cli/commands/services/init.py
@@ -221,7 +221,9 @@ def init_cmd(
         if isinstance(cfg, dict) and cfg.get("type") == "inline"
     ]
 
-    requested_profiles = tuple(dict.fromkeys(profile.strip() for profile in profiles if profile.strip()))
+    requested_profiles = tuple(
+        dict.fromkeys(profile.strip() for profile in profiles if profile.strip())
+    )
     available_profiles = discovery.get_available_profiles()
     unknown_profiles = sorted(set(requested_profiles) - available_profiles)
     if unknown_profiles:
@@ -293,7 +295,9 @@ def init_cmd(
     click.echo("Phlo infrastructure initialized.")
     click.echo("")
 
-    default_services = discovery.get_default_services(disabled_services=selection_plan.disabled_names)
+    default_services = discovery.get_default_services(
+        disabled_services=selection_plan.disabled_names
+    )
     default_names = sorted([s.name for s in default_services])
     click.echo(f"Default services: {', '.join(default_names)}")
 

--- a/src/phlo/cli/commands/services/init.py
+++ b/src/phlo/cli/commands/services/init.py
@@ -296,7 +296,7 @@ def init_cmd(
     click.echo("")
 
     default_services = discovery.get_default_services(
-        disabled_services=selection_plan.disabled_names
+        disabled_services=set(selection_plan.disabled_names)
     )
     default_names = sorted([s.name for s in default_services])
     click.echo(f"Default services: {', '.join(default_names)}")

--- a/src/phlo/cli/commands/services/planner.py
+++ b/src/phlo/cli/commands/services/planner.py
@@ -1,0 +1,56 @@
+"""Planning helpers for services lifecycle commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from phlo.cli.commands.services.utils import get_enabled_disabled_service_names
+from phlo.plugins.discovery import ServiceDefinition
+from phlo.utils import dedupe_preserve_order
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceSelectionPlan:
+    """Selected services for a services command."""
+
+    selected_services: list[ServiceDefinition]
+    disabled_names: set[str] = field(default_factory=set)
+    requested_names: list[str] = field(default_factory=list)
+    profiles: tuple[str, ...] = ()
+
+
+def build_service_selection_plan(
+    *,
+    services: dict[str, ServiceDefinition],
+    config: dict,
+    profiles: tuple[str, ...],
+    requested_names: list[str],
+) -> ServiceSelectionPlan:
+    enabled_names, disabled_names = get_enabled_disabled_service_names(config)
+    selected_names: list[str] = []
+    if requested_names:
+        selected_names.extend(requested_names)
+    else:
+        selected_names.extend(
+            service.name
+            for service in services.values()
+            if service.default and service.name not in disabled_names
+        )
+        selected_names.extend(
+            service.name
+            for service in services.values()
+            if service.profile in profiles and service.name not in disabled_names
+        )
+        selected_names.extend(name for name in enabled_names if name in services)
+
+    selected = [
+        services[name]
+        for name in dedupe_preserve_order(selected_names)
+        if name in services and name not in disabled_names
+    ]
+    return ServiceSelectionPlan(
+        selected_services=selected,
+        disabled_names=disabled_names,
+        requested_names=requested_names,
+        profiles=profiles,
+    )

--- a/src/phlo/cli/commands/services/planner.py
+++ b/src/phlo/cli/commands/services/planner.py
@@ -90,6 +90,8 @@ def build_start_preflight_plan(
         compose_file=compose_file,
         project_root=project_root,
         project_name=project_name,
-        service_names=service_names if service_names is not None else [service.name for service in services],
+        service_names=service_names
+        if service_names is not None
+        else [service.name for service in services],
         backend_name=backend_name,
     )

--- a/src/phlo/cli/commands/services/planner.py
+++ b/src/phlo/cli/commands/services/planner.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
@@ -16,9 +16,9 @@ from phlo.utils import dedupe_preserve_order
 class ServiceSelectionPlan:
     """Selected services for a services command."""
 
-    selected_services: list[ServiceDefinition]
-    disabled_names: set[str] = field(default_factory=set)
-    requested_names: list[str] = field(default_factory=list)
+    selected_services: tuple[ServiceDefinition, ...] = ()
+    disabled_names: frozenset[str] = frozenset()
+    requested_names: tuple[str, ...] = ()
     profiles: tuple[str, ...] = ()
 
 
@@ -46,6 +46,12 @@ def build_service_selection_plan(
         raise click.ClickException(f"Unknown service name(s): {', '.join(unknown_requested)}")
 
     enabled_names, disabled_names = get_enabled_disabled_service_names(config)
+    disabled_requested = [name for name in requested_names if name in disabled_names]
+    if disabled_requested:
+        raise click.ClickException(
+            f"Requested service(s) are disabled in phlo.yaml: {', '.join(disabled_requested)}"
+        )
+
     selected_names: list[str] = []
     if requested_names:
         selected_names.extend(requested_names)
@@ -68,9 +74,9 @@ def build_service_selection_plan(
         if name in services and name not in disabled_names
     ]
     return ServiceSelectionPlan(
-        selected_services=selected,
-        disabled_names=disabled_names,
-        requested_names=requested_names,
+        selected_services=tuple(selected),
+        disabled_names=frozenset(disabled_names),
+        requested_names=tuple(requested_names),
         profiles=profiles,
     )
 
@@ -81,17 +87,21 @@ def build_start_preflight_plan(
     compose_file: Path,
     project_root: Path,
     project_name: str,
-    services: list[ServiceDefinition],
     backend_name: str | None,
+    services: list[ServiceDefinition] | None = None,
     service_names: list[str] | None = None,
 ) -> StartPreflightPlan:
+    resolved_service_names = (
+        service_names if service_names is not None else [service.name for service in services or []]
+    )
+    if not resolved_service_names:
+        raise ValueError("service_names or services must include at least one service")
+
     return StartPreflightPlan(
         phlo_dir=phlo_dir,
         compose_file=compose_file,
         project_root=project_root,
         project_name=project_name,
-        service_names=service_names
-        if service_names is not None
-        else [service.name for service in services],
+        service_names=resolved_service_names,
         backend_name=backend_name,
     )

--- a/src/phlo/cli/commands/services/planner.py
+++ b/src/phlo/cli/commands/services/planner.py
@@ -83,12 +83,13 @@ def build_start_preflight_plan(
     project_name: str,
     services: list[ServiceDefinition],
     backend_name: str | None,
+    service_names: list[str] | None = None,
 ) -> StartPreflightPlan:
     return StartPreflightPlan(
         phlo_dir=phlo_dir,
         compose_file=compose_file,
         project_root=project_root,
         project_name=project_name,
-        service_names=[service.name for service in services],
+        service_names=service_names if service_names is not None else [service.name for service in services],
         backend_name=backend_name,
     )

--- a/src/phlo/cli/commands/services/planner.py
+++ b/src/phlo/cli/commands/services/planner.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import click
+
 from phlo.cli.commands.services.utils import get_enabled_disabled_service_names
 from phlo.plugins.discovery import ServiceDefinition
 from phlo.utils import dedupe_preserve_order
@@ -26,6 +28,10 @@ def build_service_selection_plan(
     profiles: tuple[str, ...],
     requested_names: list[str],
 ) -> ServiceSelectionPlan:
+    unknown_requested = [name for name in requested_names if name not in services]
+    if unknown_requested:
+        raise click.ClickException(f"Unknown service name(s): {', '.join(unknown_requested)}")
+
     enabled_names, disabled_names = get_enabled_disabled_service_names(config)
     selected_names: list[str] = []
     if requested_names:

--- a/src/phlo/cli/commands/services/planner.py
+++ b/src/phlo/cli/commands/services/planner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import click
 
@@ -19,6 +20,18 @@ class ServiceSelectionPlan:
     disabled_names: set[str] = field(default_factory=set)
     requested_names: list[str] = field(default_factory=list)
     profiles: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class StartPreflightPlan:
+    """Inputs needed by services start preflight checks."""
+
+    phlo_dir: Path
+    compose_file: Path
+    project_root: Path
+    project_name: str
+    service_names: list[str]
+    backend_name: str | None
 
 
 def build_service_selection_plan(
@@ -59,4 +72,23 @@ def build_service_selection_plan(
         disabled_names=disabled_names,
         requested_names=requested_names,
         profiles=profiles,
+    )
+
+
+def build_start_preflight_plan(
+    *,
+    phlo_dir: Path,
+    compose_file: Path,
+    project_root: Path,
+    project_name: str,
+    services: list[ServiceDefinition],
+    backend_name: str | None,
+) -> StartPreflightPlan:
+    return StartPreflightPlan(
+        phlo_dir=phlo_dir,
+        compose_file=compose_file,
+        project_root=project_root,
+        project_name=project_name,
+        service_names=[service.name for service in services],
+        backend_name=backend_name,
     )

--- a/src/phlo/cli/commands/services/start.py
+++ b/src/phlo/cli/commands/services/start.py
@@ -17,7 +17,7 @@ from phlo.cli.commands.services.common import (
     parse_service_args,
     validate_requested_profiles,
 )
-from phlo.cli.commands.services.planner import build_start_preflight_plan
+from phlo.cli.commands.services.planner import StartPreflightPlan, build_start_preflight_plan
 from phlo.cli.commands.services.ports import (
     _load_environment,
     _parse_compose_port_spec,
@@ -119,20 +119,15 @@ def _is_host_port_available(port: int) -> bool:
 
 def _preflight_requested_host_ports(
     *,
-    phlo_dir: Path,
-    compose_file: Path,
-    project_root: Path,
-    project_name: str,
-    service_names: list[str],
-    backend_name: str | None,
+    plan: StartPreflightPlan,
 ) -> None:
     """Fail early when requested stopped services would collide with local host ports."""
     try:
-        compose_config = yaml.safe_load(compose_file.read_text()) or {}
+        compose_config = yaml.safe_load(plan.compose_file.read_text()) or {}
     except OSError as exc:
-        raise click.ClickException(f"Failed to read {compose_file}: {exc}") from exc
+        raise click.ClickException(f"Failed to read {plan.compose_file}: {exc}") from exc
     except yaml.YAMLError as exc:
-        raise click.ClickException(f"Failed to parse {compose_file}: {exc}") from exc
+        raise click.ClickException(f"Failed to parse {plan.compose_file}: {exc}") from exc
 
     services = compose_config.get("services") or {}
     if not isinstance(services, dict):
@@ -140,22 +135,22 @@ def _preflight_requested_host_ports(
 
     selected_services = {
         name: service_config
-        for name in service_names
+        for name in plan.service_names
         if isinstance((service_config := services.get(name)), dict)
         and bool(service_config.get("ports"))
     }
     if not selected_services:
         return
 
-    config = _load_project_config(project_root)
-    env = _load_environment(phlo_dir, config)
-    backend = select_project_container_backend(cli_backend=backend_name)
+    config = _load_project_config(plan.project_root)
+    env = _load_environment(plan.phlo_dir, config)
+    backend = select_project_container_backend(cli_backend=plan.backend_name)
     running_containers = {
         container.service: {
             "status": container.state,
             "ports": [],
         }
-        for container in backend.list_project_containers(project_name)
+        for container in backend.list_project_containers(plan.project_name)
     }
 
     conflicts: list[tuple[str, int, str | None]] = []
@@ -205,7 +200,7 @@ def _preflight_requested_host_ports(
         )
         logger.warning(
             "services_start_invalid_host_ports",
-            project_name=project_name,
+            project_name=plan.project_name,
             invalid_ports=rendered,
         )
         raise click.ClickException(
@@ -222,7 +217,7 @@ def _preflight_requested_host_ports(
     )
     logger.warning(
         "services_start_host_port_conflicts",
-        project_name=project_name,
+        project_name=plan.project_name,
         conflicts=rendered,
     )
     raise click.ClickException(
@@ -509,12 +504,7 @@ def start_cmd(
             service_names=docker_service_names,
         )
         _preflight_requested_host_ports(
-            phlo_dir=preflight_plan.phlo_dir,
-            compose_file=preflight_plan.compose_file,
-            project_root=preflight_plan.project_root,
-            project_name=preflight_plan.project_name,
-            service_names=preflight_plan.service_names,
-            backend_name=preflight_plan.backend_name,
+            plan=preflight_plan,
         )
     elif build:
         logger.warning(

--- a/src/phlo/cli/commands/services/start.py
+++ b/src/phlo/cli/commands/services/start.py
@@ -17,6 +17,7 @@ from phlo.cli.commands.services.common import (
     parse_service_args,
     validate_requested_profiles,
 )
+from phlo.cli.commands.services.planner import build_start_preflight_plan
 from phlo.cli.commands.services.ports import (
     _load_environment,
     _parse_compose_port_spec,
@@ -498,13 +499,22 @@ def start_cmd(
 
     if not skip_docker_compose:
         require_container_backend(backend_name)
-        _preflight_requested_host_ports(
+        preflight_plan = build_start_preflight_plan(
             phlo_dir=phlo_dir,
             compose_file=compose_file,
             project_root=Path.cwd(),
             project_name=project_name,
-            service_names=docker_service_names,
+            services=resolved_services,
             backend_name=backend_name,
+            service_names=docker_service_names,
+        )
+        _preflight_requested_host_ports(
+            phlo_dir=preflight_plan.phlo_dir,
+            compose_file=preflight_plan.compose_file,
+            project_root=preflight_plan.project_root,
+            project_name=preflight_plan.project_name,
+            service_names=preflight_plan.service_names,
+            backend_name=preflight_plan.backend_name,
         )
     elif build:
         logger.warning(

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -377,3 +377,47 @@ def test_services_init_includes_requested_profile_services(
     compose = (tmp_path / ".phlo" / "docker-compose.yml").read_text()
     assert "postgres" in compose
     assert "prometheus" in compose
+
+
+def test_services_init_uses_lifecycle_planner_for_profiles(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    postgres = _service("postgres", default=True)
+    grafana = _service("grafana", profile="observability")
+    fake_discovery = FakeDiscovery(
+        {postgres.name: postgres, grafana.name: grafana},
+        default_names=(postgres.name,),
+    )
+    copied: list[str] = []
+
+    class FakeComposer:
+        def __init__(self, _discovery):
+            pass
+
+        def generate_compose(self, selected, *_args, **_kwargs):
+            copied.extend(service.name for service in selected)
+            return "services: {}\n"
+
+        def generate_env(self, _services, env_overrides=None):
+            return ""
+
+        def generate_env_local(self, _services, env_overrides=None, existing_values=None):
+            return ""
+
+        def generate_gitignore(self, _services):
+            return ""
+
+        def copy_service_files(self, *_args, **_kwargs):
+            return []
+
+    monkeypatch.chdir(tmp_path)
+    from phlo.cli.commands.services import init as init_module
+
+    monkeypatch.setattr(init_module, "ServiceDiscovery", lambda: fake_discovery)
+    monkeypatch.setattr(init_module, "ComposeGenerator", FakeComposer)
+
+    result = CliRunner().invoke(init_module.init_cmd, ["--profile", "observability"])
+
+    assert result.exit_code == 0
+    assert copied == ["postgres", "grafana"]

--- a/tests/cli/test_cli_services_planner.py
+++ b/tests/cli/test_cli_services_planner.py
@@ -39,7 +39,7 @@ def test_selection_plan_includes_default_and_profile_services() -> None:
     )
 
     assert [service.name for service in plan.selected_services] == ["postgres", "grafana"]
-    assert plan.disabled_names == set()
+    assert plan.disabled_names == frozenset()
 
 
 def test_selection_plan_excludes_disabled_services() -> None:
@@ -56,7 +56,38 @@ def test_selection_plan_excludes_disabled_services() -> None:
     )
 
     assert [service.name for service in plan.selected_services] == ["postgres"]
-    assert plan.disabled_names == {"grafana"}
+    assert plan.disabled_names == frozenset({"grafana"})
+
+
+def test_selection_plan_respects_requested_names() -> None:
+    services = {
+        "postgres": _service("postgres", default=True),
+        "grafana": _service("grafana", default=True, profile="observability"),
+    }
+
+    plan = build_service_selection_plan(
+        services=services,
+        config={},
+        profiles=("observability",),
+        requested_names=["postgres"],
+    )
+
+    assert [service.name for service in plan.selected_services] == ["postgres"]
+    assert plan.disabled_names == frozenset()
+
+
+def test_selection_plan_rejects_disabled_requested_service() -> None:
+    services = {"grafana": _service("grafana", default=True)}
+
+    with pytest.raises(click.ClickException) as exc:
+        build_service_selection_plan(
+            services=services,
+            config={"services": {"grafana": {"enabled": False}}},
+            profiles=(),
+            requested_names=["grafana"],
+        )
+
+    assert "grafana" in str(exc.value)
 
 
 def test_selection_plan_rejects_unknown_requested_service() -> None:

--- a/tests/cli/test_cli_services_planner.py
+++ b/tests/cli/test_cli_services_planner.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from phlo.cli.commands.services.planner import build_service_selection_plan
+from phlo.plugins.discovery import ServiceDefinition
+
+
+def _service(
+    name: str,
+    *,
+    default: bool = False,
+    profile: str | None = None,
+) -> ServiceDefinition:
+    return ServiceDefinition.from_dict(
+        {"name": name, "image": f"{name}:latest", "default": default, "profile": profile},
+        None,
+    )
+
+
+def test_selection_plan_includes_default_and_profile_services() -> None:
+    services = {
+        "postgres": _service("postgres", default=True),
+        "grafana": _service("grafana", profile="observability"),
+        "hasura": _service("hasura", profile="api"),
+    }
+
+    plan = build_service_selection_plan(
+        services=services,
+        config={},
+        profiles=("observability",),
+        requested_names=[],
+    )
+
+    assert [service.name for service in plan.selected_services] == ["postgres", "grafana"]
+    assert plan.disabled_names == set()
+
+
+def test_selection_plan_excludes_disabled_services() -> None:
+    services = {
+        "postgres": _service("postgres", default=True),
+        "grafana": _service("grafana", default=True),
+    }
+
+    plan = build_service_selection_plan(
+        services=services,
+        config={"services": {"grafana": {"enabled": False}}},
+        profiles=(),
+        requested_names=[],
+    )
+
+    assert [service.name for service in plan.selected_services] == ["postgres"]
+    assert plan.disabled_names == {"grafana"}

--- a/tests/cli/test_cli_services_planner.py
+++ b/tests/cli/test_cli_services_planner.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 import pytest
 
-from phlo.cli.commands.services.planner import build_service_selection_plan
+from phlo.cli.commands.services.planner import (
+    build_service_selection_plan,
+    build_start_preflight_plan,
+)
 from phlo.plugins.discovery import ServiceDefinition
 
 
@@ -66,3 +71,26 @@ def test_selection_plan_rejects_unknown_requested_service() -> None:
         )
 
     assert str(exc.value) == "Unknown service name(s): missing"
+
+
+def test_start_preflight_plan_contains_compose_inputs(tmp_path: Path) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    compose_file = phlo_dir / "docker-compose.yml"
+    project_root = tmp_path
+    service = _service("postgres", default=True)
+
+    plan = build_start_preflight_plan(
+        phlo_dir=phlo_dir,
+        compose_file=compose_file,
+        project_root=project_root,
+        project_name="demo",
+        services=[service],
+        backend_name="docker",
+    )
+
+    assert plan.phlo_dir == phlo_dir
+    assert plan.compose_file == compose_file
+    assert plan.project_root == project_root
+    assert plan.project_name == "demo"
+    assert plan.service_names == ["postgres"]
+    assert plan.backend_name == "docker"

--- a/tests/cli/test_cli_services_planner.py
+++ b/tests/cli/test_cli_services_planner.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import click
+import pytest
+
 from phlo.cli.commands.services.planner import build_service_selection_plan
 from phlo.plugins.discovery import ServiceDefinition
 
@@ -49,3 +52,17 @@ def test_selection_plan_excludes_disabled_services() -> None:
 
     assert [service.name for service in plan.selected_services] == ["postgres"]
     assert plan.disabled_names == {"grafana"}
+
+
+def test_selection_plan_rejects_unknown_requested_service() -> None:
+    services = {"postgres": _service("postgres", default=True)}
+
+    with pytest.raises(click.ClickException) as exc:
+        build_service_selection_plan(
+            services=services,
+            config={},
+            profiles=(),
+            requested_names=["missing"],
+        )
+
+    assert str(exc.value) == "Unknown service name(s): missing"

--- a/tests/cli/test_cli_services_start.py
+++ b/tests/cli/test_cli_services_start.py
@@ -5,6 +5,7 @@ from subprocess import CompletedProcess
 import pytest
 from click.testing import CliRunner
 
+from phlo.cli.commands.services.planner import StartPreflightPlan
 from phlo.cli.commands.services.utils import get_profile_service_names
 from phlo.cli.infrastructure.container_backend import ContainerInfo
 from phlo.plugins.discovery import ServiceDefinition
@@ -274,12 +275,14 @@ def test_services_start_preflights_env_local_port_collisions(
 
     with pytest.raises(Exception) as exc_info:
         start_module._preflight_requested_host_ports(
-            phlo_dir=phlo_dir,
-            compose_file=compose_file,
-            project_root=tmp_path,
-            project_name="demo",
-            service_names=["dagster"],
-            backend_name=None,
+            plan=StartPreflightPlan(
+                phlo_dir=phlo_dir,
+                compose_file=compose_file,
+                project_root=tmp_path,
+                project_name="demo",
+                service_names=["dagster"],
+                backend_name=None,
+            ),
         )
 
     assert "dagster -> 3300 (DAGSTER_PORT)" in str(exc_info.value)
@@ -313,12 +316,14 @@ def test_services_start_preflights_invalid_env_port_values(
 
     with pytest.raises(Exception) as exc_info:
         start_module._preflight_requested_host_ports(
-            phlo_dir=phlo_dir,
-            compose_file=compose_file,
-            project_root=tmp_path,
-            project_name="demo",
-            service_names=["postgres"],
-            backend_name=None,
+            plan=StartPreflightPlan(
+                phlo_dir=phlo_dir,
+                compose_file=compose_file,
+                project_root=tmp_path,
+                project_name="demo",
+                service_names=["postgres"],
+                backend_name=None,
+            ),
         )
 
     assert "invalid host port value" in str(exc_info.value)
@@ -355,12 +360,14 @@ def test_services_start_preflight_skips_already_running_project_service(
     monkeypatch.setattr(start_module, "_is_host_port_available", lambda _port: False)
 
     start_module._preflight_requested_host_ports(
-        phlo_dir=phlo_dir,
-        compose_file=compose_file,
-        project_root=tmp_path,
-        project_name="demo",
-        service_names=["dagster"],
-        backend_name=None,
+        plan=StartPreflightPlan(
+            phlo_dir=phlo_dir,
+            compose_file=compose_file,
+            project_root=tmp_path,
+            project_name="demo",
+            service_names=["dagster"],
+            backend_name=None,
+        ),
     )
 
 
@@ -468,7 +475,12 @@ def test_services_start_builds_preflight_plan_for_selected_services(
     result = CliRunner().invoke(start_module.start_cmd, ["--service", "postgres"])
 
     assert result.exit_code == 0
-    assert captured["service_names"] == ["postgres"]
+    plan = captured["plan"]
+    assert isinstance(plan, StartPreflightPlan)
+    assert plan.service_names == ["postgres"]
+    assert plan.compose_file.name == "docker-compose.yml"
+    assert plan.project_name == "demo"
+    assert plan.backend_name is None
 
 
 def test_services_start_preflights_required_env_for_selected_services(

--- a/tests/cli/test_cli_services_start.py
+++ b/tests/cli/test_cli_services_start.py
@@ -421,6 +421,56 @@ def test_services_start_includes_setup_companions_for_explicit_targets(
     assert docker_calls[0][-3:] == ["rustfs-volume-setup", "rustfs", "rustfs-setup"]
 
 
+def test_services_start_builds_preflight_plan_for_selected_services(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    from phlo.cli.commands.services import start as start_module
+
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / ".env").write_text("", encoding="utf-8")
+    (phlo_dir / "docker-compose.yml").write_text(
+        "services:\n  postgres:\n    image: postgres:16\n",
+        encoding="utf-8",
+    )
+    postgres = _service("postgres", default=True)
+    captured: dict[str, object] = {}
+
+    class PostgresFakeDiscovery(FakeDiscovery):
+        def discover(self) -> dict[str, ServiceDefinition]:
+            return {postgres.name: postgres}
+
+        def get_available_profiles(self) -> set[str]:
+            return set()
+
+    def _fake_run_command(cmd: list[str], check=False, capture_output=False) -> CompletedProcess:
+        return CompletedProcess(args=cmd, returncode=0)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(start_module, "ensure_phlo_dir", lambda: phlo_dir)
+    monkeypatch.setattr(start_module, "ServiceDiscovery", PostgresFakeDiscovery)
+    monkeypatch.setattr(start_module, "get_project_name", lambda: "demo")
+    monkeypatch.setattr(start_module, "compose_base_cmd", lambda **_kwargs: ["docker", "compose"])
+    monkeypatch.setattr(start_module, "require_container_backend", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        start_module,
+        "_preflight_requested_host_ports",
+        lambda **kwargs: captured.update(kwargs),
+    )
+    monkeypatch.setattr(start_module, "_preflight_required_env_vars", lambda **_kwargs: None)
+    monkeypatch.setattr(start_module, "run_command", _fake_run_command)
+    monkeypatch.setattr(
+        start_module, "_emit_service_lifecycle_events", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(start_module, "_run_service_hooks", lambda *args, **kwargs: None)
+
+    result = CliRunner().invoke(start_module.start_cmd, ["--service", "postgres"])
+
+    assert result.exit_code == 0
+    assert captured["service_names"] == ["postgres"]
+
+
 def test_services_start_preflights_required_env_for_selected_services(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:


### PR DESCRIPTION
**TL;DR:** Extracts service lifecycle decision-making into a small planner module so `phlo services init` and `phlo services start` share testable selection and preflight behavior.

Closes #494.

## What Changed

- Added `ServiceSelectionPlan` and `StartPreflightPlan` value objects for service command planning.
- Added `build_service_selection_plan` to centralize default services, profiles, explicit requests, disabled services, and unknown-service validation.
- Added disabled explicit-request handling so `phlo services start --service <disabled>` fails clearly instead of silently selecting nothing.
- Added `build_start_preflight_plan` and routed start preflight through the plan object.
- Updated `services init` and `services start` to delegate planning work instead of assembling those inputs inline.
- Expanded focused tests for requested service selection, disabled requested services, and preflight plan contents.

## Why

The `phlo services` commands had lifecycle rules spread through Click handlers and shared utilities. This makes the planner the module seam for selection/preflight behavior, improving locality for future service lifecycle changes and making command behavior easier to test without filesystem-heavy command tests.

## Verification

- `uv run ruff check src/phlo/cli/commands/services tests/cli/test_cli_services_planner.py tests/cli/test_cli_services_start.py`
- `uv run pytest tests/cli/test_cli_services_planner.py tests/cli/test_cli_services_init.py tests/cli/test_cli_services_start.py tests/cli/test_cli_services_status.py -q`
- `uv run ty check src/phlo/cli/commands/services`

## Notes

- A stale CodeRabbit changes-requested review from an older SHA was dismissed after its thread was addressed and resolved.