### PR TITLE
refactor: deepen Observatory v2 read models

### DIFF
--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -15,8 +15,6 @@ import re
 import socket
 import subprocess
 import sys
-import threading
-import time
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import quote
@@ -27,6 +25,7 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 
 from phlo_api.observatory_api.v2_actions import execute_v2_action
+from phlo_api.observatory_api.v2_cache import ReadModelCache
 from phlo_api.observatory_api.v2_capabilities import build_capability_inventory
 from phlo_api.observatory_api.v2_catalog import load_catalog_items
 from phlo_api.observatory_api.v2_governance import load_governance_items
@@ -98,34 +97,16 @@ _ENV_DEFAULT_RE = re.compile(r"^\$\{[^}:]+:-(?P<default>[^}]+)\}$")
 _TABLE_LIST_METADATA_PREFIX_DENYLIST = ("phlo/compiled_sql",)
 _FAST_READ_MODEL_TTL_SECONDS = 30
 _EXPENSIVE_READ_MODEL_TTL_SECONDS = 120
-_READ_MODEL_CACHE: dict[tuple[str, str], tuple[float, Any]] = {}
-_READ_MODEL_CACHE_LOCK = threading.RLock()
+_READ_MODEL_CACHE = ReadModelCache(project_key=lambda: str(_project_root()))
 _DOCKER_SOCKET = "/var/run/docker.sock"
 
 
-def _read_model_cache_key(name: str) -> tuple[str, str]:
-    return (str(_project_root()), name)
-
-
 def _cached_read_model(name: str, ttl_seconds: float, loader: Any) -> Any:
-    key = _read_model_cache_key(name)
-    now = time.monotonic()
-
-    with _READ_MODEL_CACHE_LOCK:
-        cached = _READ_MODEL_CACHE.get(key)
-        if cached is not None:
-            expires_at, value = cached
-            if expires_at > now:
-                return value
-
-        value = loader()
-        _READ_MODEL_CACHE[key] = (time.monotonic() + ttl_seconds, value)
-        return value
+    return _READ_MODEL_CACHE.cached(name, ttl_seconds, loader)
 
 
 def _clear_read_model_cache() -> None:
-    with _READ_MODEL_CACHE_LOCK:
-        _READ_MODEL_CACHE.clear()
+    _READ_MODEL_CACHE.clear()
 
 
 class V2ServiceList(BaseModel):

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -15,10 +15,8 @@ import re
 import socket
 import subprocess
 import sys
-from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import quote
-from uuid import uuid4
 
 from fastapi import APIRouter
 from fastapi import HTTPException
@@ -77,6 +75,13 @@ from phlo_api.observatory_api.v2_metadata import safe_metadata as _safe_metadata
 from phlo_api.observatory_api.v2_observability import load_observability_items
 from phlo_api.observatory_api.v2_products import load_api_items, load_bi_items
 from phlo_api.observatory_api.v2_runs import load_runs
+from phlo_api.observatory_api.v2_saved_queries import (
+    dedupe_saved_queries as _dedupe_saved_queries_impl,
+    load_saved_queries as _load_saved_queries_impl,
+    save_query as _save_query_impl,
+    validate_saved_query_sql as _validate_saved_query_sql_impl,
+    write_saved_queries as _write_saved_queries_impl,
+)
 from phlo_api.observatory_api.v2_services import load_services as _load_services_impl
 from phlo_api.observatory_api.v2_storage import load_storage_items
 
@@ -1552,73 +1557,23 @@ def _row_offset(row_id: str) -> int:
 
 
 def _load_saved_queries() -> list[V2SavedQuery]:
-    path = _saved_queries_path()
-    if not path.exists():
-        return []
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return []
-    items = payload.get("items") if isinstance(payload, Mapping) else None
-    if not isinstance(items, list):
-        return []
-    queries: list[V2SavedQuery] = []
-    for item in items:
-        if isinstance(item, Mapping):
-            try:
-                queries.append(V2SavedQuery.model_validate(item))
-            except Exception:
-                continue
-    return _dedupe_saved_queries(queries)
+    return _load_saved_queries_impl(_project_root())
 
 
 def _dedupe_saved_queries(queries: list[V2SavedQuery]) -> list[V2SavedQuery]:
-    unique: dict[tuple[str, str, str], V2SavedQuery] = {}
-    for query in sorted(queries, key=lambda item: item.updated_at, reverse=True):
-        key = (
-            query.name.strip().casefold(),
-            " ".join(query.sql.split()).casefold(),
-            (query.branch or "main").strip().casefold(),
-        )
-        unique.setdefault(key, query)
-    return list(unique.values())
+    return _dedupe_saved_queries_impl(queries)
 
 
 def _write_saved_queries(queries: list[V2SavedQuery]) -> None:
-    _saved_queries_path().write_text(
-        json.dumps({"items": [query.model_dump() for query in queries]}, indent=2),
-        encoding="utf-8",
-    )
+    _write_saved_queries_impl(_project_root(), queries)
 
 
 def _save_query(request: V2SavedQueryRequest) -> V2SavedQuery:
-    if not request.name.strip():
-        raise HTTPException(status_code=400, detail="Saved query name is required.")
-    validate_error = _validate_saved_query_sql(request.sql)
-    if validate_error:
-        raise HTTPException(status_code=400, detail=validate_error)
-
-    now = datetime.now(UTC).isoformat()
-    query = V2SavedQuery(
-        id=f"query-{uuid4().hex[:12]}",
-        name=request.name.strip(),
-        sql=request.sql.strip(),
-        branch=request.branch,
-        created_at=now,
-        updated_at=now,
-        metadata=_safe_metadata(request.metadata),
-    )
-    queries = _dedupe_saved_queries([query, *_load_saved_queries()])
-    _write_saved_queries(queries[:100])
-    return query
+    return _save_query_impl(_project_root(), request)
 
 
 def _validate_saved_query_sql(sql: str) -> str | None:
-    if not sql.strip():
-        return "SQL is required."
-    if _READ_QUERY_RE.match(sql) is None:
-        return "Only read-only SELECT * FROM <known_table> [LIMIT n] queries can be saved."
-    return None
+    return _validate_saved_query_sql_impl(sql)
 
 
 def _load_stage_diff(source_table_id: str, target_table_id: str) -> V2StageDiff:

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -16,7 +16,6 @@ import socket
 import subprocess
 import sys
 from typing import Any
-from urllib.parse import quote
 
 from fastapi import APIRouter
 from fastapi import HTTPException
@@ -82,6 +81,7 @@ from phlo_api.observatory_api.v2_saved_queries import (
     validate_saved_query_sql as _validate_saved_query_sql_impl,
     write_saved_queries as _write_saved_queries_impl,
 )
+from phlo_api.observatory_api.v2_search import search_results as _search_results_impl
 from phlo_api.observatory_api.v2_services import load_services as _load_services_impl
 from phlo_api.observatory_api.v2_storage import load_storage_items
 
@@ -1685,87 +1685,15 @@ def _load_branch_detail(branch_name: str) -> V2BranchDetail:
 
 
 def _search_results(query: str) -> list[V2SearchResult]:
-    needle = query.strip().lower()
-    if not needle:
-        return []
-
-    results: list[V2SearchResult] = []
-    for service in _load_services():
-        haystack = " ".join([service.id, service.name, service.kind, service.status]).lower()
-        if needle in haystack:
-            results.append(
-                V2SearchResult(
-                    id=f"service:{service.id}",
-                    label=service.name,
-                    kind="service",
-                    summary=f"{service.kind} · {service.status}",
-                    href="/services",
-                )
-            )
-
-    for asset in _load_assets():
-        haystack = " ".join(
-            [asset.id, asset.name, asset.group or "", asset.description or "", *asset.kinds]
-        ).lower()
-        if needle in haystack:
-            results.append(
-                V2SearchResult(
-                    id=f"asset:{asset.id}",
-                    label=asset.name,
-                    kind="asset",
-                    summary=asset.description or asset.group,
-                    href=f"/asset/{_route_path_segment(asset.id)}",
-                )
-            )
-
-    for table in _load_tables_without_catalog():
-        haystack = " ".join(
-            [table.id, table.name, table.namespace or "", table.format or "", table.branch or ""]
-        ).lower()
-        if needle in haystack:
-            results.append(
-                V2SearchResult(
-                    id=f"table:{table.id}",
-                    label=table.namespace + "." + table.name if table.namespace else table.name,
-                    kind="table",
-                    summary=f"{table.format or 'table'} · {table.branch or 'main'}",
-                    href=f"/table/{_route_path_segment(table.id)}",
-                )
-            )
-
-    for check in _load_quality():
-        haystack = " ".join(
-            [check.id, check.name, check.asset_id, check.status, check.severity or ""]
-        ).lower()
-        if needle in haystack:
-            results.append(
-                V2SearchResult(
-                    id=f"quality:{check.id}",
-                    label=check.name,
-                    kind="quality",
-                    summary=f"{check.asset_id} · {check.status}",
-                    href="/quality",
-                )
-            )
-
-    for extension in _load_extensions():
-        haystack = " ".join([extension.id, extension.name, extension.version or ""]).lower()
-        if needle in haystack:
-            results.append(
-                V2SearchResult(
-                    id=f"extension:{extension.id}",
-                    label=extension.name,
-                    kind="extension",
-                    summary=extension.settings_scope or extension.version,
-                    href=f"/extension/{_route_path_segment(extension.id)}",
-                )
-            )
-
-    return results[:25]
-
-
-def _route_path_segment(resource_id: str) -> str:
-    return quote(resource_id, safe="")
+    return _search_results_impl(
+        query=query,
+        services=_load_services(),
+        assets=_load_assets(),
+        tables=_load_tables_without_catalog(),
+        operations=_load_operations(),
+        quality=_load_quality(),
+        extensions=_load_extensions(),
+    )
 
 
 def _load_extension_detail(extension_id: str) -> V2ExtensionDetail:

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -77,6 +77,7 @@ from phlo_api.observatory_api.v2_metadata import safe_metadata as _safe_metadata
 from phlo_api.observatory_api.v2_observability import load_observability_items
 from phlo_api.observatory_api.v2_products import load_api_items, load_bi_items
 from phlo_api.observatory_api.v2_runs import load_runs
+from phlo_api.observatory_api.v2_services import load_services as _load_services_impl
 from phlo_api.observatory_api.v2_storage import load_storage_items
 
 router = APIRouter(tags=["observatory-v2"])
@@ -606,56 +607,7 @@ def _service_config_from_definition(service: Any) -> list[V2ServiceConfigEntry]:
 
 
 def _load_services() -> list[V2Service]:
-    """Load services through core discovery, falling back deterministically."""
-    try:
-        from phlo.plugins.discovery import ServiceDiscovery
-
-        discovered = ServiceDiscovery().discover().values()
-    except Exception:
-        discovered = []
-
-    services: list[V2Service] = []
-    containers = _load_docker_containers()
-    discovered = list(discovered)
-    runtime_statuses = _load_docker_service_statuses({service.name for service in discovered})
-    for service in discovered:
-        in_stack = service.name in runtime_statuses
-        status, health = runtime_statuses.get(
-            service.name,
-            ("unknown", V2Health(state="unknown", message="Runtime status unavailable")),
-        )
-        services.append(
-            V2Service(
-                id=service.name,
-                name=service.name,
-                kind=service.category or "service",
-                status=status,
-                health=health,
-                definition_state="configured" if in_stack else "available",
-                runtime_state=status,
-                in_stack=in_stack,
-                disabled=bool(getattr(service, "disabled", False)),
-                profile=_coerce_str(service.profile, "") or None,
-                backend="docker" if in_stack else "unknown",
-                depends_on=list(service.depends_on or []),
-                impacts=[],
-                links=_service_links_from_definition(service),
-                metadata=_safe_metadata(
-                    {
-                        "default": bool(service.default),
-                        "profile": service.profile,
-                        "core": bool(getattr(service, "core", False)),
-                        "description": getattr(service, "description", None),
-                    }
-                ),
-            )
-        )
-
-    services.extend(
-        _runtime_services_from_containers(containers, {service.id for service in services})
-    )
-
-    return sorted(services, key=lambda item: item.id) if services else _fallback_services()
+    return _load_services_impl(_project_root(), containers=_load_docker_containers())
 
 
 def _overview_health_from_services(services: Sequence[V2Service]) -> V2Health:

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_cache.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_cache.py
@@ -1,0 +1,37 @@
+"""Shared Observatory v2 read model cache helpers."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ReadModelCache:
+    """Small TTL cache scoped by project and read model name."""
+
+    project_key: Callable[[], str]
+    _values: dict[tuple[str, str], tuple[float, Any]] = field(default_factory=dict)
+    _lock: threading.RLock = field(default_factory=threading.RLock)
+
+    def cached(self, name: str, ttl_seconds: float, loader: Callable[[], Any]) -> Any:
+        key = (self.project_key(), name)
+        now = time.monotonic()
+
+        with self._lock:
+            cached = self._values.get(key)
+            if cached is not None:
+                expires_at, value = cached
+                if expires_at > now:
+                    return value
+
+            value = loader()
+            self._values[key] = (time.monotonic() + ttl_seconds, value)
+            return value
+
+    def clear(self) -> None:
+        with self._lock:
+            self._values.clear()

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_saved_queries.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_saved_queries.py
@@ -1,0 +1,94 @@
+"""Saved-query read model persistence for Observatory v2."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+import re
+from uuid import uuid4
+
+from fastapi import HTTPException
+
+from phlo_api.observatory_api.v2_metadata import safe_metadata
+from phlo_api.observatory_api.v2_models import V2SavedQuery, V2SavedQueryRequest
+
+READ_QUERY_RE = re.compile(
+    r"^\s*select\s+\*\s+from\s+(?P<table>[A-Za-z0-9_.:-]+)(?:\s+limit\s+(?P<limit>\d+))?\s*;?\s*$",
+    re.IGNORECASE,
+)
+
+
+def saved_queries_path(project_root: Path) -> Path:
+    state_dir = project_root / ".phlo" / "observatory-v2"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / "saved_queries.json"
+
+
+def load_saved_queries(project_root: Path) -> list[V2SavedQuery]:
+    path = saved_queries_path(project_root)
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    items = payload.get("items") if isinstance(payload, Mapping) else None
+    if not isinstance(items, list):
+        return []
+    queries: list[V2SavedQuery] = []
+    for item in items:
+        if isinstance(item, Mapping):
+            try:
+                queries.append(V2SavedQuery.model_validate(item))
+            except Exception:
+                continue
+    return dedupe_saved_queries(queries)
+
+
+def dedupe_saved_queries(queries: list[V2SavedQuery]) -> list[V2SavedQuery]:
+    unique: dict[tuple[str, str, str], V2SavedQuery] = {}
+    for query in sorted(queries, key=lambda item: item.updated_at, reverse=True):
+        key = (
+            query.name.strip().casefold(),
+            " ".join(query.sql.split()).casefold(),
+            (query.branch or "main").strip().casefold(),
+        )
+        unique.setdefault(key, query)
+    return list(unique.values())
+
+
+def write_saved_queries(project_root: Path, queries: list[V2SavedQuery]) -> None:
+    saved_queries_path(project_root).write_text(
+        json.dumps({"items": [query.model_dump() for query in queries]}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def save_query(project_root: Path, request: V2SavedQueryRequest) -> V2SavedQuery:
+    if not request.name.strip():
+        raise HTTPException(status_code=400, detail="Saved query name is required.")
+    validate_error = validate_saved_query_sql(request.sql)
+    if validate_error:
+        raise HTTPException(status_code=400, detail=validate_error)
+
+    now = datetime.now(UTC).isoformat()
+    query = V2SavedQuery(
+        id=f"query-{uuid4().hex[:12]}",
+        name=request.name.strip(),
+        sql=request.sql.strip(),
+        branch=request.branch,
+        created_at=now,
+        updated_at=now,
+        metadata=safe_metadata(request.metadata),
+    )
+    queries = dedupe_saved_queries([query, *load_saved_queries(project_root)])
+    write_saved_queries(project_root, queries[:100])
+    return query
+
+
+def validate_saved_query_sql(sql: str) -> str | None:
+    if READ_QUERY_RE.match(sql):
+        return None
+    return "Only simple SELECT preview queries can be saved."

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_search.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_search.py
@@ -75,7 +75,9 @@ def search_results(
             )
 
     for operation in operations:
-        haystack = " ".join([operation.id, operation.name, operation.kind, operation.status]).lower()
+        haystack = " ".join(
+            [operation.id, operation.name, operation.kind, operation.status]
+        ).lower()
         if needle in haystack:
             results.append(
                 V2SearchResult(

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_search.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_search.py
@@ -1,0 +1,122 @@
+"""Search result composition for Observatory v2."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from urllib.parse import quote
+
+from phlo_api.observatory_api.v2_models import (
+    V2Asset,
+    V2Extension,
+    V2Operation,
+    V2QualityCheck,
+    V2SearchResult,
+    V2Service,
+    V2Table,
+)
+
+
+def search_results(
+    *,
+    query: str,
+    services: Sequence[V2Service],
+    assets: Sequence[V2Asset],
+    tables: Sequence[V2Table],
+    operations: Sequence[V2Operation],
+    quality: Sequence[V2QualityCheck] = (),
+    extensions: Sequence[V2Extension] = (),
+) -> list[V2SearchResult]:
+    needle = query.strip().lower()
+    if not needle:
+        return []
+
+    results: list[V2SearchResult] = []
+    for service in services:
+        haystack = " ".join([service.id, service.name, service.kind, service.status]).lower()
+        if needle in haystack:
+            results.append(
+                V2SearchResult(
+                    id=f"service:{service.id}",
+                    label=service.name,
+                    kind="service",
+                    summary=f"{service.kind} · {service.status}",
+                    href="/services",
+                )
+            )
+
+    for asset in assets:
+        haystack = " ".join(
+            [asset.id, asset.name, asset.group or "", asset.description or "", *asset.kinds]
+        ).lower()
+        if needle in haystack:
+            results.append(
+                V2SearchResult(
+                    id=f"asset:{asset.id}",
+                    label=asset.name,
+                    kind="asset",
+                    summary=asset.description or asset.group,
+                    href=f"/asset/{route_path_segment(asset.id)}",
+                )
+            )
+
+    for table in tables:
+        haystack = " ".join(
+            [table.id, table.name, table.namespace or "", table.format or "", table.branch or ""]
+        ).lower()
+        if needle in haystack:
+            results.append(
+                V2SearchResult(
+                    id=f"table:{table.id}",
+                    label=table.namespace + "." + table.name if table.namespace else table.name,
+                    kind="table",
+                    summary=f"{table.format or 'table'} · {table.branch or 'main'}",
+                    href=f"/table/{route_path_segment(table.id)}",
+                )
+            )
+
+    for operation in operations:
+        haystack = " ".join([operation.id, operation.name, operation.kind, operation.status]).lower()
+        if needle in haystack:
+            results.append(
+                V2SearchResult(
+                    id=f"operation:{operation.id}",
+                    label=operation.name,
+                    kind="operation",
+                    summary=f"{operation.kind} · {operation.status}",
+                    href=f"/operations/{route_path_segment(operation.id)}",
+                )
+            )
+
+    for check in quality:
+        haystack = " ".join(
+            [check.id, check.name, check.asset_id, check.status, check.severity or ""]
+        ).lower()
+        if needle in haystack:
+            results.append(
+                V2SearchResult(
+                    id=f"quality:{check.id}",
+                    label=check.name,
+                    kind="quality",
+                    summary=f"{check.asset_id} · {check.status}",
+                    href="/quality",
+                )
+            )
+
+    for extension in extensions:
+        haystack = " ".join([extension.id, extension.name, extension.version or ""]).lower()
+        if needle in haystack:
+            results.append(
+                V2SearchResult(
+                    id=f"extension:{extension.id}",
+                    label=extension.name,
+                    kind="extension",
+                    summary=extension.settings_scope or extension.version,
+                    href=f"/extension/{route_path_segment(extension.id)}",
+                )
+            )
+
+    return results[:25]
+
+
+def route_path_segment(resource_id: str) -> str:
+    return quote(resource_id, safe="")

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
@@ -1,0 +1,438 @@
+"""Service read models for Observatory v2."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import http.client
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import subprocess
+from typing import Any
+
+from phlo_api.observatory_api.v2_metadata import safe_metadata
+from phlo_api.observatory_api.v2_models import (
+    HealthState,
+    ServiceStatus,
+    V2ExternalLink,
+    V2Health,
+    V2Service,
+    V2ServiceConfigEntry,
+    V2ServicePort,
+)
+
+DOCKER_SOCKET = "/var/run/docker.sock"
+DOCKER_SERVICE_STATUS_RANK: dict[ServiceStatus, int] = {
+    "running": 4,
+    "unhealthy": 3,
+    "starting": 2,
+    "stopped": 1,
+    "unknown": 0,
+}
+ENV_DEFAULT_RE = re.compile(r"^\$\{[^}:]+:-(?P<default>[^}]+)\}$")
+
+
+def coerce_str(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def fallback_services() -> list[V2Service]:
+    """Return deterministic service data without package-specific imports."""
+    return [
+        V2Service(
+            id="phlo-api",
+            name="phlo-api",
+            kind="api",
+            status="unknown",
+            health=V2Health(state="unknown", message="Runtime status unavailable"),
+            definition_state="configured",
+            runtime_state="unknown",
+            in_stack=True,
+            backend="native",
+            impacts=["observatory"],
+            metadata={"source": "fallback", "core": True},
+        ),
+        V2Service(
+            id="observatory",
+            name="observatory",
+            kind="ui",
+            status="unknown",
+            health=V2Health(state="unknown", message="Runtime status unavailable"),
+            definition_state="configured",
+            runtime_state="unknown",
+            in_stack=True,
+            backend="native",
+            depends_on=["phlo-api"],
+            metadata={"source": "fallback", "core": True},
+        ),
+    ]
+
+
+def docker_status_from_container(
+    container: Mapping[str, Any],
+) -> tuple[ServiceStatus, V2Health]:
+    state = coerce_str(container.get("State"), "unknown").lower()
+    status_text = coerce_str(container.get("Status"), "")
+    status_lower = status_text.lower()
+
+    if state == "running" and "(unhealthy)" in status_lower:
+        return "unhealthy", V2Health(state="error", message=status_text)
+    if state == "running" and "starting" in status_lower:
+        return "starting", V2Health(state="warning", message=status_text)
+    if state == "running":
+        health: HealthState = "ok" if "(healthy)" in status_lower else "unknown"
+        return "running", V2Health(state=health, message=status_text or None)
+    if state in {"created", "restarting"}:
+        return "starting", V2Health(state="warning", message=status_text or state)
+    if state == "exited" and "exited (0)" in status_lower:
+        return "stopped", V2Health(state="ok", message=status_text or "Completed")
+    if state in {"exited", "dead", "removing"}:
+        return "stopped", V2Health(state="warning", message=status_text or state)
+    return "unknown", V2Health(state="unknown", message=status_text or None)
+
+
+def container_labels(container: Mapping[str, Any]) -> dict[str, str]:
+    labels = container.get("Labels")
+    if isinstance(labels, Mapping):
+        return {str(key): str(value) for key, value in labels.items()}
+    if not isinstance(labels, str) or not labels:
+        return {}
+    parsed: dict[str, str] = {}
+    for item in labels.split(","):
+        if "=" not in item:
+            continue
+        key, value = item.split("=", 1)
+        parsed[key] = value
+    return parsed
+
+
+class UnixSocketHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, socket_path: str):
+        super().__init__("localhost")
+        self.socket_path = socket_path
+
+    def connect(self) -> None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(self.socket_path)
+        self.sock = sock
+
+
+def docker_socket_json(path: str, socket_path: str = DOCKER_SOCKET) -> Any:
+    connection = UnixSocketHTTPConnection(socket_path)
+    try:
+        connection.request("GET", path)
+        response = connection.getresponse()
+        if response.status >= 400:
+            return None
+        body = response.read().decode()
+        return json.loads(body) if body else None
+    except (OSError, json.JSONDecodeError, http.client.HTTPException):
+        return None
+    finally:
+        connection.close()
+
+
+def normalize_docker_api_container(container: Mapping[str, Any]) -> dict[str, Any]:
+    names = container.get("Names")
+    if isinstance(names, list) and names:
+        name = str(names[0]).lstrip("/")
+    else:
+        name = coerce_str(container.get("Names") or container.get("Name"), "").lstrip("/")
+    return {
+        "ID": coerce_str(container.get("Id") or container.get("ID"), ""),
+        "Names": name,
+        "State": coerce_str(container.get("State"), ""),
+        "Status": coerce_str(container.get("Status"), ""),
+        "Labels": container.get("Labels") if isinstance(container.get("Labels"), Mapping) else {},
+    }
+
+
+def load_docker_containers() -> list[dict[str, Any]]:
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "-a", "--format", "{{json .}}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        result = None
+
+    if result is not None and result.returncode == 0:
+        containers: list[dict[str, Any]] = []
+        for line in result.stdout.splitlines():
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, Mapping):
+                containers.append(dict(parsed))
+        return containers
+
+    if not Path(DOCKER_SOCKET).exists():
+        return []
+    payload = docker_socket_json("/containers/json?all=1")
+    if not isinstance(payload, list):
+        return []
+    return [
+        normalize_docker_api_container(container)
+        for container in payload
+        if isinstance(container, Mapping)
+    ]
+
+
+def current_compose_project(containers: Sequence[Mapping[str, Any]]) -> str | None:
+    configured = os.environ.get("PHLO_COMPOSE_PROJECT") or os.environ.get("COMPOSE_PROJECT_NAME")
+    if configured:
+        return configured
+
+    hostname = os.environ.get("HOSTNAME", "")
+    if not hostname:
+        return None
+
+    for container in containers:
+        container_id = coerce_str(container.get("ID") or container.get("Id"), "")
+        if container_id and container_id.startswith(hostname):
+            labels = container_labels(container)
+            project = labels.get("com.docker.compose.project")
+            if project:
+                return project
+
+    inspected = docker_socket_json(f"/containers/{hostname}/json")
+    if isinstance(inspected, Mapping):
+        config = inspected.get("Config")
+        labels = config.get("Labels") if isinstance(config, Mapping) else None
+        if isinstance(labels, Mapping):
+            project = labels.get("com.docker.compose.project")
+            if project:
+                return str(project)
+    return None
+
+
+def compose_service_name(container: Mapping[str, Any]) -> str | None:
+    labels = container_labels(container)
+    service_name = labels.get("com.docker.compose.service")
+    if service_name:
+        return service_name
+    name = coerce_str(container.get("Names"), "")
+    if name.endswith("-1") and "-" in name:
+        return name.rsplit("-", 2)[-2]
+    return None
+
+
+def service_name_from_container(name: str, service_ids: set[str]) -> str | None:
+    ordered_service_ids = list(service_ids)
+    ordered_service_ids.sort(key=lambda value: len(value), reverse=True)
+    for service_id in ordered_service_ids:
+        if name == service_id or name.endswith(f"-{service_id}-1"):
+            return service_id
+    return None
+
+
+def load_docker_service_statuses(
+    service_ids: set[str],
+    containers: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, tuple[ServiceStatus, V2Health]]:
+    if not service_ids:
+        return {}
+
+    statuses: dict[str, tuple[ServiceStatus, V2Health]] = {}
+    containers = containers if containers is not None else load_docker_containers()
+    compose_project = current_compose_project(containers)
+    for container in containers:
+        if compose_project:
+            labels = container_labels(container)
+            if labels.get("com.docker.compose.project") != compose_project:
+                continue
+        name = coerce_str(container.get("Names"), "")
+        service_id = compose_service_name(container) or service_name_from_container(
+            name, service_ids
+        )
+        if service_id not in service_ids:
+            service_id = service_name_from_container(name, service_ids)
+        if service_id is None:
+            continue
+        status, health = docker_status_from_container(container)
+        current = statuses.get(service_id)
+        if (
+            current is None
+            or DOCKER_SERVICE_STATUS_RANK[status] > DOCKER_SERVICE_STATUS_RANK[current[0]]
+        ):
+            statuses[service_id] = (status, health)
+    return statuses
+
+
+def runtime_services_from_containers(
+    containers: Sequence[Mapping[str, Any]],
+    known_ids: set[str],
+) -> list[V2Service]:
+    compose_project = current_compose_project(containers)
+    services: list[V2Service] = []
+    for container in containers:
+        labels = container_labels(container)
+        if compose_project and labels.get("com.docker.compose.project") != compose_project:
+            continue
+        service_id = compose_service_name(container)
+        if not service_id or service_id in known_ids:
+            continue
+        status, health = docker_status_from_container(container)
+        services.append(
+            V2Service(
+                id=service_id,
+                name=service_id,
+                kind=labels.get("phlo.service.category", "service"),
+                status=status,
+                health=health,
+                definition_state="configured",
+                runtime_state=status,
+                in_stack=True,
+                backend="docker",
+                metadata=safe_metadata({"source": "docker", "compose_project": compose_project}),
+            )
+        )
+        known_ids.add(service_id)
+    return services
+
+
+def service_links_from_definition(service: Any) -> list[V2ExternalLink]:
+    compose = getattr(service, "compose", {}) if service is not None else {}
+    labels = compose.get("labels") if isinstance(compose, Mapping) else {}
+    ports = compose.get("ports") if isinstance(compose, Mapping) else []
+    links: list[V2ExternalLink] = []
+
+    if isinstance(labels, Mapping):
+        for key, value in labels.items():
+            if str(key).endswith(".rule") and "Host(`" in str(value):
+                host = str(value).split("Host(`", 1)[1].split("`)", 1)[0]
+                if host and "$" not in host:
+                    links.append(V2ExternalLink(label="Open", url=f"http://{host}", kind="app"))
+
+    for port in ports if isinstance(ports, list) else []:
+        if not isinstance(port, str) or ":" not in port:
+            continue
+        published = resolve_env_default(port.split(":", 1)[0])
+        target = port.rsplit(":", 1)[-1]
+        if published.isdigit():
+            links.append(
+                V2ExternalLink(
+                    label=f":{target}",
+                    url=f"http://localhost:{published}",
+                    kind="port",
+                )
+            )
+
+    return links[:4]
+
+
+def service_ports_from_definition(service: Any) -> list[V2ServicePort]:
+    compose = getattr(service, "compose", {}) if service is not None else {}
+    ports = compose.get("ports") if isinstance(compose, Mapping) else []
+    exposed: list[V2ServicePort] = []
+    for index, port in enumerate(ports if isinstance(ports, list) else []):
+        if not isinstance(port, str):
+            continue
+        if ":" in port:
+            published, target = port.rsplit(":", 1)
+        else:
+            published, target = None, port
+        exposed.append(
+            V2ServicePort(
+                name=f"port-{index + 1}",
+                published=resolve_env_default(published) if published else None,
+                target=target,
+            )
+        )
+    return exposed
+
+
+def resolve_env_default(value: str) -> str:
+    match = ENV_DEFAULT_RE.match(value)
+    if match is not None:
+        return match.group("default")
+    return value
+
+
+def service_config_from_definition(service: Any) -> list[V2ServiceConfigEntry]:
+    env_vars = getattr(service, "env_vars", {}) if service is not None else {}
+    if not isinstance(env_vars, Mapping):
+        return []
+
+    entries: list[V2ServiceConfigEntry] = []
+    for name, config in sorted(env_vars.items()):
+        if not isinstance(config, Mapping):
+            continue
+        secret = bool(config.get("secret"))
+        entries.append(
+            V2ServiceConfigEntry(
+                name=str(name),
+                value=None if secret else coerce_str(config.get("default"), "") or None,
+                description=coerce_str(config.get("description"), "") or None,
+                secret=secret,
+            )
+        )
+    return entries[:12]
+
+
+def load_services(
+    project_root: Path,
+    containers: Sequence[Mapping[str, Any]] | None = None,
+) -> list[V2Service]:
+    """Load services through core discovery, falling back deterministically."""
+    _ = project_root
+    try:
+        from phlo.plugins.discovery import ServiceDiscovery
+
+        discovered = ServiceDiscovery().discover().values()
+    except Exception:
+        discovered = []
+
+    services: list[V2Service] = []
+    containers = containers if containers is not None else load_docker_containers()
+    discovered = list(discovered)
+    runtime_statuses = load_docker_service_statuses(
+        {service.name for service in discovered},
+        containers,
+    )
+    for service in discovered:
+        in_stack = service.name in runtime_statuses
+        status, health = runtime_statuses.get(
+            service.name,
+            ("unknown", V2Health(state="unknown", message="Runtime status unavailable")),
+        )
+        services.append(
+            V2Service(
+                id=service.name,
+                name=service.name,
+                kind=service.category or "service",
+                status=status,
+                health=health,
+                definition_state="configured" if in_stack else "available",
+                runtime_state=status,
+                in_stack=in_stack,
+                disabled=bool(getattr(service, "disabled", False)),
+                profile=coerce_str(service.profile, "") or None,
+                backend="docker" if in_stack else "unknown",
+                depends_on=list(service.depends_on or []),
+                impacts=[],
+                links=service_links_from_definition(service),
+                metadata=safe_metadata(
+                    {
+                        "default": bool(service.default),
+                        "profile": service.profile,
+                        "core": bool(getattr(service, "core", False)),
+                        "description": getattr(service, "description", None),
+                    }
+                ),
+            )
+        )
+
+    services.extend(
+        runtime_services_from_containers(containers, {service.id for service in services})
+    )
+
+    return sorted(services, key=lambda item: item.id) if services else fallback_services()

--- a/packages/phlo-api/tests/test_observatory_v2_read_models.py
+++ b/packages/phlo-api/tests/test_observatory_v2_read_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from phlo_api.observatory_api.v2_cache import ReadModelCache
+from phlo_api.observatory_api.v2_saved_queries import validate_saved_query_sql
 from phlo_api.observatory_api.v2_services import (
     docker_status_from_container,
     service_name_from_container,
@@ -42,3 +43,14 @@ def test_docker_status_from_running_container() -> None:
 
 def test_service_name_from_container_matches_known_service_id() -> None:
     assert service_name_from_container("demo-postgres-1", {"postgres"}) == "postgres"
+
+
+def test_validate_saved_query_sql_accepts_select_star_limit() -> None:
+    assert validate_saved_query_sql("select * from raw.events limit 10") is None
+
+
+def test_validate_saved_query_sql_rejects_delete() -> None:
+    assert (
+        validate_saved_query_sql("delete from raw.events")
+        == "Only simple SELECT preview queries can be saved."
+    )

--- a/packages/phlo-api/tests/test_observatory_v2_read_models.py
+++ b/packages/phlo-api/tests/test_observatory_v2_read_models.py
@@ -35,9 +35,7 @@ def test_read_model_cache_clear_removes_values() -> None:
 
 
 def test_docker_status_from_running_container() -> None:
-    status, health = docker_status_from_container(
-        {"State": "running", "Status": "Up 10 seconds"}
-    )
+    status, health = docker_status_from_container({"State": "running", "Status": "Up 10 seconds"})
 
     assert status == "running"
     assert health.state == "unknown"

--- a/packages/phlo-api/tests/test_observatory_v2_read_models.py
+++ b/packages/phlo-api/tests/test_observatory_v2_read_models.py
@@ -1,0 +1,27 @@
+"""Tests for extracted Observatory v2 read models."""
+
+from __future__ import annotations
+
+from phlo_api.observatory_api.v2_cache import ReadModelCache
+
+
+def test_read_model_cache_returns_cached_value_before_ttl() -> None:
+    cache = ReadModelCache(project_key=lambda: "demo")
+    calls: list[str] = []
+
+    first = cache.cached("services", 30, lambda: calls.append("called") or ["postgres"])
+    second = cache.cached("services", 30, lambda: calls.append("called") or ["trino"])
+
+    assert first == ["postgres"]
+    assert second == ["postgres"]
+    assert calls == ["called"]
+
+
+def test_read_model_cache_clear_removes_values() -> None:
+    cache = ReadModelCache(project_key=lambda: "demo")
+    cache.cached("services", 30, lambda: ["postgres"])
+
+    cache.clear()
+    value = cache.cached("services", 30, lambda: ["trino"])
+
+    assert value == ["trino"]

--- a/packages/phlo-api/tests/test_observatory_v2_read_models.py
+++ b/packages/phlo-api/tests/test_observatory_v2_read_models.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from phlo_api.observatory_api.v2_cache import ReadModelCache
+from phlo_api.observatory_api.v2_models import V2Asset, V2Health, V2Service
 from phlo_api.observatory_api.v2_saved_queries import validate_saved_query_sql
+from phlo_api.observatory_api.v2_search import search_results
 from phlo_api.observatory_api.v2_services import (
     docker_status_from_container,
     service_name_from_container,
@@ -54,3 +56,23 @@ def test_validate_saved_query_sql_rejects_delete() -> None:
         validate_saved_query_sql("delete from raw.events")
         == "Only simple SELECT preview queries can be saved."
     )
+
+
+def test_search_results_matches_services_and_assets() -> None:
+    results = search_results(
+        query="post",
+        services=[
+            V2Service(
+                id="postgres",
+                name="Postgres",
+                kind="service",
+                status="running",
+                health=V2Health(state="ok"),
+            )
+        ],
+        assets=[V2Asset(id="raw.events", name="Raw Events", group="raw")],
+        tables=[],
+        operations=[],
+    )
+
+    assert [result.id for result in results] == ["service:postgres"]

--- a/packages/phlo-api/tests/test_observatory_v2_read_models.py
+++ b/packages/phlo-api/tests/test_observatory_v2_read_models.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from phlo_api.observatory_api.v2_cache import ReadModelCache
+from phlo_api.observatory_api.v2_services import (
+    docker_status_from_container,
+    service_name_from_container,
+)
 
 
 def test_read_model_cache_returns_cached_value_before_ttl() -> None:
@@ -25,3 +29,16 @@ def test_read_model_cache_clear_removes_values() -> None:
     value = cache.cached("services", 30, lambda: ["trino"])
 
     assert value == ["trino"]
+
+
+def test_docker_status_from_running_container() -> None:
+    status, health = docker_status_from_container(
+        {"State": "running", "Status": "Up 10 seconds"}
+    )
+
+    assert status == "running"
+    assert health.state == "unknown"
+
+
+def test_service_name_from_container_matches_known_service_id() -> None:
+    assert service_name_from_container("demo-postgres-1", {"postgres"}) == "postgres"


### PR DESCRIPTION
**TL;DR:** Splits Observatory v2 read-model behavior out of the large route module into focused modules for cache, services, saved queries, and search.

Closes #496.

## What Changed

- Added `v2_cache.py` with a reusable project-scoped TTL read-model cache.
- Added `v2_services.py` for service read-model loading, Docker status normalization, service links, ports, and config entries.
- Added `v2_saved_queries.py` for saved-query persistence, deduplication, and SQL validation.
- Added `v2_search.py` for provider-neutral search result composition.
- Kept `v2.py` as the FastAPI route wiring layer while delegating extracted read-model work to focused modules.
- Added focused read-model tests covering cache behavior, service helpers, saved-query validation, and search composition.

## Why

`v2.py` mixed route wiring, caching, Docker integration, saved-query persistence, and search composition. Extracting these modules gives each Observatory surface better locality and lets tests exercise read-model behavior without loading the whole route module.

## Verification

- `uv run pytest packages/phlo-api/tests/test_observatory_v2_api.py packages/phlo-api/tests/test_observatory_v2_surfaces.py -v`
- `uv run ruff check packages/phlo-api/src/phlo_api/observatory_api packages/phlo-api/tests/test_observatory_v2_read_models.py`
- `uv run pytest packages/phlo-api/tests/test_observatory_v2_read_models.py packages/phlo-api/tests/test_observatory_v2_api.py packages/phlo-api/tests/test_observatory_v2_storage.py packages/phlo-api/tests/test_observatory_v2_surfaces.py -v`
- `uv run ty check packages/phlo-api/src/phlo_api/observatory_api`