### PR TITLE
chore(release): phlo 0.9.0 + 11 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## [phlo 0.9.0 + 11 packages] - 2026-05-16
+
+### Added
+- phlo: add package-driven workflow wizard (#503)
+- phlo: add lakehouse helper utilities (#509)
+- phlo-api: add package-driven workflow wizard (#503)
+- phlo-dagster: add package-driven workflow wizard (#503)
+- phlo-dbt: add package-driven workflow wizard (#503)
+- phlo-dbt: add lakehouse helper utilities (#509)
+- phlo-delta: add lakehouse helper utilities (#509)
+- phlo-dlt: add package-driven workflow wizard (#503)
+- phlo-iceberg: add lakehouse helper utilities (#509)
+- phlo-observatory: add package-driven workflow wizard (#503)
+- phlo-openmetadata: add package-driven workflow wizard (#503)
+- phlo-pandera: add package-driven workflow wizard (#503)
+- phlo-pandera: add lakehouse helper utilities (#509)
+- phlo-sling: add package-driven workflow wizard (#503)
+- phlo-sling: add lakehouse helper utilities (#509)
+
+### Changed
+- phlo: deepen service package manifest resolution (#501)
+- phlo: deepen services lifecycle planning (#498)
+- phlo: deepen capability catalog registration (#502)
+- phlo: deepen table store capability semantics (#500)
+- phlo: deepen Observatory v2 read models (#499)
+- phlo-api: deepen Observatory v2 read models (#499)
+- phlo-delta: deepen table store capability semantics (#500)
+- phlo-iceberg: deepen table store capability semantics (#500)
+
+### Fixed
+- phlo: improve observatory react health (#505)
+- phlo: repair nightly integration suite (#506)
+- phlo-delta: repair nightly integration suite (#506)
+- phlo-iceberg: repair nightly integration suite (#506)
+- phlo-observatory: improve observatory react health (#505)
+- phlo-pandera: repair nightly integration suite (#506)
+- phlo-trino: repair nightly integration suite (#506)
+
+### Contributors
+Thanks to our contributors for this release:
+- @iamgp (32 commits)
+
 ## [phlo 0.8.3 + 21 packages] - 2026-05-05
 
 ### Fixed

--- a/packages/phlo-api/pyproject.toml
+++ b/packages/phlo-api/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 description = "Phlo API - Backend service exposing Phlo internals to Observatory"
 name = "phlo-api"
 requires-python = ">=3.11"
-version = "0.3.1"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/pyproject.toml
+++ b/packages/phlo-dagster/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Dagster service plugin for Phlo"
 name = "phlo-dagster"
 requires-python = ">=3.11"
-version = "0.3.3"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/src/phlo_dagster/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "authorize_daemon_run",
     "create_daemon_principal",
 ]
-__version__ = "0.3.3"
+__version__ = "0.4.0"

--- a/packages/phlo-dbt/pyproject.toml
+++ b/packages/phlo-dbt/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "dbt integration capability plugin for Phlo"
 name = "phlo-dbt"
 requires-python = ">=3.11"
-version = "0.3.1"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-delta/pyproject.toml
+++ b/packages/phlo-delta/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Delta Lake table-store capability plugin for Phlo"
 name = "phlo-delta"
 requires-python = ">=3.11"
-version = "0.3.0"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dlt/pyproject.toml
+++ b/packages/phlo-dlt/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 description = "DLT ingestion engine capability plugin for Phlo"
 name = "phlo-dlt"
 requires-python = ">=3.11"
-version = "0.3.3"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-iceberg/pyproject.toml
+++ b/packages/phlo-iceberg/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Iceberg table-store capability plugin for Phlo"
 name = "phlo-iceberg"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/pyproject.toml
+++ b/packages/phlo-observatory/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["phlo>=0.1.0"]
 description = "Phlo Observatory - Data platform UI (bundled with phlo core)"
 name = "phlo-observatory"
 requires-python = ">=3.11"
-version = "0.3.1"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/src/phlo_observatory/__init__.py
+++ b/packages/phlo-observatory/src/phlo_observatory/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "get_settings",
     "get_settings_service",
 ]
-__version__ = "0.3.1"
+__version__ = "0.4.0"

--- a/packages/phlo-openmetadata/pyproject.toml
+++ b/packages/phlo-openmetadata/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "OpenMetadata integration for Phlo"
 name = "phlo-openmetadata"
 requires-python = ">=3.11"
-version = "0.3.1"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-pandera/pyproject.toml
+++ b/packages/phlo-pandera/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Quality checks and schema utilities for Phlo"
 name = "phlo-pandera"
 requires-python = ">=3.11"
-version = "0.3.3"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-sling/pyproject.toml
+++ b/packages/phlo-sling/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Sling replication ingestion provider for Phlo"
 name = "phlo-sling"
 requires-python = ">=3.11"
-version = "0.3.1"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/pyproject.toml
+++ b/packages/phlo-trino/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "Trino service plugin for Phlo"
 name = "phlo-trino"
 requires-python = ">=3.11"
-version = "0.3.1"
+version = "0.3.2"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/src/phlo_trino/__init__.py
+++ b/packages/phlo-trino/src/phlo_trino/__init__.py
@@ -32,4 +32,4 @@ __all__ = [
     "TrinoSettings",
     "get_settings",
 ]
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.8.3"
+version = "0.9.0"
 
 [project.entry-points."phlo.plugins.quality"]
 

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.8.3"
+__version__ = "0.9.0"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -307,4 +307,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.8.3"
+__version__ = "0.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2982,7 +2982,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.8.3"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3222,7 +3222,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-api"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/phlo-api" }
 dependencies = [
     { name = "anyio" },
@@ -3352,7 +3352,7 @@ provides-extras = ["dev", "quality"]
 
 [[package]]
 name = "phlo-dagster"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "packages/phlo-dagster" }
 dependencies = [
     { name = "dagster-graphql" },
@@ -3398,7 +3398,7 @@ provides-extras = ["alerting", "dev", "iceberg", "nessie", "observatory"]
 
 [[package]]
 name = "phlo-dbt"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/phlo-dbt" }
 dependencies = [
     { name = "dbt-core" },
@@ -3434,7 +3434,7 @@ provides-extras = ["dagster", "dev", "quality"]
 
 [[package]]
 name = "phlo-delta"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/phlo-delta" }
 dependencies = [
     { name = "deltalake" },
@@ -3466,7 +3466,7 @@ provides-extras = ["dev", "minio"]
 
 [[package]]
 name = "phlo-dlt"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "packages/phlo-dlt" }
 dependencies = [
     { name = "dlt" },
@@ -3552,7 +3552,7 @@ provides-extras = ["dev", "postgres"]
 
 [[package]]
 name = "phlo-iceberg"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "packages/phlo-iceberg" }
 dependencies = [
     { name = "pandera" },
@@ -3768,7 +3768,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-observatory"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/phlo-observatory" }
 dependencies = [
     { name = "phlo" },
@@ -3809,7 +3809,7 @@ requires-dist = [
 
 [[package]]
 name = "phlo-openmetadata"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/phlo-openmetadata" }
 dependencies = [
     { name = "phlo" },
@@ -3885,7 +3885,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-pandera"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "packages/phlo-pandera" }
 dependencies = [
     { name = "click" },
@@ -4051,7 +4051,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-sling"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/phlo-sling" }
 dependencies = [
     { name = "phlo" },
@@ -4169,7 +4169,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-trino"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "packages/phlo-trino" }
 dependencies = [
     { name = "phlo" },


### PR DESCRIPTION
## Release summary

## [phlo 0.9.0 + 11 packages] - 2026-05-16

### Added
- phlo: add package-driven workflow wizard (#503)
- phlo: add lakehouse helper utilities (#509)
- phlo-api: add package-driven workflow wizard (#503)
- phlo-dagster: add package-driven workflow wizard (#503)
- phlo-dbt: add package-driven workflow wizard (#503)
- phlo-dbt: add lakehouse helper utilities (#509)
- phlo-delta: add lakehouse helper utilities (#509)
- phlo-dlt: add package-driven workflow wizard (#503)
- phlo-iceberg: add lakehouse helper utilities (#509)
- phlo-observatory: add package-driven workflow wizard (#503)
- phlo-openmetadata: add package-driven workflow wizard (#503)
- phlo-pandera: add package-driven workflow wizard (#503)
- phlo-pandera: add lakehouse helper utilities (#509)
- phlo-sling: add package-driven workflow wizard (#503)
- phlo-sling: add lakehouse helper utilities (#509)

### Changed
- phlo: deepen service package manifest resolution (#501)
- phlo: deepen services lifecycle planning (#498)
- phlo: deepen capability catalog registration (#502)
- phlo: deepen table store capability semantics (#500)
- phlo: deepen Observatory v2 read models (#499)
- phlo-api: deepen Observatory v2 read models (#499)
- phlo-delta: deepen table store capability semantics (#500)
- phlo-iceberg: deepen table store capability semantics (#500)

### Fixed
- phlo: improve observatory react health (#505)
- phlo: repair nightly integration suite (#506)
- phlo-delta: repair nightly integration suite (#506)
- phlo-iceberg: repair nightly integration suite (#506)
- phlo-observatory: improve observatory react health (#505)
- phlo-pandera: repair nightly integration suite (#506)
- phlo-trino: repair nightly integration suite (#506)

### Contributors
Thanks to our contributors for this release:
- @iamgp (32 commits)

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release