### PR TITLE
refactor: deepen table store capability semantics

### DIFF
--- a/packages/phlo-delta/src/phlo_delta/resource.py
+++ b/packages/phlo-delta/src/phlo_delta/resource.py
@@ -75,9 +75,10 @@ def _resolve_delta_ref(override_ref: str | None) -> None:
     if override_ref in (None, "", "main"):
         return
     raise PhloConfigError(
-        message=f"Delta table_store does not support override_ref={override_ref!r}",
+        message=f"Delta table_store does not support refs; got override_ref={override_ref!r}",
         suggestions=[
             "Use the default main ref when writing to Delta tables",
+            "Use resource.support.supports_refs to branch behaviour before calling table-store operations",
             "Use phlo-iceberg if you need Nessie branch-aware table writes",
         ],
     )

--- a/packages/phlo-delta/src/phlo_delta/resource.py
+++ b/packages/phlo-delta/src/phlo_delta/resource.py
@@ -23,6 +23,7 @@ from typing import Any, cast
 import pyarrow as pa
 from pandera.pandas import DataFrameModel
 
+from phlo.capabilities.interfaces import TableStoreSupport
 from phlo.exceptions import PhloConfigError
 from phlo.logging import get_logger
 from phlo_delta.settings import get_settings
@@ -160,6 +161,17 @@ class DeltaResource:
         stats = resource.append_parquet("raw.events", "/data/file.parquet")
 
     """
+
+    @property
+    def support(self) -> TableStoreSupport:
+        """Return Delta table-store support metadata."""
+        return TableStoreSupport(
+            supports_refs=False,
+            partition_transforms=frozenset({"identity"}),
+            supports_snapshots=True,
+            supports_compaction=True,
+            supports_vacuum=True,
+        )
 
     def table_uri(self, table_name: str) -> str:
         """Construct the full S3 path for a Delta table.

--- a/packages/phlo-delta/tests/test_delta_resource.py
+++ b/packages/phlo-delta/tests/test_delta_resource.py
@@ -9,6 +9,16 @@ from phlo.exceptions import PhloConfigError
 from phlo_delta.resource import DeltaResource
 
 
+def test_delta_resource_support_is_main_ref_identity_partitioned() -> None:
+    support = DeltaResource().support
+
+    assert support.supports_refs is False
+    assert support.partition_transforms == frozenset({"identity"})
+    assert support.supports_snapshots is True
+    assert support.supports_compaction is True
+    assert support.supports_vacuum is True
+
+
 def test_delta_resource_ensure_table_maps_identity_partition_spec() -> None:
     """DeltaResource should translate identity partition specs into Delta columns."""
     resource = DeltaResource()

--- a/packages/phlo-delta/tests/test_delta_resource.py
+++ b/packages/phlo-delta/tests/test_delta_resource.py
@@ -78,10 +78,22 @@ def test_delta_resource_merge_parquet_rejects_non_main_override_ref() -> None:
     """DeltaResource should reject branch-like override refs it cannot honor."""
     resource = DeltaResource()
 
-    with pytest.raises(PhloConfigError, match="does not support override_ref='dev'"):
+    with pytest.raises(PhloConfigError, match="does not support refs; got override_ref='dev'"):
         resource.merge_parquet(
             table_name="raw.pokemon_species",
             data_path="/tmp/pokemon.parquet",
             unique_key="pokemon_id",
             override_ref="dev",
         )
+
+
+def test_delta_ref_validation_error_mentions_support_metadata() -> None:
+    with pytest.raises(PhloConfigError) as exc:
+        DeltaResource().merge_parquet(
+            table_name="raw.events",
+            data_path="/tmp/events.parquet",
+            unique_key="id",
+            override_ref="dev",
+        )
+
+    assert "does not support refs" in str(exc.value)

--- a/packages/phlo-iceberg/src/phlo_iceberg/resource.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/resource.py
@@ -55,6 +55,7 @@ from pyiceberg.catalog import Catalog
 from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 
+from phlo.capabilities.interfaces import TableStoreSupport
 from phlo.logging import get_logger
 from phlo_iceberg.catalog import get_catalog
 from phlo_iceberg.settings import get_settings
@@ -106,6 +107,17 @@ class IcebergResource:
     """
 
     ref: str = field(default_factory=lambda: get_settings().iceberg_default_ref)
+
+    @property
+    def support(self) -> TableStoreSupport:
+        """Return Iceberg table-store support metadata."""
+        return TableStoreSupport(
+            supports_refs=True,
+            partition_transforms=frozenset({"identity", "day", "hour", "month", "year"}),
+            supports_snapshots=True,
+            supports_compaction=False,
+            supports_vacuum=True,
+        )
 
     def get_catalog(self, override_ref: str | None = None) -> Catalog:
         """Return an Iceberg catalog client for the active branch.

--- a/packages/phlo-iceberg/tests/test_resources.py
+++ b/packages/phlo-iceberg/tests/test_resources.py
@@ -64,6 +64,18 @@ class TestResourcesUnitTests:
             table_name="raw.entries", data_path="/path/to/data.parquet", ref="dev"
         )
 
+    def test_iceberg_resource_supports_refs_and_partition_transforms(self) -> None:
+        """IcebergResource should advertise branch and partition transform support."""
+        support = IcebergResource().support
+
+        assert support.supports_refs is True
+        assert support.partition_transforms == frozenset(
+            {"identity", "day", "hour", "month", "year"}
+        )
+        assert support.supports_snapshots is True
+        assert support.supports_vacuum is True
+        assert support.supports_compaction is False
+
     @patch("phlo_trino.resource.connect")
     @patch("phlo_trino.resource.config")
     def test_trino_resource_get_connection_creates_connections_with_correct_catalog(

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -9,6 +9,20 @@ from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 
+@dataclass(frozen=True, slots=True)
+class TableStoreSupport:
+    """Explicit support metadata for table-store adapters."""
+
+    supports_refs: bool = False
+    partition_transforms: frozenset[str] = frozenset({"identity"})
+    supports_snapshots: bool = False
+    supports_compaction: bool = False
+    supports_vacuum: bool = False
+
+    def supports_partition_transform(self, transform: str) -> bool:
+        return transform in self.partition_transforms
+
+
 @runtime_checkable
 class TableStore(Protocol):
     """Protocol for table-store providers used by ingestion components.

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -33,6 +33,11 @@ class TableStore(Protocol):
     ``NotImplementedError`` by default so providers opt in incrementally.
     """
 
+    @property
+    def support(self) -> TableStoreSupport:
+        """Return explicit support metadata for this table-store adapter."""
+        return TableStoreSupport()
+
     def ensure_table(
         self,
         *,

--- a/tests/plugins/test_table_store_support.py
+++ b/tests/plugins/test_table_store_support.py
@@ -1,0 +1,20 @@
+"""Tests for table-store support metadata."""
+
+from phlo.capabilities.interfaces import TableStoreSupport
+
+
+def test_table_store_support_defaults_to_basic_writes() -> None:
+    support = TableStoreSupport()
+
+    assert support.supports_refs is False
+    assert support.partition_transforms == frozenset({"identity"})
+    assert support.supports_snapshots is False
+    assert support.supports_compaction is False
+    assert support.supports_vacuum is False
+
+
+def test_table_store_support_reports_partition_transform_support() -> None:
+    support = TableStoreSupport(partition_transforms=frozenset({"identity", "day"}))
+
+    assert support.supports_partition_transform("identity") is True
+    assert support.supports_partition_transform("bucket") is False

--- a/tests/plugins/test_table_store_support.py
+++ b/tests/plugins/test_table_store_support.py
@@ -1,6 +1,6 @@
 """Tests for table-store support metadata."""
 
-from phlo.capabilities.interfaces import TableStoreSupport
+from phlo.capabilities.interfaces import TableStore, TableStoreSupport
 
 
 def test_table_store_support_defaults_to_basic_writes() -> None:
@@ -18,3 +18,38 @@ def test_table_store_support_reports_partition_transform_support() -> None:
 
     assert support.supports_partition_transform("identity") is True
     assert support.supports_partition_transform("bucket") is False
+
+
+class MinimalStore:
+    support = TableStoreSupport()
+
+    def ensure_table(self, *, table_name, schema, partition_spec=None, override_ref=None):
+        return object()
+
+    def append_parquet(self, *, table_name, data_path, override_ref=None):
+        return {"rows_inserted": 1}
+
+    def merge_parquet(self, *, table_name, data_path, unique_key, override_ref=None):
+        return {"rows_inserted": 1, "rows_deleted": 0}
+
+    def overwrite_parquet(self, *, table_name, data_path, override_ref=None):
+        return {"rows_inserted": 1}
+
+    def delete_rows(self, *, table_name, predicate, override_ref=None):
+        return {"rows_deleted": 1}
+
+    def compact(self, *, table_name, override_ref=None):
+        return {}
+
+    def list_snapshots(self, *, table_name, limit=10):
+        return []
+
+    def rollback_to_snapshot(self, *, table_name, snapshot_id):
+        return {}
+
+    def vacuum(self, *, table_name, retain_hours=168):
+        return {}
+
+
+def test_table_store_protocol_accepts_support_property() -> None:
+    assert isinstance(MinimalStore(), TableStore)


### PR DESCRIPTION
**TL;DR:** Makes table-store adapter capabilities explicit so callers can inspect Iceberg and Delta support for refs, partition transforms, snapshots, compaction, and vacuum.

Closes #497.

## What Changed

- Added `TableStoreSupport` metadata to the core capability interfaces.
- Exposed a `support` property on the `TableStore` protocol.
- Added Iceberg support metadata for branch refs, partition transforms, snapshots, and vacuum support.
- Added Delta support metadata for identity partitioning, snapshots, compaction, and vacuum support.
- Updated Delta ref validation to explain that Delta does not support refs and point callers toward support metadata.
- Added tests for support defaults, protocol compatibility, Iceberg support, Delta support, and Delta ref validation behavior.

## Why

The table-store seam is real because Phlo has multiple adapters, but the old interface made callers discover adapter-specific caveats by attempting operations and handling failures. Explicit support metadata improves locality for table-store rules and gives ingestion/maintenance callers a small interface for provider capability checks.

## Verification

- `uv run ruff check src/phlo/capabilities/interfaces.py packages/phlo-iceberg/src/phlo_iceberg/resource.py packages/phlo-delta/src/phlo_delta/resource.py tests/plugins/test_table_store_support.py`
- `uv run pytest tests/plugins/test_table_store_support.py packages/phlo-iceberg/tests/test_resources.py packages/phlo-delta/tests/test_delta_resource.py packages/phlo-dlt/tests/test_ingestion_decorator.py -v`
- `uv run ty check src/phlo/capabilities packages/phlo-iceberg/src/phlo_iceberg packages/phlo-delta/src/phlo_delta`