### PR TITLE
fix: repair nightly integration suite

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,7 @@ to all tests in the repository.
 import os
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 # Disable Telemetry aggressively at system level before any imports
 # Note: Lowercase 'false' is safer for TOML-based config parsers in dlt
@@ -52,6 +53,44 @@ def _register_workspace_plugins() -> None:
 _register_workspace_plugins()
 
 # Import fixtures from phlo_testing - these are auto-discovered by pytest
+
+
+def _minio_container_endpoint(minio_service) -> str:
+    """Return the HTTP endpoint for the current testcontainers MinIO API."""
+    if hasattr(minio_service, "get_url"):
+        return minio_service.get_url()
+    if hasattr(minio_service, "get_config"):
+        endpoint = minio_service.get_config()["endpoint"]
+        return endpoint if endpoint.startswith(("http://", "https://")) else f"http://{endpoint}"
+    host = minio_service.get_container_host_ip()
+    port = minio_service.get_exposed_port(getattr(minio_service, "port_to_expose", 9000))
+    return f"http://{host}:{port}"
+
+
+@pytest.fixture
+def configured_minio_object_store(minio_service, monkeypatch):
+    """Register MinIO's object-store capability for tests that need S3 metadata."""
+    if not minio_service:
+        return None
+
+    endpoint = _minio_container_endpoint(minio_service)
+    parsed_endpoint = urlparse(endpoint)
+    endpoint_host = parsed_endpoint.hostname or "127.0.0.1"
+    endpoint_port = parsed_endpoint.port or 80
+
+    monkeypatch.setenv("MINIO_HOST", endpoint_host)
+    monkeypatch.setenv("MINIO_API_PORT", str(endpoint_port))
+    monkeypatch.setenv("MINIO_ROOT_USER", minio_service.access_key)
+    monkeypatch.setenv("MINIO_ROOT_PASSWORD", minio_service.secret_key)
+
+    from phlo_minio.plugin import MinioResourceProvider
+    from phlo_minio.settings import get_settings as get_minio_settings
+
+    from phlo.capabilities import register_object_store, resolve_capability
+
+    get_minio_settings.cache_clear()
+    register_object_store(MinioResourceProvider().get_object_stores()[0])
+    return resolve_capability("object_store", "minio")
 
 
 @pytest.fixture(autouse=True)
@@ -130,7 +169,7 @@ def minio_service():
 
 
 @pytest.fixture
-def iceberg_catalog(minio_service, tmp_path):
+def iceberg_catalog(configured_minio_object_store, tmp_path):
     """
     Return a PyIceberg catalog.
     If minio_service is available, uses MinIO (S3).
@@ -143,15 +182,17 @@ def iceberg_catalog(minio_service, tmp_path):
         "uri": f"sqlite:///{tmp_path}/catalog.db",
     }
 
-    if minio_service:
+    if configured_minio_object_store:
+        provider = configured_minio_object_store.provider
+        config = provider.to_sling_connection()
         warehouse_path = "s3://warehouse"
         catalog_config.update(
             {
                 "warehouse": warehouse_path,
-                "s3.endpoint": minio_service.get_url(),
-                "s3.access-key-id": minio_service.access_key,
-                "s3.secret-access-key": minio_service.secret_key,
-                "s3.region": "us-east-1",
+                "s3.endpoint": config["endpoint"],
+                "s3.access-key-id": config["access_key_id"],
+                "s3.secret-access-key": config["secret_access_key"],
+                "s3.region": config["region"],
                 "py-io-impl": "pyiceberg.io.fsspec.FsspecFileIO",
             }
         )
@@ -167,14 +208,17 @@ def iceberg_catalog(minio_service, tmp_path):
     catalog = load_catalog("default", **catalog_config)
 
     # Init warehouse
-    if minio_service:
+    if configured_minio_object_store:
         import s3fs
 
+        provider = configured_minio_object_store.provider
+        config = provider.to_sling_connection()
+
         fs = s3fs.S3FileSystem(
-            endpoint_url=minio_service.get_url(),
-            key=minio_service.access_key,
-            secret=minio_service.secret_key,
-            client_kwargs={"region_name": "us-east-1"},
+            endpoint_url=config["endpoint"],
+            key=config["access_key_id"],
+            secret=config["secret_access_key"],
+            client_kwargs={"region_name": config["region"]},
         )
         with contextlib.suppress(FileExistsError):
             fs.mkdir("warehouse")

--- a/conftest.py
+++ b/conftest.py
@@ -60,8 +60,11 @@ def _minio_container_endpoint(minio_service) -> str:
     if hasattr(minio_service, "get_url"):
         return minio_service.get_url()
     if hasattr(minio_service, "get_config"):
-        endpoint = minio_service.get_config()["endpoint"]
-        return endpoint if endpoint.startswith(("http://", "https://")) else f"http://{endpoint}"
+        endpoint = (minio_service.get_config() or {}).get("endpoint")
+        if isinstance(endpoint, str) and endpoint:
+            return (
+                endpoint if endpoint.startswith(("http://", "https://")) else f"http://{endpoint}"
+            )
     host = minio_service.get_container_host_ip()
     port = minio_service.get_exposed_port(getattr(minio_service, "port_to_expose", 9000))
     return f"http://{host}:{port}"

--- a/packages/phlo-delta/tests/test_integration_delta_trino.py
+++ b/packages/phlo-delta/tests/test_integration_delta_trino.py
@@ -12,10 +12,10 @@ Requires Docker.  Run with:
 # ruff: noqa: E402
 
 import os
+from subprocess import CalledProcessError
 import time
 from collections.abc import Generator
 from pathlib import Path
-
 
 import pandas as pd
 import pyarrow as pa
@@ -79,7 +79,10 @@ def _wait_for_url(url: str, *, timeout: int = 120) -> None:
 def stack() -> Generator[DockerCompose]:
     """Boot the MinIO + Trino compose stack (file-based metastore)."""
     compose = DockerCompose(context=COMPOSE_DIR, wait=False)
-    compose.start()
+    try:
+        compose.start()
+    except (CalledProcessError, FileNotFoundError) as exc:
+        pytest.skip(f"Docker Compose is not available for this integration test: {exc}")
     try:
         trino_host = compose.get_service_host("trino", 8080)
         trino_port = compose.get_service_port("trino", 8080)

--- a/packages/phlo-iceberg/tests/test_integration_iceberg.py
+++ b/packages/phlo-iceberg/tests/test_integration_iceberg.py
@@ -350,16 +350,27 @@ class TestAppendToTable:
 
 
 @pytest.fixture
-def iceberg_catalog(minio_service, monkeypatch):
+def iceberg_catalog(configured_minio_object_store, monkeypatch):
     """Fixture providing a real Iceberg catalog for testing."""
-    # Explicit endpoint removes hidden dependency on default "minio" DNS alias.
     try:
+        from phlo.capabilities import resolve_capability
         from phlo_iceberg.catalog import get_catalog, reset_catalog_cache
         from phlo_iceberg.settings import get_settings as get_iceberg_settings
-        from phlo_minio.settings import get_settings as get_minio_settings
         from phlo_nessie.settings import get_settings as get_nessie_settings
 
-        endpoint = minio_service.get_url() if minio_service else "http://127.0.0.1:10001"
+        object_store = (
+            resolve_capability("object_store", "minio") if configured_minio_object_store else None
+        )
+        if object_store:
+            config = object_store.provider.to_sling_connection()
+            endpoint = config["endpoint"]
+            monkeypatch.setenv("ICEBERG_S3_ENDPOINT", endpoint)
+            monkeypatch.setenv("ICEBERG_S3_ACCESS_KEY", config["access_key_id"])
+            monkeypatch.setenv("ICEBERG_S3_SECRET_KEY", config["secret_access_key"])
+            monkeypatch.setenv("ICEBERG_S3_REGION", config["region"])
+        else:
+            endpoint = "http://127.0.0.1:10001"
+
         parsed_endpoint = urlparse(endpoint)
         endpoint_host = parsed_endpoint.hostname or "127.0.0.1"
         endpoint_port = parsed_endpoint.port or 80
@@ -370,11 +381,8 @@ def iceberg_catalog(minio_service, monkeypatch):
         except OSError:
             pytest.skip(f"MinIO endpoint not reachable at {endpoint}")
 
-        monkeypatch.setenv("ICEBERG_S3_ENDPOINT", endpoint)
-
         reset_catalog_cache()
         get_iceberg_settings.cache_clear()
-        get_minio_settings.cache_clear()
         get_nessie_settings.cache_clear()
 
         catalog = get_catalog()

--- a/packages/phlo-pandera/src/phlo_pandera/cli_schema.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_schema.py
@@ -400,7 +400,9 @@ def _load_old_schema(schema_cls: type, schema_name: str, old_ref: str) -> dict[s
         ValueError: If schema cannot be loaded from the reference.
 
     """
-    source_path = inspect.getsourcefile(schema_cls)
+    source_path = getattr(schema_cls, "__phlo_schema_source_path__", None)
+    if source_path is None:
+        source_path = inspect.getsourcefile(schema_cls)
     if source_path is None:
         raise ValueError(f"Could not determine source file for schema '{schema_name}'")
 

--- a/packages/phlo-pandera/src/phlo_pandera/cli_schema_utils.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_schema_utils.py
@@ -142,6 +142,7 @@ def discover_pandera_schemas(
                             and obj is not DataFrameModel
                             and obj.__module__ == module.__name__
                         ):
+                            setattr(obj, "__phlo_schema_source_path__", str(py_file.resolve()))
                             schemas[name] = obj
 
                 except Exception:

--- a/packages/phlo-trino/tests/test_integration_trino.py
+++ b/packages/phlo-trino/tests/test_integration_trino.py
@@ -498,10 +498,12 @@ class TestTrinoExports:
 
     def test_version_defined(self):
         """Test that version is defined."""
+        from importlib.metadata import version
+
         import phlo_trino
 
         assert hasattr(phlo_trino, "__version__")
-        assert phlo_trino.__version__ == "0.1.0"
+        assert phlo_trino.__version__ == version("phlo-trino")
 
     def test_expected_exports(self):
         """Test that expected classes are exported."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ dev = [
     "testcontainers>=4.13.3",
     "pyiceberg>=0.10.0",
     "s3fs>=2025.9.0",
-    "testcontainers-minio>=0.0.1rc1",
     "pymdx>=0.1.1",
+    "minio>=7.2.20",
 ]
 
 [project]

--- a/tests/runtime/test_core_service_autoconfig.py
+++ b/tests/runtime/test_core_service_autoconfig.py
@@ -15,7 +15,7 @@ from phlo_trino.plugin import TrinoServicePlugin
 
 pytestmark = pytest.mark.integration
 
-PLACEHOLDER_RE = re.compile(r"\$\{([A-Z0-9_]+)(?::-[^}]+)?\}")
+REQUIRED_PLACEHOLDER_RE = re.compile(r"\$\{([A-Z0-9_]+)\}")
 
 
 class ServiceFixture:
@@ -41,63 +41,63 @@ CORE_SERVICES = {
 }
 
 
-def _extract_placeholders(value: str) -> set[str]:
-    """Extract environment placeholder names from a string.
+def _extract_required_placeholders(value: str) -> set[str]:
+    """Extract environment placeholder names that have no inline default.
 
     Args:
         value: String that may contain `${VAR}` placeholders.
 
     Returns:
-        set[str]: Placeholder names without delimiters.
+        set[str]: Required placeholder names without delimiters.
     """
-    return {match.group(1) for match in PLACEHOLDER_RE.finditer(value)}
+    return {match.group(1) for match in REQUIRED_PLACEHOLDER_RE.finditer(value)}
 
 
-def _collect_placeholders(values: Iterable[object]) -> set[str]:
-    """Collect placeholder names from iterable string values.
+def _collect_required_placeholders(values: Iterable[object]) -> set[str]:
+    """Collect required placeholder names from iterable string values.
 
     Args:
         values: Values to scan for placeholders.
 
     Returns:
-        set[str]: Union of extracted placeholder names.
+        set[str]: Union of extracted required placeholder names.
     """
     placeholders: set[str] = set()
     for item in values:
         if isinstance(item, str):
-            placeholders.update(_extract_placeholders(item))
+            placeholders.update(_extract_required_placeholders(item))
     return placeholders
 
 
-def _collect_service_placeholders(definition: Mapping[str, Any]) -> set[str]:
-    """Collect placeholders referenced by a service definition.
+def _collect_required_service_placeholders(definition: Mapping[str, Any]) -> set[str]:
+    """Collect required placeholders referenced by a service definition.
 
     Args:
         definition: Service definition mapping.
 
     Returns:
-        set[str]: Placeholder names referenced in image, build args, and compose data.
+        set[str]: Required placeholder names referenced in image, build args, and compose data.
     """
     placeholders: set[str] = set()
 
     image = definition.get("image")
     if isinstance(image, str):
-        placeholders.update(_extract_placeholders(image))
+        placeholders.update(_extract_required_placeholders(image))
 
     build = definition.get("build")
     if isinstance(build, dict):
         args = build.get("args")
         if isinstance(args, dict):
-            placeholders.update(_collect_placeholders(args.values()))
+            placeholders.update(_collect_required_placeholders(args.values()))
 
     compose = definition.get("compose")
     if isinstance(compose, dict):
         environment = compose.get("environment")
         if isinstance(environment, dict):
-            placeholders.update(_collect_placeholders(environment.values()))
+            placeholders.update(_collect_required_placeholders(environment.values()))
         ports = compose.get("ports")
         if isinstance(ports, list):
-            placeholders.update(_collect_placeholders(ports))
+            placeholders.update(_collect_required_placeholders(ports))
 
     return placeholders
 
@@ -108,7 +108,7 @@ def test_core_service_dependencies_are_declared() -> None:
         "dagster": {"postgres", "minio", "nessie", "trino"},
         "nessie": {"postgres", "minio"},
         "trino": {"nessie", "minio"},
-        "postgres": set(),
+        "postgres": {"postgres-volume-setup"},
         "minio": set(),
     }
 
@@ -139,15 +139,15 @@ def test_core_service_hooks_configured_for_auto_setup() -> None:
     assert any(hook.get("name") == "init-branches" for hook in post_start if isinstance(hook, dict))
 
 
-def test_core_service_placeholders_defined_in_env_vars() -> None:
-    """Verify referenced placeholders are defined in service env var maps."""
+def test_core_service_required_placeholders_defined_in_env_vars() -> None:
+    """Verify required placeholders are defined in service env var maps."""
     available_env = set()
     placeholders: set[str] = set()
     for fixture in CORE_SERVICES.values():
         env_vars = fixture.definition.get("env_vars", {})
         if isinstance(env_vars, dict):
             available_env.update(env_vars.keys())
-        placeholders.update(_collect_service_placeholders(fixture.definition))
+        placeholders.update(_collect_required_service_placeholders(fixture.definition))
 
     allowed_extras = {"SUPERSET_ADMIN_PASSWORD"}
     missing = placeholders - available_env - allowed_extras

--- a/uv.lock
+++ b/uv.lock
@@ -3033,6 +3033,7 @@ openmetadata = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "minio" },
     { name = "phlo-alerting" },
     { name = "phlo-alloy" },
     { name = "phlo-api" },
@@ -3075,7 +3076,6 @@ dev = [
     { name = "s3fs" },
     { name = "sqlfluff" },
     { name = "testcontainers" },
-    { name = "testcontainers-minio" },
     { name = "ty" },
 ]
 
@@ -3122,6 +3122,7 @@ provides-extras = ["core-services", "defaults", "openmetadata"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "minio", specifier = ">=7.2.20" },
     { name = "phlo-alerting", editable = "packages/phlo-alerting" },
     { name = "phlo-alloy", editable = "packages/phlo-alloy" },
     { name = "phlo-api", editable = "packages/phlo-api" },
@@ -3164,7 +3165,6 @@ dev = [
     { name = "s3fs", specifier = ">=2025.9.0" },
     { name = "sqlfluff", specifier = ">=3.5.0" },
     { name = "testcontainers", specifier = ">=4.13.3" },
-    { name = "testcontainers-minio", specifier = ">=0.0.1rc1" },
     { name = "ty", specifier = "==0.0.29" },
 ]
 
@@ -5643,30 +5643,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/ac/a597c3a0e02b26cbed6dd07df68be1e57684766fd1c381dee9b170a99690/testcontainers-4.14.2.tar.gz", hash = "sha256:1340ccf16fe3acd9389a6c9e1d9ab21d9fe99a8afdf8165f89c3e69c1967d239", size = 166841, upload-time = "2026-03-18T05:19:16.696Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/2d/26b8b30067d94339afee62c3edc9b803a6eb9332f521ba77d8aaab5de873/testcontainers-4.14.2-py3-none-any.whl", hash = "sha256:0d0522c3cd8f8d9627cda41f7a6b51b639fa57bdc492923c045117933c668d68", size = 125712, upload-time = "2026-03-18T05:19:15.29Z" },
-]
-
-[[package]]
-name = "testcontainers-core"
-version = "0.0.1rc1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docker" },
-    { name = "wrapt" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/84/ac813e7aed7a527e5bc4c7cbb6e47d72498e76b8371e3805ccab96619b38/testcontainers_core-0.0.1rc1-py3-none-any.whl", hash = "sha256:69a8bf2ddb52ac2d03c26401b12c70db0453cced40372ad783d6dce417e52095", size = 11628, upload-time = "2023-01-06T16:37:25.437Z" },
-]
-
-[[package]]
-name = "testcontainers-minio"
-version = "0.0.1rc1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "minio" },
-    { name = "testcontainers-core" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/c4/85466f9aaa1cdbcd94ec57ac6f1d8167f233057779e6af0196beecb593d9/testcontainers_minio-0.0.1rc1-py3-none-any.whl", hash = "sha256:54d330d085c0a11fc5da0b001af87aec4dd3e814104376bf7513e8646c77442a", size = 3218, upload-time = "2023-01-06T16:36:36.653Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- align core service integration expectations with the postgres volume setup service and Dagster credential env vars
- replace the stale testcontainers-minio dependency with direct minio client support so current testcontainers compose/minio imports work
- preserve discovered Pandera schema source paths for schema diff, and compare phlo-trino version against installed package metadata
- skip the Delta/Trino compose integration cleanly when Docker Compose is unavailable locally

## Verification
- uv run --locked ruff check conftest.py packages/phlo-delta/tests/test_integration_delta_trino.py packages/phlo-iceberg/tests/test_integration_iceberg.py packages/phlo-pandera/src/phlo_pandera/cli_schema.py packages/phlo-pandera/src/phlo_pandera/cli_schema_utils.py packages/phlo-trino/tests/test_integration_trino.py tests/runtime/test_core_service_autoconfig.py
- uv run --locked pytest -m integration --tb=short tests/runtime/test_core_service_autoconfig.py packages/phlo-pandera/tests/test_cli_004_schema_catalog.py::TestSchemaCommands::test_schema_diff packages/phlo-pandera/tests/test_cli_004_schema_catalog.py::TestSchemaCommands::test_schema_diff_json packages/phlo-pandera/tests/test_cli_004_schema_catalog.py::TestSchemaCommands::test_schema_diff_with_old_file packages/phlo-trino/tests/test_integration_trino.py::TestTrinoExports::test_version_defined packages/phlo-delta/tests/test_integration_delta_trino.py packages/phlo-dlt/tests/test_integration_dlt.py::test_phlo_ingestion_execution_real
- uv run --locked pytest -m integration --tb=short tests packages/*/tests

Full integration result locally: 434 passed, 63 skipped, 2246 deselected, 3 warnings.