### PR TITLE
refactor: deepen capability catalog registration

### DIFF
--- a/src/phlo/capabilities/catalog.py
+++ b/src/phlo/capabilities/catalog.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 from collections.abc import Callable, Hashable
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar
+from typing import Generic, Protocol, TypeVar
 
 SpecT = TypeVar("SpecT")
 KeyT = TypeVar("KeyT", bound=Hashable)
+
+
+class NamedSpec(Protocol):
+    name: str
+
+
+NamedSpecT = TypeVar("NamedSpecT", bound=NamedSpec)
 
 
 @dataclass(slots=True)
@@ -25,3 +32,7 @@ class CapabilityFamily(Generic[SpecT, KeyT]):
 
     def clear(self) -> None:
         self._items.clear()
+
+
+def named_family() -> CapabilityFamily[NamedSpecT, str]:
+    return CapabilityFamily(key=lambda spec: spec.name)

--- a/src/phlo/capabilities/catalog.py
+++ b/src/phlo/capabilities/catalog.py
@@ -1,0 +1,27 @@
+"""Shared catalog storage for capability registrations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Hashable
+from dataclasses import dataclass, field
+from typing import Generic, TypeVar
+
+SpecT = TypeVar("SpecT")
+KeyT = TypeVar("KeyT", bound=Hashable)
+
+
+@dataclass(slots=True)
+class CapabilityFamily(Generic[SpecT, KeyT]):
+    """Registration storage for one capability family."""
+
+    key: Callable[[SpecT], KeyT]
+    _items: dict[KeyT, SpecT] = field(default_factory=dict)
+
+    def register(self, spec: SpecT) -> None:
+        self._items[self.key(spec)] = spec
+
+    def list(self) -> list[SpecT]:
+        return list(self._items.values())
+
+    def clear(self) -> None:
+        self._items.clear()

--- a/src/phlo/capabilities/catalog.py
+++ b/src/phlo/capabilities/catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 from collections.abc import Callable, Hashable
 from dataclasses import dataclass, field
 from typing import Generic, Protocol, TypeVar
@@ -27,8 +28,8 @@ class CapabilityFamily(Generic[SpecT, KeyT]):
     def register(self, spec: SpecT) -> None:
         self._items[self.key(spec)] = spec
 
-    def list(self) -> list[SpecT]:
-        return list(self._items.values())
+    def list(self) -> builtins.list[SpecT]:
+        return builtins.list(self._items.values())
 
     def clear(self) -> None:
         self._items.clear()

--- a/src/phlo/capabilities/registry.py
+++ b/src/phlo/capabilities/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass, field
 
-from phlo.capabilities.catalog import CapabilityFamily
+from phlo.capabilities.catalog import CapabilityFamily, named_family
 from phlo.capabilities.specs import (
     AlertSinkSpec,
     ApiBackendSpec,
@@ -79,6 +79,11 @@ class CapabilityRegistry:
         init=False,
         repr=False,
     )
+    _table_store_family: CapabilityFamily[TableStoreSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def register_asset(self, spec: AssetSpec) -> None:
@@ -147,12 +152,13 @@ class CapabilityRegistry:
     def register_table_store(self, spec: TableStoreSpec) -> None:
         """Register or replace a table store spec by name."""
         with self._lock:
-            self.table_stores[spec.name] = spec
+            self._table_store_family.register(spec)
+            self.table_stores = dict(self._table_store_family._items)
 
     def list_table_stores(self) -> list[TableStoreSpec]:
         """Return a snapshot list of registered table store specs."""
         with self._lock:
-            return list(self.table_stores.values())
+            return self._table_store_family.list()
 
     def register_catalog(self, spec: CatalogSpec) -> None:
         """Register or replace a catalog spec by name."""
@@ -364,7 +370,8 @@ class CapabilityRegistry:
             self.checks = dict(self._check_family._items)
             self._resource_family.clear()
             self.resources = dict(self._resource_family._items)
-            self.table_stores.clear()
+            self._table_store_family.clear()
+            self.table_stores = dict(self._table_store_family._items)
             self.catalogs.clear()
             self.catalog_scanners.clear()
             self.query_engines.clear()

--- a/src/phlo/capabilities/registry.py
+++ b/src/phlo/capabilities/registry.py
@@ -84,6 +84,108 @@ class CapabilityRegistry:
         init=False,
         repr=False,
     )
+    _catalog_family: CapabilityFamily[CatalogSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _catalog_scanner_family: CapabilityFamily[CatalogScannerSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _query_engine_family: CapabilityFamily[QueryEngineSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _object_store_family: CapabilityFamily[ObjectStoreSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _quality_backend_family: CapabilityFamily[QualityBackendSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _maintenance_read_model_family: CapabilityFamily[MaintenanceReadModelSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _metadata_catalog_family: CapabilityFamily[MetadataCatalogSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _lineage_sink_family: CapabilityFamily[LineageSinkSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _governance_backend_family: CapabilityFamily[GovernanceBackendSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _authorization_policy_backend_family: CapabilityFamily[AuthorizationPolicyBackendSpec, str] = (
+        field(
+            default_factory=named_family,
+            init=False,
+            repr=False,
+        )
+    )
+    _authentication_provider_family: CapabilityFamily[AuthenticationProviderSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _publish_target_family: CapabilityFamily[PublishTargetSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _alert_sink_family: CapabilityFamily[AlertSinkSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _api_backend_family: CapabilityFamily[ApiBackendSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _secret_backend_family: CapabilityFamily[SecretBackendSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _schema_migrator_family: CapabilityFamily[SchemaMigrationSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _data_migration_source_family: CapabilityFamily[DataMigrationSourceSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _observability_backend_family: CapabilityFamily[ObservabilityBackendSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _regulated_surface_family: CapabilityFamily[RegulatedSurfaceSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
+    _ui_contribution_family: CapabilityFamily[UiContributionSpec, str] = field(
+        default_factory=named_family,
+        init=False,
+        repr=False,
+    )
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def register_asset(self, spec: AssetSpec) -> None:
@@ -163,202 +265,224 @@ class CapabilityRegistry:
     def register_catalog(self, spec: CatalogSpec) -> None:
         """Register or replace a catalog spec by name."""
         with self._lock:
-            self.catalogs[spec.name] = spec
+            self._catalog_family.register(spec)
+            self.catalogs = dict(self._catalog_family._items)
 
     def list_catalogs(self) -> list[CatalogSpec]:
         """Return a snapshot list of registered catalog specs."""
         with self._lock:
-            return list(self.catalogs.values())
+            return self._catalog_family.list()
 
     def register_catalog_scanner(self, spec: CatalogScannerSpec) -> None:
         """Register or replace a catalog scanner spec by name."""
         with self._lock:
-            self.catalog_scanners[spec.name] = spec
+            self._catalog_scanner_family.register(spec)
+            self.catalog_scanners = dict(self._catalog_scanner_family._items)
 
     def list_catalog_scanners(self) -> list[CatalogScannerSpec]:
         """Return a snapshot list of registered catalog scanner specs."""
         with self._lock:
-            return list(self.catalog_scanners.values())
+            return self._catalog_scanner_family.list()
 
     def register_query_engine(self, spec: QueryEngineSpec) -> None:
         """Register or replace a query engine spec by name."""
         with self._lock:
-            self.query_engines[spec.name] = spec
+            self._query_engine_family.register(spec)
+            self.query_engines = dict(self._query_engine_family._items)
 
     def list_query_engines(self) -> list[QueryEngineSpec]:
         """Return a snapshot list of registered query engine specs."""
         with self._lock:
-            return list(self.query_engines.values())
+            return self._query_engine_family.list()
 
     def register_object_store(self, spec: ObjectStoreSpec) -> None:
         """Register or replace an object store spec by name."""
         with self._lock:
-            self.object_stores[spec.name] = spec
+            self._object_store_family.register(spec)
+            self.object_stores = dict(self._object_store_family._items)
 
     def list_object_stores(self) -> list[ObjectStoreSpec]:
         """Return a snapshot list of registered object store specs."""
         with self._lock:
-            return list(self.object_stores.values())
+            return self._object_store_family.list()
 
     def register_quality_backend(self, spec: QualityBackendSpec) -> None:
         """Register or replace a quality backend spec by name."""
         with self._lock:
-            self.quality_backends[spec.name] = spec
+            self._quality_backend_family.register(spec)
+            self.quality_backends = dict(self._quality_backend_family._items)
 
     def list_quality_backends(self) -> list[QualityBackendSpec]:
         """Return a snapshot list of registered quality backend specs."""
         with self._lock:
-            return list(self.quality_backends.values())
+            return self._quality_backend_family.list()
 
     def register_maintenance_read_model(self, spec: MaintenanceReadModelSpec) -> None:
         """Register or replace a maintenance read-model spec by name."""
         with self._lock:
-            self.maintenance_read_models[spec.name] = spec
+            self._maintenance_read_model_family.register(spec)
+            self.maintenance_read_models = dict(self._maintenance_read_model_family._items)
 
     def list_maintenance_read_models(self) -> list[MaintenanceReadModelSpec]:
         """Return a snapshot list of maintenance read-model specs."""
         with self._lock:
-            return list(self.maintenance_read_models.values())
+            return self._maintenance_read_model_family.list()
 
     def register_metadata_catalog(self, spec: MetadataCatalogSpec) -> None:
         """Register or replace a metadata catalog spec by name."""
         with self._lock:
-            self.metadata_catalogs[spec.name] = spec
+            self._metadata_catalog_family.register(spec)
+            self.metadata_catalogs = dict(self._metadata_catalog_family._items)
 
     def list_metadata_catalogs(self) -> list[MetadataCatalogSpec]:
         """Return a snapshot list of registered metadata catalog specs."""
         with self._lock:
-            return list(self.metadata_catalogs.values())
+            return self._metadata_catalog_family.list()
 
     def register_lineage_sink(self, spec: LineageSinkSpec) -> None:
         """Register or replace a lineage sink spec by name."""
         with self._lock:
-            self.lineage_sinks[spec.name] = spec
+            self._lineage_sink_family.register(spec)
+            self.lineage_sinks = dict(self._lineage_sink_family._items)
 
     def list_lineage_sinks(self) -> list[LineageSinkSpec]:
         """Return a snapshot list of registered lineage sink specs."""
         with self._lock:
-            return list(self.lineage_sinks.values())
+            return self._lineage_sink_family.list()
 
     def register_governance_backend(self, spec: GovernanceBackendSpec) -> None:
         """Register or replace a governance backend spec by name."""
         with self._lock:
-            self.governance_backends[spec.name] = spec
+            self._governance_backend_family.register(spec)
+            self.governance_backends = dict(self._governance_backend_family._items)
 
     def list_governance_backends(self) -> list[GovernanceBackendSpec]:
         """Return a snapshot list of registered governance backend specs."""
         with self._lock:
-            return list(self.governance_backends.values())
+            return self._governance_backend_family.list()
 
     def register_authorization_policy_backend(self, spec: AuthorizationPolicyBackendSpec) -> None:
         """Register or replace an authorization policy backend spec by name."""
         with self._lock:
-            self.authorization_policy_backends[spec.name] = spec
+            self._authorization_policy_backend_family.register(spec)
+            self.authorization_policy_backends = dict(
+                self._authorization_policy_backend_family._items
+            )
 
     def list_authorization_policy_backends(self) -> list[AuthorizationPolicyBackendSpec]:
         """Return a snapshot list of registered authorization policy backend specs."""
         with self._lock:
-            return list(self.authorization_policy_backends.values())
+            return self._authorization_policy_backend_family.list()
 
     def register_authentication_provider(self, spec: AuthenticationProviderSpec) -> None:
         """Register or replace an authentication provider spec by name."""
         with self._lock:
-            self.authentication_providers[spec.name] = spec
+            self._authentication_provider_family.register(spec)
+            self.authentication_providers = dict(self._authentication_provider_family._items)
 
     def list_authentication_providers(self) -> list[AuthenticationProviderSpec]:
         """Return a snapshot list of registered authentication provider specs."""
         with self._lock:
-            return list(self.authentication_providers.values())
+            return self._authentication_provider_family.list()
 
     def register_publish_target(self, spec: PublishTargetSpec) -> None:
         """Register or replace a publish target spec by name."""
         with self._lock:
-            self.publish_targets[spec.name] = spec
+            self._publish_target_family.register(spec)
+            self.publish_targets = dict(self._publish_target_family._items)
 
     def list_publish_targets(self) -> list[PublishTargetSpec]:
         """Return a snapshot list of registered publish target specs."""
         with self._lock:
-            return list(self.publish_targets.values())
+            return self._publish_target_family.list()
 
     def register_alert_sink(self, spec: AlertSinkSpec) -> None:
         """Register or replace an alert sink spec by name."""
         with self._lock:
-            self.alert_sinks[spec.name] = spec
+            self._alert_sink_family.register(spec)
+            self.alert_sinks = dict(self._alert_sink_family._items)
 
     def list_alert_sinks(self) -> list[AlertSinkSpec]:
         """Return a snapshot list of registered alert sink specs."""
         with self._lock:
-            return list(self.alert_sinks.values())
+            return self._alert_sink_family.list()
 
     def register_api_backend(self, spec: ApiBackendSpec) -> None:
         """Register or replace an API backend spec by name."""
         with self._lock:
-            self.api_backends[spec.name] = spec
+            self._api_backend_family.register(spec)
+            self.api_backends = dict(self._api_backend_family._items)
 
     def list_api_backends(self) -> list[ApiBackendSpec]:
         """Return a snapshot list of registered API backend specs."""
         with self._lock:
-            return list(self.api_backends.values())
+            return self._api_backend_family.list()
 
     def register_secret_backend(self, spec: SecretBackendSpec) -> None:
         """Register or replace a secret backend spec by name."""
         with self._lock:
-            self.secret_backends[spec.name] = spec
+            self._secret_backend_family.register(spec)
+            self.secret_backends = dict(self._secret_backend_family._items)
 
     def list_secret_backends(self) -> list[SecretBackendSpec]:
         """Return a snapshot list of registered secret backend specs."""
         with self._lock:
-            return list(self.secret_backends.values())
+            return self._secret_backend_family.list()
 
     def register_schema_migrator(self, spec: SchemaMigrationSpec) -> None:
         """Register or replace a schema migrator spec by name."""
         with self._lock:
-            self.schema_migrators[spec.name] = spec
+            self._schema_migrator_family.register(spec)
+            self.schema_migrators = dict(self._schema_migrator_family._items)
 
     def list_schema_migrators(self) -> list[SchemaMigrationSpec]:
         """Return a snapshot list of registered schema migrator specs."""
         with self._lock:
-            return list(self.schema_migrators.values())
+            return self._schema_migrator_family.list()
 
     def register_data_migration_source(self, spec: DataMigrationSourceSpec) -> None:
         """Register or replace a data migration source adapter spec by name."""
         with self._lock:
-            self.data_migration_sources[spec.name] = spec
+            self._data_migration_source_family.register(spec)
+            self.data_migration_sources = dict(self._data_migration_source_family._items)
 
     def list_data_migration_sources(self) -> list[DataMigrationSourceSpec]:
         """Return a snapshot list of registered migration source adapter specs."""
         with self._lock:
-            return list(self.data_migration_sources.values())
+            return self._data_migration_source_family.list()
 
     def register_observability_backend(self, spec: ObservabilityBackendSpec) -> None:
         """Register or replace an observability backend spec by name."""
         with self._lock:
-            self.observability_backends[spec.name] = spec
+            self._observability_backend_family.register(spec)
+            self.observability_backends = dict(self._observability_backend_family._items)
 
     def list_observability_backends(self) -> list[ObservabilityBackendSpec]:
         """Return a snapshot list of registered observability backend specs."""
         with self._lock:
-            return list(self.observability_backends.values())
+            return self._observability_backend_family.list()
 
     def register_regulated_surface(self, spec: RegulatedSurfaceSpec) -> None:
         """Register or replace a regulated surface spec by name."""
         with self._lock:
-            self.regulated_surfaces[spec.name] = spec
+            self._regulated_surface_family.register(spec)
+            self.regulated_surfaces = dict(self._regulated_surface_family._items)
 
     def list_regulated_surfaces(self) -> list[RegulatedSurfaceSpec]:
         """Return a snapshot list of registered regulated surface specs."""
         with self._lock:
-            return list(self.regulated_surfaces.values())
+            return self._regulated_surface_family.list()
 
     def register_ui_contribution(self, spec: UiContributionSpec) -> None:
         """Register or replace a UI contribution spec by name."""
         with self._lock:
-            self.ui_contributions[spec.name] = spec
+            self._ui_contribution_family.register(spec)
+            self.ui_contributions = dict(self._ui_contribution_family._items)
 
     def list_ui_contributions(self) -> list[UiContributionSpec]:
         """Return a snapshot list of registered UI contribution specs."""
         with self._lock:
-            return list(self.ui_contributions.values())
+            return self._ui_contribution_family.list()
 
     def clear(self) -> None:
         """Remove all assets, checks, and resources from the registry."""
@@ -372,26 +496,48 @@ class CapabilityRegistry:
             self.resources = dict(self._resource_family._items)
             self._table_store_family.clear()
             self.table_stores = dict(self._table_store_family._items)
-            self.catalogs.clear()
-            self.catalog_scanners.clear()
-            self.query_engines.clear()
-            self.object_stores.clear()
-            self.quality_backends.clear()
-            self.maintenance_read_models.clear()
-            self.metadata_catalogs.clear()
-            self.lineage_sinks.clear()
-            self.governance_backends.clear()
-            self.authorization_policy_backends.clear()
-            self.authentication_providers.clear()
-            self.publish_targets.clear()
-            self.alert_sinks.clear()
-            self.api_backends.clear()
-            self.secret_backends.clear()
-            self.schema_migrators.clear()
-            self.data_migration_sources.clear()
-            self.observability_backends.clear()
-            self.regulated_surfaces.clear()
-            self.ui_contributions.clear()
+            self._catalog_family.clear()
+            self.catalogs = dict(self._catalog_family._items)
+            self._catalog_scanner_family.clear()
+            self.catalog_scanners = dict(self._catalog_scanner_family._items)
+            self._query_engine_family.clear()
+            self.query_engines = dict(self._query_engine_family._items)
+            self._object_store_family.clear()
+            self.object_stores = dict(self._object_store_family._items)
+            self._quality_backend_family.clear()
+            self.quality_backends = dict(self._quality_backend_family._items)
+            self._maintenance_read_model_family.clear()
+            self.maintenance_read_models = dict(self._maintenance_read_model_family._items)
+            self._metadata_catalog_family.clear()
+            self.metadata_catalogs = dict(self._metadata_catalog_family._items)
+            self._lineage_sink_family.clear()
+            self.lineage_sinks = dict(self._lineage_sink_family._items)
+            self._governance_backend_family.clear()
+            self.governance_backends = dict(self._governance_backend_family._items)
+            self._authorization_policy_backend_family.clear()
+            self.authorization_policy_backends = dict(
+                self._authorization_policy_backend_family._items
+            )
+            self._authentication_provider_family.clear()
+            self.authentication_providers = dict(self._authentication_provider_family._items)
+            self._publish_target_family.clear()
+            self.publish_targets = dict(self._publish_target_family._items)
+            self._alert_sink_family.clear()
+            self.alert_sinks = dict(self._alert_sink_family._items)
+            self._api_backend_family.clear()
+            self.api_backends = dict(self._api_backend_family._items)
+            self._secret_backend_family.clear()
+            self.secret_backends = dict(self._secret_backend_family._items)
+            self._schema_migrator_family.clear()
+            self.schema_migrators = dict(self._schema_migrator_family._items)
+            self._data_migration_source_family.clear()
+            self.data_migration_sources = dict(self._data_migration_source_family._items)
+            self._observability_backend_family.clear()
+            self.observability_backends = dict(self._observability_backend_family._items)
+            self._regulated_surface_family.clear()
+            self.regulated_surfaces = dict(self._regulated_surface_family._items)
+            self._ui_contribution_family.clear()
+            self.ui_contributions = dict(self._ui_contribution_family._items)
 
     def clear_checks(self) -> None:
         """Remove all registered checks while preserving assets/resources."""

--- a/src/phlo/capabilities/registry.py
+++ b/src/phlo/capabilities/registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import threading
 from dataclasses import dataclass, field
 
+from phlo.capabilities.catalog import CapabilityFamily
 from phlo.capabilities.specs import (
     AlertSinkSpec,
     ApiBackendSpec,
@@ -63,6 +64,21 @@ class CapabilityRegistry:
     observability_backends: dict[str, ObservabilityBackendSpec] = field(default_factory=dict)
     regulated_surfaces: dict[str, RegulatedSurfaceSpec] = field(default_factory=dict)
     ui_contributions: dict[str, UiContributionSpec] = field(default_factory=dict)
+    _asset_family: CapabilityFamily[AssetSpec, str] = field(
+        default_factory=lambda: CapabilityFamily(key=lambda spec: spec.key),
+        init=False,
+        repr=False,
+    )
+    _check_family: CapabilityFamily[AssetCheckSpec, tuple[str, str]] = field(
+        default_factory=lambda: CapabilityFamily(key=lambda spec: (spec.asset_key, spec.name)),
+        init=False,
+        repr=False,
+    )
+    _resource_family: CapabilityFamily[ResourceSpec, str] = field(
+        default_factory=lambda: CapabilityFamily(key=lambda spec: spec.name),
+        init=False,
+        repr=False,
+    )
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def register_asset(self, spec: AssetSpec) -> None:
@@ -73,7 +89,8 @@ class CapabilityRegistry:
         """
 
         with self._lock:
-            self.assets[spec.key] = spec
+            self._asset_family.register(spec)
+            self.assets = dict(self._asset_family._items)
 
     def register_check(self, spec: AssetCheckSpec) -> None:
         """Register or replace an asset check spec by asset/name tuple.
@@ -83,7 +100,8 @@ class CapabilityRegistry:
         """
 
         with self._lock:
-            self.checks[(spec.asset_key, spec.name)] = spec
+            self._check_family.register(spec)
+            self.checks = dict(self._check_family._items)
 
     def register_resource(self, spec: ResourceSpec) -> None:
         """Register or replace a resource spec by name.
@@ -93,7 +111,8 @@ class CapabilityRegistry:
         """
 
         with self._lock:
-            self.resources[spec.name] = spec
+            self._resource_family.register(spec)
+            self.resources = dict(self._resource_family._items)
 
     def list_assets(self) -> list[AssetSpec]:
         """Return a snapshot list of all registered assets.
@@ -103,7 +122,7 @@ class CapabilityRegistry:
         """
 
         with self._lock:
-            return list(self.assets.values())
+            return self._asset_family.list()
 
     def list_checks(self) -> list[AssetCheckSpec]:
         """Return a snapshot list of all registered checks.
@@ -113,7 +132,7 @@ class CapabilityRegistry:
         """
 
         with self._lock:
-            return list(self.checks.values())
+            return self._check_family.list()
 
     def list_resources(self) -> list[ResourceSpec]:
         """Return a snapshot list of all registered resources.
@@ -123,7 +142,7 @@ class CapabilityRegistry:
         """
 
         with self._lock:
-            return list(self.resources.values())
+            return self._resource_family.list()
 
     def register_table_store(self, spec: TableStoreSpec) -> None:
         """Register or replace a table store spec by name."""
@@ -339,9 +358,12 @@ class CapabilityRegistry:
         """Remove all assets, checks, and resources from the registry."""
 
         with self._lock:
-            self.assets.clear()
-            self.checks.clear()
-            self.resources.clear()
+            self._asset_family.clear()
+            self.assets = dict(self._asset_family._items)
+            self._check_family.clear()
+            self.checks = dict(self._check_family._items)
+            self._resource_family.clear()
+            self.resources = dict(self._resource_family._items)
             self.table_stores.clear()
             self.catalogs.clear()
             self.catalog_scanners.clear()
@@ -368,7 +390,8 @@ class CapabilityRegistry:
         """Remove all registered checks while preserving assets/resources."""
 
         with self._lock:
-            self.checks.clear()
+            self._check_family.clear()
+            self.checks = dict(self._check_family._items)
 
 
 _GLOBAL_REGISTRY = CapabilityRegistry()

--- a/tests/plugins/test_capability_catalog.py
+++ b/tests/plugins/test_capability_catalog.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from phlo.capabilities.catalog import CapabilityFamily
+
+
+@dataclass(frozen=True)
+class DummySpec:
+    name: str
+    value: int
+
+
+def test_capability_family_registers_and_lists_snapshot() -> None:
+    family = CapabilityFamily[DummySpec, str](key=lambda spec: spec.name)
+
+    family.register(DummySpec(name="trino", value=1))
+    listed = family.list()
+    listed.append(DummySpec(name="duckdb", value=2))
+
+    assert family.list() == [DummySpec(name="trino", value=1)]
+
+
+def test_capability_family_replaces_same_key() -> None:
+    family = CapabilityFamily[DummySpec, str](key=lambda spec: spec.name)
+
+    family.register(DummySpec(name="trino", value=1))
+    family.register(DummySpec(name="trino", value=2))
+
+    assert family.list() == [DummySpec(name="trino", value=2)]

--- a/tests/plugins/test_capability_catalog.py
+++ b/tests/plugins/test_capability_catalog.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from phlo.capabilities.catalog import CapabilityFamily
+from phlo.capabilities.registry import CapabilityRegistry
+from phlo.capabilities.specs import AssetCheckSpec, AssetSpec, ResourceSpec, RunSpec
 
 
 @dataclass(frozen=True)
@@ -28,3 +30,23 @@ def test_capability_family_replaces_same_key() -> None:
     family.register(DummySpec(name="trino", value=2))
 
     assert family.list() == [DummySpec(name="trino", value=2)]
+
+
+def test_registry_core_families_keep_existing_interface() -> None:
+    registry = CapabilityRegistry()
+    asset = AssetSpec(
+        key="raw.events",
+        group=None,
+        description=None,
+        run=RunSpec(fn=lambda _ctx: []),
+    )
+    check = AssetCheckSpec(asset_key="raw.events", name="freshness", fn=lambda _ctx: None)
+    resource = ResourceSpec(name="trino", resource=object())
+
+    registry.register_asset(asset)
+    registry.register_check(check)
+    registry.register_resource(resource)
+
+    assert registry.list_assets() == [asset]
+    assert registry.list_checks() == [check]
+    assert registry.list_resources() == [resource]

--- a/tests/plugins/test_capability_catalog.py
+++ b/tests/plugins/test_capability_catalog.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from phlo.capabilities.catalog import CapabilityFamily
+from phlo.capabilities.catalog import CapabilityFamily, named_family
 from phlo.capabilities.registry import CapabilityRegistry
 from phlo.capabilities.specs import AssetCheckSpec, AssetSpec, ResourceSpec, RunSpec
 
@@ -50,3 +50,11 @@ def test_registry_core_families_keep_existing_interface() -> None:
     assert registry.list_assets() == [asset]
     assert registry.list_checks() == [check]
     assert registry.list_resources() == [resource]
+
+
+def test_named_family_uses_spec_name() -> None:
+    family: CapabilityFamily[DummySpec, str] = named_family()
+
+    family.register(DummySpec(name="iceberg", value=1))
+
+    assert family.list() == [DummySpec(name="iceberg", value=1)]

--- a/tests/plugins/test_capability_catalog.py
+++ b/tests/plugins/test_capability_catalog.py
@@ -4,7 +4,14 @@ from dataclasses import dataclass
 
 from phlo.capabilities.catalog import CapabilityFamily, named_family
 from phlo.capabilities.registry import CapabilityRegistry
-from phlo.capabilities.specs import AssetCheckSpec, AssetSpec, ResourceSpec, RunSpec
+from phlo.capabilities.specs import (
+    AssetCheckSpec,
+    AssetSpec,
+    QueryEngineSpec,
+    ResourceSpec,
+    RunSpec,
+    TableStoreSpec,
+)
 
 
 @dataclass(frozen=True)
@@ -58,3 +65,15 @@ def test_named_family_uses_spec_name() -> None:
     family.register(DummySpec(name="iceberg", value=1))
 
     assert family.list() == [DummySpec(name="iceberg", value=1)]
+
+
+def test_registry_named_provider_families_keep_existing_interface() -> None:
+    registry = CapabilityRegistry()
+    table_store = TableStoreSpec(name="iceberg", provider=object())
+    query_engine = QueryEngineSpec(name="trino", provider=object())
+
+    registry.register_table_store(table_store)
+    registry.register_query_engine(query_engine)
+
+    assert registry.list_table_stores() == [table_store]
+    assert registry.list_query_engines() == [query_engine]


### PR DESCRIPTION
**TL;DR:** Adds generic capability family storage and delegates the registry’s repeated register/list behavior through it while keeping the existing registry interface intact.

Closes #495.

## What Changed

- Added `CapabilityFamily` for shared register/list/clear semantics.
- Added `named_family` for capability specs keyed by `spec.name`.
- Delegated asset, check, and resource registry storage through capability families.
- Delegated named provider families such as table stores, catalogs, query engines, object stores, quality backends, governance backends, API backends, UI contributions, and related capability specs.
- Preserved the existing `CapabilityRegistry` methods and module-level registration helpers.
- Added focused tests for generic family behavior, replacement semantics, named families, and registry compatibility.

## Why

`CapabilityRegistry` had many nearly identical register/list methods, which made every new capability family touch the same large module. This keeps the public interface stable while moving the repeated behavior into a deeper internal module with reusable semantics.

## Verification

- `uv run ruff check src/phlo/capabilities tests/plugins/test_capability_catalog.py`
- `uv run pytest tests/plugins/test_capability_catalog.py tests/plugins/test_capabilities_runtime.py tests/plugins/test_default_capabilities.py tests/plugins/test_plugin_loading.py -v`
- `uv run ty check src/phlo/capabilities`