### PR TITLE
refactor: deepen service package manifest resolution

### DIFF
--- a/src/phlo/cli/commands/services/utils.py
+++ b/src/phlo/cli/commands/services/utils.py
@@ -19,6 +19,7 @@ from phlo.cli.output import missing_compose_file_error, missing_phlo_project_err
 from phlo.infrastructure.containers import resolve_container_name as _resolve_container_name
 from phlo.logging import get_logger
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
+from phlo.plugins.discovery.service_manifest import ServiceManifestResolver
 from phlo.utils import dedupe_preserve_order
 
 logger = get_logger(__name__)
@@ -701,34 +702,16 @@ def expand_service_dependencies(
 ) -> list[ServiceDefinition]:
     """Expand a list of services with their transitive dependencies and setup companions.
 
-    Returns services in topological (dependency) order via ``discovery.resolve_dependencies``.
+    Returns services in topological (dependency) order via manifest resolution.
     """
     if not services:
         return []
 
-    all_services = discovery.discover()
-
-    selected: dict[str, ServiceDefinition] = {service.name: service for service in services}
-    queue = list(services)
-    while queue:
-        service = queue.pop(0)
-        for dependency_name in service.depends_on:
-            dependency = all_services.get(dependency_name)
-            if dependency and dependency.name not in selected:
-                selected[dependency.name] = dependency
-                queue.append(dependency)
-
-    bootstrap_companions = [
-        service
-        for service in all_services.values()
-        if service.name.endswith("-setup")
-        and service.depends_on
-        and all(dependency in selected for dependency in service.depends_on)
-    ]
-    for companion in bootstrap_companions:
-        selected.setdefault(companion.name, companion)
-
-    return discovery.resolve_dependencies(list(selected.values()))
+    all_services = list(discovery.discover().values())
+    return ServiceManifestResolver.expand_dependencies(
+        all_services,
+        [service.name for service in services],
+    )
 
 
 def _regenerate_compose(discovery, config: dict, phlo_dir: Path):

--- a/src/phlo/plugins/discovery/service_manifest.py
+++ b/src/phlo/plugins/discovery/service_manifest.py
@@ -4,14 +4,48 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 from phlo.plugins.discovery._service_definition import ServiceDefinition
+from phlo.plugins.discovery._service_loading import resolve_plugin_source_path
+from phlo.plugins.discovery.plugins import discover_plugins
+from phlo.plugins.discovery.registry import get_global_registry
 
 
 def _is_service_yaml(filename: str) -> bool:
     return filename == "service.yaml" or filename.endswith(("-setup.yaml", "-daemon.yaml"))
+
+
+def get_registered_service_plugins() -> dict[str, Any]:
+    registry = get_global_registry()
+    return {
+        name: plugin
+        for name in registry.list_services()
+        if (plugin := registry.get_service(name)) is not None
+    }
+
+
+def _companion_manifests(
+    source_path: Path | None,
+    existing_names: set[str],
+) -> list[ServiceManifest]:
+    if not source_path or not source_path.exists():
+        return []
+
+    manifests: list[ServiceManifest] = []
+    for yaml_path in sorted(source_path.rglob("*.yaml")):
+        if yaml_path.name == "service.yaml":
+            continue
+        if not yaml_path.name.endswith(("-setup.yaml", "-daemon.yaml")):
+            continue
+        definition = ServiceDefinition.from_yaml(yaml_path)
+        if definition.name in existing_names:
+            continue
+        existing_names.add(definition.name)
+        manifests.append(ServiceManifest(definition=definition, source_path=yaml_path))
+    return manifests
 
 
 class ServiceManifestError(ValueError):
@@ -57,6 +91,27 @@ class ServiceManifestResolver:
     """Resolve service package manifests from plugins and local service directories."""
 
     services_dir: Path | None = None
+
+    def resolve_plugin_manifests(self) -> list[ServiceManifest]:
+        discover_plugins(plugin_type="services", auto_register=True)
+        manifests: list[ServiceManifest] = []
+        names: set[str] = set()
+        for name, plugin in get_registered_service_plugins().items():
+            source_path = resolve_plugin_source_path(plugin)
+            try:
+                definition = ServiceDefinition.from_dict(plugin.service_definition, source_path)
+            except (KeyError, ValueError) as exc:
+                raise ServiceManifestError(
+                    "invalid plugin service definition",
+                    service_name=name,
+                    source_path=source_path,
+                ) from exc
+            if definition.name in names:
+                continue
+            names.add(definition.name)
+            manifests.append(ServiceManifest(definition=definition, source_path=source_path))
+            manifests.extend(_companion_manifests(source_path, names))
+        return manifests
 
     def resolve_directory_manifests(self) -> list[ServiceManifest]:
         if not self.services_dir or not self.services_dir.exists():

--- a/src/phlo/plugins/discovery/service_manifest.py
+++ b/src/phlo/plugins/discovery/service_manifest.py
@@ -1,0 +1,46 @@
+"""Service package manifest resolution primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from phlo.plugins.discovery._service_definition import ServiceDefinition
+
+
+class ServiceManifestError(ValueError):
+    """Raised when a service package manifest cannot be resolved."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        service_name: str | None = None,
+        source_path: Path | None = None,
+    ) -> None:
+        self.message = message
+        self.service_name = service_name
+        self.source_path = source_path
+        super().__init__(self.__str__())
+
+    def __str__(self) -> str:
+        details: list[str] = []
+        if self.service_name:
+            details.append(f"service={self.service_name}")
+        if self.source_path:
+            details.append(f"source={self.source_path}")
+        if not details:
+            return self.message
+        return f"{self.message}: {' '.join(details)}"
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceManifest:
+    """Resolved service package manifest with source context."""
+
+    definition: ServiceDefinition
+    source_path: Path | None = None
+
+    @property
+    def name(self) -> str:
+        return self.definition.name

--- a/src/phlo/plugins/discovery/service_manifest.py
+++ b/src/phlo/plugins/discovery/service_manifest.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 from phlo.plugins.discovery._service_definition import ServiceDefinition
+
+
+def _is_service_yaml(filename: str) -> bool:
+    return filename == "service.yaml" or filename.endswith(("-setup.yaml", "-daemon.yaml"))
 
 
 class ServiceManifestError(ValueError):
@@ -44,3 +50,30 @@ class ServiceManifest:
     @property
     def name(self) -> str:
         return self.definition.name
+
+
+@dataclass(slots=True)
+class ServiceManifestResolver:
+    """Resolve service package manifests from plugins and local service directories."""
+
+    services_dir: Path | None = None
+
+    def resolve_directory_manifests(self) -> list[ServiceManifest]:
+        if not self.services_dir or not self.services_dir.exists():
+            return []
+
+        manifests: list[ServiceManifest] = []
+        for yaml_path in sorted(self.services_dir.rglob("*.yaml")):
+            if ".schema" in str(yaml_path):
+                continue
+            if not _is_service_yaml(yaml_path.name):
+                continue
+            try:
+                definition = ServiceDefinition.from_yaml(yaml_path)
+            except (yaml.YAMLError, KeyError, ValueError) as exc:
+                raise ServiceManifestError(
+                    "invalid service definition file",
+                    source_path=yaml_path,
+                ) from exc
+            manifests.append(ServiceManifest(definition=definition, source_path=yaml_path))
+        return manifests

--- a/src/phlo/plugins/discovery/service_manifest.py
+++ b/src/phlo/plugins/discovery/service_manifest.py
@@ -9,6 +9,7 @@ from typing import Any
 import yaml
 
 from phlo.plugins.discovery._service_definition import ServiceDefinition
+from phlo.plugins.discovery._service_dependency_resolution import resolve_service_dependencies
 from phlo.plugins.discovery._service_loading import resolve_plugin_source_path
 from phlo.plugins.discovery.plugins import discover_plugins
 from phlo.plugins.discovery.registry import get_global_registry
@@ -132,3 +133,40 @@ class ServiceManifestResolver:
                 ) from exc
             manifests.append(ServiceManifest(definition=definition, source_path=yaml_path))
         return manifests
+
+    @staticmethod
+    def expand_dependencies(
+        services: list[ServiceDefinition],
+        requested_names: list[str],
+    ) -> list[ServiceDefinition]:
+        service_by_name = {service.name: service for service in services}
+        missing = [name for name in requested_names if name not in service_by_name]
+        if missing:
+            raise ServiceManifestError(
+                "unknown service dependency request",
+                service_name=", ".join(missing),
+            )
+
+        selected: dict[str, ServiceDefinition] = {}
+
+        def include(service: ServiceDefinition) -> None:
+            for dependency_name in service.depends_on:
+                dependency = service_by_name.get(dependency_name)
+                if dependency is not None:
+                    include(dependency)
+            selected[service.name] = service
+
+        for name in requested_names:
+            include(service_by_name[name])
+
+        bootstrap_companions = [
+            service
+            for service in services
+            if service.name.endswith("-setup")
+            and service.depends_on
+            and all(dependency in selected for dependency in service.depends_on)
+        ]
+        for companion in bootstrap_companions:
+            selected.setdefault(companion.name, companion)
+
+        return resolve_service_dependencies(list(selected.values()))

--- a/src/phlo/plugins/discovery/services.py
+++ b/src/phlo/plugins/discovery/services.py
@@ -10,6 +10,7 @@ from phlo.plugins.discovery._service_cycles import find_cycles as _find_cycles_i
 from phlo.plugins.discovery._service_definition import ServiceDefinition
 from phlo.plugins.discovery._service_dependency_resolution import resolve_service_dependencies
 from phlo.plugins.discovery.registry import get_global_registry
+from phlo.plugins.discovery.service_manifest import ServiceManifestError, ServiceManifestResolver
 
 logger = get_logger(__name__)
 
@@ -98,13 +99,27 @@ class ServiceDiscovery:
         )
 
         self._services = {}
-        plugin_service_count = self._load_service_plugins()
-        import phlo.plugins.discovery._service_loading as _service_loading
+        resolver = ServiceManifestResolver(services_dir=self.services_dir)
+        try:
+            plugin_manifests = resolver.resolve_plugin_manifests()
+            directory_manifests = resolver.resolve_directory_manifests()
+        except ServiceManifestError as exc:
+            _emit_service_discovery_signal(
+                event_name="service_discovery_manifest_load_failed",
+                level="warning",
+                services_dir=self.services_dir,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            )
+            raise
 
-        file_service_count = _service_loading.load_services_from_directory(
-            self.services_dir,
-            self._services,
-        )
+        for manifest in plugin_manifests:
+            self._services.setdefault(manifest.name, manifest.definition)
+        for manifest in directory_manifests:
+            self._services.setdefault(manifest.name, manifest.definition)
+
+        plugin_service_count = len(plugin_manifests)
+        file_service_count = len(directory_manifests)
 
         self._loaded = True
         _emit_service_discovery_signal(

--- a/tests/plugins/test_service_manifest_resolver.py
+++ b/tests/plugins/test_service_manifest_resolver.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import pytest
 
 from phlo.plugins.discovery._service_definition import ServiceDefinition
-from phlo.plugins.discovery.service_manifest import ServiceManifest, ServiceManifestError
+from phlo.plugins.discovery.service_manifest import (
+    ServiceManifest,
+    ServiceManifestError,
+    ServiceManifestResolver,
+)
 
 
 def test_service_manifest_wraps_definition_and_source_path(tmp_path: Path) -> None:
@@ -32,3 +36,36 @@ def test_service_manifest_error_includes_context() -> None:
     )
 
     assert str(error) == "invalid service definition: service=postgres source=services/postgres/service.yaml"
+
+
+def test_resolver_loads_service_yaml_files_from_directory(tmp_path: Path) -> None:
+    service_dir = tmp_path / "services"
+    service_dir.mkdir()
+    (service_dir / "postgres.service.schema.yaml").write_text("name: ignored\n", encoding="utf-8")
+    (service_dir / "postgres.yaml").write_text("name: ignored\nimage: busybox\n", encoding="utf-8")
+    (service_dir / "service.yaml").write_text(
+        "name: postgres\ndescription: Postgres\nimage: postgres:16\ndefault: true\n",
+        encoding="utf-8",
+    )
+
+    resolver = ServiceManifestResolver(services_dir=service_dir)
+
+    manifests = resolver.resolve_directory_manifests()
+
+    assert [manifest.name for manifest in manifests] == ["postgres"]
+    assert manifests[0].definition.image == "postgres:16"
+
+
+def test_resolver_raises_contextual_error_for_bad_yaml(tmp_path: Path) -> None:
+    service_dir = tmp_path / "services"
+    service_dir.mkdir()
+    bad_yaml = service_dir / "service.yaml"
+    bad_yaml.write_text("name: [", encoding="utf-8")
+
+    resolver = ServiceManifestResolver(services_dir=service_dir)
+
+    with pytest.raises(ServiceManifestError) as exc:
+        resolver.resolve_directory_manifests()
+
+    assert "invalid service definition file" in str(exc.value)
+    assert f"source={bad_yaml}" in str(exc.value)

--- a/tests/plugins/test_service_manifest_resolver.py
+++ b/tests/plugins/test_service_manifest_resolver.py
@@ -4,12 +4,12 @@ import pytest
 
 from phlo.plugins.discovery._service_definition import ServiceDefinition
 from phlo.plugins.discovery.registry import get_global_registry
-from phlo.plugins.discovery.services import ServiceDiscovery
 from phlo.plugins.discovery.service_manifest import (
     ServiceManifest,
     ServiceManifestError,
     ServiceManifestResolver,
 )
+from phlo.plugins.discovery.services import ServiceDiscovery
 
 
 def test_service_manifest_wraps_definition_and_source_path(tmp_path: Path) -> None:
@@ -178,3 +178,17 @@ def test_service_discovery_uses_manifest_resolver_for_directory_services(
 
     assert list(services) == ["postgres"]
     assert services["postgres"].image == "postgres:16"
+
+
+def test_resolver_expands_requested_services_with_dependencies(tmp_path: Path) -> None:
+    definitions = [
+        ServiceDefinition.from_dict({"name": "postgres", "image": "postgres:16"}, tmp_path),
+        ServiceDefinition.from_dict(
+            {"name": "api", "image": "api:latest", "depends_on": ["postgres"]},
+            tmp_path,
+        ),
+    ]
+
+    expanded = ServiceManifestResolver.expand_dependencies(definitions, ["api"])
+
+    assert [service.name for service in expanded] == ["postgres", "api"]

--- a/tests/plugins/test_service_manifest_resolver.py
+++ b/tests/plugins/test_service_manifest_resolver.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+import pytest
+
+from phlo.plugins.discovery._service_definition import ServiceDefinition
+from phlo.plugins.discovery.service_manifest import ServiceManifest, ServiceManifestError
+
+
+def test_service_manifest_wraps_definition_and_source_path(tmp_path: Path) -> None:
+    definition = ServiceDefinition.from_dict(
+        {
+            "name": "postgres",
+            "image": "postgres:16",
+            "default": True,
+            "depends_on": [],
+        },
+        tmp_path / "service.yaml",
+    )
+
+    manifest = ServiceManifest(definition=definition, source_path=tmp_path / "service.yaml")
+
+    assert manifest.name == "postgres"
+    assert manifest.definition is definition
+    assert manifest.source_path == tmp_path / "service.yaml"
+
+
+def test_service_manifest_error_includes_context() -> None:
+    error = ServiceManifestError(
+        "invalid service definition",
+        service_name="postgres",
+        source_path=Path("services/postgres/service.yaml"),
+    )
+
+    assert str(error) == "invalid service definition: service=postgres source=services/postgres/service.yaml"

--- a/tests/plugins/test_service_manifest_resolver.py
+++ b/tests/plugins/test_service_manifest_resolver.py
@@ -69,3 +69,82 @@ def test_resolver_raises_contextual_error_for_bad_yaml(tmp_path: Path) -> None:
 
     assert "invalid service definition file" in str(exc.value)
     assert f"source={bad_yaml}" in str(exc.value)
+
+
+def test_resolver_loads_plugin_manifest_and_companion_files(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_dir = tmp_path / "phlo_fake"
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (package_dir / "worker-setup.yaml").write_text(
+        "name: worker-setup\ndescription: Worker setup\nimage: busybox\ndefault: false\n",
+        encoding="utf-8",
+    )
+
+    class FakePlugin:
+        service_definition = {
+            "name": "worker",
+            "description": "Worker",
+            "image": "busybox",
+            "default": True,
+        }
+
+    plugin = FakePlugin()
+
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda plugin_type="services", auto_register=True: None,
+    )
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.get_registered_service_plugins",
+        lambda: {"worker": plugin},
+    )
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.resolve_plugin_source_path",
+        lambda _plugin: package_dir,
+    )
+
+    resolver = ServiceManifestResolver()
+
+    manifests = resolver.resolve_plugin_manifests()
+
+    assert [manifest.name for manifest in manifests] == ["worker", "worker-setup"]
+
+
+def test_resolver_skips_companion_duplicate_names(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    package_dir = tmp_path / "phlo_fake"
+    package_dir.mkdir()
+    (package_dir / "service-setup.yaml").write_text(
+        "name: worker\ndescription: Duplicate worker\nimage: duplicate\n",
+        encoding="utf-8",
+    )
+
+    class FakePlugin:
+        service_definition = {
+            "name": "worker",
+            "description": "Worker",
+            "image": "busybox",
+        }
+
+    plugin = FakePlugin()
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda **_: None,
+    )
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.get_registered_service_plugins",
+        lambda: {"worker": plugin},
+    )
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.resolve_plugin_source_path",
+        lambda _plugin: package_dir,
+    )
+
+    manifests = ServiceManifestResolver().resolve_plugin_manifests()
+
+    assert [manifest.name for manifest in manifests] == ["worker"]

--- a/tests/plugins/test_service_manifest_resolver.py
+++ b/tests/plugins/test_service_manifest_resolver.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 
 from phlo.plugins.discovery._service_definition import ServiceDefinition
+from phlo.plugins.discovery.registry import get_global_registry
+from phlo.plugins.discovery.services import ServiceDiscovery
 from phlo.plugins.discovery.service_manifest import (
     ServiceManifest,
     ServiceManifestError,
@@ -148,3 +150,31 @@ def test_resolver_skips_companion_duplicate_names(
     manifests = ServiceManifestResolver().resolve_plugin_manifests()
 
     assert [manifest.name for manifest in manifests] == ["worker"]
+
+
+def test_service_discovery_uses_manifest_resolver_for_directory_services(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    get_global_registry().clear()
+    monkeypatch.setattr(
+        "phlo.plugins.discovery._service_loading.discover_plugins",
+        lambda plugin_type, auto_register: None,
+    )
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda plugin_type="services", auto_register=True: None,
+    )
+    service_dir = tmp_path / "services"
+    service_dir.mkdir()
+    (service_dir / "service.yaml").write_text(
+        "name: postgres\ndescription: Postgres\nimage: postgres:16\n",
+        encoding="utf-8",
+    )
+
+    discovery = ServiceDiscovery(services_dir=service_dir)
+
+    services = discovery.discover(refresh=True)
+
+    assert list(services) == ["postgres"]
+    assert services["postgres"].image == "postgres:16"

--- a/tests/plugins/test_service_manifest_resolver.py
+++ b/tests/plugins/test_service_manifest_resolver.py
@@ -37,7 +37,10 @@ def test_service_manifest_error_includes_context() -> None:
         source_path=Path("services/postgres/service.yaml"),
     )
 
-    assert str(error) == "invalid service definition: service=postgres source=services/postgres/service.yaml"
+    assert (
+        str(error)
+        == "invalid service definition: service=postgres source=services/postgres/service.yaml"
+    )
 
 
 def test_resolver_loads_service_yaml_files_from_directory(tmp_path: Path) -> None:

--- a/tests/runtime/test_services_discovery.py
+++ b/tests/runtime/test_services_discovery.py
@@ -8,6 +8,7 @@ import pytest
 from phlo.plugins import PluginMetadata, ServicePlugin
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery, get_global_registry
 from phlo.plugins.discovery._service_discovery import ServiceDiscovery as CompatServiceDiscovery
+from phlo.plugins.discovery.service_manifest import ServiceManifest, ServiceManifestError
 
 pytestmark = pytest.mark.core_regression
 
@@ -122,28 +123,30 @@ def test_service_discovery_includes_plugins(
     assert services["dummy_service"].category == "core"
 
 
-def test_service_discovery_skips_non_mapping_plugin_service_definitions(
+def test_service_discovery_raises_for_non_mapping_plugin_service_definitions(
     clean_registry: object,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     service_discovery_signals: list[DiscoverySignal],
 ) -> None:
-    """A plugin returning non-mapping service data is skipped without aborting discovery."""
+    """A plugin returning non-mapping service data raises a contextual manifest error."""
     registry = get_global_registry()
     registry.register_service(DummyServicePlugin(), replace=True)
     registry.register_service(NonMappingServicePlugin(), replace=True)
     monkeypatch.setattr(
-        "phlo.plugins.discovery._service_loading.discover_plugins",
-        lambda plugin_type, auto_register: None,
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda plugin_type="services", auto_register=True: None,
     )
 
-    services = ServiceDiscovery(services_dir=tmp_path).discover()
+    with pytest.raises(ServiceManifestError) as exc:
+        ServiceDiscovery(services_dir=tmp_path).discover()
 
-    assert set(services) == {"dummy_service"}
+    assert "invalid plugin service definition" in str(exc.value)
+    assert "service=bad_service" in str(exc.value)
     assert any(
-        signal["event"] == "service_discovery_plugin_load_failed"
-        and signal["fields"]["plugin_name"] == "bad_service"
-        and signal["fields"]["error_type"] == "ValueError"
+        signal["event"] == "service_discovery_manifest_load_failed"
+        and signal["fields"]["error_type"] == "ServiceManifestError"
+        and "bad_service" in str(signal["fields"]["error"])
         for signal in service_discovery_signals
     )
 
@@ -192,8 +195,8 @@ def test_service_discovery_refresh_reloads_stale_cache(
 ) -> None:
     """Verify cached discovery remains stale until explicit refresh."""
     monkeypatch.setattr(
-        "phlo.plugins.discovery._service_loading.discover_plugins",
-        lambda plugin_type, auto_register: None,
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda plugin_type="services", auto_register=True: None,
     )
     _write_service_yaml(tmp_path, "alpha", "alpha")
 
@@ -220,33 +223,39 @@ def test_service_discovery_delegates_loading_behind_cache(
     plugin_loads = 0
     directory_loads = 0
 
-    def _load_plugin_services(self: ServiceDiscovery) -> int:
+    def _resolve_plugin_manifests(self) -> list[ServiceManifest]:
         nonlocal plugin_loads
         plugin_loads += 1
-        self._services["plugin"] = ServiceDefinition(
-            name="plugin",
-            description="Plugin service",
-            category="core",
-        )
-        return 1
+        return [
+            ServiceManifest(
+                ServiceDefinition(
+                    name="plugin",
+                    description="Plugin service",
+                    category="core",
+                )
+            )
+        ]
 
-    def _load_services_from_directory(
-        _services_dir: Path | None,
-        services: dict[str, ServiceDefinition],
-    ) -> int:
+    def _resolve_directory_manifests(self) -> list[ServiceManifest]:
         nonlocal directory_loads
         directory_loads += 1
-        services["file"] = ServiceDefinition(
-            name="file",
-            description="File service",
-            category="core",
-        )
-        return 1
+        return [
+            ServiceManifest(
+                ServiceDefinition(
+                    name="file",
+                    description="File service",
+                    category="core",
+                )
+            )
+        ]
 
-    monkeypatch.setattr(ServiceDiscovery, "_load_service_plugins", _load_plugin_services)
     monkeypatch.setattr(
-        "phlo.plugins.discovery._service_loading.load_services_from_directory",
-        _load_services_from_directory,
+        "phlo.plugins.discovery.service_manifest.ServiceManifestResolver.resolve_plugin_manifests",
+        _resolve_plugin_manifests,
+    )
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.ServiceManifestResolver.resolve_directory_manifests",
+        _resolve_directory_manifests,
     )
 
     discovery = ServiceDiscovery()
@@ -260,6 +269,74 @@ def test_service_discovery_delegates_loading_behind_cache(
     assert directory_loads == 2
 
 
+def test_service_discovery_reports_manifest_load_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    service_discovery_signals: list[DiscoverySignal],
+) -> None:
+    """Resolver errors are logged with context and re-raised."""
+
+    def _raise_manifest_error(self) -> list[ServiceManifest]:
+        raise ServiceManifestError("bad manifest", service_name="broken")
+
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.ServiceManifestResolver.resolve_plugin_manifests",
+        _raise_manifest_error,
+    )
+
+    with pytest.raises(ServiceManifestError, match="bad manifest: service=broken"):
+        ServiceDiscovery().discover()
+
+    assert any(
+        signal["event"] == "service_discovery_manifest_load_failed"
+        and signal["fields"]["error_type"] == "ServiceManifestError"
+        and signal["fields"]["error"] == "bad manifest: service=broken"
+        for signal in service_discovery_signals
+    )
+
+
+def test_service_discovery_resolver_counts_completion_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    service_discovery_signals: list[DiscoverySignal],
+) -> None:
+    """Completion signals report plugin and directory manifest counts."""
+
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.ServiceManifestResolver.resolve_plugin_manifests",
+        lambda self: [
+            ServiceManifest(
+                ServiceDefinition(
+                    name="plugin",
+                    description="Plugin service",
+                    category="core",
+                )
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "phlo.plugins.discovery.service_manifest.ServiceManifestResolver.resolve_directory_manifests",
+        lambda self: [
+            ServiceManifest(
+                ServiceDefinition(
+                    name="file",
+                    description="File service",
+                    category="core",
+                )
+            )
+        ],
+    )
+
+    services = ServiceDiscovery().discover()
+
+    assert set(services) == {"plugin", "file"}
+    completed = next(
+        signal
+        for signal in service_discovery_signals
+        if signal["event"] == "service_discovery_completed"
+    )
+    assert completed["fields"]["plugin_service_count"] == 1
+    assert completed["fields"]["file_service_count"] == 1
+
+
 def test_service_discovery_clear_cache_and_refresh_alias(
     clean_registry: object,
     monkeypatch: pytest.MonkeyPatch,
@@ -267,8 +344,8 @@ def test_service_discovery_clear_cache_and_refresh_alias(
 ) -> None:
     """Verify cache invalidation API triggers rediscovery."""
     monkeypatch.setattr(
-        "phlo.plugins.discovery._service_loading.discover_plugins",
-        lambda plugin_type, auto_register: None,
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda plugin_type="services", auto_register=True: None,
     )
     _write_service_yaml(tmp_path, "alpha", "alpha")
 
@@ -293,8 +370,8 @@ def test_service_discovery_emits_cache_refresh_observability_signals(
 ) -> None:
     """Cache and refresh flows emit structured, queryable discovery signals."""
     monkeypatch.setattr(
-        "phlo.plugins.discovery._service_loading.discover_plugins",
-        lambda plugin_type, auto_register: None,
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda plugin_type="services", auto_register=True: None,
     )
     _write_service_yaml(tmp_path, "alpha", "alpha")
 
@@ -349,8 +426,8 @@ def test_service_discovery_filters_services_by_profile(
 ) -> None:
     """Profile lookup returns only matching discovered service definitions."""
     monkeypatch.setattr(
-        "phlo.plugins.discovery.services.discover_plugins",
-        lambda plugin_type, auto_register: None,
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda plugin_type="services", auto_register=True: None,
     )
     _write_service_yaml(tmp_path, "core", "core-service")
     profile_service = tmp_path / "analytics" / "service.yaml"
@@ -420,38 +497,33 @@ def test_service_discovery_loads_companion_service_files(
     )
 
 
-def test_service_discovery_skips_non_mapping_directory_service_files(
+def test_service_discovery_raises_for_non_mapping_directory_service_files(
     clean_registry: object,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    service_discovery_signals: list[DiscoverySignal],
 ) -> None:
-    """Non-mapping service YAML is skipped without aborting directory discovery."""
-    from phlo.plugins.discovery import _service_loading
-
-    events: list[DiscoverySignal] = []
+    """Non-mapping service YAML raises a contextual manifest error."""
     monkeypatch.setattr(
-        _service_loading, "discover_plugins", lambda plugin_type, auto_register: None
-    )
-    monkeypatch.setattr(
-        _service_loading,
-        "log_event",
-        lambda logger, level, event, **fields: events.append(
-            {"level": level, "event": event, "fields": fields}
-        ),
+        "phlo.plugins.discovery.service_manifest.discover_plugins",
+        lambda plugin_type="services", auto_register=True: None,
     )
     _write_service_yaml(tmp_path, "valid", "valid")
     broken = tmp_path / "broken" / "service.yaml"
     broken.parent.mkdir()
     broken.write_text("- not\n- a\n- mapping\n", encoding="utf-8")
 
-    services = ServiceDiscovery(services_dir=tmp_path).discover()
+    with pytest.raises(ServiceManifestError) as exc:
+        ServiceDiscovery(services_dir=tmp_path).discover()
 
-    assert set(services) == {"valid"}
-    assert len(events) == 1
-    assert events[0]["level"] == "warning"
-    assert events[0]["event"] == "service_definition_file_load_failed"
-    assert events[0]["fields"]["path"] == str(broken)
-    assert "Service definition must be a mapping" in str(events[0]["fields"]["error"])
+    assert "invalid service definition file" in str(exc.value)
+    assert f"source={broken}" in str(exc.value)
+    assert any(
+        signal["event"] == "service_discovery_manifest_load_failed"
+        and signal["fields"]["error_type"] == "ServiceManifestError"
+        and str(broken) in str(signal["fields"]["error"])
+        for signal in service_discovery_signals
+    )
 
 
 def test_service_discovery_skips_malformed_companion_service_files(


### PR DESCRIPTION
**TL;DR:** Introduces a service manifest resolver so service discovery, plugin manifests, companion YAML files, and dependency expansion live behind one deeper module.

Closes #493.

## What Changed

- Added `ServiceManifest`, `ServiceManifestError`, and `ServiceManifestResolver`.
- Added directory manifest resolution for local service YAML files with contextual errors.
- Added plugin manifest resolution, including companion `*-setup.yaml` and `*-daemon.yaml` files.
- Routed `ServiceDiscovery` through manifest resolution while preserving its public behavior.
- Centralized service dependency expansion behind `ServiceManifestResolver.expand_dependencies`.
- Added focused tests for manifest value objects, directory loading, plugin loading, duplicate companion handling, dependency expansion, and `ServiceDiscovery` compatibility.

## Why

Service package discovery was spread across discovery modules and CLI utility code. The new resolver concentrates service package manifest knowledge in one module, improving locality for discovery bugs and giving `phlo services` commands a higher-leverage interface for resolved services.

## Verification

- `uv run pytest tests/runtime/test_services_discovery.py tests/cli/test_cli_services_init.py tests/cli/test_cli_services_start.py -q`
- `uv run ruff check src/phlo/plugins/discovery src/phlo/cli/commands/services tests/plugins/test_service_manifest_resolver.py`
- `uv run pytest tests/plugins/test_service_manifest_resolver.py tests/cli/test_cli_services_init.py tests/cli/test_cli_services_start.py tests/runtime/test_services_discovery.py -v`
- `uv run ty check src/phlo/plugins/discovery src/phlo/cli/commands/services`