### PR TITLE
feat: complete Observatory v2 runtime flows

### DIFF
--- a/docs/reference/observatory-v2-contracts.md
+++ b/docs/reference/observatory-v2-contracts.md
@@ -129,6 +129,25 @@ Action endpoints:
 Both endpoints should return user-visible status and failure reasons that are
 safe to display in browser UI and support bundles.
 
+## Operation Journal
+
+Observatory v2 records guarded action outcomes in the provider-neutral operation
+journal at `.phlo/observatory-v2/operation_journal.json` for the active project.
+The journal is exposed through `GET /api/observatory/v2/operations` and
+`GET /api/observatory/v2/operations/{operation_id}`.
+
+Journaled operations use the same `V2Operation` contract as provider-backed
+maintenance read models. Action outcomes may have `succeeded`, `failed`, or
+`skipped` status. A skipped operation means Observatory declined the action
+because the required provider contract, capability, service state, or guardrail
+was not available.
+
+Operation metadata follows the standard v2 metadata rules. It may include safe
+values such as action id, action kind, risk level, required capability, message,
+recorded timestamp, and affected file paths. It must not include secrets,
+provider credentials, private connection strings, raw provider URLs, or signed
+URLs.
+
 ## Native Links
 
 Native links may eventually point users to provider-native tools when Observatory

--- a/packages/phlo-api/src/phlo_api/main.py
+++ b/packages/phlo-api/src/phlo_api/main.py
@@ -58,6 +58,7 @@ _cors_origins = [o.strip() for o in _cors_origins_raw.split(",") if o.strip()]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
+    allow_origin_regex=r"^https?://(localhost|127\.0\.0\.1):\d+$",
     allow_credentials=_cors_origins != ["*"],
     allow_methods=["*"],
     allow_headers=["*"],

--- a/packages/phlo-api/src/phlo_api/observatory_api/dagster.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/dagster.py
@@ -36,8 +36,12 @@ from datetime import datetime
 from typing import Any
 
 import httpx
+from dagster_graphql.client.query import (
+    LAUNCH_PIPELINE_EXECUTION_MUTATION,
+    LAUNCH_PIPELINE_REEXECUTION_MUTATION,
+)
 from fastapi import APIRouter, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from phlo.config.env import project_env_value
 from phlo.config.network import resolve_url
@@ -372,12 +376,19 @@ class MaterializeAssetRequest(BaseModel):
 
     dry_run: bool = True
     partition_key: str | None = None
+    job_name: str | None = None
+    repository_location_name: str | None = None
+    repository_name: str | None = None
+    run_config: dict[str, Any] | None = None
+    tags: dict[str, str] = Field(default_factory=dict)
 
 
 class RetryRunRequest(BaseModel):
     """Request to retry one Dagster run."""
 
     dry_run: bool = True
+    strategy: str = "FROM_FAILURE"
+    tags: dict[str, str] = Field(default_factory=dict)
 
 
 class DagsterOperationResponse(BaseModel):
@@ -487,6 +498,64 @@ async def graphql_request(
         )
         response.raise_for_status()
         return response.json()
+
+
+def _tags_for_execution(tags: dict[str, str]) -> list[dict[str, str]]:
+    return [{"key": str(key), "value": str(value)} for key, value in tags.items()]
+
+
+def _launch_error_message(result: dict[str, Any]) -> str:
+    if result.get("message"):
+        return str(result["message"])
+    errors = result.get("errors")
+    if isinstance(errors, list) and errors:
+        first_error = errors[0]
+        if isinstance(first_error, dict) and first_error.get("message"):
+            return str(first_error["message"])
+    invalid_step = result.get("invalidStepKey")
+    if invalid_step:
+        return f"Invalid step key: {invalid_step}"
+    return str(result.get("__typename") or "Dagster launch failed")
+
+
+def _launch_operation_response(
+    *,
+    operation: str,
+    dry_run: bool,
+    launch_result: dict[str, Any],
+    asset_key_path: str | None = None,
+    partition_key: str | None = None,
+    fallback_run_id: str | None = None,
+) -> DagsterOperationResponse:
+    typename = str(launch_result.get("__typename") or "DagsterLaunchResult")
+    run = launch_result.get("run") if isinstance(launch_result.get("run"), dict) else {}
+    if typename in {"LaunchRunSuccess", "LaunchPipelineRunSuccess"} and run:
+        run_id = str(run.get("runId") or fallback_run_id or "")
+        status = str(run.get("status") or "STARTED")
+        return DagsterOperationResponse(
+            operation=operation,
+            dry_run=dry_run,
+            accepted=True,
+            run_id=run_id or None,
+            asset_key_path=asset_key_path,
+            partition_key=partition_key,
+            status=status,
+            message=f"Dagster accepted {operation}.",
+            details={"typename": typename},
+        )
+
+    message = _launch_error_message(launch_result)
+    return DagsterOperationResponse(
+        operation=operation,
+        dry_run=dry_run,
+        accepted=False,
+        run_id=fallback_run_id,
+        asset_key_path=asset_key_path,
+        partition_key=partition_key,
+        status=typename,
+        message=message,
+        details={"typename": typename},
+    )
 
 
 def infer_layer(key_path: str) -> str:
@@ -946,14 +1015,6 @@ async def materialize_asset(
     if not asset_key_path:
         return {"error": "Asset key is required"}
 
-    if not payload.dry_run:
-        return {
-            "error": (
-                "Live Dagster materialization launch is not implemented yet. "
-                "Use dry_run=true to validate the request."
-            )
-        }
-
     details = await get_asset_details(asset_key_path, dagster_url=dagster_url)
     if isinstance(details, dict) and details.get("error"):
         return details
@@ -963,6 +1024,66 @@ async def materialize_asset(
     else:
         has_permission = details.has_materialize_permission
         op_names = details.op_names
+
+    if not payload.dry_run:
+        if not has_permission:
+            return DagsterOperationResponse(
+                operation="materialize_asset",
+                dry_run=False,
+                accepted=False,
+                asset_key_path=asset_key_path,
+                partition_key=payload.partition_key,
+                status="NOT_MATERIALIZABLE",
+                message="Dagster reports this asset is not materializable by the current principal.",
+                details={"op_names": op_names},
+            )
+        if not payload.job_name:
+            return DagsterOperationResponse(
+                operation="materialize_asset",
+                dry_run=False,
+                accepted=False,
+                asset_key_path=asset_key_path,
+                partition_key=payload.partition_key,
+                status="MISSING_JOB_NAME",
+                message="Dagster job_name is required to launch live asset materialization.",
+                details={"op_names": op_names},
+            )
+
+        tags = {
+            "phlo/operation": "materialize_asset",
+            "phlo/asset_key": asset_key_path,
+            **payload.tags,
+        }
+        if payload.partition_key:
+            tags.setdefault("dagster/partition", payload.partition_key)
+
+        execution_params: dict[str, Any] = {
+            "selector": {
+                "pipelineName": payload.job_name,
+                "repositoryLocationName": payload.repository_location_name,
+                "repositoryName": payload.repository_name,
+                "assetSelection": [{"path": asset_key_path.split("/")}],
+            },
+            "runConfigData": payload.run_config or {},
+            "mode": "default",
+            "executionMetadata": {"tags": _tags_for_execution(tags)},
+        }
+        result = await graphql_request(
+            resolve_dagster_url(dagster_url),
+            LAUNCH_PIPELINE_EXECUTION_MUTATION,
+            {"executionParams": execution_params},
+            initiator="observatory",
+        )
+        if result.get("errors"):
+            return {"error": result["errors"][0].get("message", "GraphQL error")}
+        launch_result = result.get("data", {}).get("launchPipelineExecution", {})
+        return _launch_operation_response(
+            operation="materialize_asset",
+            dry_run=False,
+            launch_result=launch_result,
+            asset_key_path=asset_key_path,
+            partition_key=payload.partition_key,
+        )
 
     return DagsterOperationResponse(
         operation="materialize_asset",
@@ -1164,15 +1285,48 @@ async def retry_run(
     if isinstance(status, dict) and status.get("error"):
         return status
 
-    if not payload.dry_run:
-        return {
-            "error": (
-                "Live Dagster run retry launch is not implemented yet. "
-                "Use dry_run=true to validate the request."
-            )
-        }
-
     run_status = status.get("status") if isinstance(status, dict) else status.status
+    if not payload.dry_run:
+        if run_status != "FAILURE":
+            return DagsterOperationResponse(
+                operation="retry_failed_run",
+                dry_run=False,
+                accepted=False,
+                run_id=run_id,
+                status=str(run_status),
+                message=f"Run status is {run_status}; only FAILURE runs are retry candidates.",
+                details={"run_status": run_status},
+            )
+
+        tags = {
+            "phlo/operation": "retry_failed_run",
+            "phlo/parent_run_id": run_id,
+            **payload.tags,
+        }
+        result = await graphql_request(
+            resolve_dagster_url(dagster_url),
+            LAUNCH_PIPELINE_REEXECUTION_MUTATION,
+            {
+                "executionParams": None,
+                "reexecutionParams": {
+                    "parentRunId": run_id,
+                    "strategy": payload.strategy,
+                    "extraTags": _tags_for_execution(tags),
+                    "useParentRunTags": True,
+                },
+            },
+            initiator="observatory",
+        )
+        if result.get("errors"):
+            return {"error": result["errors"][0].get("message", "GraphQL error")}
+        launch_result = result.get("data", {}).get("launchPipelineReexecution", {})
+        return _launch_operation_response(
+            operation="retry_failed_run",
+            dry_run=False,
+            launch_result=launch_result,
+            fallback_run_id=run_id,
+        )
+
     return DagsterOperationResponse(
         operation="retry_failed_run",
         dry_run=True,

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -874,16 +874,18 @@ def _load_operations() -> list[V2Operation]:
 
 
 def _load_logs() -> list[V2LogEvent]:
+    project_root = _project_root()
+    events = _load_project_log_events(project_root)
     try:
         from phlo.capabilities.telemetry import iter_telemetry_events
     except Exception:
-        return []
+        return events
 
-    events: list[V2LogEvent] = []
     try:
-        raw_events = list(iter_telemetry_events())[-50:]
+        telemetry_path = project_root / ".phlo" / "telemetry" / "events.jsonl"
+        raw_events = list(iter_telemetry_events(telemetry_path))[-50:]
     except Exception:
-        return []
+        return events
 
     for index, event in enumerate(reversed(raw_events)):
         timestamp = event.get("timestamp")
@@ -899,7 +901,46 @@ def _load_logs() -> list[V2LogEvent]:
                 metadata=_safe_metadata(event),
             )
         )
-    return events
+    return events[:100]
+
+
+def _load_project_log_events(project_root: Path) -> list[V2LogEvent]:
+    """Load structured Phlo project logs from `.phlo/logs/*.log`."""
+    logs_dir = project_root / ".phlo" / "logs"
+    if not logs_dir.exists():
+        return []
+
+    events: list[V2LogEvent] = []
+    for log_path in sorted(logs_dir.glob("*.log"), reverse=True):
+        try:
+            lines = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            continue
+        for line_number, line in enumerate(lines[-100:], start=max(len(lines) - 99, 1)):
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                if not line.strip():
+                    continue
+                payload = {"message": line.strip(), "level": "info"}
+            if not isinstance(payload, Mapping):
+                continue
+            message = _coerce_str(
+                payload.get("message") or payload.get("event") or payload.get("logger"),
+                "log event",
+            )
+            events.append(
+                V2LogEvent(
+                    id=f"phlo:{log_path.name}:{line_number}",
+                    timestamp=_coerce_str(payload.get("timestamp"), "") or None,
+                    level=_coerce_str(payload.get("level"), "info").lower(),
+                    message=message,
+                    source=_coerce_str(payload.get("logger") or payload.get("service"), "")
+                    or "phlo",
+                    metadata=_safe_metadata(payload),
+                )
+            )
+    return sorted(events, key=lambda event: event.timestamp or "", reverse=True)[:50]
 
 
 def _asset_related_logs(asset_id: str, logs: list[V2LogEvent]) -> list[V2LogEvent]:

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -1891,6 +1891,7 @@ def _providers_matching(extensions: Sequence[V2Extension], *needles: str) -> lis
 
 def _load_capabilities() -> V2Capabilities:
     inventory = build_capability_inventory(_load_capability_registry())
+    _add_orchestrator_plugin_providers(inventory)
     _filter_capabilities_to_project_services(inventory, _load_services())
     _add_runtime_capability_providers(inventory)
     pages = _pages_from_inventory(inventory)
@@ -1905,6 +1906,7 @@ def _load_capabilities() -> V2Capabilities:
 
 
 _RUNTIME_SERVICE_CAPABILITIES: dict[str, tuple[str, ...]] = {
+    "dagster": ("orchestrator",),
     "trino": ("query_engine",),
     "nessie": ("catalog", "catalog_scanner"),
     "minio": ("object_store", "table_store"),
@@ -1938,6 +1940,7 @@ _PROVIDER_SERVICE_DEPENDENCIES: dict[tuple[str, str], tuple[str, ...]] = {
     ("observability_backend", "grafana"): ("grafana",),
     ("observability_backend", "loki"): ("loki",),
     ("observability_backend", "prometheus"): ("prometheus",),
+    ("orchestrator", "dagster"): ("dagster", "dagster-daemon"),
     ("publish_target", "clickhouse"): ("clickhouse",),
     ("publish_target", "postgres"): ("postgres",),
     ("publish_target", "trino"): ("trino",),
@@ -1947,6 +1950,35 @@ _PROVIDER_SERVICE_DEPENDENCIES: dict[tuple[str, str], tuple[str, ...]] = {
     ("table_store", "delta"): ("trino", "minio"),
     ("table_store", "iceberg"): ("trino", "minio", "nessie"),
 }
+
+
+def _add_orchestrator_plugin_providers(inventory: V2CapabilityInventory) -> None:
+    """Expose installed orchestrator plugins as route-gating capabilities."""
+    try:
+        from phlo.plugins.discovery import discover_plugins, list_plugins
+
+        discover_plugins(plugin_type="orchestrators", auto_register=True)
+        orchestrators = list_plugins("orchestrators").get("orchestrators", [])
+    except Exception:
+        orchestrators = []
+
+    providers = inventory.providers.setdefault("orchestrator", [])
+    for orchestrator in orchestrators:
+        if any(provider.name == orchestrator for provider in providers):
+            continue
+        providers.append(
+            V2CapabilityProvider(
+                capability_type="orchestrator",
+                name=orchestrator,
+                display_name=orchestrator,
+                metadata=_safe_metadata(
+                    {
+                        "source": "plugin",
+                        "service": orchestrator,
+                    }
+                ),
+            )
+        )
 
 
 def _filter_capabilities_to_project_services(

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -982,13 +982,22 @@ def _asset_related_operations(asset_id: str, operations: list[V2Operation]) -> l
 
 def _service_actions(service: V2Service) -> list[V2Action]:
     if not service.in_stack:
+        package_installed = service.metadata.get("package_installed") is not False
+        package_name = _coerce_str(service.metadata.get("package"), service.name)
         return [
             V2Action(
-                id=f"{service.id}:configure",
-                label="Configure",
-                kind="service.configure",
-                enabled=False,
-                reason="This service is available as a definition but is not configured in the current stack.",
+                id=f"{service.id}:add",
+                label="Add to stack",
+                kind="service.add",
+                enabled=package_installed,
+                reason=None
+                if package_installed
+                else f"Install {package_name} before adding this service to the stack.",
+                equivalent_cli_command=f"phlo services add {service.id}",
+                expected_evidence=[
+                    f"{service.id} appears in .phlo/docker-compose.yml",
+                    f"{service.id} is present in phlo services status",
+                ],
             )
         ]
 
@@ -2186,7 +2195,7 @@ def _execute_action(request: V2ActionRequest) -> V2ActionResult:
     resource_id, action_name = parts
     services = _load_services()
     service = next((item for item in services if item.id == resource_id), None)
-    if service is None or action_name not in {"start", "stop", "restart"}:
+    if service is None or action_name not in {"add", "start", "stop", "restart"}:
         raise HTTPException(status_code=400, detail="Unsupported action.")
 
     action = next(
@@ -2204,7 +2213,10 @@ def _execute_action(request: V2ActionRequest) -> V2ActionResult:
             message=message,
         )
 
-    command = ["phlo", "services", action_name, "--service", service.id]
+    if action_name == "add":
+        command = ["phlo", "services", "add", service.id]
+    else:
+        command = ["phlo", "services", action_name, "--service", service.id]
     try:
         result = subprocess.run(
             command,

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -402,13 +402,24 @@ def _normalize_docker_api_container(container: Mapping[str, Any]) -> dict[str, A
 
 
 def _load_docker_containers() -> list[dict[str, Any]]:
+    command = ["docker", "ps", "-a"]
+    compose_project = os.environ.get("PHLO_COMPOSE_PROJECT") or os.environ.get(
+        "COMPOSE_PROJECT_NAME"
+    )
+    if compose_project is None:
+        compose_project = _project_compose_name(_project_root())
+    if compose_project:
+        command.extend(["--filter", f"label=com.docker.compose.project={compose_project}"])
+    else:
+        return []
+    command.extend(["--format", "{{json .}}"])
     try:
         result = subprocess.run(
-            ["docker", "ps", "-a", "--format", "{{json .}}"],
+            command,
             capture_output=True,
             text=True,
             check=False,
-            timeout=2,
+            timeout=30,
         )
     except (OSError, subprocess.TimeoutExpired):
         result = None
@@ -1913,8 +1924,11 @@ _RUNTIME_SERVICE_CAPABILITIES: dict[str, tuple[str, ...]] = {
 _PROVIDER_SERVICE_DEPENDENCIES: dict[tuple[str, str], tuple[str, ...]] = {
     ("api_backend", "hasura"): ("hasura",),
     ("api_backend", "postgrest"): ("postgrest",),
+    ("alert_sink", "alerting"): ("prometheus",),
     ("catalog", "nessie"): ("nessie",),
     ("catalog_scanner", "nessie"): ("nessie",),
+    ("governance_backend", "trino"): ("trino",),
+    ("lineage_sink", "phlo-lineage"): ("trino", "minio", "nessie"),
     ("maintenance_read_model", "default"): ("phlo-api",),
     ("metadata_catalog", "openmetadata"): ("openmetadata",),
     ("object_store", "minio"): ("minio",),
@@ -1945,8 +1959,6 @@ def _filter_capabilities_to_project_services(
         for service in services
         if service.in_stack or service.definition_state == "configured"
     }
-    if not project_service_ids:
-        return
 
     for capability_type, providers in list(inventory.providers.items()):
         filtered: list[V2CapabilityProvider] = []

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -6,12 +6,14 @@ import asyncio
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, is_dataclass
+import importlib
 import importlib.util
 import http.client
 import json
 import os
 from pathlib import Path
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -49,6 +51,8 @@ from phlo_api.observatory_api.v2_models import (
     V2Operation,
     V2OperationDetail,
     V2Overview,
+    V2PackageInstallRequest,
+    V2PackageInstallResult,
     V2QualityCheck,
     V2QualityDetail,
     V2QueryRequest,
@@ -100,6 +104,8 @@ from phlo_api.observatory_api.v2_workflow_wizard import (
     build_workflow_proposal,
     build_workflow_wizard_payload,
 )
+from phlo.cli.commands.plugin.install import resolve_install_target
+from phlo.plugins.registry_client import get_registry_data
 
 router = APIRouter(tags=["observatory-v2"])
 
@@ -2242,6 +2248,131 @@ def _execute_action(request: V2ActionRequest) -> V2ActionResult:
     )
 
 
+def _trusted_registry_service_packages() -> dict[str, dict[str, Any]]:
+    try:
+        registry = get_registry_data()
+    except Exception as exc:
+        raise HTTPException(status_code=503, detail="Package registry is unavailable.") from exc
+
+    plugins = registry.get("plugins") if isinstance(registry, Mapping) else None
+    if not isinstance(plugins, Mapping):
+        return {}
+
+    packages: dict[str, dict[str, Any]] = {}
+    for name, payload in plugins.items():
+        if not isinstance(payload, Mapping):
+            continue
+        package = str(payload.get("package") or "").strip()
+        if not package:
+            continue
+        normalized = dict(payload)
+        normalized["name"] = str(name)
+        for key in {str(name), package, package.removeprefix("phlo-")}:
+            if key:
+                packages[key] = normalized
+    return packages
+
+
+def _uv_project_root() -> Path | None:
+    configured = os.environ.get("PHLO_UV_PROJECT") or os.environ.get("UV_PROJECT")
+    if configured:
+        path = Path(configured).expanduser()
+        if (path / "pyproject.toml").exists():
+            return path
+
+    for candidate in [_project_root(), Path.cwd(), *Path.cwd().parents]:
+        if (candidate / "pyproject.toml").exists():
+            return candidate
+    return None
+
+
+def _run_python_package_install(package_spec: str) -> tuple[bool, str]:
+    uv = shutil.which("uv")
+    if uv is not None:
+        project_root = _uv_project_root()
+        if project_root is not None:
+            command = [uv, "add", "--active", package_spec]
+            cwd = project_root
+        else:
+            command = [uv, "pip", "install", package_spec]
+            cwd = None
+    elif importlib.util.find_spec("pip") is not None:
+        command = [sys.executable, "-m", "pip", "install", package_spec]
+        cwd = None
+    else:
+        raise RuntimeError("Neither uv nor pip is available to install packages.")
+
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+    message = (result.stdout or result.stderr or "").strip()
+    return result.returncode == 0, message or "Install command completed."
+
+
+def _install_python_package(request: V2PackageInstallRequest) -> V2PackageInstallResult:
+    requested = request.package_name.strip()
+    if not requested:
+        raise HTTPException(status_code=400, detail="Package name is required.")
+
+    trusted_packages = _trusted_registry_service_packages()
+    registry_entry = trusted_packages.get(requested)
+    if registry_entry is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Only trusted Phlo packages from the registry can be installed.",
+        )
+
+    registry_name = str(registry_entry["name"])
+    package_name = str(registry_entry["package"])
+    package_spec, _display_name = resolve_install_target(registry_name)
+    if not package_spec.startswith(package_name):
+        package_spec = package_name
+        version = str(registry_entry.get("version") or "").strip()
+        if version:
+            package_spec = f"{package_name}=={version}"
+
+    try:
+        succeeded, install_message = _run_python_package_install(package_spec)
+    except Exception as exc:
+        return V2PackageInstallResult(
+            package_name=package_name,
+            package_spec=package_spec,
+            status="failed",
+            message=f"Install failed: {exc}",
+            services=[registry_name],
+        )
+    if not succeeded:
+        return V2PackageInstallResult(
+            package_name=package_name,
+            package_spec=package_spec,
+            status="failed",
+            message=install_message[-500:],
+            services=[registry_name],
+        )
+
+    importlib.invalidate_caches()
+    _clear_read_model_cache()
+    installed_services = [
+        service.id
+        for service in _load_services()
+        if service.metadata.get("package") == package_name
+    ]
+    return V2PackageInstallResult(
+        package_name=package_name,
+        package_spec=package_spec,
+        status="succeeded",
+        message=(
+            f"Installed {package_name}. Regenerate the Phlo service stack before starting it."
+        ),
+        services=installed_services or [registry_name],
+    )
+
+
 def _execute_branch_action(request: V2ActionRequest) -> V2ActionResult:
     parts = request.action_id.split(":", 2)
     if len(parts) != 3 or parts[0] != "branch":
@@ -2757,3 +2888,11 @@ def post_v2_action(request: V2ActionRequest) -> V2ActionResult:
     recorded = record_action_result(_project_root(), result)
     _clear_read_model_cache()
     return recorded
+
+
+@router.post("/packages/install", response_model=V2PackageInstallResult)
+def post_v2_package_install(request: V2PackageInstallRequest) -> V2PackageInstallResult:
+    """Install a trusted Phlo Python package into the current environment."""
+    result = _install_python_package(request)
+    _clear_read_model_cache()
+    return result

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -90,6 +90,7 @@ from phlo_api.observatory_api.v2_saved_queries import (
 )
 from phlo_api.observatory_api.v2_search import search_results as _search_results_impl
 from phlo_api.observatory_api.v2_services import load_services as _load_services_impl
+from phlo_api.observatory_api.v2_services import project_compose_name as _project_compose_name
 from phlo_api.observatory_api.v2_storage import load_storage_items
 from phlo_api.observatory_api.v2_workflow_wizard import (
     V2WorkflowActionRequest,
@@ -439,6 +440,9 @@ def _current_compose_project(containers: Sequence[Mapping[str, Any]]) -> str | N
     configured = os.environ.get("PHLO_COMPOSE_PROJECT") or os.environ.get("COMPOSE_PROJECT_NAME")
     if configured:
         return configured
+    configured_project = _project_compose_name(_project_root())
+    if configured_project:
+        return configured_project
 
     hostname = os.environ.get("HOSTNAME", "")
     if not hostname:
@@ -492,11 +496,13 @@ def _load_docker_service_statuses(
     statuses: dict[str, tuple[ServiceStatus, V2Health]] = {}
     containers = _load_docker_containers()
     compose_project = _current_compose_project(containers)
+    if not compose_project:
+        return statuses
+
     for container in containers:
-        if compose_project:
-            labels = _container_labels(container)
-            if labels.get("com.docker.compose.project") != compose_project:
-                continue
+        labels = _container_labels(container)
+        if labels.get("com.docker.compose.project") != compose_project:
+            continue
         name = _coerce_str(container.get("Names"), "")
         service_id = _compose_service_name(container) or _service_name_from_container(
             name, service_ids
@@ -521,9 +527,12 @@ def _runtime_services_from_containers(
 ) -> list[V2Service]:
     compose_project = _current_compose_project(containers)
     services: list[V2Service] = []
+    if not compose_project:
+        return services
+
     for container in containers:
         labels = _container_labels(container)
-        if compose_project and labels.get("com.docker.compose.project") != compose_project:
+        if labels.get("com.docker.compose.project") != compose_project:
             continue
         service_id = _compose_service_name(container)
         if not service_id or service_id in known_ids:
@@ -1830,6 +1839,7 @@ def _providers_matching(extensions: Sequence[V2Extension], *needles: str) -> lis
 
 def _load_capabilities() -> V2Capabilities:
     inventory = build_capability_inventory(_load_capability_registry())
+    _filter_capabilities_to_project_services(inventory, _load_services())
     _add_runtime_capability_providers(inventory)
     pages = _pages_from_inventory(inventory)
     features = {page.id: page.available for page in pages}
@@ -1857,6 +1867,71 @@ _RUNTIME_SERVICE_CAPABILITIES: dict[str, tuple[str, ...]] = {
     "hasura": ("api_backend",),
     "superset": ("publish_target",),
 }
+
+
+_PROVIDER_SERVICE_DEPENDENCIES: dict[tuple[str, str], tuple[str, ...]] = {
+    ("api_backend", "hasura"): ("hasura",),
+    ("api_backend", "postgrest"): ("postgrest",),
+    ("catalog", "nessie"): ("nessie",),
+    ("catalog_scanner", "nessie"): ("nessie",),
+    ("maintenance_read_model", "default"): ("phlo-api",),
+    ("metadata_catalog", "openmetadata"): ("openmetadata",),
+    ("object_store", "minio"): ("minio",),
+    ("object_store", "rustfs"): ("rustfs",),
+    ("observability_backend", "default"): ("clickstack",),
+    ("observability_backend", "clickstack"): ("clickstack",),
+    ("observability_backend", "grafana"): ("grafana",),
+    ("observability_backend", "loki"): ("loki",),
+    ("observability_backend", "prometheus"): ("prometheus",),
+    ("publish_target", "clickhouse"): ("clickhouse",),
+    ("publish_target", "postgres"): ("postgres",),
+    ("publish_target", "trino"): ("trino",),
+    ("query_engine", "clickhouse"): ("clickhouse",),
+    ("query_engine", "trino"): ("trino",),
+    ("table_store", "clickhouse"): ("clickhouse",),
+    ("table_store", "delta"): ("trino", "minio"),
+    ("table_store", "iceberg"): ("trino", "minio", "nessie"),
+}
+
+
+def _filter_capabilities_to_project_services(
+    inventory: V2CapabilityInventory,
+    services: Sequence[V2Service],
+) -> None:
+    """Keep service-backed providers aligned with the current project stack."""
+    project_service_ids = {
+        service.id
+        for service in services
+        if service.in_stack or service.definition_state == "configured"
+    }
+    if not project_service_ids:
+        return
+
+    for capability_type, providers in list(inventory.providers.items()):
+        filtered: list[V2CapabilityProvider] = []
+        for provider in providers:
+            dependencies = _provider_service_dependencies(capability_type, provider)
+            if not dependencies or any(
+                service_id in project_service_ids for service_id in dependencies
+            ):
+                filtered.append(provider)
+        inventory.providers[capability_type] = filtered
+
+
+def _provider_service_dependencies(
+    capability_type: str,
+    provider: V2CapabilityProvider,
+) -> tuple[str, ...]:
+    metadata = provider.metadata
+    service_name = metadata.get("service_name") or metadata.get("service")
+    if isinstance(service_name, str) and service_name:
+        return (service_name,)
+
+    dependencies = metadata.get("service_dependencies") or metadata.get("default_stack")
+    if isinstance(dependencies, list):
+        return tuple(str(item) for item in dependencies if str(item))
+
+    return _PROVIDER_SERVICE_DEPENDENCIES.get((capability_type, provider.name), ())
 
 
 def _add_runtime_capability_providers(inventory: V2CapabilityInventory) -> None:

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -2404,7 +2404,7 @@ def get_v2_overview() -> V2Overview:
 @router.get("/capabilities", response_model=V2Capabilities)
 def get_v2_capabilities() -> V2Capabilities:
     """Get the provider-neutral Observatory surface capabilities."""
-    return _cached_read_model("capabilities", _EXPENSIVE_READ_MODEL_TTL_SECONDS, _load_capabilities)
+    return _load_capabilities()
 
 
 @router.get("/capability-inventory", response_model=V2CapabilityInventory)

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -957,41 +957,40 @@ def _service_actions(service: V2Service) -> list[V2Action]:
 
 
 def _quality_actions(check: V2QualityCheck) -> list[V2Action]:
+    registry = _load_capability_registry()
+    executable = False
+    if registry is not None:
+        try:
+            executable = any(
+                f"{item.asset_key}:{item.name}" == check.id and callable(getattr(item, "fn", None))
+                for item in registry.list_checks()
+            )
+        except Exception:
+            executable = False
     return [
         V2Action(
             id=f"{check.id}:rerun",
             label="Re-run",
             kind="quality.rerun",
-            enabled=False,
-            reason="Quality execution needs a guarded phlo-api operation contract.",
-        ),
-        V2Action(
-            id=f"{check.id}:acknowledge",
-            label="Acknowledge",
-            kind="quality.acknowledge",
-            enabled=False,
-            reason="Acknowledgements need a persisted v2 workflow contract.",
+            enabled=executable,
+            reason=None if executable else "This quality check has no executable function.",
         ),
     ]
 
 
 def _operation_actions(operation: V2Operation) -> list[V2Action]:
-    return [
-        V2Action(
-            id=f"{operation.id}:retry",
-            label="Retry",
-            kind="operation.retry",
-            enabled=False,
-            reason="Retries need a guarded phlo-api operation execution contract.",
-        ),
-        V2Action(
-            id=f"{operation.id}:open-target",
-            label="Open Target",
-            kind="operation.open_target",
-            enabled=operation.target is not None,
-            requires_confirmation=False,
-        ),
-    ]
+    actions = []
+    if operation.target is not None:
+        actions.append(
+            V2Action(
+                id=f"{operation.id}:open-target",
+                label="Open Target",
+                kind="operation.open_target",
+                enabled=True,
+                requires_confirmation=False,
+            )
+        )
+    return actions
 
 
 def _table_columns_from_metadata(table: V2Table) -> list[str]:
@@ -1254,9 +1253,86 @@ def _find_table(table_id: str, tables: list[V2Table] | None = None) -> V2Table |
     )
 
 
+def _catalog_branch_provider() -> Any | None:
+    registry = _load_capability_registry()
+    if registry is None:
+        return None
+    try:
+        catalog_specs = registry.list_catalogs()
+    except Exception:
+        return None
+    for spec in catalog_specs:
+        provider = getattr(spec, "provider", None)
+        if any(
+            callable(getattr(provider, method_name, None))
+            for method_name in ("list_branches", "create_branch", "merge_branch", "delete_branch")
+        ):
+            return provider
+    return None
+
+
+def _provider_branch_name(branch: Any) -> str | None:
+    if isinstance(branch, Mapping):
+        value = branch.get("name") or branch.get("id")
+    else:
+        value = getattr(branch, "name", None) or getattr(branch, "id", None)
+    return str(value) if value else None
+
+
+def _provider_branch_metadata(branch: Any) -> dict[str, Any]:
+    if isinstance(branch, Mapping):
+        raw = dict(branch)
+    else:
+        raw = {
+            key: getattr(branch, key)
+            for key in ("hash", "commit_hash", "created_at", "metadata")
+            if hasattr(branch, key)
+        }
+    metadata = raw.get("metadata") if isinstance(raw.get("metadata"), Mapping) else {}
+    return _safe_metadata(
+        {
+            "source": "catalog-provider",
+            **dict(metadata),
+            "hash": raw.get("hash") or raw.get("commit_hash"),
+            "created_at": raw.get("created_at"),
+        }
+    )
+
+
+def _load_provider_branches() -> list[V2Branch]:
+    provider = _catalog_branch_provider()
+    list_branches = getattr(provider, "list_branches", None)
+    if not callable(list_branches):
+        return []
+    try:
+        raw_branches = list_branches()
+    except Exception:
+        return []
+
+    branches: list[V2Branch] = []
+    for raw_branch in raw_branches or []:
+        name = _provider_branch_name(raw_branch)
+        if not name or name == "main":
+            continue
+        branches.append(
+            V2Branch(
+                id=name,
+                name=name,
+                current=False,
+                protected=False,
+                metadata=_provider_branch_metadata(raw_branch),
+            )
+        )
+    return branches
+
+
 def _load_branches() -> list[V2Branch]:
     """Return neutral branch data; core-only fallback is the main branch."""
-    branches = [V2Branch(id="main", name="main", current=True, protected=True)]
+    branches_by_id = {
+        "main": V2Branch(id="main", name="main", current=True, protected=True),
+    }
+    for branch in _load_provider_branches():
+        branches_by_id.setdefault(branch.id, branch)
     path = _branches_path()
     if path.exists():
         try:
@@ -1272,8 +1348,8 @@ def _load_branches() -> list[V2Branch]:
                     except Exception:
                         continue
                     if branch.id != "main":
-                        branches.append(branch)
-    return sorted(branches, key=lambda item: (not item.current, item.name))
+                        branches_by_id[branch.id] = branch
+    return sorted(branches_by_id.values(), key=lambda item: (not item.current, item.name))
 
 
 def _write_branches(branches: list[V2Branch]) -> None:
@@ -1811,7 +1887,9 @@ def _add_runtime_capability_providers(inventory: V2CapabilityInventory) -> None:
 
 def _branches_available() -> bool:
     """Return whether branch actions can be backed by a catalog provider."""
-    return False
+    if _load_capabilities().features.get("branches") is False:
+        return False
+    return _catalog_branch_provider() is not None
 
 
 def _pages_from_inventory(inventory: V2CapabilityInventory) -> list[V2CapabilityPage]:
@@ -2014,7 +2092,8 @@ def _execute_branch_action(request: V2ActionRequest) -> V2ActionResult:
     if not branch_name:
         raise HTTPException(status_code=400, detail="Branch name is required.")
 
-    branches_available = _branches_available()
+    provider = _catalog_branch_provider()
+    branches_available = _branches_available() and provider is not None
     branch_unavailable_reason = "A catalog provider is required for branch actions."
     action = V2Action(
         id=request.action_id,
@@ -2036,35 +2115,95 @@ def _execute_branch_action(request: V2ActionRequest) -> V2ActionResult:
     existing = next((branch for branch in branches if branch.id == branch_name), None)
     if action_name == "create":
         if existing is None:
-            branches.append(
-                V2Branch(
-                    id=branch_name,
-                    name=branch_name,
-                    current=False,
-                    protected=False,
-                    metadata={"source": "observatory-v2"},
-                )
-            )
-            _write_branches(branches)
-            status = "succeeded"
-            message = f"Branch {branch_name} created."
+            create_branch = getattr(provider, "create_branch", None)
+            if not callable(create_branch):
+                status = "skipped"
+                message = "Catalog provider does not support branch creation."
+            else:
+                try:
+                    branch_hash = create_branch(branch_name, from_ref="main")
+                except Exception as exc:
+                    status = "failed"
+                    message = f"Branch {branch_name} creation failed: {exc}"
+                else:
+                    if branch_hash:
+                        branches.append(
+                            V2Branch(
+                                id=branch_name,
+                                name=branch_name,
+                                current=False,
+                                protected=False,
+                                metadata=_safe_metadata(
+                                    {
+                                        "source": "catalog-provider",
+                                        "hash": branch_hash,
+                                    }
+                                ),
+                            )
+                        )
+                        _write_branches(branches)
+                        status = "succeeded"
+                        message = f"Branch {branch_name} created."
+                    else:
+                        status = "failed"
+                        message = f"Catalog provider did not create branch {branch_name}."
         else:
             status = "skipped"
             message = f"Branch {branch_name} already exists."
     elif action_name == "delete":
         if branch_name == "main":
             raise HTTPException(status_code=400, detail="The main branch is protected.")
-        branches = [branch for branch in branches if branch.id != branch_name]
-        _write_branches(branches)
-        status = "succeeded"
-        message = f"Branch {branch_name} deleted."
+        if existing is None:
+            status = "skipped"
+            message = f"Branch {branch_name} does not exist."
+        else:
+            delete_branch = getattr(provider, "delete_branch", None)
+            if not callable(delete_branch):
+                status = "skipped"
+                message = "Catalog provider does not support branch deletion."
+            else:
+                try:
+                    deleted = bool(delete_branch(branch_name))
+                except Exception as exc:
+                    status = "failed"
+                    message = f"Branch {branch_name} deletion failed: {exc}"
+                else:
+                    if deleted:
+                        branches = [branch for branch in branches if branch.id != branch_name]
+                        _write_branches(branches)
+                        status = "succeeded"
+                        message = f"Branch {branch_name} deleted."
+                    else:
+                        status = "failed"
+                        message = f"Catalog provider did not delete branch {branch_name}."
     elif action_name == "promote":
         if existing is None:
             raise _not_found("branch", branch_name)
-        status = "skipped"
-        message = "Promotion requires a catalog provider write contract."
+        merge_branch = getattr(provider, "merge_branch", None)
+        if not callable(merge_branch):
+            status = "skipped"
+            message = "Catalog provider does not support branch promotion."
+        else:
+            try:
+                promoted = bool(merge_branch(branch_name, target="main"))
+            except Exception as exc:
+                status = "failed"
+                message = f"Branch {branch_name} promotion failed: {exc}"
+            else:
+                status = "succeeded" if promoted else "failed"
+                message = (
+                    f"Branch {branch_name} promoted to main."
+                    if promoted
+                    else f"Catalog provider did not promote branch {branch_name}."
+                )
     else:
         raise HTTPException(status_code=400, detail="Unsupported branch action.")
+
+    health_state = "ok"
+    if status == "skipped":
+        health_state = "warning"
+    elif status == "failed":
+        health_state = "error"
 
     return V2ActionResult(
         action=action,
@@ -2074,8 +2213,8 @@ def _execute_branch_action(request: V2ActionRequest) -> V2ActionResult:
             id=request.action_id,
             name=action.label,
             kind=action.kind,
-            status="succeeded" if status in {"succeeded", "skipped"} else "failed",
-            health=V2Health(state="ok" if status in {"succeeded", "skipped"} else "error"),
+            status=status,  # type: ignore[arg-type]
+            health=V2Health(state=health_state, message=message),  # type: ignore[arg-type]
             target=V2ResourceRef(kind="branch", id=branch_name, label=branch_name),
         ),
     )
@@ -2450,7 +2589,11 @@ def post_v2_action(request: V2ActionRequest) -> V2ActionResult:
         and action_name in {"start", "stop", "restart"}
         and any(service.id == resource_id for service in services)
     )
-    result = _execute_action(request) if is_service_control_action else execute_v2_action(request)
+    result = (
+        _execute_action(request)
+        if is_service_control_action
+        else execute_v2_action(request, registry=_load_capability_registry())
+    )
     recorded = record_action_result(_project_root(), result)
     _clear_read_model_cache()
     return recorded

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -72,6 +72,13 @@ from phlo_api.observatory_api.v2_models import (
 )
 from phlo_api.observatory_api.v2_metadata import safe_metadata as _safe_metadata
 from phlo_api.observatory_api.v2_observability import load_observability_items
+from phlo_api.observatory_api.v2_operation_journal import (
+    append_operation,
+    load_operation_journal,
+    operation_from_workflow_action,
+    record_action_result,
+    sort_operations,
+)
 from phlo_api.observatory_api.v2_products import load_api_items, load_bi_items
 from phlo_api.observatory_api.v2_runs import load_runs
 from phlo_api.observatory_api.v2_saved_queries import (
@@ -838,11 +845,11 @@ def _operation_from_maintenance_status(status: Any) -> V2Operation:
 
 
 def _load_operations() -> list[V2Operation]:
+    operations = list(load_operation_journal(_project_root()))
     registry = _load_capability_registry()
     if registry is None:
-        return []
+        return sort_operations(operations)
 
-    operations: list[V2Operation] = []
     for spec in registry.list_maintenance_read_models():
         provider = getattr(spec, "provider", None)
         loader = getattr(provider, "load_maintenance_status", None)
@@ -854,7 +861,7 @@ def _load_operations() -> list[V2Operation]:
             continue
         for status in getattr(snapshot, "operations", []):
             operations.append(_operation_from_maintenance_status(status))
-    return sorted(operations, key=lambda item: item.id)
+    return sort_operations(operations)
 
 
 def _load_logs() -> list[V2LogEvent]:
@@ -2347,8 +2354,9 @@ def get_v2_branches() -> V2BranchList:
 def post_v2_branch_action(request: V2ActionRequest) -> V2ActionResult:
     """Execute a guarded branch workflow action."""
     result = _execute_branch_action(request)
+    recorded = record_action_result(_project_root(), result)
     _clear_read_model_cache()
-    return result
+    return recorded
 
 
 @router.get("/branches/{branch_name:path}", response_model=V2BranchDetail)
@@ -2397,7 +2405,31 @@ def post_v2_workflow_wizard_proposal(request: V2WorkflowProposalRequest) -> dict
 def post_v2_workflow_wizard_action(request: V2WorkflowActionRequest) -> V2WorkflowActionResult:
     """Run a guarded workflow wizard apply action."""
 
-    result = apply_workflow_action(_project_root(), request)
+    try:
+        result = apply_workflow_action(_project_root(), request)
+    except HTTPException as exc:
+        message = str(exc.detail)
+        append_operation(
+            _project_root(),
+            operation_from_workflow_action(
+                action_id=request.action_id,
+                status="failed",
+                message=message,
+                files=[],
+            ),
+        )
+        _clear_read_model_cache()
+        raise
+
+    append_operation(
+        _project_root(),
+        operation_from_workflow_action(
+            action_id=request.action_id,
+            status=result.status,
+            message=result.message,
+            files=result.files,
+        ),
+    )
     _clear_read_model_cache()
     return result
 
@@ -2412,11 +2444,13 @@ def get_v2_search(q: str) -> V2SearchList:
 def post_v2_action(request: V2ActionRequest) -> V2ActionResult:
     """Execute a guarded Observatory v2 action."""
     resource_id, separator, action_name = request.action_id.rpartition(":")
+    services = _load_services()
     is_service_control_action = (
         bool(separator)
         and action_name in {"start", "stop", "restart"}
-        and any(service.id == resource_id for service in _load_services())
+        and any(service.id == resource_id for service in services)
     )
     result = _execute_action(request) if is_service_control_action else execute_v2_action(request)
+    recorded = record_action_result(_project_root(), result)
     _clear_read_model_cache()
-    return result
+    return recorded

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -2889,7 +2889,7 @@ def post_v2_action(request: V2ActionRequest) -> V2ActionResult:
     services = _load_services()
     is_service_control_action = (
         bool(separator)
-        and action_name in {"start", "stop", "restart"}
+        and action_name in {"add", "start", "stop", "restart"}
         and any(service.id == resource_id for service in services)
     )
     result = (

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_actions.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_actions.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Literal
+from dataclasses import dataclass, field
+import logging
+from typing import Any, Literal
 
+from phlo.capabilities.resolver import resolve_capability
+from phlo.capabilities.runtime import RuntimeRouting
+
+from phlo_api.observatory_api.v2_metadata import safe_metadata
 from phlo_api.observatory_api.v2_models import (
     V2Action,
     V2ActionRequest,
     V2ActionResult,
     V2Health,
     V2Operation,
+    V2ResourceRef,
 )
 
 
@@ -22,6 +28,33 @@ class _ActionFamily:
     reason: str
     risk_level: Literal["low", "medium", "high", "critical"] = "low"
     required_capability: str | None = None
+
+
+@dataclass
+class _ActionRuntimeContext:
+    run_id: str | None = None
+    partition_key: str | None = None
+    tags: dict[str, str] = field(default_factory=dict)
+    _resources: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def logger(self) -> Any:
+        return logging.getLogger("phlo.observatory.v2.actions")
+
+    @property
+    def resources(self) -> dict[str, Any]:
+        return self._resources
+
+    @property
+    def routing(self) -> RuntimeRouting:
+        return RuntimeRouting(
+            partition_key=self.partition_key,
+            run_id=self.run_id,
+            resources=self._resources,
+        )
+
+    def get_resource(self, name: str) -> Any:
+        return self._resources[name]
 
 
 _ACTION_FAMILIES = (
@@ -44,7 +77,7 @@ _ACTION_FAMILIES = (
         prefix="storage:",
         kind="storage.maintenance",
         label="Run storage maintenance",
-        reason="Storage maintenance needs a table storage provider write contract.",
+        reason="No executable table storage provider is registered for this maintenance action.",
         risk_level="medium",
         required_capability="table_store",
     ),
@@ -52,7 +85,7 @@ _ACTION_FAMILIES = (
         prefix="metadata:",
         kind="metadata.sync",
         label="Sync metadata",
-        reason="Metadata sync needs a metadata provider write contract.",
+        reason="No executable metadata provider is registered for this sync action.",
         required_capability="metadata_catalog",
     ),
     _ActionFamily(
@@ -101,6 +134,214 @@ def _skipped_action_result(request: V2ActionRequest, family: _ActionFamily) -> V
     )
 
 
+def _action_for_family(
+    request: V2ActionRequest,
+    family: _ActionFamily,
+    *,
+    enabled: bool,
+    reason: str | None = None,
+) -> V2Action:
+    return V2Action(
+        id=request.action_id,
+        label=family.label,
+        kind=family.kind,
+        enabled=enabled,
+        requires_confirmation=True,
+        reason=reason,
+        risk_level=family.risk_level,
+        required_capability=family.required_capability,
+    )
+
+
+def _operation(
+    request: V2ActionRequest,
+    action: V2Action,
+    *,
+    status: Literal["succeeded", "failed", "skipped"],
+    message: str,
+    target: V2ResourceRef | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> V2Operation:
+    state: Literal["ok", "warning", "error"] = "ok"
+    if status == "skipped":
+        state = "warning"
+    elif status == "failed":
+        state = "error"
+    return V2Operation(
+        id=request.action_id,
+        name=action.label,
+        kind=action.kind,
+        status=status,
+        health=V2Health(state=state, message=message),
+        target=target,
+        metadata=safe_metadata(metadata or {}),
+    )
+
+
+def _check_for_action(action_id: str, registry: Any) -> Any | None:
+    check_action_id = action_id.removeprefix("quality:")
+    try:
+        checks = registry.list_checks()
+    except Exception:
+        return None
+    for check in checks:
+        if f"{check.asset_key}:{check.name}:rerun" == check_action_id:
+            return check
+    return None
+
+
+def _execute_quality_action(
+    request: V2ActionRequest,
+    family: _ActionFamily,
+    registry: Any | None,
+) -> V2ActionResult | None:
+    if registry is None:
+        return None
+
+    check = _check_for_action(request.action_id, registry)
+    if check is None:
+        message = "Quality check is not registered in the capability registry."
+        action = _action_for_family(request, family, enabled=False, reason=message)
+        return V2ActionResult(
+            action=action,
+            status="skipped",
+            message=message,
+            operation=_operation(request, action, status="skipped", message=message),
+        )
+
+    if not callable(getattr(check, "fn", None)):
+        message = "Quality check has no executable function."
+        action = _action_for_family(request, family, enabled=False, reason=message)
+        return V2ActionResult(
+            action=action,
+            status="skipped",
+            message=message,
+            operation=_operation(
+                request,
+                action,
+                status="skipped",
+                message=message,
+                target=V2ResourceRef(
+                    kind="quality",
+                    id=f"{check.asset_key}:{check.name}",
+                    label=check.name,
+                ),
+            ),
+        )
+
+    action = _action_for_family(request, family, enabled=True)
+    context = _ActionRuntimeContext(tags={"phlo/action_id": request.action_id})
+    try:
+        result = check.fn(context)
+    except Exception as exc:
+        message = f"Quality check execution failed: {exc}"
+        return V2ActionResult(
+            action=action,
+            status="failed",
+            message=message,
+            operation=_operation(
+                request,
+                action,
+                status="failed",
+                message=message,
+                target=V2ResourceRef(
+                    kind="quality",
+                    id=f"{check.asset_key}:{check.name}",
+                    label=check.name,
+                ),
+            ),
+        )
+
+    passed = bool(getattr(result, "passed", False))
+    status: Literal["succeeded", "failed"] = "succeeded" if passed else "failed"
+    message = (
+        f"Quality check {check.name} passed." if passed else f"Quality check {check.name} failed."
+    )
+    metadata = {
+        "asset_key": getattr(result, "asset_key", check.asset_key),
+        "check_name": getattr(result, "check_name", check.name),
+        "severity": getattr(result, "severity", getattr(check, "severity", None)),
+        "metadata": getattr(result, "metadata", {}),
+    }
+    return V2ActionResult(
+        action=action,
+        status=status,
+        message=message,
+        operation=_operation(
+            request,
+            action,
+            status=status,
+            message=message,
+            target=V2ResourceRef(
+                kind="quality",
+                id=f"{check.asset_key}:{check.name}",
+                label=check.name,
+            ),
+            metadata=metadata,
+        ),
+    )
+
+
+def _execute_alert_action(
+    request: V2ActionRequest,
+    family: _ActionFamily,
+    registry: Any | None,
+) -> V2ActionResult | None:
+    if registry is None:
+        return None
+
+    resolution = resolve_capability("alert_sink", registry=registry)
+    sink = resolution.provider if resolution is not None else None
+    send_alert = getattr(sink, "send_alert", None)
+    if not callable(send_alert):
+        return None
+
+    action = _action_for_family(request, family, enabled=True)
+    try:
+        sent = bool(
+            send_alert(
+                title="Observatory action requested",
+                message=f"Observatory executed action {request.action_id}.",
+                severity="warning",
+            )
+        )
+    except Exception as exc:
+        message = f"Alert workflow failed: {exc}"
+        return V2ActionResult(
+            action=action,
+            status="failed",
+            message=message,
+            operation=_operation(request, action, status="failed", message=message),
+        )
+
+    status: Literal["succeeded", "failed"] = "succeeded" if sent else "failed"
+    message = "Alert workflow sent." if sent else "Alert sink declined the alert."
+    return V2ActionResult(
+        action=action,
+        status=status,
+        message=message,
+        operation=_operation(
+            request,
+            action,
+            status=status,
+            message=message,
+            metadata={"provider": resolution.name if resolution is not None else None},
+        ),
+    )
+
+
+def _provider_action_result(
+    request: V2ActionRequest,
+    family: _ActionFamily,
+    registry: Any | None,
+) -> V2ActionResult | None:
+    if family.kind == "quality.rerun":
+        return _execute_quality_action(request, family, registry)
+    if family.kind == "alert.workflow":
+        return _execute_alert_action(request, family, registry)
+    return None
+
+
 def _failed_action_result(request: V2ActionRequest) -> V2ActionResult:
     message = f"Unsupported Observatory v2 action: {request.action_id}"
     action = V2Action(
@@ -125,9 +366,12 @@ def _failed_action_result(request: V2ActionRequest) -> V2ActionResult:
     )
 
 
-def execute_v2_action(request: V2ActionRequest) -> V2ActionResult:
+def execute_v2_action(request: V2ActionRequest, *, registry: Any | None = None) -> V2ActionResult:
     """Execute or decline a guarded Observatory v2 action."""
     family = _known_family_for_action(request.action_id)
     if family is not None:
+        result = _provider_action_result(request, family, registry)
+        if result is not None:
+            return result
         return _skipped_action_result(request, family)
     return _failed_action_result(request)

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_capabilities.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_capabilities.py
@@ -105,8 +105,9 @@ ROUTE_REQUIREMENTS = [
         route_id="runs",
         label="Runs",
         path="/runs",
+        required_any=["orchestrator"],
         optional=["maintenance_read_model"],
-        reason="Core provider-neutral run history surface.",
+        reason="Install an orchestrator provider to inspect run history.",
     ),
     V2RouteRequirement(
         route_id="storage",

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_capabilities.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_capabilities.py
@@ -83,9 +83,8 @@ ROUTE_REQUIREMENTS = [
         route_id="logs",
         label="Logs",
         path="/logs",
-        required_any=["observability_backend"],
-        optional=["maintenance_read_model"],
-        reason="Install an observability backend to inspect logs.",
+        optional=["observability_backend", "maintenance_read_model"],
+        reason="Core Phlo log evidence surface.",
     ),
     V2RouteRequirement(
         route_id="branches",

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_models.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_models.py
@@ -168,6 +168,22 @@ class V2ActionResult(BaseModel):
     operation: "V2Operation | None" = None
 
 
+class V2PackageInstallRequest(BaseModel):
+    """Request to install a Phlo package from the trusted registry."""
+
+    package_name: str
+
+
+class V2PackageInstallResult(BaseModel):
+    """Result of a Python package install requested by Observatory."""
+
+    package_name: str
+    package_spec: str
+    status: Literal["succeeded", "failed", "skipped"]
+    message: str
+    services: list[str] = Field(default_factory=list)
+
+
 class V2ServicePort(BaseModel):
     """Provider-neutral service port exposure."""
 

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_models.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_models.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 HealthState = Literal["ok", "warning", "error", "unknown"]
 ServiceStatus = Literal["running", "stopped", "unhealthy", "starting", "unknown"]
 ServiceDefinitionState = Literal["configured", "available"]
-OperationStatus = Literal["queued", "running", "succeeded", "failed", "unknown"]
+OperationStatus = Literal["queued", "running", "succeeded", "failed", "skipped", "unknown"]
 RunStatus = Literal["queued", "running", "succeeded", "failed", "cancelled", "unknown"]
 QualityStatus = Literal["passing", "failing", "warning", "unknown"]
 

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_operation_journal.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_operation_journal.py
@@ -1,0 +1,190 @@
+"""Persistent operation journal for Observatory v2."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import cast
+from uuid import uuid4
+
+from phlo_api.observatory_api.v2_metadata import safe_metadata
+from phlo_api.observatory_api.v2_models import (
+    HealthState,
+    OperationStatus,
+    V2ActionResult,
+    V2Health,
+    V2Operation,
+    V2ResourceRef,
+)
+
+MAX_OPERATION_RECORDS = 200
+
+
+def operation_journal_path(project_root: Path) -> Path:
+    state_dir = project_root / ".phlo" / "observatory-v2"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / "operation_journal.json"
+
+
+def load_operation_journal(project_root: Path) -> list[V2Operation]:
+    path = operation_journal_path(project_root)
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+
+    items = payload.get("items") if isinstance(payload, Mapping) else None
+    if not isinstance(items, list):
+        return []
+
+    operations: list[V2Operation] = []
+    for item in items:
+        if not isinstance(item, Mapping):
+            continue
+        try:
+            operations.append(V2Operation.model_validate(item))
+        except Exception:
+            continue
+    return sort_operations(operations)
+
+
+def write_operation_journal(project_root: Path, operations: Iterable[V2Operation]) -> None:
+    records = sort_operations(list(operations))[:MAX_OPERATION_RECORDS]
+    operation_journal_path(project_root).write_text(
+        json.dumps({"items": [operation.model_dump() for operation in records]}, indent=2),
+        encoding="utf-8",
+    )
+
+
+def append_operation(
+    project_root: Path,
+    operation: V2Operation,
+    *,
+    record_id: str | None = None,
+    recorded_at: str | None = None,
+) -> V2Operation:
+    timestamp = recorded_at or datetime.now(UTC).isoformat()
+    original_id = operation.id
+    metadata = safe_metadata(
+        {
+            **operation.metadata,
+            "original_operation_id": original_id,
+            "recorded_at": timestamp,
+        }
+    )
+    recorded = operation.model_copy(
+        update={
+            "id": record_id or f"op-{uuid4().hex[:12]}",
+            "started_at": operation.started_at or timestamp,
+            "completed_at": operation.completed_at or timestamp,
+            "duration_seconds": operation.duration_seconds
+            if operation.duration_seconds is not None
+            else 0.0,
+            "metadata": metadata,
+        }
+    )
+    write_operation_journal(project_root, [recorded, *load_operation_journal(project_root)])
+    return recorded
+
+
+def record_action_result(
+    project_root: Path,
+    result: V2ActionResult,
+    *,
+    target: V2ResourceRef | None = None,
+    record_id: str | None = None,
+    recorded_at: str | None = None,
+) -> V2ActionResult:
+    operation = result.operation or operation_from_action_result(result, target=target)
+    recorded = append_operation(
+        project_root,
+        operation,
+        record_id=record_id,
+        recorded_at=recorded_at,
+    )
+    return result.model_copy(update={"operation": recorded})
+
+
+def operation_from_action_result(
+    result: V2ActionResult,
+    *,
+    target: V2ResourceRef | None = None,
+) -> V2Operation:
+    action = result.action
+    return V2Operation(
+        id=action.id,
+        name=action.label,
+        kind=action.kind,
+        status=result.status,
+        health=V2Health(
+            state=_health_state_for_action_status(result.status),
+            message=result.message[:200],
+        ),
+        target=target,
+        metadata=safe_metadata(
+            {
+                "action_id": action.id,
+                "action_kind": action.kind,
+                "risk_level": action.risk_level,
+                "required_capability": action.required_capability,
+                "required_service": action.required_service,
+                "message": result.message,
+            }
+        ),
+    )
+
+
+def operation_from_workflow_action(
+    *,
+    action_id: str,
+    status: str,
+    message: str,
+    files: list[str],
+) -> V2Operation:
+    return V2Operation(
+        id=f"workflow:{action_id}",
+        name="Apply workflow proposal",
+        kind="workflow.apply",
+        status=_coerce_operation_status(status),
+        health=V2Health(
+            state=_health_state_for_action_status(status),
+            message=message[:200],
+        ),
+        target=V2ResourceRef(kind="workflow", id=action_id, label=action_id),
+        metadata=safe_metadata(
+            {
+                "action_id": action_id,
+                "files": files,
+                "message": message,
+            }
+        ),
+    )
+
+
+def sort_operations(operations: Iterable[V2Operation]) -> list[V2Operation]:
+    return sorted(operations, key=_operation_sort_key, reverse=True)
+
+
+def _operation_sort_key(operation: V2Operation) -> tuple[str, str]:
+    timestamp = operation.completed_at or operation.started_at or ""
+    return (timestamp, operation.id)
+
+
+def _health_state_for_action_status(status: str) -> HealthState:
+    if status == "succeeded":
+        return "ok"
+    if status == "failed":
+        return "error"
+    if status == "skipped":
+        return "warning"
+    return "unknown"
+
+
+def _coerce_operation_status(status: str) -> OperationStatus:
+    if status in {"queued", "running", "succeeded", "failed", "skipped", "unknown"}:
+        return cast(OperationStatus, status)
+    return "unknown"

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
@@ -605,7 +605,7 @@ def load_services(
     registry_services = _registry_service_entries(registry_entries)
     configured_services = configured_compose_services(project_root)
     runtime_statuses = load_docker_service_statuses(
-        {service.name for service in discovered},
+        {service.name for service in discovered} | set(registry_services),
         containers,
         project_root,
     )
@@ -648,7 +648,23 @@ def load_services(
     for service_name, entry in registry_services.items():
         if service_name in discovered_names:
             continue
-        services.append(_available_registry_service(service_name, entry))
+        service = _available_registry_service(service_name, entry)
+        status, health = runtime_statuses.get(
+            service_name,
+            ("unknown", V2Health(state="unknown", message="Runtime status unavailable")),
+        )
+        if service_name in runtime_statuses:
+            service = service.model_copy(
+                update={
+                    "status": status,
+                    "health": health,
+                    "definition_state": "configured",
+                    "runtime_state": status,
+                    "in_stack": True,
+                    "backend": "docker",
+                }
+            )
+        services.append(service)
 
     services.extend(
         runtime_services_from_containers(

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
@@ -12,6 +12,8 @@ import socket
 import subprocess
 from typing import Any
 
+import yaml
+
 from phlo_api.observatory_api.v2_metadata import safe_metadata
 from phlo_api.observatory_api.v2_models import (
     HealthState,
@@ -186,10 +188,58 @@ def load_docker_containers() -> list[dict[str, Any]]:
     ]
 
 
-def current_compose_project(containers: Sequence[Mapping[str, Any]]) -> str | None:
+def project_compose_name(project_root: Path) -> str | None:
+    """Resolve the compose project name for a Phlo project root."""
     configured = os.environ.get("PHLO_COMPOSE_PROJECT") or os.environ.get("COMPOSE_PROJECT_NAME")
     if configured:
         return configured
+
+    compose_file = project_root / ".phlo" / "docker-compose.yml"
+    if not compose_file.exists():
+        return None
+
+    config_file = project_root / "phlo.yaml"
+    if config_file.exists():
+        try:
+            payload = yaml.safe_load(config_file.read_text()) or {}
+        except (OSError, yaml.YAMLError):
+            payload = {}
+        if isinstance(payload, Mapping):
+            name = payload.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+
+    return project_root.name
+
+
+def configured_compose_services(project_root: Path) -> set[str]:
+    """Return service names declared in the generated project compose file."""
+    compose_file = project_root / ".phlo" / "docker-compose.yml"
+    if not compose_file.exists():
+        return set()
+    try:
+        payload = yaml.safe_load(compose_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return set()
+    if not isinstance(payload, Mapping):
+        return set()
+    services = payload.get("services")
+    if not isinstance(services, Mapping):
+        return set()
+    return {str(name) for name in services}
+
+
+def current_compose_project(
+    containers: Sequence[Mapping[str, Any]],
+    project_root: Path | None = None,
+) -> str | None:
+    configured = os.environ.get("PHLO_COMPOSE_PROJECT") or os.environ.get("COMPOSE_PROJECT_NAME")
+    if configured:
+        return configured
+    if project_root is not None:
+        project_name = project_compose_name(project_root)
+        if project_name:
+            return project_name
 
     hostname = os.environ.get("HOSTNAME", "")
     if not hostname:
@@ -237,18 +287,21 @@ def service_name_from_container(name: str, service_ids: set[str]) -> str | None:
 def load_docker_service_statuses(
     service_ids: set[str],
     containers: Sequence[Mapping[str, Any]] | None = None,
+    project_root: Path | None = None,
 ) -> dict[str, tuple[ServiceStatus, V2Health]]:
     if not service_ids:
         return {}
 
     statuses: dict[str, tuple[ServiceStatus, V2Health]] = {}
     containers = containers if containers is not None else load_docker_containers()
-    compose_project = current_compose_project(containers)
+    compose_project = current_compose_project(containers, project_root)
+    if not compose_project:
+        return statuses
+
     for container in containers:
-        if compose_project:
-            labels = container_labels(container)
-            if labels.get("com.docker.compose.project") != compose_project:
-                continue
+        labels = container_labels(container)
+        if labels.get("com.docker.compose.project") != compose_project:
+            continue
         name = coerce_str(container.get("Names"), "")
         service_id = compose_service_name(container) or service_name_from_container(
             name, service_ids
@@ -270,12 +323,16 @@ def load_docker_service_statuses(
 def runtime_services_from_containers(
     containers: Sequence[Mapping[str, Any]],
     known_ids: set[str],
+    project_root: Path | None = None,
 ) -> list[V2Service]:
-    compose_project = current_compose_project(containers)
+    compose_project = current_compose_project(containers, project_root)
+    if not compose_project:
+        return []
+
     services: list[V2Service] = []
     for container in containers:
         labels = container_labels(container)
-        if compose_project and labels.get("com.docker.compose.project") != compose_project:
+        if labels.get("com.docker.compose.project") != compose_project:
             continue
         service_id = compose_service_name(container)
         if not service_id or service_id in known_ids:
@@ -383,7 +440,6 @@ def load_services(
     containers: Sequence[Mapping[str, Any]] | None = None,
 ) -> list[V2Service]:
     """Load services through core discovery, falling back deterministically."""
-    _ = project_root
     try:
         from phlo.plugins.discovery import ServiceDiscovery
 
@@ -394,12 +450,15 @@ def load_services(
     services: list[V2Service] = []
     containers = containers if containers is not None else load_docker_containers()
     discovered = list(discovered)
+    configured_services = configured_compose_services(project_root)
     runtime_statuses = load_docker_service_statuses(
         {service.name for service in discovered},
         containers,
+        project_root,
     )
     for service in discovered:
         in_stack = service.name in runtime_statuses
+        configured = in_stack or service.name in configured_services
         status, health = runtime_statuses.get(
             service.name,
             ("unknown", V2Health(state="unknown", message="Runtime status unavailable")),
@@ -411,7 +470,7 @@ def load_services(
                 kind=service.category or "service",
                 status=status,
                 health=health,
-                definition_state="configured" if in_stack else "available",
+                definition_state="configured" if configured else "available",
                 runtime_state=status,
                 in_stack=in_stack,
                 disabled=bool(getattr(service, "disabled", False)),
@@ -432,7 +491,9 @@ def load_services(
         )
 
     services.extend(
-        runtime_services_from_containers(containers, {service.id for service in services})
+        runtime_services_from_containers(
+            containers, {service.id for service in services}, project_root
+        )
     )
 
     return sorted(services, key=lambda item: item.id) if services else fallback_services()

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
@@ -26,6 +26,7 @@ from phlo_api.observatory_api.v2_models import (
 )
 
 DOCKER_SOCKET = "/var/run/docker.sock"
+DOCKER_PS_TIMEOUT_SECONDS = 30
 DOCKER_SERVICE_STATUS_RANK: dict[ServiceStatus, int] = {
     "running": 4,
     "unhealthy": 3,
@@ -153,27 +154,42 @@ def normalize_docker_api_container(container: Mapping[str, Any]) -> dict[str, An
     }
 
 
-def load_docker_containers() -> list[dict[str, Any]]:
+def parse_docker_ps_output(output: str) -> list[dict[str, Any]]:
+    containers: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, Mapping):
+            containers.append(dict(parsed))
+    return containers
+
+
+def docker_ps_containers(*filters: str) -> list[dict[str, Any]] | None:
+    command = ["docker", "ps", "-a"]
+    for filter_value in filters:
+        command.extend(["--filter", filter_value])
+    command.extend(["--format", "{{json .}}"])
     try:
         result = subprocess.run(
-            ["docker", "ps", "-a", "--format", "{{json .}}"],
+            command,
             capture_output=True,
             text=True,
             check=False,
-            timeout=2,
+            timeout=DOCKER_PS_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.TimeoutExpired):
-        result = None
+        return None
 
-    if result is not None and result.returncode == 0:
-        containers: list[dict[str, Any]] = []
-        for line in result.stdout.splitlines():
-            try:
-                parsed = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(parsed, Mapping):
-                containers.append(dict(parsed))
+    if result.returncode != 0:
+        return None
+    return parse_docker_ps_output(result.stdout)
+
+
+def load_docker_containers() -> list[dict[str, Any]]:
+    containers = docker_ps_containers()
+    if containers is not None:
         return containers
 
     if not Path(DOCKER_SOCKET).exists():
@@ -186,6 +202,15 @@ def load_docker_containers() -> list[dict[str, Any]]:
         for container in payload
         if isinstance(container, Mapping)
     ]
+
+
+def load_project_docker_containers(project_root: Path) -> list[dict[str, Any]]:
+    compose_project = project_compose_name(project_root)
+    if compose_project:
+        containers = docker_ps_containers(f"label=com.docker.compose.project={compose_project}")
+        if containers is not None:
+            return containers
+    return []
 
 
 def project_compose_name(project_root: Path) -> str | None:
@@ -293,7 +318,9 @@ def load_docker_service_statuses(
         return {}
 
     statuses: dict[str, tuple[ServiceStatus, V2Health]] = {}
-    containers = containers if containers is not None else load_docker_containers()
+    containers = (
+        containers if containers is not None else load_project_docker_containers(project_root)
+    )
     compose_project = current_compose_project(containers, project_root)
     if not compose_project:
         return statuses

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_services.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 import http.client
+import importlib.metadata
 import json
 import os
 from pathlib import Path
@@ -13,6 +14,7 @@ import subprocess
 from typing import Any
 
 import yaml
+from phlo.plugins.registry_client import get_registry_data
 
 from phlo_api.observatory_api.v2_metadata import safe_metadata
 from phlo_api.observatory_api.v2_models import (
@@ -35,6 +37,128 @@ DOCKER_SERVICE_STATUS_RANK: dict[ServiceStatus, int] = {
     "unknown": 0,
 }
 ENV_DEFAULT_RE = re.compile(r"^\$\{[^}:]+:-(?P<default>[^}]+)\}$")
+
+
+def _registry_package_entries() -> dict[str, dict[str, Any]]:
+    """Return trusted registry entries keyed by package and friendly aliases."""
+    try:
+        registry = get_registry_data()
+    except Exception:
+        return {}
+
+    plugins = registry.get("plugins") if isinstance(registry, Mapping) else None
+    if not isinstance(plugins, Mapping):
+        return {}
+
+    entries: dict[str, dict[str, Any]] = {}
+    for name, payload in plugins.items():
+        if not isinstance(payload, Mapping):
+            continue
+        package = coerce_str(payload.get("package"), "")
+        if not package:
+            continue
+        normalized = dict(payload)
+        normalized["name"] = str(name)
+        for key in {str(name), package, package.removeprefix("phlo-")}:
+            if key:
+                entries[key] = normalized
+    return entries
+
+
+def _registry_service_entries(
+    entries: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Mapping[str, Any]]:
+    """Return registry entries that should appear before stack discovery."""
+    services: dict[str, Mapping[str, Any]] = {}
+    for entry in entries.values():
+        if entry.get("type") != "service":
+            continue
+        name = coerce_str(entry.get("name"), "")
+        if name:
+            services[name] = entry
+    return services
+
+
+def _registry_entry_for_service(
+    service_name: str,
+    entries: Mapping[str, Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    candidates = [service_name]
+    parts = service_name.split("-")
+    candidates.extend("-".join(parts[:index]) for index in range(len(parts) - 1, 0, -1))
+    candidates.extend(f"phlo-{candidate}" for candidate in list(candidates))
+
+    for candidate in candidates:
+        entry = entries.get(candidate)
+        if isinstance(entry, Mapping):
+            return entry
+    return None
+
+
+def _package_installed(package: str) -> bool:
+    try:
+        importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    return True
+
+
+def _registry_metadata(
+    service_name: str,
+    entries: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    entry = _registry_entry_for_service(service_name, entries)
+    if not isinstance(entry, Mapping):
+        return {}
+
+    package = coerce_str(entry.get("package"), "")
+    installed = _package_installed(package) if package else False
+    return {
+        "registry_name": coerce_str(entry.get("name"), service_name),
+        "package": package,
+        "package_version": coerce_str(entry.get("version"), ""),
+        "package_installed": installed,
+        "installable": not installed,
+        "verified": bool(entry.get("verified")),
+        "description": coerce_str(entry.get("description"), ""),
+        "tags": list(entry.get("tags", [])) if isinstance(entry.get("tags"), list) else [],
+    }
+
+
+def _available_registry_service(
+    service_name: str,
+    entry: Mapping[str, Any],
+) -> V2Service:
+    package = coerce_str(entry.get("package"), "")
+    description = coerce_str(entry.get("description"), "")
+    tags = list(entry.get("tags", [])) if isinstance(entry.get("tags"), list) else []
+    return V2Service(
+        id=service_name,
+        name=service_name,
+        kind=coerce_str(entry.get("type"), "service") or "service",
+        status="unknown",
+        health=V2Health(
+            state="unknown",
+            message="Package is available to install.",
+        ),
+        definition_state="available",
+        runtime_state="unknown",
+        in_stack=False,
+        backend="registry",
+        metadata=safe_metadata(
+            {
+                "source": "registry",
+                "registry_name": service_name,
+                "package": package,
+                "package_version": coerce_str(entry.get("version"), ""),
+                "package_installed": False,
+                "installable": True,
+                "verified": bool(entry.get("verified")),
+                "description": description,
+                "tags": tags,
+            }
+        ),
+    )
 
 
 def coerce_str(value: Any, default: str = "") -> str:
@@ -477,6 +601,8 @@ def load_services(
     services: list[V2Service] = []
     containers = containers if containers is not None else load_docker_containers()
     discovered = list(discovered)
+    registry_entries = _registry_package_entries()
+    registry_services = _registry_service_entries(registry_entries)
     configured_services = configured_compose_services(project_root)
     runtime_statuses = load_docker_service_statuses(
         {service.name for service in discovered},
@@ -512,10 +638,17 @@ def load_services(
                         "profile": service.profile,
                         "core": bool(getattr(service, "core", False)),
                         "description": getattr(service, "description", None),
+                        **_registry_metadata(service.name, registry_entries),
                     }
                 ),
             )
         )
+
+    discovered_names = {service.id for service in services}
+    for service_name, entry in registry_services.items():
+        if service_name in discovered_names:
+            continue
+        services.append(_available_registry_service(service_name, entry))
 
     services.extend(
         runtime_services_from_containers(

--- a/packages/phlo-api/tests/test_cors.py
+++ b/packages/phlo-api/tests/test_cors.py
@@ -19,3 +19,17 @@ def test_cors_allows_docker_observatory_origin():
 
     assert response.status_code == 200
     assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:3001"
+
+
+def test_cors_allows_local_observatory_dev_ports():
+    """Parallel Observatory QA/dev servers can fetch the API directly."""
+    response = TestClient(app).options(
+        "/health",
+        headers={
+            "Origin": "http://127.0.0.1:3002",
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == "http://127.0.0.1:3002"

--- a/packages/phlo-api/tests/test_integration_api.py
+++ b/packages/phlo-api/tests/test_integration_api.py
@@ -544,6 +544,63 @@ class TestDagsterGraphEndpoints:
         assert payload["partition_key"] == "2026-04-26"
         assert payload["details"]["op_names"] == ["orders_op"]
 
+    def test_dagster_materialize_live_launches_dagster_run(self, monkeypatch):
+        """Live materialize endpoint sends a Dagster launch mutation."""
+        from fastapi.testclient import TestClient
+        from phlo_api.main import app
+
+        captured = {}
+
+        async def fake_asset_details(asset_key_path: str, dagster_url: str | None = None):
+            return {
+                "key_path": asset_key_path,
+                "has_materialize_permission": True,
+                "op_names": ["orders_op"],
+            }
+
+        async def fake_graphql_request(url, query, variables=None, timeout=10.0, initiator=None):
+            captured["query"] = query
+            captured["variables"] = variables
+            captured["initiator"] = initiator
+            return {
+                "data": {
+                    "launchPipelineExecution": {
+                        "__typename": "LaunchRunSuccess",
+                        "run": {"runId": "run-live-1", "status": "STARTED"},
+                    }
+                }
+            }
+
+        monkeypatch.setattr(
+            "phlo_api.observatory_api.dagster.get_asset_details", fake_asset_details
+        )
+        monkeypatch.setattr(
+            "phlo_api.observatory_api.dagster.graphql_request", fake_graphql_request
+        )
+
+        client = TestClient(app)
+        response = client.post(
+            "/api/dagster/assets/silver/orders/materialize",
+            json={
+                "dry_run": False,
+                "partition_key": "2026-04-26",
+                "job_name": "daily_orders",
+                "repository_location_name": "repo_location",
+                "repository_name": "repo",
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["dry_run"] is False
+        assert payload["accepted"] is True
+        assert payload["run_id"] == "run-live-1"
+        assert "launchPipelineExecution" in captured["query"]
+        execution_params = captured["variables"]["executionParams"]
+        assert execution_params["selector"]["pipelineName"] == "daily_orders"
+        assert execution_params["selector"]["assetSelection"] == [{"path": ["silver", "orders"]}]
+        assert captured["initiator"] == "observatory"
+
     def test_dagster_run_status_endpoint_transforms_payload(self, monkeypatch):
         """Run status endpoint normalizes Dagster GraphQL run payloads."""
         from fastapi.testclient import TestClient
@@ -636,6 +693,48 @@ class TestDagsterGraphEndpoints:
         assert payload["dry_run"] is True
         assert payload["accepted"] is True
         assert payload["run_id"] == "run-123"
+
+    def test_dagster_retry_live_launches_reexecution(self, monkeypatch):
+        """Live retry endpoint sends a Dagster reexecution mutation."""
+        from fastapi.testclient import TestClient
+        from phlo_api.main import app
+        from phlo_api.observatory_api.dagster import DagsterRunStatus
+
+        captured = {}
+
+        async def fake_run_status(run_id: str, dagster_url: str | None = None):
+            return DagsterRunStatus(run_id=run_id, status="FAILURE")
+
+        async def fake_graphql_request(url, query, variables=None, timeout=10.0, initiator=None):
+            captured["query"] = query
+            captured["variables"] = variables
+            captured["initiator"] = initiator
+            return {
+                "data": {
+                    "launchPipelineReexecution": {
+                        "__typename": "LaunchRunSuccess",
+                        "run": {"runId": "retry-run-1", "status": "STARTED"},
+                    }
+                }
+            }
+
+        monkeypatch.setattr("phlo_api.observatory_api.dagster.get_run_status", fake_run_status)
+        monkeypatch.setattr(
+            "phlo_api.observatory_api.dagster.graphql_request", fake_graphql_request
+        )
+
+        client = TestClient(app)
+        response = client.post("/api/dagster/runs/run-123/retry", json={"dry_run": False})
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["dry_run"] is False
+        assert payload["accepted"] is True
+        assert payload["run_id"] == "retry-run-1"
+        assert "launchPipelineReexecution" in captured["query"]
+        assert captured["variables"]["reexecutionParams"]["parentRunId"] == "run-123"
+        assert captured["variables"]["reexecutionParams"]["strategy"] == "FROM_FAILURE"
+        assert captured["initiator"] == "observatory"
 
 
 class TestContributingRowsEndpoints:

--- a/packages/phlo-api/tests/test_observatory_v2_actions.py
+++ b/packages/phlo-api/tests/test_observatory_v2_actions.py
@@ -1,3 +1,6 @@
+from phlo.capabilities.registry import CapabilityRegistry
+from phlo.capabilities.specs import AlertSinkSpec, AssetCheckSpec, CheckResult
+
 from phlo_api.observatory_api.v2_actions import execute_v2_action
 from phlo_api.observatory_api.v2_models import V2Action, V2ActionRequest
 
@@ -32,3 +35,55 @@ def test_execute_v2_action_returns_skipped_for_unimplemented_known_family() -> N
     assert result.status == "skipped"
     assert result.action.kind == "quality.rerun"
     assert result.action.required_capability == "quality_backend"
+
+
+def test_execute_v2_action_runs_registered_quality_check() -> None:
+    registry = CapabilityRegistry()
+    seen_context = {}
+
+    def check_fn(context):
+        seen_context["action_id"] = context.tags["phlo/action_id"]
+        return CheckResult(
+            check_name="not_null",
+            asset_key="orders",
+            passed=True,
+            metadata={"rows_checked": 3},
+        )
+
+    registry.register_check(AssetCheckSpec(name="not_null", asset_key="orders", fn=check_fn))
+
+    result = execute_v2_action(
+        V2ActionRequest(action_id="quality:orders:not_null:rerun"),
+        registry=registry,
+    )
+
+    assert result.status == "succeeded"
+    assert result.action.enabled is True
+    assert result.operation is not None
+    assert result.operation.status == "succeeded"
+    assert result.operation.target is not None
+    assert result.operation.target.kind == "quality"
+    assert result.operation.metadata["metadata"] == {"rows_checked": 3}
+    assert seen_context == {"action_id": "quality:orders:not_null:rerun"}
+
+
+def test_execute_v2_action_runs_registered_alert_sink() -> None:
+    class Sink:
+        def __init__(self) -> None:
+            self.messages = []
+
+        def send_alert(self, **kwargs) -> bool:
+            self.messages.append(kwargs)
+            return True
+
+    sink = Sink()
+    registry = CapabilityRegistry()
+    registry.register_alert_sink(AlertSinkSpec(name="alerts", provider=sink))
+
+    result = execute_v2_action(V2ActionRequest(action_id="alert:incident"), registry=registry)
+
+    assert result.status == "succeeded"
+    assert result.action.enabled is True
+    assert result.operation is not None
+    assert result.operation.metadata["provider"] == "alerts"
+    assert sink.messages[0]["severity"] == "warning"

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -12,6 +12,7 @@ from phlo.capabilities.registry import CapabilityRegistry
 from phlo.capabilities.specs import CatalogSpec
 from phlo_api.main import app
 from phlo_api.observatory_api import v2
+from phlo_api.observatory_api import v2_services
 from phlo_api.observatory_api.v2 import (
     _execute_action,
     _fallback_services,
@@ -326,6 +327,33 @@ def test_v2_load_services_includes_runtime_containers_missing_from_discovery(mon
     assert postgres.status == "running"
 
 
+def test_v2_service_registry_metadata_matches_helper_services(monkeypatch) -> None:
+    monkeypatch.setattr(
+        v2_services,
+        "get_registry_data",
+        lambda: {
+            "plugins": {
+                "openmetadata": {
+                    "type": "hooks",
+                    "package": "phlo-openmetadata",
+                    "version": "0.1.0",
+                    "description": "OpenMetadata integration",
+                    "verified": True,
+                    "tags": ["metadata"],
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(v2_services, "_package_installed", lambda package: False)
+
+    entries = v2_services._registry_package_entries()
+    metadata = v2_services._registry_metadata("openmetadata-mysql", entries)
+
+    assert metadata["registry_name"] == "openmetadata"
+    assert metadata["package"] == "phlo-openmetadata"
+    assert metadata["installable"] is True
+
+
 def test_v2_docker_statuses_ignore_containers_without_project_scope(monkeypatch) -> None:
     def fake_run(*args, **kwargs):
         return subprocess.CompletedProcess(
@@ -499,6 +527,73 @@ def test_v2_service_action_records_subprocess_result(
     operations = TestClient(app).get("/api/observatory/v2/operations").json()["items"]
     assert operations[0]["id"] == payload["operation"]["id"]
     assert operations[0]["status"] == "succeeded"
+
+
+def test_v2_package_install_uses_trusted_registry_package(monkeypatch) -> None:
+    monkeypatch.setattr(
+        v2,
+        "get_registry_data",
+        lambda: {
+            "plugins": {
+                "openmetadata": {
+                    "type": "service",
+                    "package": "phlo-openmetadata",
+                    "version": "0.1.0",
+                }
+            }
+        },
+    )
+    installed: list[str] = []
+
+    def fake_install(package_spec: str) -> tuple[bool, str]:
+        installed.append(package_spec)
+        return True, "installed"
+
+    monkeypatch.setattr(v2, "_run_python_package_install", fake_install)
+    monkeypatch.setattr(v2, "_load_services", lambda: [])
+
+    response = TestClient(app).post(
+        "/api/observatory/v2/packages/install",
+        json={"package_name": "openmetadata"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "succeeded"
+    assert payload["package_name"] == "phlo-openmetadata"
+    assert installed == ["phlo-openmetadata==0.1.0"]
+
+
+def test_v2_package_install_rejects_unknown_package(monkeypatch) -> None:
+    monkeypatch.setattr(v2, "get_registry_data", lambda: {"plugins": {}})
+
+    response = TestClient(app).post(
+        "/api/observatory/v2/packages/install",
+        json={"package_name": "not-a-phlo-package"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_v2_package_install_prefers_uv_add_for_uv_projects(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    commands: list[tuple[list[str], Path | None]] = []
+
+    def fake_run(command, **kwargs):
+        commands.append((command, kwargs.get("cwd")))
+        return subprocess.CompletedProcess(command, returncode=0, stdout="ok")
+
+    monkeypatch.setattr(v2.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(v2, "_uv_project_root", lambda: tmp_path)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    succeeded, message = v2._run_python_package_install("phlo-openmetadata==0.1.0")
+
+    assert succeeded is True
+    assert message == "ok"
+    assert commands == [(["/usr/bin/uv", "add", "--active", "phlo-openmetadata==0.1.0"], tmp_path)]
 
 
 def test_v2_overview_endpoint_returns_provider_neutral_payload() -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -571,10 +571,38 @@ def test_v2_capabilities_gate_provider_pages_when_providers_are_absent(
     assert pages["issues"]["available"] is False
     assert pages["quality"]["available"] is False
     assert pages["quality"]["nav"] is False
-    assert pages["logs"]["available"] is False
+    assert pages["logs"]["available"] is True
+    assert pages["logs"]["nav"] is True
     assert pages["extensions"]["available"] is False
     assert pages["extensions"]["nav"] is False
     _assert_no_provider_url_settings(payload)
+
+
+def test_v2_logs_include_project_phlo_logs(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    v2._clear_read_model_cache()
+    log_dir = tmp_path / ".phlo" / "logs"
+    log_dir.mkdir(parents=True)
+    (log_dir / "20260517.log").write_text(
+        json.dumps(
+            {
+                "timestamp": "2026-05-17T10:00:00Z",
+                "level": "warning",
+                "logger": "phlo.test",
+                "event": "project_log_seen",
+                "path": "/api/observatory/v2/logs",
+            }
+        )
+        + "\n"
+    )
+
+    response = TestClient(app).get("/api/observatory/v2/logs")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"][0]["message"] == "project_log_seen"
+    assert payload["items"][0]["source"] == "phlo.test"
+    assert payload["items"][0]["level"] == "warning"
 
 
 def test_v2_overview_health_describes_missing_runtime_containers() -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -218,6 +218,7 @@ def test_v2_docker_statuses_match_services_without_provider_imports(monkeypatch)
                             "Names": "phlo-trino-1",
                             "State": "running",
                             "Status": "Up 3 minutes (healthy)",
+                            "Labels": "com.docker.compose.project=phlo,com.docker.compose.service=trino",
                         }
                     ),
                     json.dumps(
@@ -225,6 +226,7 @@ def test_v2_docker_statuses_match_services_without_provider_imports(monkeypatch)
                             "Names": "old-trino-1",
                             "State": "exited",
                             "Status": "Exited (0) yesterday",
+                            "Labels": "com.docker.compose.project=old,com.docker.compose.service=trino",
                         }
                     ),
                     json.dumps(
@@ -232,6 +234,7 @@ def test_v2_docker_statuses_match_services_without_provider_imports(monkeypatch)
                             "Names": "phlo-dagster-1",
                             "State": "created",
                             "Status": "Created",
+                            "Labels": "com.docker.compose.project=phlo,com.docker.compose.service=dagster",
                         }
                     ),
                 ]
@@ -239,6 +242,7 @@ def test_v2_docker_statuses_match_services_without_provider_imports(monkeypatch)
         )
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setenv("PHLO_COMPOSE_PROJECT", "phlo")
 
     statuses = _load_docker_service_statuses({"trino", "dagster"})
 
@@ -312,6 +316,27 @@ def test_v2_load_services_includes_runtime_containers_missing_from_discovery(mon
     assert postgres.in_stack is True
     assert postgres.backend == "docker"
     assert postgres.status == "running"
+
+
+def test_v2_docker_statuses_ignore_containers_without_project_scope(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "Names": "pokehunt-postgres",
+                    "State": "running",
+                    "Status": "Up 3 minutes (healthy)",
+                }
+            ),
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.delenv("PHLO_COMPOSE_PROJECT", raising=False)
+    monkeypatch.delenv("COMPOSE_PROJECT_NAME", raising=False)
+
+    assert _load_docker_service_statuses({"postgres"}) == {}
 
 
 def test_v2_capabilities_include_running_service_backed_providers(monkeypatch) -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -207,7 +207,15 @@ def test_v2_fallback_services_are_deterministic_and_provider_neutral() -> None:
 
 def test_v2_docker_statuses_match_services_without_provider_imports(monkeypatch) -> None:
     def fake_run(*args, **kwargs):
-        assert args[0] == ["docker", "ps", "-a", "--format", "{{json .}}"]
+        assert args[0] == [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            "label=com.docker.compose.project=phlo",
+            "--format",
+            "{{json .}}",
+        ]
         return subprocess.CompletedProcess(
             args=args[0],
             returncode=0,

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -431,6 +431,53 @@ def test_v2_disabled_service_action_skips_without_subprocess(monkeypatch) -> Non
     assert result.operation is None
 
 
+def test_v2_available_installed_service_can_be_added_to_stack(monkeypatch) -> None:
+    service = V2Service(
+        id="alloy",
+        name="alloy",
+        kind="observability",
+        status="unknown",
+        health=V2Health(state="unknown"),
+        in_stack=False,
+        metadata={"package": "phlo-alloy", "package_installed": True},
+    )
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, returncode=0, stdout="Services added.")
+
+    monkeypatch.setattr(v2, "_load_services", lambda: [service])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = _execute_action(V2ActionRequest(action_id="alloy:add"))
+
+    assert result.status == "succeeded"
+    assert result.action.label == "Add to stack"
+    assert commands == [["phlo", "services", "add", "alloy"]]
+
+
+def test_v2_available_missing_package_service_add_is_disabled(monkeypatch) -> None:
+    service = V2Service(
+        id="plugin-example",
+        name="plugin-example",
+        kind="service",
+        status="unknown",
+        health=V2Health(state="unknown"),
+        in_stack=False,
+        metadata={"package": "phlo-plugin-example", "package_installed": False},
+    )
+
+    monkeypatch.setattr(v2, "_load_services", lambda: [service])
+
+    result = _execute_action(V2ActionRequest(action_id="plugin-example:add"))
+
+    assert result.status == "skipped"
+    assert result.action.label == "Add to stack"
+    assert result.action.enabled is False
+    assert "Install phlo-plugin-example" in result.message
+
+
 def test_v2_operations_endpoint_includes_journal_records(
     monkeypatch,
     tmp_path: Path,

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -327,6 +327,50 @@ def test_v2_load_services_includes_runtime_containers_missing_from_discovery(mon
     assert postgres.status == "running"
 
 
+def test_v2_load_services_marks_registry_service_runtime_container_in_stack(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    containers = [
+        {
+            "ID": "abc123",
+            "Names": "phlo-postgres-1",
+            "State": "running",
+            "Status": "Up 3 minutes (healthy)",
+            "Labels": ("com.docker.compose.project=phlo,com.docker.compose.service=postgres"),
+        }
+    ]
+
+    monkeypatch.setenv("PHLO_COMPOSE_PROJECT", "phlo")
+    monkeypatch.setattr(v2_services, "load_docker_containers", lambda: containers)
+    monkeypatch.setattr(
+        v2_services, "load_project_docker_containers", lambda project_root: containers
+    )
+    monkeypatch.setattr(
+        v2_services,
+        "get_registry_data",
+        lambda: {
+            "plugins": {
+                "postgres": {
+                    "type": "service",
+                    "package": "phlo-postgres",
+                    "version": "0.1.0",
+                    "description": "PostgreSQL database",
+                    "tags": ["core", "database"],
+                }
+            }
+        },
+    )
+
+    services = v2_services.load_services(tmp_path, containers=containers)
+
+    postgres = next(service for service in services if service.id == "postgres")
+    assert postgres.in_stack is True
+    assert postgres.backend == "docker"
+    assert postgres.status == "running"
+    assert postgres.definition_state == "configured"
+
+
 def test_v2_service_registry_metadata_matches_helper_services(monkeypatch) -> None:
     monkeypatch.setattr(
         v2_services,

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 import subprocess
 
 from fastapi.testclient import TestClient
 
 from phlo_api.main import app
+from phlo_api.observatory_api import v2
 from phlo_api.observatory_api.v2 import (
     _execute_action,
     _fallback_services,
@@ -37,6 +39,7 @@ from phlo_api.observatory_api.v2_models import (
     V2Table,
     V2TablePreview,
 )
+from phlo_api.observatory_api.v2_operation_journal import append_operation
 
 _PROVIDER_URL_SETTING_NAMES = (
     "dagster_url",
@@ -363,6 +366,104 @@ def test_v2_disabled_service_action_skips_without_subprocess(monkeypatch) -> Non
     assert result.message == result.action.reason
     assert subprocess_calls == []
     assert result.operation is None
+
+
+def test_v2_operations_endpoint_includes_journal_records(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setattr(v2, "_load_capability_registry", lambda: None)
+    v2._clear_read_model_cache()
+    append_operation(
+        tmp_path,
+        V2Operation(
+            id="phlo-api:restart",
+            name="Restart",
+            kind="service.restart",
+            status="succeeded",
+            health=V2Health(state="ok", message="Restarted"),
+            target=V2ResourceRef(kind="service", id="phlo-api", label="phlo-api"),
+        ),
+        record_id="op-restart",
+        recorded_at="2026-05-16T12:00:00+00:00",
+    )
+
+    response = TestClient(app).get("/api/observatory/v2/operations")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"][0]["id"] == "op-restart"
+    assert payload["items"][0]["kind"] == "service.restart"
+    assert payload["items"][0]["target"]["id"] == "phlo-api"
+
+
+def test_v2_generic_skipped_action_records_operation(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setattr(v2, "_load_services", lambda: [])
+    monkeypatch.setattr(v2, "_load_capability_registry", lambda: None)
+    v2._clear_read_model_cache()
+
+    response = TestClient(app).post(
+        "/api/observatory/v2/actions",
+        json={"action_id": "quality:raw.orders:rerun"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "skipped"
+    assert payload["operation"]["status"] == "skipped"
+    assert payload["operation"]["kind"] == "quality.rerun"
+
+    operations = TestClient(app).get("/api/observatory/v2/operations").json()["items"]
+    assert operations[0]["id"] == payload["operation"]["id"]
+    assert operations[0]["metadata"]["action_id"] == "quality:raw.orders:rerun"
+
+
+def test_v2_service_action_records_subprocess_result(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setattr(v2, "_load_capability_registry", lambda: None)
+    v2._clear_read_model_cache()
+    service = V2Service(
+        id="phlo-api",
+        name="phlo-api",
+        kind="api",
+        status="stopped",
+        health=V2Health(state="warning", message="stopped"),
+        in_stack=True,
+    )
+
+    def fake_run(*args, **kwargs):
+        assert args[0] == ["phlo", "services", "start", "--service", "phlo-api"]
+        return subprocess.CompletedProcess(
+            args=args[0],
+            returncode=0,
+            stdout="phlo-api start requested\n",
+        )
+
+    monkeypatch.setattr(v2, "_load_services", lambda: [service])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    response = TestClient(app).post(
+        "/api/observatory/v2/actions",
+        json={"action_id": "phlo-api:start"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "succeeded"
+    assert payload["operation"]["kind"] == "service.start"
+    assert payload["operation"]["target"]["id"] == "phlo-api"
+
+    operations = TestClient(app).get("/api/observatory/v2/operations").json()["items"]
+    assert operations[0]["id"] == payload["operation"]["id"]
+    assert operations[0]["status"] == "succeeded"
 
 
 def test_v2_overview_endpoint_returns_provider_neutral_payload() -> None:
@@ -831,7 +932,7 @@ def test_v2_branch_action_contract_skips_until_provider_write_contract_exists(
     assert set(payload) == {"action", "status", "message", "operation"}
     assert payload["status"] == "skipped"
     assert payload["action"]["enabled"] is False
-    assert payload["operation"] is None
+    assert payload["operation"]["status"] == "skipped"
     _assert_no_provider_url_settings(payload)
 
 
@@ -861,7 +962,31 @@ def test_v2_branch_action_skips_when_branches_capability_is_unavailable(
     assert payload["action"]["kind"] == "branch.create"
     assert payload["action"]["enabled"] is False
     assert "catalog provider" in payload["message"]
-    assert payload["operation"] is None
+    assert payload["operation"]["status"] == "skipped"
+
+
+def test_v2_branch_action_skip_is_recorded(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setattr(v2, "_load_capability_registry", lambda: None)
+    v2._clear_read_model_cache()
+
+    response = TestClient(app).post(
+        "/api/observatory/v2/branches/actions",
+        json={"action_id": "branch:create:experiment"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "skipped"
+    assert payload["operation"]["status"] == "skipped"
+    assert payload["operation"]["kind"] == "branch.create"
+
+    operations = TestClient(app).get("/api/observatory/v2/operations").json()["items"]
+    assert operations[0]["id"] == payload["operation"]["id"]
+    assert operations[0]["metadata"]["action_id"] == "branch:create:experiment"
 
 
 def test_v2_quality_endpoint_returns_provider_neutral_payload() -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -562,6 +562,26 @@ def test_v2_capabilities_endpoint_returns_provider_neutral_payload() -> None:
     _assert_no_provider_url_settings(payload)
 
 
+def test_v2_capabilities_endpoint_reloads_project_capabilities(monkeypatch) -> None:
+    """Route gating must reflect package/service inventory changes immediately."""
+    calls = 0
+
+    def load_capabilities() -> V2Capabilities:
+        nonlocal calls
+        calls += 1
+        return V2Capabilities(features={"data": calls == 2})
+
+    monkeypatch.setattr(v2, "_load_capabilities", load_capabilities)
+
+    first = TestClient(app).get("/api/observatory/v2/capabilities")
+    second = TestClient(app).get("/api/observatory/v2/capabilities")
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["features"] == {"data": False}
+    assert second.json()["features"] == {"data": True}
+
+
 def test_v2_capabilities_gate_provider_pages_when_providers_are_absent(
     monkeypatch,
 ) -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -8,6 +8,8 @@ import subprocess
 
 from fastapi.testclient import TestClient
 
+from phlo.capabilities.registry import CapabilityRegistry
+from phlo.capabilities.specs import CatalogSpec
 from phlo_api.main import app
 from phlo_api.observatory_api import v2
 from phlo_api.observatory_api.v2 import (
@@ -922,6 +924,8 @@ def test_v2_branch_action_contract_skips_until_provider_write_contract_exists(
     monkeypatch, tmp_path
 ) -> None:
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setattr(v2, "_load_capability_registry", lambda: None)
+    v2._clear_read_model_cache()
     response = TestClient(app).post(
         "/api/observatory/v2/branches/actions",
         json={"action_id": "branch:create:review/demo"},
@@ -987,6 +991,63 @@ def test_v2_branch_action_skip_is_recorded(
     operations = TestClient(app).get("/api/observatory/v2/operations").json()["items"]
     assert operations[0]["id"] == payload["operation"]["id"]
     assert operations[0]["metadata"]["action_id"] == "branch:create:experiment"
+
+
+def test_v2_branch_actions_use_registered_catalog_provider(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    class CatalogProvider:
+        def __init__(self) -> None:
+            self.branches: dict[str, str] = {}
+            self.promoted: list[tuple[str, str]] = []
+
+        def list_branches(self):
+            return [
+                {"name": name, "hash": hash_value} for name, hash_value in self.branches.items()
+            ]
+
+        def create_branch(self, name: str, from_ref: str = "main") -> str | None:
+            self.branches[name] = f"{from_ref}-hash"
+            return self.branches[name]
+
+        def merge_branch(self, source: str, target: str = "main") -> bool:
+            self.promoted.append((source, target))
+            return source in self.branches
+
+        def delete_branch(self, name: str) -> bool:
+            return self.branches.pop(name, None) is not None
+
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    provider = CatalogProvider()
+    registry = CapabilityRegistry()
+    registry.register_catalog(CatalogSpec(name="catalog", provider=provider))
+    monkeypatch.setattr(v2, "_load_capability_registry", lambda: registry)
+    v2._clear_read_model_cache()
+
+    client = TestClient(app)
+    create_response = client.post(
+        "/api/observatory/v2/branches/actions",
+        json={"action_id": "branch:create:experiment"},
+    )
+    promote_response = client.post(
+        "/api/observatory/v2/branches/actions",
+        json={"action_id": "branch:promote:experiment"},
+    )
+    delete_response = client.post(
+        "/api/observatory/v2/branches/actions",
+        json={"action_id": "branch:delete:experiment"},
+    )
+
+    assert create_response.status_code == 200
+    assert create_response.json()["status"] == "succeeded"
+    assert create_response.json()["operation"]["status"] == "succeeded"
+    assert promote_response.status_code == 200
+    assert promote_response.json()["status"] == "succeeded"
+    assert provider.promoted == [("experiment", "main")]
+    assert delete_response.status_code == 200
+    assert delete_response.json()["status"] == "succeeded"
+    assert provider.branches == {}
 
 
 def test_v2_quality_endpoint_returns_provider_neutral_payload() -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -457,6 +457,40 @@ def test_v2_available_installed_service_can_be_added_to_stack(monkeypatch) -> No
     assert commands == [["phlo", "services", "add", "alloy"]]
 
 
+def test_v2_actions_endpoint_routes_add_service_action(monkeypatch, tmp_path: Path) -> None:
+    service = V2Service(
+        id="pgweb",
+        name="pgweb",
+        kind="admin",
+        status="unknown",
+        health=V2Health(state="unknown"),
+        in_stack=False,
+        metadata={"package": "phlo-pgweb", "package_installed": True},
+    )
+    commands: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, returncode=0, stdout="Services added.")
+
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setattr(v2, "_load_services", lambda: [service])
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    v2._clear_read_model_cache()
+
+    response = TestClient(app).post(
+        "/api/observatory/v2/actions",
+        json={"action_id": "pgweb:add"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "succeeded"
+    assert payload["action"]["label"] == "Add to stack"
+    assert payload["action"]["kind"] == "service.add"
+    assert commands == [["phlo", "services", "add", "pgweb"]]
+
+
 def test_v2_available_missing_package_service_add_is_disabled(monkeypatch) -> None:
     service = V2Service(
         id="plugin-example",

--- a/packages/phlo-api/tests/test_observatory_v2_capabilities.py
+++ b/packages/phlo-api/tests/test_observatory_v2_capabilities.py
@@ -218,7 +218,7 @@ def test_build_capability_inventory_route_requirements_use_emitted_provider_keys
     assert requirements["branches"].required_any == ["catalog"]
     assert requirements["branches"].optional == ["table_store"]
     assert requirements["operations"].required_any == ["maintenance_read_model"]
-    assert requirements["runs"].required_any == []
+    assert requirements["runs"].required_any == ["orchestrator"]
     assert requirements["runs"].optional == ["maintenance_read_model"]
     assert requirements["storage"].required_any == ["table_store", "object_store"]
     assert requirements["storage"].optional == []
@@ -251,7 +251,7 @@ def test_build_capability_inventory_route_requirements_use_emitted_provider_keys
             for requirement in requirements.values()
         )
     )
-    assert "orchestrator" not in set().union(
+    assert "orchestrator" in set().union(
         *(
             set(requirement.required_any) | set(requirement.optional)
             for requirement in requirements.values()

--- a/packages/phlo-api/tests/test_observatory_v2_capabilities.py
+++ b/packages/phlo-api/tests/test_observatory_v2_capabilities.py
@@ -1,7 +1,10 @@
 from types import SimpleNamespace
 
 from phlo_api.observatory_api.v2_capabilities import build_capability_inventory
-from phlo_api.observatory_api.v2 import _pages_from_inventory
+from phlo_api.observatory_api.v2 import (
+    _filter_capabilities_to_project_services,
+    _pages_from_inventory,
+)
 from phlo_api.observatory_api.v2_models import (
     V2CapabilityInventory,
     V2CapabilityProvider,
@@ -207,8 +210,11 @@ def test_build_capability_inventory_route_requirements_use_emitted_provider_keys
     assert requirements["issues"].nav is True
     assert requirements["quality"].required_any == ["quality_backend"]
     assert requirements["quality"].nav is False
-    assert requirements["logs"].required_any == ["observability_backend"]
-    assert requirements["logs"].optional == ["maintenance_read_model"]
+    assert requirements["logs"].required_any == []
+    assert requirements["logs"].optional == [
+        "observability_backend",
+        "maintenance_read_model",
+    ]
     assert requirements["branches"].required_any == ["catalog"]
     assert requirements["branches"].optional == ["table_store"]
     assert requirements["operations"].required_any == ["maintenance_read_model"]
@@ -289,3 +295,74 @@ def test_pages_from_inventory_enables_routes_by_required_capabilities() -> None:
         "storage": False,
     }
     assert pages[0].providers == ["trino"]
+
+
+def test_project_service_filter_removes_service_backed_providers_without_project_stack() -> None:
+    inventory = V2CapabilityInventory(
+        providers={
+            "query_engine": [
+                V2CapabilityProvider(
+                    capability_type="query_engine",
+                    name="trino",
+                    display_name="Trino",
+                )
+            ],
+            "observability_backend": [
+                V2CapabilityProvider(
+                    capability_type="observability_backend",
+                    name="loki",
+                    display_name="Loki",
+                )
+            ],
+            "lineage_sink": [
+                V2CapabilityProvider(
+                    capability_type="lineage_sink",
+                    name="phlo-lineage",
+                    display_name="Phlo Lineage",
+                )
+            ],
+        },
+    )
+
+    _filter_capabilities_to_project_services(inventory, [])
+
+    assert inventory.providers["query_engine"] == []
+    assert inventory.providers["observability_backend"] == []
+    assert inventory.providers["lineage_sink"] == []
+
+
+def test_project_service_filter_keeps_configured_service_providers() -> None:
+    inventory = V2CapabilityInventory(
+        providers={
+            "query_engine": [
+                V2CapabilityProvider(
+                    capability_type="query_engine",
+                    name="trino",
+                    display_name="Trino",
+                )
+            ],
+            "observability_backend": [
+                V2CapabilityProvider(
+                    capability_type="observability_backend",
+                    name="loki",
+                    display_name="Loki",
+                )
+            ],
+            "lineage_sink": [
+                V2CapabilityProvider(
+                    capability_type="lineage_sink",
+                    name="phlo-lineage",
+                    display_name="Phlo Lineage",
+                )
+            ],
+        },
+    )
+    services = [
+        SimpleNamespace(id="trino", in_stack=False, definition_state="configured"),
+    ]
+
+    _filter_capabilities_to_project_services(inventory, services)
+
+    assert [provider.name for provider in inventory.providers["query_engine"]] == ["trino"]
+    assert [provider.name for provider in inventory.providers["lineage_sink"]] == ["phlo-lineage"]
+    assert inventory.providers["observability_backend"] == []

--- a/packages/phlo-api/tests/test_observatory_v2_operation_journal.py
+++ b/packages/phlo-api/tests/test_observatory_v2_operation_journal.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from phlo_api.observatory_api.v2_models import (
+    V2Action,
+    V2ActionResult,
+    V2Health,
+    V2Operation,
+    V2ResourceRef,
+)
+from phlo_api.observatory_api.v2_operation_journal import (
+    append_operation,
+    load_operation_journal,
+    operation_from_action_result,
+    record_action_result,
+)
+
+
+def test_append_operation_persists_newest_record_first(tmp_path: Path) -> None:
+    first = V2Operation(
+        id="service:restart",
+        name="Restart",
+        kind="service.restart",
+        status="succeeded",
+        health=V2Health(state="ok", message="done"),
+        target=V2ResourceRef(kind="service", id="phlo-api", label="phlo-api"),
+        metadata={"unsafe_url": "http://internal", "safe_count": 1},
+    )
+    second = first.model_copy(update={"id": "service:stop", "name": "Stop"})
+
+    append_operation(
+        tmp_path,
+        first,
+        record_id="op-first",
+        recorded_at="2026-05-16T10:00:00+00:00",
+    )
+    append_operation(
+        tmp_path,
+        second,
+        record_id="op-second",
+        recorded_at="2026-05-16T10:01:00+00:00",
+    )
+
+    records = load_operation_journal(tmp_path)
+
+    assert [record.id for record in records] == ["op-second", "op-first"]
+    assert records[0].metadata["original_operation_id"] == "service:stop"
+    assert records[1].metadata["safe_count"] == 1
+    assert "unsafe_url" not in records[1].metadata
+
+
+def test_operation_from_action_result_creates_skipped_operation() -> None:
+    action = V2Action(
+        id="quality:raw.orders:rerun",
+        label="Re-run quality check",
+        kind="quality.rerun",
+        enabled=False,
+        reason="Quality re-runs need a provider-backed execution contract.",
+        required_capability="quality_backend",
+    )
+    result = V2ActionResult(
+        action=action,
+        status="skipped",
+        message="Quality re-runs need a provider-backed execution contract.",
+    )
+
+    operation = operation_from_action_result(
+        result,
+        target=V2ResourceRef(kind="quality", id="raw.orders", label="raw.orders"),
+    )
+
+    assert operation.id == "quality:raw.orders:rerun"
+    assert operation.name == "Re-run quality check"
+    assert operation.kind == "quality.rerun"
+    assert operation.status == "skipped"
+    assert operation.health.state == "warning"
+    assert operation.target is not None
+    assert operation.target.kind == "quality"
+    assert operation.metadata["action_id"] == "quality:raw.orders:rerun"
+
+
+def test_record_action_result_returns_result_with_recorded_operation(tmp_path: Path) -> None:
+    action = V2Action(
+        id="unsupported:thing",
+        label="Unsupported action",
+        kind="unsupported",
+        enabled=False,
+    )
+    result = V2ActionResult(
+        action=action,
+        status="failed",
+        message="Unsupported Observatory v2 action: unsupported:thing",
+    )
+
+    recorded_result = record_action_result(
+        tmp_path,
+        result,
+        record_id="op-recorded",
+        recorded_at="2026-05-16T11:00:00+00:00",
+    )
+
+    assert recorded_result.operation is not None
+    assert recorded_result.operation.id == "op-recorded"
+    assert recorded_result.operation.status == "failed"
+    assert load_operation_journal(tmp_path)[0].id == "op-recorded"

--- a/packages/phlo-api/tests/test_observatory_v2_read_models.py
+++ b/packages/phlo-api/tests/test_observatory_v2_read_models.py
@@ -7,7 +7,9 @@ from phlo_api.observatory_api.v2_models import V2Asset, V2Health, V2Service
 from phlo_api.observatory_api.v2_saved_queries import validate_saved_query_sql
 from phlo_api.observatory_api.v2_search import search_results
 from phlo_api.observatory_api.v2_services import (
+    configured_compose_services,
     docker_status_from_container,
+    load_docker_service_statuses,
     service_name_from_container,
 )
 
@@ -43,6 +45,32 @@ def test_docker_status_from_running_container() -> None:
 
 def test_service_name_from_container_matches_known_service_id() -> None:
     assert service_name_from_container("demo-postgres-1", {"postgres"}) == "postgres"
+
+
+def test_docker_statuses_require_project_scope(monkeypatch) -> None:
+    containers = [
+        {
+            "Names": "pokehunt-postgres",
+            "State": "running",
+            "Status": "Up 10 seconds",
+            "Labels": "",
+        }
+    ]
+
+    monkeypatch.delenv("PHLO_COMPOSE_PROJECT", raising=False)
+    monkeypatch.delenv("COMPOSE_PROJECT_NAME", raising=False)
+
+    assert load_docker_service_statuses({"postgres"}, containers) == {}
+
+
+def test_configured_compose_services_reads_generated_compose(tmp_path) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / "docker-compose.yml").write_text(
+        "services:\n  postgres:\n    image: postgres\n  trino:\n    image: trino\n"
+    )
+
+    assert configured_compose_services(tmp_path) == {"postgres", "trino"}
 
 
 def test_validate_saved_query_sql_accepts_select_star_limit() -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_read_models.py
+++ b/packages/phlo-api/tests/test_observatory_v2_read_models.py
@@ -7,8 +7,11 @@ from phlo_api.observatory_api.v2_models import V2Asset, V2Health, V2Service
 from phlo_api.observatory_api.v2_saved_queries import validate_saved_query_sql
 from phlo_api.observatory_api.v2_search import search_results
 from phlo_api.observatory_api.v2_services import (
+    DOCKER_PS_TIMEOUT_SECONDS,
     configured_compose_services,
     docker_status_from_container,
+    load_docker_containers,
+    load_project_docker_containers,
     load_docker_service_statuses,
     service_name_from_container,
 )
@@ -41,6 +44,38 @@ def test_docker_status_from_running_container() -> None:
 
     assert status == "running"
     assert health.state == "unknown"
+
+
+def test_load_docker_containers_allows_multi_stack_local_daemon_latency(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+
+    def fake_run(*args, **kwargs):
+        observed["timeout"] = kwargs.get("timeout")
+
+        class Result:
+            returncode = 0
+            stdout = ""
+
+        return Result()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    assert load_docker_containers() == []
+    assert observed["timeout"] == DOCKER_PS_TIMEOUT_SECONDS
+    assert DOCKER_PS_TIMEOUT_SECONDS >= 10
+
+
+def test_load_project_docker_containers_skips_global_scan_without_compose_project(
+    monkeypatch, tmp_path
+) -> None:
+    def fail_run(*args, **kwargs):
+        raise AssertionError("global docker scan should not run without a project scope")
+
+    monkeypatch.delenv("PHLO_COMPOSE_PROJECT", raising=False)
+    monkeypatch.delenv("COMPOSE_PROJECT_NAME", raising=False)
+    monkeypatch.setattr("subprocess.run", fail_run)
+
+    assert load_project_docker_containers(tmp_path) == []
 
 
 def test_service_name_from_container_matches_known_service_id() -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_workflow_wizard.py
+++ b/packages/phlo-api/tests/test_observatory_v2_workflow_wizard.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from phlo_api.main import app
+from phlo_api.observatory_api import v2
 
 
 client = TestClient(app)
@@ -289,3 +290,91 @@ def test_workflow_wizard_apply_fails_on_conflict(
 
     assert apply_response.status_code == 409
     assert "File conflicts" in apply_response.json()["detail"]
+
+
+def test_workflow_wizard_apply_records_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    v2._clear_read_model_cache()
+    proposal_response = client.post(
+        "/api/observatory/v2/workflow-wizard/proposals",
+        json={
+            "workflow_name": "customer_health",
+            "domain": "customers",
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "source",
+                        "contribution_id": "dlt.rest-api-source",
+                        "stage": "source",
+                        "values": {
+                            "domain": "customers",
+                            "table_name": "orders",
+                            "unique_key": "order_id",
+                        },
+                    }
+                ],
+                "edges": [],
+            },
+        },
+    )
+    proposal = proposal_response.json()
+
+    apply_response = client.post(
+        "/api/observatory/v2/workflow-wizard/actions",
+        json={"action_id": proposal["actions"][0]["id"], "proposal": proposal},
+    )
+
+    assert apply_response.status_code == 200
+    operations = client.get("/api/observatory/v2/operations").json()["items"]
+    assert operations[0]["kind"] == "workflow.apply"
+    assert operations[0]["status"] == "succeeded"
+    assert operations[0]["metadata"]["action_id"] == proposal["actions"][0]["id"]
+    assert "workflows/ingestion/customers/orders.py" in operations[0]["metadata"]["files"]
+
+
+def test_workflow_wizard_conflict_records_failed_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    v2._clear_read_model_cache()
+    existing = tmp_path / "workflows" / "ingestion" / "customers"
+    existing.mkdir(parents=True)
+    (existing / "orders.py").write_text("# existing\n", encoding="utf-8")
+    proposal_response = client.post(
+        "/api/observatory/v2/workflow-wizard/proposals",
+        json={
+            "workflow_name": "customer_health",
+            "domain": "customers",
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "source",
+                        "contribution_id": "dlt.rest-api-source",
+                        "stage": "source",
+                        "values": {
+                            "domain": "customers",
+                            "table_name": "orders",
+                            "unique_key": "order_id",
+                        },
+                    }
+                ],
+                "edges": [],
+            },
+        },
+    )
+    proposal = proposal_response.json()
+
+    apply_response = client.post(
+        "/api/observatory/v2/workflow-wizard/actions",
+        json={"action_id": proposal["actions"][0]["id"], "proposal": proposal},
+    )
+
+    assert apply_response.status_code == 409
+    operations = client.get("/api/observatory/v2/operations").json()["items"]
+    assert operations[0]["kind"] == "workflow.apply"
+    assert operations[0]["status"] == "failed"
+    assert "File conflicts" in operations[0]["health"]["message"]

--- a/packages/phlo-clickhouse/src/phlo_clickhouse/service.yaml
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/service.yaml
@@ -29,8 +29,8 @@ compose:
     - "${CLICKHOUSE_NATIVE_PORT:-19000}:9000"
     - "${CLICKHOUSE_METRICS_PORT:-9363}:9363"
   volumes:
-    - ./volumes/clickhouse/data:/var/lib/clickhouse
-    - ./volumes/clickhouse/logs:/var/log/clickhouse-server
+    - clickhouse-data:/var/lib/clickhouse
+    - clickhouse-logs:/var/log/clickhouse-server
   healthcheck:
     test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8123/ping"]
     interval: 10s

--- a/packages/phlo-clickhouse/tests/test_clickhouse_plugin.py
+++ b/packages/phlo-clickhouse/tests/test_clickhouse_plugin.py
@@ -14,6 +14,8 @@ def test_clickhouse_service_definition():
 
     assert service_definition["name"] == "clickhouse"
     assert service_definition["category"] == "data"
+    assert "clickhouse-data:/var/lib/clickhouse" in service_definition["compose"]["volumes"]
+    assert "clickhouse-logs:/var/log/clickhouse-server" in service_definition["compose"]["volumes"]
 
 
 def test_clickhouse_service_metadata():

--- a/packages/phlo-observatory/src/phlo_observatory/src/routeTree.gen.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as ExtensionsIndexRouteImport } from './routes/extensions/index'
 import { Route as DataIndexRouteImport } from './routes/data/index'
 import { Route as BranchesIndexRouteImport } from './routes/branches/index'
 import { Route as AssetsIndexRouteImport } from './routes/assets/index'
+import { Route as WorkflowsNewRouteImport } from './routes/workflows/new'
 import { Route as V2StorageRouteImport } from './routes/v2/storage'
 import { Route as V2SettingsRouteImport } from './routes/v2/settings'
 import { Route as V2ServicesRouteImport } from './routes/v2/services'
@@ -172,6 +173,11 @@ const BranchesIndexRoute = BranchesIndexRouteImport.update({
 const AssetsIndexRoute = AssetsIndexRouteImport.update({
   id: '/assets/',
   path: '/assets/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const WorkflowsNewRoute = WorkflowsNewRouteImport.update({
+  id: '/workflows/new',
+  path: '/workflows/new',
   getParentRoute: () => rootRouteImport,
 } as any)
 const V2StorageRoute = V2StorageRouteImport.update({
@@ -406,6 +412,7 @@ export interface FileRoutesByFullPath {
   '/v2/services': typeof V2ServicesRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2/storage': typeof V2StorageRoute
+  '/workflows/new': typeof WorkflowsNewRoute
   '/assets': typeof AssetsIndexRoute
   '/branches': typeof BranchesIndexRoute
   '/data': typeof DataIndexRoute
@@ -465,6 +472,7 @@ export interface FileRoutesByTo {
   '/v2/services': typeof V2ServicesRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2/storage': typeof V2StorageRoute
+  '/workflows/new': typeof WorkflowsNewRoute
   '/assets': typeof AssetsIndexRoute
   '/branches': typeof BranchesIndexRoute
   '/data': typeof DataIndexRoute
@@ -527,6 +535,7 @@ export interface FileRoutesById {
   '/v2/services': typeof V2ServicesRoute
   '/v2/settings': typeof V2SettingsRoute
   '/v2/storage': typeof V2StorageRoute
+  '/workflows/new': typeof WorkflowsNewRoute
   '/assets/': typeof AssetsIndexRoute
   '/branches/': typeof BranchesIndexRoute
   '/data/': typeof DataIndexRoute
@@ -590,6 +599,7 @@ export interface FileRouteTypes {
     | '/v2/services'
     | '/v2/settings'
     | '/v2/storage'
+    | '/workflows/new'
     | '/assets'
     | '/branches'
     | '/data'
@@ -649,6 +659,7 @@ export interface FileRouteTypes {
     | '/v2/services'
     | '/v2/settings'
     | '/v2/storage'
+    | '/workflows/new'
     | '/assets'
     | '/branches'
     | '/data'
@@ -710,6 +721,7 @@ export interface FileRouteTypes {
     | '/v2/services'
     | '/v2/settings'
     | '/v2/storage'
+    | '/workflows/new'
     | '/assets/'
     | '/branches/'
     | '/data/'
@@ -756,6 +768,7 @@ export interface RootRouteChildren {
   ExtensionsExtensionNameRoute: typeof ExtensionsExtensionNameRoute
   HubPluginsRoute: typeof HubPluginsRoute
   TableTableIdRoute: typeof TableTableIdRoute
+  WorkflowsNewRoute: typeof WorkflowsNewRoute
   AssetsIndexRoute: typeof AssetsIndexRoute
   BranchesIndexRoute: typeof BranchesIndexRoute
   DataIndexRoute: typeof DataIndexRoute
@@ -913,6 +926,13 @@ declare module '@tanstack/react-router' {
       path: '/assets'
       fullPath: '/assets'
       preLoaderRoute: typeof AssetsIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/workflows/new': {
+      id: '/workflows/new'
+      path: '/workflows/new'
+      fullPath: '/workflows/new'
+      preLoaderRoute: typeof WorkflowsNewRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/v2/storage': {
@@ -1334,6 +1354,7 @@ const rootRouteChildren: RootRouteChildren = {
   ExtensionsExtensionNameRoute: ExtensionsExtensionNameRoute,
   HubPluginsRoute: HubPluginsRoute,
   TableTableIdRoute: TableTableIdRoute,
+  WorkflowsNewRoute: WorkflowsNewRoute,
   AssetsIndexRoute: AssetsIndexRoute,
   BranchesIndexRoute: BranchesIndexRoute,
   DataIndexRoute: DataIndexRoute,

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/__root.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/__root.tsx
@@ -67,7 +67,9 @@ const V2_THEME_BOOTSTRAP = `;(() => {
 
 function runtimeBootstrapScript() {
   const browserApiUrl =
-    typeof process !== 'undefined' ? process.env.PHLO_API_BROWSER_URL || '' : ''
+    typeof process !== 'undefined'
+      ? process.env.PHLO_API_BROWSER_URL || 'http://localhost:4000'
+      : 'http://localhost:4000'
   return `;(() => {
     window.__PHLO_API_BROWSER_URL__ = ${JSON.stringify(browserApiUrl)};
   })();`

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/__root.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/__root.tsx
@@ -65,22 +65,34 @@ const V2_THEME_BOOTSTRAP = `;(() => {
   } catch (_) {}
 })();`
 
+function runtimeBrowserApiUrl() {
+  return typeof process !== 'undefined'
+    ? process.env.PHLO_API_BROWSER_URL || 'http://localhost:4000'
+    : 'http://localhost:4000'
+}
+
 function runtimeBootstrapScript() {
-  const browserApiUrl =
-    typeof process !== 'undefined'
-      ? process.env.PHLO_API_BROWSER_URL || 'http://localhost:4000'
-      : 'http://localhost:4000'
+  const browserApiUrl = runtimeBrowserApiUrl()
   return `;(() => {
     window.__PHLO_API_BROWSER_URL__ = ${JSON.stringify(browserApiUrl)};
   })();`
 }
 
 function RootLayout() {
+  const browserApiUrl = runtimeBrowserApiUrl()
+
   return (
     <html lang="en" className="" suppressHydrationWarning>
       <head>
-        <script suppressHydrationWarning>{V2_THEME_BOOTSTRAP}</script>
-        <script suppressHydrationWarning>{runtimeBootstrapScript()}</script>
+        <meta name="phlo-api-browser-url" content={browserApiUrl} />
+        <script
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: V2_THEME_BOOTSTRAP }}
+        />
+        <script
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: runtimeBootstrapScript() }}
+        />
         <HeadContent />
       </head>
       <body className="phlo-v2-document min-h-svh bg-background text-foreground">

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/apis.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/apis.tsx
@@ -15,8 +15,8 @@ export function APIs() {
   return (
     <V2SurfacePage
       contract="/api/observatory/v2/apis"
-      description="Provider-neutral API backend and published data API surfaces."
-      emptyCopy="API providers can add shallow published-surface summaries here before action or schema-management contracts are added."
+      description="Published data APIs and backend services exposed by this stack."
+      emptyCopy="Published APIs will appear here when a matching package reports them."
       error={result.error}
       items={items}
       kicker="APIs"

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/bi.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/bi.tsx
@@ -15,8 +15,8 @@ export function BI() {
   return (
     <V2SurfacePage
       contract="/api/observatory/v2/bi"
-      description="Provider-neutral BI publish targets and analytics delivery surfaces."
-      emptyCopy="BI providers can add shallow publish-target summaries here without requiring vendor-specific dashboard adapters."
+      description="Dashboards, reports, and analytics destinations connected to this project."
+      emptyCopy="Analytics destinations will appear here when a BI package reports them."
       error={result.error}
       items={items}
       kicker="BI"

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/branches.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/branches.tsx
@@ -13,7 +13,10 @@ import {
   runV2BranchAction,
 } from '@/v2/api/resources'
 import { V2Page } from '@/v2/components/V2Page'
-import { useLiveResource } from '@/v2/routes/liveResource'
+import {
+  invalidateCachedResources,
+  useLiveResource,
+} from '@/v2/routes/liveResource'
 
 export const Route = createFileRoute('/v2/branches')({
   component: Branches,
@@ -58,7 +61,7 @@ function branchesReducer(
 }
 
 export function Branches() {
-  const result = useLiveResource(getV2Branches)
+  const result = useLiveResource(getV2Branches, 60_000, 'v2:branches')
   const [
     { actionMessage, activePanel, createdBranches, detail, selectedId },
     dispatch,
@@ -119,6 +122,7 @@ export function Branches() {
                 void runV2BranchAction({
                   data: { actionId: `branch:create:${branchName}` },
                 }).then((next) => {
+                  invalidateCachedResources(['v2:operations', 'v2:branches'])
                   const message =
                     next.data?.message ??
                     next.error ??

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/branches.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/branches.tsx
@@ -177,8 +177,8 @@ export function Branches() {
           <div className="phlo-v2-inspector-label">Change controls</div>
           <h2>{selected?.name ?? 'No branch selected'}</h2>
           <p>
-            Branch state, compare summary, and commit history from the catalog
-            read model.
+            Branch state, compare summary, and commit history for the selected
+            catalog branch.
           </p>
           <div className="phlo-v2-action-row">
             <button

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/catalog.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/catalog.tsx
@@ -15,8 +15,8 @@ export function Catalog() {
   return (
     <V2SurfacePage
       contract="/api/observatory/v2/catalog"
-      description="Provider-neutral metadata catalog and scanner surfaces."
-      emptyCopy="Catalog providers can add shallow metadata summaries here without binding the UI to a catalog vendor."
+      description="Metadata catalogs and scanners connected to this project."
+      emptyCopy="Catalog entries will appear here when a catalog package reports them."
       error={result.error}
       items={items}
       kicker="Catalog"

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/governance.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/governance.tsx
@@ -15,8 +15,8 @@ export function Governance() {
   return (
     <V2SurfacePage
       contract="/api/observatory/v2/governance"
-      description="Provider-neutral governance, policy, identity, and regulated-surface summaries."
-      emptyCopy="Governance providers can add shallow summaries here before deeper policy editing or audit workflows exist."
+      description="Policies, ownership, identity, and compliance signals for this project."
+      emptyCopy="Governance signals will appear here when a governance package reports them."
       error={result.error}
       items={items}
       kicker="Governance"

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/logs.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/logs.tsx
@@ -201,7 +201,9 @@ export function Logs() {
           ) : (
             <>
               <h2>No events</h2>
-              <p>Connect a v2 telemetry read model to populate this console.</p>
+              <p>
+                Logs will appear here as Phlo and stack services emit events.
+              </p>
             </>
           )}
           <div className="phlo-v2-detail-list">

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/observability.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/observability.tsx
@@ -19,8 +19,8 @@ export function Observability() {
   return (
     <V2SurfacePage
       contract="/api/observatory/v2/observability"
-      description="Provider-neutral telemetry, alerting, and monitoring surfaces."
-      emptyCopy="Observability providers can add shallow telemetry summaries here without introducing backend-specific dashboards yet."
+      description="Telemetry, alerting, and monitoring signals from the running stack."
+      emptyCopy="Telemetry summaries will appear here when an observability package reports them."
       error={result.error}
       items={items}
       kicker="Observability"

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/operations.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/operations.tsx
@@ -17,7 +17,11 @@ import {
 import { ActionButton } from '@/v2/components/ActionButton'
 import { V2FlowCanvas } from '@/v2/components/V2FlowCanvas'
 import { V2Page } from '@/v2/components/V2Page'
-import { readMetric, useLiveResource } from '@/v2/routes/liveResource'
+import {
+  invalidateCachedResources,
+  readMetric,
+  useLiveResource,
+} from '@/v2/routes/liveResource'
 
 export const Route = createFileRoute('/v2/operations')({
   component: Operations,
@@ -30,23 +34,28 @@ export function Operations() {
     'v2:operations',
   )
   const operations = result.data ?? []
+  const [localOperations, setLocalOperations] = useState<Array<V2Operation>>([])
+  const visibleOperations = mergeOperations(localOperations, operations)
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const latest =
-    operations.find((operation) => operation.id === selectedId) ??
-    operations[0] ??
+    visibleOperations.find((operation) => operation.id === selectedId) ??
+    visibleOperations[0] ??
     null
   const [detail, setDetail] = useState<V2ResourceResult<V2OperationDetail>>({
     data: null,
     error: null,
   })
   const [actionMessage, setActionMessage] = useState<string | null>(null)
-  const failed = operations.filter(
+  const failed = visibleOperations.filter(
     (operation) => operation.status === 'failed',
   ).length
-  const recovered = operations.filter(
+  const recovered = visibleOperations.filter(
     (operation) => operation.status === 'succeeded',
   ).length
-  const graph = useMemo(() => buildOperationGraph(operations), [operations])
+  const graph = useMemo(
+    () => buildOperationGraph(visibleOperations),
+    [visibleOperations],
+  )
 
   useEffect(() => {
     if (!latest) {
@@ -69,11 +78,13 @@ export function Operations() {
       kicker="Actions"
       title="Recovery activity"
       description="Phlo-owned actions, maintenance status, and service-impacting work."
-      action={<span className="phlo-v2-pill">{operations.length} actions</span>}
+      action={
+        <span className="phlo-v2-pill">{visibleOperations.length} actions</span>
+      }
     >
       <section className="phlo-v2-command">
         <div className="phlo-v2-command-primary">
-          {operations.length > 0 ? (
+          {visibleOperations.length > 0 ? (
             <>
               <div className="phlo-v2-flow-band">
                 <div className="phlo-v2-workspace-toolbar">
@@ -111,7 +122,7 @@ export function Operations() {
                 />
               </div>
               <div className="phlo-v2-timeline">
-                {operations.map((operation) => (
+                {visibleOperations.map((operation) => (
                   <OperationLine
                     key={operation.id}
                     onSelect={setSelectedId}
@@ -188,6 +199,13 @@ export function Operations() {
                     key={action.id}
                     onRun={(actionId) => {
                       void runV2Action({ data: { actionId } }).then((next) => {
+                        const operation = next.data?.operation
+                        if (operation) {
+                          setLocalOperations((current) =>
+                            mergeOperations([operation], current),
+                          )
+                        }
+                        invalidateCachedResources(['v2:operations'])
                         setActionMessage(
                           next.data?.message ??
                             next.error ??
@@ -282,6 +300,23 @@ function OperationLine({
       <span className="phlo-v2-pill">{operation.status}</span>
     </button>
   )
+}
+
+function mergeOperations(
+  primary: Array<V2Operation>,
+  secondary: Array<V2Operation>,
+): Array<V2Operation> {
+  const merged = new Map<string, V2Operation>()
+  for (const operation of [...primary, ...secondary]) {
+    merged.set(operation.id, operation)
+  }
+  return Array.from(merged.values()).sort((left, right) =>
+    operationTimestamp(right).localeCompare(operationTimestamp(left)),
+  )
+}
+
+function operationTimestamp(operation: V2Operation): string {
+  return operation.completed_at ?? operation.started_at ?? operation.id
 }
 
 function buildOperationGraph(operations: Array<V2Operation>): {

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/quality.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/quality.tsx
@@ -17,7 +17,11 @@ import {
 import { ActionButton } from '@/v2/components/ActionButton'
 import { V2FlowCanvas } from '@/v2/components/V2FlowCanvas'
 import { V2Page } from '@/v2/components/V2Page'
-import { loadCachedResource, useLiveResource } from '@/v2/routes/liveResource'
+import {
+  invalidateCachedResources,
+  loadCachedResource,
+  useLiveResource,
+} from '@/v2/routes/liveResource'
 
 export const Route = createFileRoute('/v2/quality')({
   component: Quality,
@@ -195,6 +199,10 @@ export function Quality() {
                       onRun={(actionId) => {
                         void runV2Action({ data: { actionId } }).then(
                           (next) => {
+                            invalidateCachedResources([
+                              'v2:operations',
+                              'v2:quality',
+                            ])
                             setActionMessage(
                               next.data?.message ??
                                 next.error ??

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/quality.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/quality.tsx
@@ -352,7 +352,7 @@ function qualityStatusLabel(check: V2QualityCheck): string {
 
 function qualityResultSummary(check: V2QualityCheck): string {
   if (check.status === 'unknown') {
-    return 'No result has been returned by the quality read model yet.'
+    return 'No quality result has been recorded for this check yet.'
   }
   if (check.status === 'passing') return 'Latest observed run passed.'
   if (check.status === 'warning') return 'Latest observed run raised a warning.'

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/runs.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/runs.tsx
@@ -23,7 +23,7 @@ export function Runs() {
     <V2Page
       kicker="Runs"
       title="Orchestrator runs"
-      description="Provider-neutral run history, linked assets, checks, and evidence."
+      description="Pipeline run history with linked assets, checks, logs, and evidence."
       action={<span className="phlo-v2-pill">{runs.length} runs</span>}
     >
       <section className="phlo-v2-command phlo-v2-runs-shell">
@@ -63,8 +63,8 @@ export function Runs() {
                   </span>
                   <h2>Run history is quiet.</h2>
                   <p>
-                    A maintenance read model or orchestrator provider can
-                    populate provider-neutral runs here.
+                    Runs will appear here after a workflow starts or your
+                    orchestrator reports recent activity.
                   </p>
                 </div>
                 <div className="phlo-v2-detail-list">
@@ -114,7 +114,7 @@ export function Runs() {
           ) : (
             <>
               <h2>No run selected</h2>
-              <p>There are no provider-neutral run records yet.</p>
+              <p>There are no runs to inspect yet.</p>
             </>
           )}
           {result.error && (

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/services.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/services.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import {
+  Download,
   ExternalLink,
   Layers3,
   Package,
@@ -20,6 +21,7 @@ import {
   getV2ServiceDetail,
   getV2Services,
   getV2ServicesDirect,
+  installV2Package,
   runV2Action,
 } from '@/v2/api/resources'
 import { V2Page } from '@/v2/components/V2Page'
@@ -33,6 +35,17 @@ export const Route = createFileRoute('/v2/services')({
   component: Services,
 })
 
+type ServicePackageGroup = {
+  id: string
+  name: string
+  kind: string
+  packageName: string | null
+  primary: V2Service
+  services: Array<V2Service>
+  inStack: boolean
+  installable: boolean
+}
+
 export function Services() {
   const result = useLiveResource(getV2Services, 120_000, 'v2:services')
   const [directResult, setDirectResult] = useState<V2ResourceResult<
@@ -40,24 +53,33 @@ export function Services() {
   > | null>(null)
   const services = result.data ?? directResult?.data ?? []
   const [selectedId, setSelectedId] = useState<string | null>(null)
-  const runtimeServices = useMemo(
-    () => services.filter((service) => isRuntimeService(service)),
+  const serviceGroups = useMemo(
+    () => groupServicesByPackage(services),
     [services],
   )
-  const availableServices = useMemo(
-    () => services.filter((service) => !isRuntimeService(service)),
-    [services],
+  const runtimeServiceGroups = useMemo(
+    () => serviceGroups.filter((group) => group.inStack),
+    [serviceGroups],
+  )
+  const availableServiceGroups = useMemo(
+    () => serviceGroups.filter((group) => !group.inStack),
+    [serviceGroups],
   )
   const availableSections = useMemo(
-    () => groupServicesByKind(availableServices),
-    [availableServices],
+    () => groupServicePackagesByKind(availableServiceGroups),
+    [availableServiceGroups],
   )
   const selected =
-    services.find((service) => service.id === selectedId) ??
-    runtimeServices.find((service) => service.status === 'running') ??
-    runtimeServices[0] ??
-    services[0] ??
+    serviceGroups.find((group) => group.id === selectedId) ??
+    runtimeServiceGroups.find((group) => group.primary.status === 'running') ??
+    runtimeServiceGroups[0] ??
+    serviceGroups[0] ??
     null
+  const selectedService = selected?.primary ?? null
+  const runtimeServices = useMemo(
+    () => runtimeServiceGroups.flatMap((group) => group.services),
+    [runtimeServiceGroups],
+  )
   const [detail, setDetail] = useState<V2ResourceResult<V2ServiceDetail>>({
     data: null,
     error: null,
@@ -85,18 +107,22 @@ export function Services() {
           service.health.state === 'error' ||
           (service.status === 'stopped' && service.health.state !== 'ok'),
       ).length,
-      runtime: runtimeServices.length,
-      available: availableServices.length,
+      runtime: runtimeServiceGroups.length,
+      available: availableServiceGroups.length,
     }),
-    [availableServices.length, runtimeServices, services],
+    [
+      availableServiceGroups.length,
+      runtimeServiceGroups.length,
+      runtimeServices,
+    ],
   )
 
   useEffect(() => {
-    if (!selected) return
+    if (!selectedService) return
     let cancelled = false
     void loadCachedResource(
-      `v2:service-detail:${selected.id}`,
-      () => getV2ServiceDetail({ data: { serviceId: selected.id } }),
+      `v2:service-detail:${selectedService.id}`,
+      () => getV2ServiceDetail({ data: { serviceId: selectedService.id } }),
       { staleMs: 120_000 },
     ).then((next) => {
       if (!cancelled) setDetail(next)
@@ -104,7 +130,7 @@ export function Services() {
     return () => {
       cancelled = true
     }
-  }, [selected])
+  }, [selectedService])
 
   return (
     <V2Page
@@ -121,11 +147,11 @@ export function Services() {
       <section className="phlo-v2-services-workbench">
         <div className="phlo-v2-service-directory">
           <ServiceSection
-            countLabel={`${runtimeServices.length} services`}
+            countLabel={`${runtimeServiceGroups.length} packages`}
             icon={<Server className="size-4" />}
             onSelect={setSelectedId}
             selectedId={selected?.id}
-            services={runtimeServices}
+            services={runtimeServiceGroups}
             title="Runtime stack"
           />
           <section className="phlo-v2-service-section phlo-v2-service-definitions">
@@ -135,7 +161,7 @@ export function Services() {
                 Available definitions
               </span>
               <span className="phlo-v2-pill">
-                {availableServices.length} optional
+                {availableServiceGroups.length} optional
               </span>
             </div>
             <p className="phlo-v2-section-note">
@@ -162,6 +188,7 @@ export function Services() {
           {selected ? (
             <ServiceDetail
               detail={detail.data}
+              group={selected}
               onAction={(actionId) => {
                 if (
                   !window.confirm(
@@ -178,8 +205,28 @@ export function Services() {
                   )
                 })
               }}
-              runtime={isRuntimeService(selected)}
-              service={selected}
+              onInstall={(packageName) => {
+                if (
+                  !window.confirm(
+                    `Install ${packageName}? This will modify the Python environment used by phlo-api.`,
+                  )
+                ) {
+                  return
+                }
+                setActionMessage(`Installing ${packageName}…`)
+                void installV2Package({ data: { packageName } }).then(
+                  (next) => {
+                    invalidateCachedResources([
+                      'v2:capabilities',
+                      'v2:operations',
+                      'v2:services',
+                    ])
+                    setActionMessage(
+                      next.data?.message ?? next.error ?? 'Install completed',
+                    )
+                  },
+                )
+              }}
             />
           ) : (
             <p>No services returned yet.</p>
@@ -204,38 +251,56 @@ export function Services() {
 
 function ServiceDetail({
   detail,
+  group,
   onAction,
-  runtime,
-  service,
+  onInstall,
 }: {
   detail: V2ServiceDetail | null
+  group: ServicePackageGroup
   onAction: (actionId: string) => void
-  runtime: boolean
-  service: V2Service
+  onInstall: (packageName: string) => void
 }) {
-  const actions = runtime ? (detail?.actions ?? []) : []
+  const { primary: service } = group
+  const actions = group.inStack ? (detail?.actions ?? []) : []
+  const description =
+    typeof service.metadata.description === 'string'
+      ? service.metadata.description
+      : null
   return (
     <>
       <div className="phlo-v2-detail-header">
-        <span>{service.kind}</span>
-        <h2>{service.name}</h2>
+        <span>{group.packageName ?? service.kind}</span>
+        <h2>{group.name}</h2>
         <p>
-          {runtime
+          {group.inStack
             ? (service.health.message ?? 'No runtime health message returned.')
-            : 'Available definition. Not part of the current runtime stack.'}
+            : (description ??
+              'Available package. Install it into the Python environment before adding it to this stack.')}
         </p>
       </div>
       <dl className="phlo-v2-facts">
-        <Fact label="Status" value={runtime ? service.status : 'available'} />
-        <Fact label="Health" value={runtime ? service.health.state : 'n/a'} />
         <Fact
-          label="Depends on"
-          value={service.depends_on.join(', ') || 'none'}
+          label="Status"
+          value={group.inStack ? service.status : 'available'}
         />
-        <Fact label="Impacts" value={service.impacts.join(', ') || 'none'} />
+        <Fact
+          label="Health"
+          value={group.inStack ? service.health.state : 'n/a'}
+        />
+        <Fact label="Package" value={group.packageName ?? 'unknown'} />
+        <Fact
+          label="Included services"
+          value={group.services.map((item) => item.name).join(', ') || 'none'}
+        />
       </dl>
-      {actions.length > 0 && (
+      {(actions.length > 0 || (group.installable && group.packageName)) && (
         <div className="phlo-v2-action-row">
+          {group.installable && group.packageName && (
+            <button onClick={() => onInstall(group.packageName!)} type="button">
+              <Download className="size-3.5" />
+              Install package
+            </button>
+          )}
           {actions.map((action) => (
             <button
               disabled={!action.enabled}
@@ -326,7 +391,7 @@ function ServiceSection({
   icon: ReactNode
   onSelect: (id: string) => void
   selectedId?: string | null
-  services: Array<V2Service>
+  services: Array<ServicePackageGroup>
   title: string
 }) {
   return (
@@ -352,7 +417,12 @@ function ServiceSection({
               data-state={serviceDotState(service)}
             />
             <span>{service.name}</span>
-            <small>{service.kind}</small>
+            <small>
+              {service.packageName ?? service.kind}
+              {service.services.length > 1
+                ? ` · ${service.services.length} services`
+                : ''}
+            </small>
             <strong>{serviceStatusLabel(service)}</strong>
           </button>
         ))}
@@ -364,11 +434,13 @@ function ServiceSection({
   )
 }
 
-function groupServicesByKind(services: Array<V2Service>): Array<{
+function groupServicePackagesByKind(
+  services: Array<ServicePackageGroup>,
+): Array<{
   kind: string
-  services: Array<V2Service>
+  services: Array<ServicePackageGroup>
 }> {
-  const groups = new Map<string, Array<V2Service>>()
+  const groups = new Map<string, Array<ServicePackageGroup>>()
   for (const service of services) {
     const kind = service.kind || 'other'
     groups.set(kind, [...(groups.get(kind) ?? []), service])
@@ -376,6 +448,85 @@ function groupServicesByKind(services: Array<V2Service>): Array<{
   return Array.from(groups.entries())
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([kind, kindServices]) => ({ kind, services: kindServices }))
+}
+
+function groupServicesByPackage(
+  services: Array<V2Service>,
+): Array<ServicePackageGroup> {
+  const groups = new Map<string, Array<V2Service>>()
+  for (const service of services) {
+    const key = servicePackageKey(service)
+    groups.set(key, [...(groups.get(key) ?? []), service])
+  }
+
+  return Array.from(groups.entries())
+    .map(([key, groupServices]) => servicePackageGroup(key, groupServices))
+    .sort((left, right) => left.name.localeCompare(right.name))
+}
+
+function servicePackageGroup(
+  key: string,
+  services: Array<V2Service>,
+): ServicePackageGroup {
+  const primary = primaryServiceForPackage(key, services)
+  const packageName = servicePackageName(primary)
+  return {
+    id: key,
+    name: serviceDisplayName(primary, packageName),
+    kind: primary.kind || 'service',
+    packageName,
+    primary,
+    services: services
+      .slice()
+      .sort((left, right) => left.name.localeCompare(right.name)),
+    inStack: services.some((service) => isRuntimeService(service)),
+    installable: services.some(
+      (service) => service.metadata.installable === true,
+    ),
+  }
+}
+
+function primaryServiceForPackage(
+  key: string,
+  services: Array<V2Service>,
+): V2Service {
+  const packageLabel = key.startsWith('package:')
+    ? key.slice('package:'.length).replace(/^phlo-/, '')
+    : key
+  return (
+    services.find((service) => service.name === packageLabel) ??
+    services.find((service) => service.id === packageLabel) ??
+    services.find(
+      (service) => service.metadata.registry_name === packageLabel,
+    ) ??
+    services
+      .slice()
+      .sort((left, right) => left.name.length - right.name.length)[0]
+  )
+}
+
+function servicePackageKey(service: V2Service): string {
+  const packageName = servicePackageName(service)
+  if (packageName) return `package:${packageName}`
+  return `service:${service.id}`
+}
+
+function servicePackageName(service: V2Service): string | null {
+  return typeof service.metadata.package === 'string'
+    ? service.metadata.package
+    : null
+}
+
+function serviceDisplayName(
+  service: V2Service,
+  packageName: string | null,
+): string {
+  if (!packageName) return service.name
+  const packageLabel = packageName.replace(/^phlo-/, '')
+  if (service.name === packageLabel || service.id === packageLabel) {
+    return service.name
+  }
+  return packageLabel
 }
 
 function isRuntimeService(service: V2Service): boolean {
@@ -387,19 +538,24 @@ function isRuntimeService(service: V2Service): boolean {
   )
 }
 
-function serviceStatusLabel(service: V2Service): string {
-  if (!isRuntimeService(service)) return 'available'
-  if (service.status === 'stopped' && service.health.state === 'ok') {
+function serviceStatusLabel(service: ServicePackageGroup): string {
+  if (!service.inStack) {
+    return service.installable ? 'not installed' : 'available'
+  }
+  const primary = service.primary
+  if (primary.status === 'stopped' && primary.health.state === 'ok') {
     return 'completed'
   }
-  return service.status
+  return primary.status
 }
 
-function serviceDotState(service: V2Service): string {
-  if (service.status === 'stopped' && service.health.state === 'ok') {
+function serviceDotState(service: ServicePackageGroup): string {
+  if (!service.inStack) return service.installable ? 'unknown' : 'stopped'
+  const primary = service.primary
+  if (primary.status === 'stopped' && primary.health.state === 'ok') {
     return 'ok'
   }
-  return service.status
+  return primary.status
 }
 
 function labelize(value: string): string {

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/services.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/services.tsx
@@ -208,10 +208,11 @@ export function Services() {
             <ServiceDetail
               detail={detail.data}
               group={selected}
-              onAction={(actionId) => {
+              onAction={(actionId, confirmationMessage) => {
                 if (
                   !window.confirm(
-                    `Run ${actionId}? This will call phlo-api to change a local service.`,
+                    confirmationMessage ??
+                      `Run ${actionId}? This will call phlo-api to change a local service.`,
                   )
                 ) {
                   return
@@ -298,7 +299,7 @@ function ServiceDetail({
 }: {
   detail: V2ServiceDetail | null
   group: ServicePackageGroup
-  onAction: (actionId: string) => void
+  onAction: (actionId: string, confirmationMessage?: string) => void
   onInstall: (packageName: string) => void
 }) {
   const { primary: service } = group
@@ -310,6 +311,12 @@ function ServiceDetail({
   const visibleActions = canAddToStack
     ? actions.filter((action) => action.id !== addActionId)
     : actions
+  const servicesAddedWithPrimary = addableDependencyNames(group, detail)
+  const addImpactMessage =
+    servicesAddedWithPrimary.length > 0
+      ? `Adding ${group.name} will also add ${formatHumanList(servicesAddedWithPrimary)}.`
+      : `Adding ${group.name} will only add ${group.name}.`
+  const addConfirmationMessage = `${addImpactMessage}\n\nContinue?`
   const description =
     typeof service.metadata.description === 'string'
       ? service.metadata.description
@@ -344,10 +351,19 @@ function ServiceDetail({
           value={group.services.map((item) => item.name).join(', ') || 'none'}
         />
       </dl>
+      {canAddToStack && (
+        <div className="phlo-v2-service-impact">
+          <span>Stack impact</span>
+          <strong>{addImpactMessage}</strong>
+        </div>
+      )}
       {(actions.length > 0 || canAddToStack || canInstallPackage) && (
         <div className="phlo-v2-action-row">
           {canAddToStack && (
-            <button onClick={() => onAction(addActionId)} type="button">
+            <button
+              onClick={() => onAction(addActionId, addConfirmationMessage)}
+              type="button"
+            >
               <Play className="size-3.5" />
               Add to stack
             </button>
@@ -492,6 +508,26 @@ function ServiceSection({
       </div>
     </section>
   )
+}
+
+function addableDependencyNames(
+  group: ServicePackageGroup,
+  detail: V2ServiceDetail | null,
+): Array<string> {
+  const dependencyNames = new Set<string>()
+  for (const dependency of detail?.dependencies ?? []) {
+    if (dependency.in_stack || dependency.id === group.primary.id) continue
+    dependencyNames.add(dependency.name)
+  }
+  return Array.from(dependencyNames).sort((left, right) =>
+    left.localeCompare(right),
+  )
+}
+
+function formatHumanList(items: Array<string>): string {
+  if (items.length <= 1) return items[0] ?? ''
+  if (items.length === 2) return `${items[0]} and ${items[1]}`
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`
 }
 
 function serviceActionsForDetail(

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/services.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/services.tsx
@@ -23,7 +23,11 @@ import {
   runV2Action,
 } from '@/v2/api/resources'
 import { V2Page } from '@/v2/components/V2Page'
-import { loadCachedResource, useLiveResource } from '@/v2/routes/liveResource'
+import {
+  invalidateCachedResources,
+  loadCachedResource,
+  useLiveResource,
+} from '@/v2/routes/liveResource'
 
 export const Route = createFileRoute('/v2/services')({
   component: Services,
@@ -168,6 +172,7 @@ export function Services() {
                 }
                 setActionMessage('Running action…')
                 void runV2Action({ data: { actionId } }).then((next) => {
+                  invalidateCachedResources(['v2:operations', 'v2:services'])
                   setActionMessage(
                     next.data?.message ?? next.error ?? 'Action completed',
                   )

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/services.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/services.tsx
@@ -19,10 +19,13 @@ import type {
 } from '@/v2/api/types'
 import {
   getV2ServiceDetail,
+  getV2ServiceDetailDirect,
   getV2Services,
   getV2ServicesDirect,
   installV2Package,
+  installV2PackageDirect,
   runV2Action,
+  runV2ActionDirect,
 } from '@/v2/api/resources'
 import { V2Page } from '@/v2/components/V2Page'
 import {
@@ -122,7 +125,23 @@ export function Services() {
     let cancelled = false
     void loadCachedResource(
       `v2:service-detail:${selectedService.id}`,
-      () => getV2ServiceDetail({ data: { serviceId: selectedService.id } }),
+      async () => {
+        const directResponse = await getV2ServiceDetailDirect({
+          serviceId: selectedService.id,
+        })
+        if (directResponse.data || !directResponse.error) return directResponse
+        const response = await getV2ServiceDetail({
+          data: { serviceId: selectedService.id },
+        }).catch((error: unknown) => ({
+          data: null,
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Lakehouse API is unavailable',
+        }))
+        if (response.data || !response.error) return response
+        return directResponse
+      },
       { staleMs: 120_000 },
     ).then((next) => {
       if (!cancelled) setDetail(next)
@@ -197,8 +216,19 @@ export function Services() {
                 ) {
                   return
                 }
-                setActionMessage('Running action…')
-                void runV2Action({ data: { actionId } }).then((next) => {
+                setActionMessage('Running action...')
+                void runV2ActionDirect({ actionId }).then(async (next) => {
+                  if (!next.data && next.error) {
+                    next = await runV2Action({ data: { actionId } }).catch(
+                      (error: unknown) => ({
+                        data: null,
+                        error:
+                          error instanceof Error
+                            ? error.message
+                            : 'Action failed',
+                      }),
+                    )
+                  }
                   invalidateCachedResources(['v2:operations', 'v2:services'])
                   setActionMessage(
                     next.data?.message ?? next.error ?? 'Action completed',
@@ -213,9 +243,20 @@ export function Services() {
                 ) {
                   return
                 }
-                setActionMessage(`Installing ${packageName}…`)
-                void installV2Package({ data: { packageName } }).then(
-                  (next) => {
+                setActionMessage(`Installing ${packageName}...`)
+                void installV2PackageDirect({ packageName }).then(
+                  async (next) => {
+                    if (!next.data && next.error) {
+                      next = await installV2Package({
+                        data: { packageName },
+                      }).catch((error: unknown) => ({
+                        data: null,
+                        error:
+                          error instanceof Error
+                            ? error.message
+                            : 'Install failed',
+                      }))
+                    }
                     invalidateCachedResources([
                       'v2:capabilities',
                       'v2:operations',
@@ -237,7 +278,7 @@ export function Services() {
           {detail.error && (
             <div className="phlo-v2-panel-footer">{detail.error}</div>
           )}
-          {result.error && (
+          {services.length === 0 && result.error && (
             <div className="phlo-v2-panel-footer">{result.error}</div>
           )}
           {!result.error && directResult?.error && (
@@ -261,7 +302,14 @@ function ServiceDetail({
   onInstall: (packageName: string) => void
 }) {
   const { primary: service } = group
-  const actions = group.inStack ? (detail?.actions ?? []) : []
+  const actions = serviceActionsForDetail(group, detail)
+  const addActionId = `${service.id}:add`
+  const packageInstalled = service.metadata.package_installed !== false
+  const canAddToStack = !group.inStack && packageInstalled
+  const canInstallPackage = !packageInstalled && Boolean(group.packageName)
+  const visibleActions = canAddToStack
+    ? actions.filter((action) => action.id !== addActionId)
+    : actions
   const description =
     typeof service.metadata.description === 'string'
       ? service.metadata.description
@@ -274,8 +322,11 @@ function ServiceDetail({
         <p>
           {group.inStack
             ? (service.health.message ?? 'No runtime health message returned.')
-            : (description ??
-              'Available package. Install it into the Python environment before adding it to this stack.')}
+            : packageInstalled
+              ? (description ??
+                'This service package is installed and ready to add to this stack.')
+              : (description ??
+                'Install this package, then add it to this stack.')}
         </p>
       </div>
       <dl className="phlo-v2-facts">
@@ -293,15 +344,21 @@ function ServiceDetail({
           value={group.services.map((item) => item.name).join(', ') || 'none'}
         />
       </dl>
-      {(actions.length > 0 || (group.installable && group.packageName)) && (
+      {(actions.length > 0 || canAddToStack || canInstallPackage) && (
         <div className="phlo-v2-action-row">
-          {group.installable && group.packageName && (
+          {canAddToStack && (
+            <button onClick={() => onAction(addActionId)} type="button">
+              <Play className="size-3.5" />
+              Add to stack
+            </button>
+          )}
+          {canInstallPackage && group.packageName && (
             <button onClick={() => onInstall(group.packageName!)} type="button">
               <Download className="size-3.5" />
               Install package
             </button>
           )}
-          {actions.map((action) => (
+          {visibleActions.map((action) => (
             <button
               disabled={!action.enabled}
               key={action.id}
@@ -319,9 +376,12 @@ function ServiceDetail({
         <div className="phlo-v2-mini-row">
           <span>Safe actions</span>
           <small>
-            {actions.length
-              ? `${actions.filter((action) => action.enabled).length} enabled`
-              : 'No action contract exposed'}
+            {visibleActions.length || canAddToStack
+              ? `${
+                  visibleActions.filter((action) => action.enabled).length +
+                  (canAddToStack ? 1 : 0)
+                } enabled`
+              : 'No actions available'}
           </small>
         </div>
         <div className="phlo-v2-mini-row">
@@ -432,6 +492,40 @@ function ServiceSection({
       </div>
     </section>
   )
+}
+
+function serviceActionsForDetail(
+  group: ServicePackageGroup,
+  detail: V2ServiceDetail | null,
+) {
+  const actions = detail?.actions ?? []
+  if (
+    group.inStack ||
+    actions.some((action) => action.id === `${group.primary.id}:add`)
+  ) {
+    return actions
+  }
+  const packageInstalled = group.primary.metadata.package_installed !== false
+  return [
+    ...actions,
+    {
+      id: `${group.primary.id}:add`,
+      label: 'Add to stack',
+      kind: 'service.add',
+      enabled: packageInstalled,
+      requires_confirmation: true,
+      reason: packageInstalled
+        ? null
+        : `Install ${group.packageName ?? group.primary.name} before adding it to the stack.`,
+      risk_level: 'low' as const,
+      required_capability: null,
+      required_service: null,
+      required_permission: null,
+      equivalent_cli_command: `phlo services add ${group.primary.id}`,
+      expected_evidence: [],
+      background_operation_id: null,
+    },
+  ]
 }
 
 function groupServicePackagesByKind(

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/settings.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/settings.tsx
@@ -116,6 +116,7 @@ function useSettingsRoute() {
     [draft, settings],
   )
   const capabilityFeatures = capabilities?.data?.features ?? {}
+  const saveHint = dirty ? 'Save browser preferences' : 'No changes to save'
 
   useEffect(() => {
     dispatch({ type: 'draft', draft: settings })
@@ -124,7 +125,8 @@ function useSettingsRoute() {
   useEffect(() => {
     void fetchStats()
     void loadCachedResource('v2:capabilities', getV2Capabilities, {
-      staleMs: 120_000,
+      force: true,
+      staleMs: 30_000,
     }).then((nextCapabilities) =>
       dispatch({ type: 'capabilities', capabilities: nextCapabilities }),
     )
@@ -193,12 +195,24 @@ function useSettingsRoute() {
               <RotateCcw className="size-3.5" />
               Reset
             </button>
-            <button disabled={!dirty} onClick={save} type="button">
+            <button
+              aria-label={saveHint}
+              disabled={!dirty}
+              onClick={save}
+              title={saveHint}
+              type="button"
+            >
               <Save className="size-3.5" />
               Save
             </button>
           </div>
         </div>
+
+        {!dirty && (
+          <div className="phlo-v2-panel-footer">
+            Settings are saved. Change a preference to enable Save.
+          </div>
+        )}
 
         {error && <div className="phlo-v2-settings-error">{error}</div>}
 

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/storage.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/storage.tsx
@@ -15,8 +15,8 @@ export function Storage() {
   return (
     <V2SurfacePage
       contract="/api/observatory/v2/storage"
-      description="Provider-neutral table stores, object stores, and storage-facing lakehouse surfaces."
-      emptyCopy="Storage providers can add shallow surface summaries here without coupling Observatory to a table format or object store adapter."
+      description="Table stores, object stores, and storage services used by this project."
+      emptyCopy="Storage resources will appear here when a storage package reports them."
       error={result.error}
       items={items}
       kicker="Storage"

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/workflows/new.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/workflows/new.tsx
@@ -32,7 +32,10 @@ import {
   runV2WorkflowAction,
 } from '@/v2/api/resources'
 import { V2Page } from '@/v2/components/V2Page'
-import { loadCachedResource } from '@/v2/routes/liveResource'
+import {
+  invalidateCachedResource,
+  loadCachedResource,
+} from '@/v2/routes/liveResource'
 
 export const Route = createFileRoute('/v2/workflows/new')({
   component: WorkflowCanvasBuilder,
@@ -250,6 +253,7 @@ function useWorkflowCanvasBuilder() {
     void runV2WorkflowAction({
       data: { actionId: action.id, proposal: proposal.data },
     }).then((result) => {
+      invalidateCachedResource('v2:operations')
       setActionMessage(
         result.data?.message ?? result.error ?? 'Action finished',
       )

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/workflows/new.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/workflows/new.tsx
@@ -85,7 +85,7 @@ const WORKFLOW_STEPS: Array<{
   },
 ]
 
-function WorkflowCanvasBuilder() {
+export function WorkflowCanvasBuilder() {
   return useWorkflowCanvasBuilder()
 }
 

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/workflows/new.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/workflows/new.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { WorkflowCanvasBuilder } from '@/routes/v2/workflows/new'
+
+export const Route = createFileRoute('/workflows/new')({
+  component: WorkflowCanvasBuilder,
+})

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
@@ -90,11 +90,12 @@ async function browserApiGet<T>(endpoint: string): Promise<T> {
 async function browserApiPost<T>(
   endpoint: string,
   body: Record<string, unknown>,
+  timeoutMs = 12000,
 ): Promise<T> {
   const base = browserApiBase()
   if (!base) throw new Error('Browser API fallback is unavailable during SSR')
   const controller = new AbortController()
-  const timeout = window.setTimeout(() => controller.abort(), 12000)
+  const timeout = window.setTimeout(() => controller.abort(), timeoutMs)
   let response: Response
   try {
     response = await fetch(`${base}${endpoint}`, {
@@ -191,6 +192,21 @@ export const getV2ServiceDetail = createServerFn()
       }
     },
   )
+
+export async function getV2ServiceDetailDirect({
+  serviceId,
+}: {
+  serviceId: string
+}): Promise<V2ResourceResult<V2ServiceDetail>> {
+  try {
+    const data = await browserApiGet<V2ServiceDetail>(
+      `${V2_API_PREFIX}/services/${encodeURIComponent(serviceId)}`,
+    )
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2ServiceDetail>(error)
+  }
+}
 
 async function getRawCollection<T>(
   endpoint: string,
@@ -530,6 +546,23 @@ export const runV2Action = createServerFn()
     },
   )
 
+export async function runV2ActionDirect({
+  actionId,
+}: {
+  actionId: string
+}): Promise<V2ResourceResult<V2ActionResult>> {
+  try {
+    const data = await browserApiPost<V2ActionResult>(
+      `${V2_API_PREFIX}/actions`,
+      { action_id: actionId },
+      130000,
+    )
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2ActionResult>(error)
+  }
+}
+
 export const installV2Package = createServerFn()
   .inputValidator((input: { packageName: string }) => input)
   .handler(
@@ -548,6 +581,23 @@ export const installV2Package = createServerFn()
       }
     },
   )
+
+export async function installV2PackageDirect({
+  packageName,
+}: {
+  packageName: string
+}): Promise<V2ResourceResult<V2PackageInstallResult>> {
+  try {
+    const data = await browserApiPost<V2PackageInstallResult>(
+      `${V2_API_PREFIX}/packages/install`,
+      { package_name: packageName },
+      310000,
+    )
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2PackageInstallResult>(error)
+  }
+}
 
 export const runV2BranchAction = createServerFn()
   .inputValidator((input: { actionId: string }) => input)

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
@@ -54,7 +54,12 @@ function apiUnavailable<T>(error: unknown): V2ResourceResult<T> {
 
 function browserApiBase(): string | null {
   if (typeof window === 'undefined') return null
-  return window.__PHLO_API_BROWSER_URL__ || null
+  return (
+    window.__PHLO_API_BROWSER_URL__ ||
+    document.querySelector<HTMLMetaElement>('meta[name="phlo-api-browser-url"]')
+      ?.content ||
+    null
+  )
 }
 
 async function browserApiGet<T>(endpoint: string): Promise<T> {
@@ -77,6 +82,41 @@ async function browserApiGet<T>(endpoint: string): Promise<T> {
   }
   if (!response.ok) {
     throw new Error(`phlo-api error: ${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}
+
+async function browserApiPost<T>(
+  endpoint: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const base = browserApiBase()
+  if (!base) throw new Error('Browser API fallback is unavailable during SSR')
+  const controller = new AbortController()
+  const timeout = window.setTimeout(() => controller.abort(), 12000)
+  let response: Response
+  try {
+    response = await fetch(`${base}${endpoint}`, {
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+      signal: controller.signal,
+    })
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw new Error('phlo-api request timed out')
+    }
+    throw error
+  } finally {
+    window.clearTimeout(timeout)
+  }
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null)
+    const detail =
+      payload && typeof payload === 'object' && 'detail' in payload
+        ? String(payload.detail)
+        : `${response.status} ${response.statusText}`
+    throw new Error(`phlo-api error: ${detail}`)
   }
   return response.json()
 }
@@ -256,52 +296,53 @@ export function getV2TableRecords() {
   return getRawCollection<V2Table>('tables')
 }
 
-export const getV2TablePreview = createServerFn()
-  .inputValidator(
-    (input: { tableId: string; limit?: number; offset?: number }) => input,
-  )
-  .handler(
-    async ({
-      data: { tableId, limit = 50, offset = 0 },
-    }): Promise<V2ResourceResult<V2TablePreview>> => {
-      try {
-        const data = await apiGet<V2TablePreview>(
-          `${V2_API_PREFIX}/table-preview/${encodeURIComponent(tableId)}`,
-          { limit, offset },
-          8000,
-        )
-        return { data, error: null }
-      } catch (error) {
-        return apiUnavailable<V2TablePreview>(error)
-      }
-    },
-  )
+export async function getV2TablePreview({
+  data: { tableId, limit = 50, offset = 0 },
+}: {
+  data: { tableId: string; limit?: number; offset?: number }
+}): Promise<V2ResourceResult<V2TablePreview>> {
+  try {
+    const endpoint = `${V2_API_PREFIX}/table-preview/${encodeURIComponent(tableId)}`
+    if (browserApiBase()) {
+      const searchParams = new URLSearchParams({
+        limit: String(limit),
+        offset: String(offset),
+      })
+      const data = await browserApiGet<V2TablePreview>(
+        `${endpoint}?${searchParams}`,
+      )
+      return { data, error: null }
+    }
+    const data = await apiGet<V2TablePreview>(endpoint, { limit, offset }, 8000)
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2TablePreview>(error)
+  }
+}
 
-export const runV2Query = createServerFn()
-  .inputValidator(
-    (input: {
-      sql: string
-      branch?: string
-      limit?: number
-      offset?: number
-    }) => input,
-  )
-  .handler(
-    async ({
-      data: { sql, branch, limit = 100, offset = 0 },
-    }): Promise<V2ResourceResult<V2QueryResult>> => {
-      try {
-        const data = await apiPost<V2QueryResult>(
+export async function runV2Query({
+  data: { sql, branch, limit = 100, offset = 0 },
+}: {
+  data: { sql: string; branch?: string; limit?: number; offset?: number }
+}): Promise<V2ResourceResult<V2QueryResult>> {
+  try {
+    const data = browserApiBase()
+      ? await browserApiPost<V2QueryResult>(`${V2_API_PREFIX}/query`, {
+          sql,
+          branch,
+          limit,
+          offset,
+        })
+      : await apiPost<V2QueryResult>(
           `${V2_API_PREFIX}/query`,
           { sql, branch, limit, offset },
           12000,
         )
-        return { data, error: null }
-      } catch (error) {
-        return apiUnavailable<V2QueryResult>(error)
-      }
-    },
-  )
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2QueryResult>(error)
+  }
+}
 
 export async function getV2SavedQueries(): Promise<
   V2ResourceResult<Array<V2SavedQuery>>
@@ -316,31 +357,34 @@ export async function getV2SavedQueries(): Promise<
   }
 }
 
-export const saveV2Query = createServerFn()
-  .inputValidator(
-    (input: {
-      name: string
-      sql: string
-      branch?: string
-      metadata?: Record<string, unknown>
-    }) => input,
-  )
-  .handler(
-    async ({
-      data: { name, sql, branch, metadata = {} },
-    }): Promise<V2ResourceResult<V2SavedQuery>> => {
-      try {
-        const data = await apiPost<V2SavedQuery>(
+export async function saveV2Query({
+  data: { name, sql, branch, metadata = {} },
+}: {
+  data: {
+    name: string
+    sql: string
+    branch?: string
+    metadata?: Record<string, unknown>
+  }
+}): Promise<V2ResourceResult<V2SavedQuery>> {
+  try {
+    const data = browserApiBase()
+      ? await browserApiPost<V2SavedQuery>(`${V2_API_PREFIX}/saved-queries`, {
+          name,
+          sql,
+          branch,
+          metadata,
+        })
+      : await apiPost<V2SavedQuery>(
           `${V2_API_PREFIX}/saved-queries`,
           { name, sql, branch, metadata },
           8000,
         )
-        return { data, error: null }
-      } catch (error) {
-        return apiUnavailable<V2SavedQuery>(error)
-      }
-    },
-  )
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2SavedQuery>(error)
+  }
+}
 
 export const getV2RowJourney = createServerFn()
   .inputValidator((input: { tableId: string; rowId: string }) => input)

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
@@ -81,50 +81,43 @@ async function browserApiGet<T>(endpoint: string): Promise<T> {
   return response.json()
 }
 
-export const getV2Overview = createServerFn().handler(
-  async (): Promise<V2ResourceResult<V2Overview>> => {
-    try {
-      const data = await apiGet<V2Overview>(
-        `${V2_API_PREFIX}/overview`,
-        undefined,
-        8000,
-      )
-      return { data, error: null }
-    } catch (error) {
-      return apiUnavailable<V2Overview>(error)
-    }
-  },
-)
+async function v2ApiGet<T>(endpoint: string): Promise<T> {
+  if (browserApiBase()) return browserApiGet<T>(endpoint)
+  return apiGet<T>(endpoint, undefined, 8000)
+}
 
-export const getV2Capabilities = createServerFn().handler(
-  async (): Promise<V2ResourceResult<V2Capabilities>> => {
-    try {
-      const data = await apiGet<V2Capabilities>(
-        `${V2_API_PREFIX}/capabilities`,
-        undefined,
-        8000,
-      )
-      return { data, error: null }
-    } catch (error) {
-      return apiUnavailable<V2Capabilities>(error)
-    }
-  },
-)
+export async function getV2Overview(): Promise<V2ResourceResult<V2Overview>> {
+  try {
+    const data = await v2ApiGet<V2Overview>(`${V2_API_PREFIX}/overview`)
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2Overview>(error)
+  }
+}
 
-export const getV2Services = createServerFn().handler(
-  async (): Promise<V2ResourceResult<Array<V2Service>>> => {
-    try {
-      const response = await apiGet<{ items: Array<V2Service> }>(
-        `${V2_API_PREFIX}/services`,
-        undefined,
-        8000,
-      )
-      return { data: response.items, error: null }
-    } catch (error) {
-      return apiUnavailable<Array<V2Service>>(error)
-    }
-  },
-)
+export async function getV2Capabilities(): Promise<
+  V2ResourceResult<V2Capabilities>
+> {
+  try {
+    const data = await v2ApiGet<V2Capabilities>(`${V2_API_PREFIX}/capabilities`)
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2Capabilities>(error)
+  }
+}
+
+export async function getV2Services(): Promise<
+  V2ResourceResult<Array<V2Service>>
+> {
+  try {
+    const response = await v2ApiGet<{ items: Array<V2Service> }>(
+      `${V2_API_PREFIX}/services`,
+    )
+    return { data: response.items, error: null }
+  } catch (error) {
+    return apiUnavailable<Array<V2Service>>(error)
+  }
+}
 
 export async function getV2ServicesDirect(): Promise<
   V2ResourceResult<Array<V2Service>>
@@ -162,10 +155,8 @@ async function getRawCollection<T>(
   endpoint: string,
 ): Promise<V2ResourceResult<Array<T>>> {
   try {
-    const response = await apiGet<{ items: Array<T> }>(
+    const response = await v2ApiGet<{ items: Array<T> }>(
       `${V2_API_PREFIX}/${endpoint}`,
-      undefined,
-      8000,
     )
     return { data: response.items, error: null }
   } catch (error) {
@@ -177,10 +168,8 @@ async function getCollection(
   endpoint: string,
 ): Promise<V2ResourceResult<Array<V2ResourceItem>>> {
   try {
-    const response = await apiGet<{ items: Array<Record<string, unknown>> }>(
+    const response = await v2ApiGet<{ items: Array<Record<string, unknown>> }>(
       `${V2_API_PREFIX}/${endpoint}`,
-      undefined,
-      8000,
     )
     return {
       data: response.items.map((item) => normalizeItem(endpoint, item)),
@@ -191,9 +180,9 @@ async function getCollection(
   }
 }
 
-export const getV2OperationRecords = createServerFn().handler(() =>
-  getRawCollection<V2Operation>('operations'),
-)
+export function getV2OperationRecords() {
+  return getRawCollection<V2Operation>('operations')
+}
 
 export const getV2OperationDetail = createServerFn()
   .inputValidator((input: { operationId: string }) => input)
@@ -214,37 +203,37 @@ export const getV2OperationDetail = createServerFn()
     },
   )
 
-export const getV2RunRecords = createServerFn().handler(() =>
-  getRawCollection<V2Run>('runs'),
-)
+export function getV2RunRecords() {
+  return getRawCollection<V2Run>('runs')
+}
 
-export const getV2StorageItems = createServerFn().handler(() =>
-  getRawCollection<V2SurfaceItem>('storage'),
-)
+export function getV2StorageItems() {
+  return getRawCollection<V2SurfaceItem>('storage')
+}
 
-export const getV2ObservabilityItems = createServerFn().handler(() =>
-  getRawCollection<V2SurfaceItem>('observability'),
-)
+export function getV2ObservabilityItems() {
+  return getRawCollection<V2SurfaceItem>('observability')
+}
 
-export const getV2GovernanceItems = createServerFn().handler(() =>
-  getRawCollection<V2SurfaceItem>('governance'),
-)
+export function getV2GovernanceItems() {
+  return getRawCollection<V2SurfaceItem>('governance')
+}
 
-export const getV2CatalogItems = createServerFn().handler(() =>
-  getRawCollection<V2SurfaceItem>('catalog'),
-)
+export function getV2CatalogItems() {
+  return getRawCollection<V2SurfaceItem>('catalog')
+}
 
-export const getV2ApiItems = createServerFn().handler(() =>
-  getRawCollection<V2SurfaceItem>('apis'),
-)
+export function getV2ApiItems() {
+  return getRawCollection<V2SurfaceItem>('apis')
+}
 
-export const getV2BiItems = createServerFn().handler(() =>
-  getRawCollection<V2SurfaceItem>('bi'),
-)
+export function getV2BiItems() {
+  return getRawCollection<V2SurfaceItem>('bi')
+}
 
-export const getV2AssetRecords = createServerFn().handler(() =>
-  getRawCollection<V2Asset>('assets'),
-)
+export function getV2AssetRecords() {
+  return getRawCollection<V2Asset>('assets')
+}
 
 export const getV2AssetDetail = createServerFn()
   .inputValidator((input: { assetId: string }) => input)
@@ -263,9 +252,9 @@ export const getV2AssetDetail = createServerFn()
     },
   )
 
-export const getV2TableRecords = createServerFn().handler(() =>
-  getRawCollection<V2Table>('tables'),
-)
+export function getV2TableRecords() {
+  return getRawCollection<V2Table>('tables')
+}
 
 export const getV2TablePreview = createServerFn()
   .inputValidator(
@@ -314,20 +303,18 @@ export const runV2Query = createServerFn()
     },
   )
 
-export const getV2SavedQueries = createServerFn().handler(
-  async (): Promise<V2ResourceResult<Array<V2SavedQuery>>> => {
-    try {
-      const response = await apiGet<{ items: Array<V2SavedQuery> }>(
-        `${V2_API_PREFIX}/saved-queries`,
-        undefined,
-        8000,
-      )
-      return { data: response.items, error: null }
-    } catch (error) {
-      return apiUnavailable<Array<V2SavedQuery>>(error)
-    }
-  },
-)
+export async function getV2SavedQueries(): Promise<
+  V2ResourceResult<Array<V2SavedQuery>>
+> {
+  try {
+    const response = await v2ApiGet<{ items: Array<V2SavedQuery> }>(
+      `${V2_API_PREFIX}/saved-queries`,
+    )
+    return { data: response.items, error: null }
+  } catch (error) {
+    return apiUnavailable<Array<V2SavedQuery>>(error)
+  }
+}
 
 export const saveV2Query = createServerFn()
   .inputValidator(
@@ -374,9 +361,9 @@ export const getV2RowJourney = createServerFn()
     },
   )
 
-export const getV2QualityRecords = createServerFn().handler(() =>
-  getRawCollection<V2QualityCheck>('quality'),
-)
+export function getV2QualityRecords() {
+  return getRawCollection<V2QualityCheck>('quality')
+}
 
 export const getV2QualityDetail = createServerFn()
   .inputValidator((input: { checkId: string }) => input)
@@ -397,32 +384,26 @@ export const getV2QualityDetail = createServerFn()
     },
   )
 
-export const getV2LogRecords = createServerFn().handler(() =>
-  getRawCollection<V2LogEvent>('logs'),
-)
+export function getV2LogRecords() {
+  return getRawCollection<V2LogEvent>('logs')
+}
 
-export const getV2LogFacets = createServerFn().handler(
-  async (): Promise<V2ResourceResult<V2LogFacets>> => {
-    try {
-      const data = await apiGet<V2LogFacets>(
-        `${V2_API_PREFIX}/logs/facets`,
-        undefined,
-        8000,
-      )
-      return { data, error: null }
-    } catch (error) {
-      return apiUnavailable<V2LogFacets>(error)
-    }
-  },
-)
+export async function getV2LogFacets(): Promise<V2ResourceResult<V2LogFacets>> {
+  try {
+    const data = await v2ApiGet<V2LogFacets>(`${V2_API_PREFIX}/logs/facets`)
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2LogFacets>(error)
+  }
+}
 
-export const getV2Branches = createServerFn().handler(() =>
-  getCollection('branches'),
-)
+export function getV2Branches() {
+  return getCollection('branches')
+}
 
-export const getV2BranchRecords = createServerFn().handler(() =>
-  getRawCollection<V2Branch>('branches'),
-)
+export function getV2BranchRecords() {
+  return getRawCollection<V2Branch>('branches')
+}
 
 export const getV2BranchDetail = createServerFn()
   .inputValidator((input: { branchName: string }) => input)
@@ -443,9 +424,9 @@ export const getV2BranchDetail = createServerFn()
     },
   )
 
-export const getV2Extensions = createServerFn().handler(() =>
-  getRawCollection<V2Extension>('extensions'),
-)
+export function getV2Extensions() {
+  return getRawCollection<V2Extension>('extensions')
+}
 
 export const getV2ExtensionDetail = createServerFn()
   .inputValidator((input: { extensionId: string }) => input)
@@ -523,20 +504,18 @@ export const runV2BranchAction = createServerFn()
     },
   )
 
-export const getV2WorkflowWizard = createServerFn().handler(
-  async (): Promise<V2ResourceResult<V2WorkflowWizardPayload>> => {
-    try {
-      const data = await apiGet<V2WorkflowWizardPayload>(
-        `${V2_API_PREFIX}/workflow-wizard`,
-        undefined,
-        8000,
-      )
-      return { data, error: null }
-    } catch (error) {
-      return apiUnavailable<V2WorkflowWizardPayload>(error)
-    }
-  },
-)
+export async function getV2WorkflowWizard(): Promise<
+  V2ResourceResult<V2WorkflowWizardPayload>
+> {
+  try {
+    const data = await v2ApiGet<V2WorkflowWizardPayload>(
+      `${V2_API_PREFIX}/workflow-wizard`,
+    )
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2WorkflowWizardPayload>(error)
+  }
+}
 
 export const createV2WorkflowProposal = createServerFn()
   .inputValidator((input: V2WorkflowProposalRequest) => input)

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
@@ -15,6 +15,7 @@ import type {
   V2Operation,
   V2OperationDetail,
   V2Overview,
+  V2PackageInstallResult,
   V2QualityCheck,
   V2QualityDetail,
   V2QueryResult,
@@ -525,6 +526,25 @@ export const runV2Action = createServerFn()
         return { data, error: null }
       } catch (error) {
         return apiUnavailable<V2ActionResult>(error)
+      }
+    },
+  )
+
+export const installV2Package = createServerFn()
+  .inputValidator((input: { packageName: string }) => input)
+  .handler(
+    async ({
+      data: { packageName },
+    }): Promise<V2ResourceResult<V2PackageInstallResult>> => {
+      try {
+        const data = await apiPost<V2PackageInstallResult>(
+          `${V2_API_PREFIX}/packages/install`,
+          { package_name: packageName },
+          310000,
+        )
+        return { data, error: null }
+      } catch (error) {
+        return apiUnavailable<V2PackageInstallResult>(error)
       }
     },
   )

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/api/types.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/api/types.ts
@@ -233,7 +233,7 @@ export interface V2Operation {
   id: string
   name: string
   kind: string
-  status: 'queued' | 'running' | 'succeeded' | 'failed' | 'unknown'
+  status: 'queued' | 'running' | 'succeeded' | 'failed' | 'skipped' | 'unknown'
   health: V2Health
   target?: V2ResourceRef | null
   started_at?: string | null

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/api/types.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/api/types.ts
@@ -202,6 +202,14 @@ export interface V2ServiceDetail {
   config: Array<V2ServiceConfigEntry>
 }
 
+export interface V2PackageInstallResult {
+  package_name: string
+  package_spec: string
+  status: 'succeeded' | 'failed' | 'skipped'
+  message: string
+  services: Array<string>
+}
+
 export interface V2Overview {
   health: V2Health
   counters: Record<string, number>

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/components/V2SurfacePage.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/components/V2SurfacePage.tsx
@@ -60,7 +60,7 @@ export function V2SurfacePage({
                   <span className="phlo-v2-inspector-label">
                     No items returned
                   </span>
-                  <h2>{title} has no provider-neutral items yet.</h2>
+                  <h2>{title} has no items yet.</h2>
                   <p>{emptyCopy}</p>
                 </div>
                 <div className="phlo-v2-detail-list">

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/design/tokens.css
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/design/tokens.css
@@ -243,6 +243,29 @@ html[data-phlo-v2-route='true'][data-phlo-v2-theme='dark']
   font-weight: 650;
 }
 
+.phlo-v2-empty-panel {
+  display: grid;
+  gap: 8px;
+  max-width: 620px;
+  padding: 22px 24px;
+}
+
+.phlo-v2-empty-panel h2 {
+  margin: 0;
+  color: var(--v2-text);
+  font-size: 16px;
+  font-weight: 680;
+  line-height: 1.25;
+}
+
+.phlo-v2-empty-panel p {
+  margin: 0;
+  max-width: 56ch;
+  color: var(--v2-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .phlo-v2-list {
   display: grid;
 }
@@ -2910,6 +2933,11 @@ html[data-phlo-v2-route='true'][data-phlo-v2-theme='dark']
   .phlo-v2-title {
     font-size: clamp(23px, 8vw, 30px);
     line-height: 1.08;
+  }
+
+  .phlo-v2-empty-panel {
+    max-width: none;
+    padding: 18px;
   }
 
   .phlo-v2-workspace-toolbar,

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/design/tokens.css
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/design/tokens.css
@@ -795,6 +795,30 @@ html[data-phlo-v2-route='true'][data-phlo-v2-theme='dark']
   margin-top: 18px;
 }
 
+.phlo-v2-service-impact {
+  display: grid;
+  gap: 4px;
+  margin-top: 16px;
+  border: 1px solid var(--v2-sheet-border);
+  border-radius: 8px;
+  background: var(--v2-sheet);
+  padding: 10px 12px;
+}
+
+.phlo-v2-service-impact span {
+  color: var(--v2-muted);
+  font-size: 11px;
+  font-weight: 720;
+  text-transform: uppercase;
+}
+
+.phlo-v2-service-impact strong {
+  color: var(--v2-ink);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.4;
+}
+
 .phlo-v2-action-row button {
   display: inline-flex;
   height: 30px;

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/OverviewRoute.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/OverviewRoute.tsx
@@ -357,7 +357,7 @@ function useOverviewRoute() {
               <div className="phlo-v2-mini-row">
                 <span>No recent evidence</span>
                 <small>
-                  Logs will appear as the API read model reports them.
+                  Logs will appear as Phlo and stack services emit events.
                 </small>
               </div>
             )}

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/OverviewRoute.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/OverviewRoute.tsx
@@ -89,11 +89,12 @@ function useOverviewRoute() {
   useEffect(() => {
     let cancelled = false
 
-    async function load() {
+    async function load(force = false) {
       const nextCapabilities = await loadCachedResource(
         'v2:capabilities',
         getV2Capabilities,
         {
+          force,
           staleMs: 120_000,
         },
       )
@@ -108,29 +109,42 @@ function useOverviewRoute() {
         nextLogs,
         nextBranches,
       ] = await Promise.all([
-        loadCachedResource('v2:overview', getV2Overview, { staleMs: 30_000 }),
-        loadCachedResource('v2:services', getV2Services, { staleMs: 60_000 }),
+        loadCachedResource('v2:overview', getV2Overview, {
+          force,
+          staleMs: 30_000,
+        }),
+        loadCachedResource('v2:services', getV2Services, {
+          force,
+          staleMs: 60_000,
+        }),
         features?.operations === false
           ? empty
           : loadCachedResource('v2:operations', getV2OperationRecords, {
+              force,
               staleMs: 60_000,
             }),
         features?.assets === false
           ? empty
           : loadCachedResource('v2:assets', getV2AssetRecords, {
+              force,
               staleMs: 60_000,
             }),
         features?.issues === false
           ? empty
           : loadCachedResource('v2:quality', getV2QualityRecords, {
+              force,
               staleMs: 60_000,
             }),
         features?.logs === false
           ? empty
-          : loadCachedResource('v2:logs', getV2LogRecords, { staleMs: 30_000 }),
+          : loadCachedResource('v2:logs', getV2LogRecords, {
+              force,
+              staleMs: 30_000,
+            }),
         features?.branches === false
           ? empty
           : loadCachedResource('v2:branches', getV2BranchRecords, {
+              force,
               staleMs: 60_000,
             }),
       ])
@@ -150,8 +164,10 @@ function useOverviewRoute() {
       }
     }
 
-    void load()
-    const interval = window.setInterval(load, 30_000)
+    void load(true)
+    const interval = window.setInterval(() => {
+      void load(true)
+    }, 30_000)
 
     return () => {
       cancelled = true

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/OverviewRoute.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/OverviewRoute.tsx
@@ -496,7 +496,7 @@ function featureEnabled(
   capabilities: V2Capabilities | null | undefined,
   key: string,
 ): boolean {
-  if (!capabilities) return true
+  if (!capabilities) return false
   return capabilities.features[key] !== false
 }
 

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.test.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  invalidateCachedResource,
+  invalidateCachedResources,
+  loadCachedResource,
+} from './liveResource'
+
+describe('liveResource cache invalidation', () => {
+  test('invalidates one cached resource key', async () => {
+    const key = 'test:single-invalidate'
+    let calls = 0
+    const load = () => {
+      calls += 1
+      return Promise.resolve({ data: [calls], error: null })
+    }
+
+    await loadCachedResource(key, load, { staleMs: 60_000 })
+    await loadCachedResource(key, load, { staleMs: 60_000 })
+    expect(calls).toBe(1)
+
+    invalidateCachedResource(key)
+    const refreshed = await loadCachedResource(key, load, { staleMs: 60_000 })
+
+    expect(calls).toBe(2)
+    expect(refreshed.data).toEqual([2])
+  })
+
+  test('invalidates several cached resource keys', async () => {
+    const firstKey = 'test:multi-invalidate:first'
+    const secondKey = 'test:multi-invalidate:second'
+    let firstCalls = 0
+    let secondCalls = 0
+
+    await loadCachedResource(firstKey, () => {
+      firstCalls += 1
+      return Promise.resolve({ data: [firstCalls], error: null })
+    })
+    await loadCachedResource(secondKey, () => {
+      secondCalls += 1
+      return Promise.resolve({ data: [secondCalls], error: null })
+    })
+
+    invalidateCachedResources([firstKey, secondKey])
+
+    await loadCachedResource(firstKey, () => {
+      firstCalls += 1
+      return Promise.resolve({ data: [firstCalls], error: null })
+    })
+    await loadCachedResource(secondKey, () => {
+      secondCalls += 1
+      return Promise.resolve({ data: [secondCalls], error: null })
+    })
+
+    expect(firstCalls).toBe(2)
+    expect(secondCalls).toBe(2)
+  })
+})

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
@@ -2,6 +2,12 @@ import { useEffect, useMemo, useState } from 'react'
 
 import type { V2ResourceResult } from '@/v2/api/types'
 
+declare global {
+  interface Window {
+    __PHLO_API_BROWSER_URL__?: string
+  }
+}
+
 type CachedEntry<T> = {
   expiresAt: number
   promise: Promise<V2ResourceResult<T>> | null
@@ -77,23 +83,28 @@ export async function loadCachedResource<T>(
   }
   if (cached?.promise) return cached.promise
 
-  const promise = load().then((result) => {
-    if (isCacheableResult(result)) {
-      resourceCache.set(versionedKey, {
-        expiresAt: Date.now() + staleMs,
-        promise: null,
-        result,
-      })
-    } else if (cached?.result) {
-      resourceCache.set(versionedKey, {
-        expiresAt: Date.now(),
-        promise: null,
-        result: cached.result,
-      })
-    } else {
-      resourceCache.delete(versionedKey)
-    }
-    return result
+  const promise = load().then(async (result) => {
+    const fallback = await browserFallbackResource<T>(key)
+    const loaded = isCacheableResult(fallback) ? fallback : result
+
+    return Promise.resolve(loaded).then((nextResult) => {
+      if (isCacheableResult(nextResult)) {
+        resourceCache.set(versionedKey, {
+          expiresAt: Date.now() + staleMs,
+          promise: null,
+          result: nextResult,
+        })
+      } else if (cached?.result) {
+        resourceCache.set(versionedKey, {
+          expiresAt: Date.now(),
+          promise: null,
+          result: cached.result,
+        })
+      } else {
+        resourceCache.delete(versionedKey)
+      }
+      return nextResult
+    })
   })
 
   resourceCache.set(versionedKey, {
@@ -103,6 +114,106 @@ export async function loadCachedResource<T>(
   })
 
   return promise
+}
+
+async function browserFallbackResource<T>(
+  key: string,
+): Promise<V2ResourceResult<T>> {
+  if (typeof window === 'undefined') return { data: null, error: null }
+  const base = window.__PHLO_API_BROWSER_URL__
+  const endpoint = fallbackEndpoint(key)
+  if (!base || !endpoint) return { data: null, error: null }
+
+  try {
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), 8000)
+    const response = await fetch(`${base}${endpoint}`, {
+      signal: controller.signal,
+    })
+    window.clearTimeout(timeout)
+    if (!response.ok) {
+      return {
+        data: null,
+        error: `phlo-api error: ${response.status} ${response.statusText}`,
+      }
+    }
+    const payload = await response.json()
+    return {
+      data: normalizeFallbackPayload<T>(key, payload),
+      error: null,
+    }
+  } catch (error) {
+    return {
+      data: null,
+      error:
+        error instanceof Error ? error.message : 'Lakehouse API is unavailable',
+    }
+  }
+}
+
+function fallbackEndpoint(key: string): string | null {
+  const prefix = '/api/observatory/v2'
+  const endpoints: Record<string, string> = {
+    'v2:overview': `${prefix}/overview`,
+    'v2:capabilities': `${prefix}/capabilities`,
+    'v2:services': `${prefix}/services`,
+    'v2:operations': `${prefix}/operations`,
+    'v2:runs': `${prefix}/runs`,
+    'v2:storage': `${prefix}/storage`,
+    'v2:observability': `${prefix}/observability`,
+    'v2:governance': `${prefix}/governance`,
+    'v2:catalog': `${prefix}/catalog`,
+    'v2:apis': `${prefix}/apis`,
+    'v2:bi': `${prefix}/bi`,
+    'v2:assets': `${prefix}/assets`,
+    'v2:tables': `${prefix}/tables`,
+    'v2:saved-queries': `${prefix}/saved-queries`,
+    'v2:quality': `${prefix}/quality`,
+    'v2:logs': `${prefix}/logs`,
+    'v2:branches': `${prefix}/branches`,
+    'v2:extensions': `${prefix}/extensions`,
+    'v2:workflow-wizard': `${prefix}/workflow-wizard`,
+  }
+  return endpoints[key] ?? null
+}
+
+function normalizeFallbackPayload<T>(key: string, payload: unknown): T {
+  if (
+    key === 'v2:branches' &&
+    isRecord(payload) &&
+    Array.isArray(payload.items)
+  ) {
+    return payload.items.map((branch) => normalizeBranchFallback(branch)) as T
+  }
+
+  if (isRecord(payload) && Array.isArray(payload.items)) {
+    return payload.items as T
+  }
+
+  return payload as T
+}
+
+function normalizeBranchFallback(value: unknown): Record<string, unknown> {
+  const branch = isRecord(value) ? value : {}
+  const id = safeString(branch.id) ?? safeString(branch.name) ?? 'branch'
+  const name = safeString(branch.name) ?? id
+  const current = branch.current === true
+  return {
+    id,
+    name,
+    kind: 'branch',
+    status: current ? 'current' : 'branch',
+    summary: current ? 'Current branch' : 'Branch',
+    metadata: isRecord(branch.metadata) ? branch.metadata : {},
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function safeString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null
 }
 
 export function invalidateCachedResource(key: string): void {

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
@@ -43,7 +43,7 @@ export function useLiveResource<T>(
       if (!cancelled) setResult(next)
     }
 
-    void refresh()
+    void refresh(true)
     const interval = window.setInterval(() => {
       void refresh(true)
     }, intervalMs)

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
@@ -16,7 +16,7 @@ type CachedEntry<T> = {
 
 const resourceCache = new Map<string, CachedEntry<unknown>>()
 const resourceKeys = new WeakMap<object, string>()
-const cacheVersion = '2026-05-01-product-workflow-cache'
+const cacheVersion = '2026-05-17-core-logs-cache'
 let nextResourceKey = 0
 
 export function useLiveResource<T>(

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
@@ -14,9 +14,11 @@ type CachedEntry<T> = {
   result: V2ResourceResult<T>
 }
 
+type LiveRefreshMode = 'preserve' | 'reset'
+
 const resourceCache = new Map<string, CachedEntry<unknown>>()
 const resourceKeys = new WeakMap<object, string>()
-const cacheVersion = '2026-05-17-observatory-runtime-v2'
+const cacheVersion = '2026-05-17-observatory-runtime-v3'
 let nextResourceKey = 0
 
 export function useLiveResource<T>(
@@ -35,7 +37,10 @@ export function useLiveResource<T>(
   useEffect(() => {
     let cancelled = false
 
-    async function refresh(force = false) {
+    async function refresh(force = false, mode: LiveRefreshMode = 'preserve') {
+      if (force && mode === 'reset' && !cancelled) {
+        setResult({ data: null, error: null })
+      }
       const next = await loadCachedResource<Array<T>>(key, load, {
         force,
         staleMs: intervalMs,
@@ -43,14 +48,24 @@ export function useLiveResource<T>(
       if (!cancelled) setResult(next)
     }
 
-    void refresh(true)
+    const refreshActiveTab = () => {
+      if (document.visibilityState !== 'hidden') {
+        void refresh(true)
+      }
+    }
+
+    void refresh(true, 'reset')
     const interval = window.setInterval(() => {
       void refresh(true)
     }, intervalMs)
+    window.addEventListener('focus', refreshActiveTab)
+    document.addEventListener('visibilitychange', refreshActiveTab)
 
     return () => {
       cancelled = true
       window.clearInterval(interval)
+      window.removeEventListener('focus', refreshActiveTab)
+      document.removeEventListener('visibilitychange', refreshActiveTab)
     }
   }, [intervalMs, key, load])
 

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
@@ -18,7 +18,7 @@ type LiveRefreshMode = 'preserve' | 'reset'
 
 const resourceCache = new Map<string, CachedEntry<unknown>>()
 const resourceKeys = new WeakMap<object, string>()
-const cacheVersion = '2026-05-17-observatory-runtime-v3'
+const cacheVersion = '2026-05-18-observatory-runtime-v4'
 let nextResourceKey = 0
 
 export function useLiveResource<T>(

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
@@ -105,6 +105,16 @@ export async function loadCachedResource<T>(
   return promise
 }
 
+export function invalidateCachedResource(key: string): void {
+  resourceCache.delete(`${cacheVersion}:${key}`)
+}
+
+export function invalidateCachedResources(keys: Array<string>): void {
+  for (const key of keys) {
+    invalidateCachedResource(key)
+  }
+}
+
 function isCacheableResult<T>(result: V2ResourceResult<T>): boolean {
   if (result.error) return false
   return hasUsefulData(result.data)

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/routes/liveResource.ts
@@ -16,7 +16,7 @@ type CachedEntry<T> = {
 
 const resourceCache = new Map<string, CachedEntry<unknown>>()
 const resourceKeys = new WeakMap<object, string>()
-const cacheVersion = '2026-05-17-core-logs-cache'
+const cacheVersion = '2026-05-17-observatory-runtime-v2'
 let nextResourceKey = 0
 
 export function useLiveResource<T>(
@@ -120,7 +120,7 @@ async function browserFallbackResource<T>(
   key: string,
 ): Promise<V2ResourceResult<T>> {
   if (typeof window === 'undefined') return { data: null, error: null }
-  const base = window.__PHLO_API_BROWSER_URL__
+  const base = browserApiBase()
   const endpoint = fallbackEndpoint(key)
   if (!base || !endpoint) return { data: null, error: null }
 
@@ -149,6 +149,15 @@ async function browserFallbackResource<T>(
         error instanceof Error ? error.message : 'Lakehouse API is unavailable',
     }
   }
+}
+
+function browserApiBase(): string | null {
+  return (
+    window.__PHLO_API_BROWSER_URL__ ||
+    document.querySelector<HTMLMetaElement>('meta[name="phlo-api-browser-url"]')
+      ?.content ||
+    null
+  )
 }
 
 function fallbackEndpoint(key: string): string | null {

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/shell/V2Shell.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/shell/V2Shell.tsx
@@ -206,7 +206,7 @@ function useV2Shell({ children }: { children: ReactNode }) {
       const next = await loadCachedResource(
         'v2:capabilities',
         getV2Capabilities,
-        { staleMs: 120_000 },
+        { force: true, staleMs: 30_000 },
       )
       if (!cancelled) {
         setCapabilities(next)

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/shell/V2Shell.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/shell/V2Shell.tsx
@@ -50,6 +50,7 @@ import { loadCachedResource } from '@/v2/routes/liveResource'
 
 const fallbackPages: Array<V2CapabilityPage> = [
   corePage('overview', 'Overview', '/'),
+  corePage('logs', 'Logs', '/logs'),
   corePage('services', 'Services', '/services'),
   corePage('settings', 'Settings', '/settings'),
 ]
@@ -152,12 +153,11 @@ function useV2Shell({ children }: { children: ReactNode }) {
   const pages = hydrated
     ? (capabilities?.data?.pages ?? fallbackPages)
     : fallbackPages
-  const navItems = hydrated
-    ? pages
-        .filter((page) => page.nav && page.available)
-        .sort((left, right) => navRank(left.id) - navRank(right.id))
-    : []
+  const navItems = pages
+    .filter((page) => page.nav && page.available)
+    .sort((left, right) => navRank(left.id) - navRank(right.id))
   const activePage = pageForPath(pathname, pages)
+  const pagePending = capabilities === null && activePage === null
   const pageUnavailable =
     hydrated &&
     capabilities?.data !== null &&
@@ -713,7 +713,13 @@ function useV2Shell({ children }: { children: ReactNode }) {
         )}
         <div className="phlo-v2-app-layout">
           <section className="phlo-v2-sheet">
-            {pageUnavailable ? <UnavailablePage page={activePage} /> : children}
+            {pagePending ? (
+              <PendingCapabilityPage />
+            ) : pageUnavailable ? (
+              <UnavailablePage page={activePage} />
+            ) : (
+              children
+            )}
           </section>
         </div>
       </div>
@@ -887,6 +893,27 @@ function hasRowCount(table: V2Table): boolean {
 
 function tableLane(table: V2Table): string {
   return String(table.namespace ?? table.schema_name ?? '').toLowerCase()
+}
+
+function PendingCapabilityPage() {
+  return (
+    <div className="phlo-v2-content">
+      <header className="phlo-v2-section-header">
+        <div>
+          <div className="phlo-v2-kicker">Checking capability</div>
+          <h1 className="phlo-v2-title">Loading surface</h1>
+          <p className="phlo-v2-subtitle">
+            Observatory is checking the project packages before opening this
+            page.
+          </p>
+        </div>
+      </header>
+      <section className="phlo-v2-panel phlo-v2-empty-panel">
+        <h2>Reading project capabilities</h2>
+        <p>Pages appear here only when the matching provider is installed.</p>
+      </section>
+    </div>
+  )
 }
 
 function UnavailablePage({ page }: { page: V2CapabilityPage }) {

--- a/packages/phlo-rustfs/src/phlo_rustfs/rustfs-volume-setup.yaml
+++ b/packages/phlo-rustfs/src/phlo_rustfs/rustfs-volume-setup.yaml
@@ -17,4 +17,4 @@ compose:
     echo 'RustFS data volume ownership initialized'
     "
   volumes:
-    - ./volumes/rustfs:/data
+    - rustfs-data:/data

--- a/packages/phlo-rustfs/src/phlo_rustfs/service.yaml
+++ b/packages/phlo-rustfs/src/phlo_rustfs/service.yaml
@@ -24,7 +24,7 @@ compose:
     - "${RUSTFS_API_PORT:-9000}:9000"
     - "${RUSTFS_CONSOLE_PORT:-9001}:9001"
   volumes:
-    - ./volumes/rustfs:/data
+    - rustfs-data:/data
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:9000/health"]
     interval: 10s

--- a/packages/phlo-rustfs/tests/test_rustfs_plugin.py
+++ b/packages/phlo-rustfs/tests/test_rustfs_plugin.py
@@ -37,6 +37,20 @@ def test_rustfs_service_definition():
     assert service_definition["default"] is False
     assert "rustfs/rustfs" in service_definition["image"]
     assert "rustfs-volume-setup" in service_definition["depends_on"]
+    assert "rustfs-data:/data" in service_definition["compose"]["volumes"]
+
+
+def test_rustfs_volume_setup_uses_named_volume():
+    """RustFS ownership setup should not require host bind-mount chown."""
+
+    import yaml
+    from importlib.resources import files
+
+    service_definition = yaml.safe_load(
+        files("phlo_rustfs").joinpath("rustfs-volume-setup.yaml").read_text()
+    )
+
+    assert "rustfs-data:/data" in service_definition["compose"]["volumes"]
 
 
 def test_rustfs_plugin_metadata():

--- a/src/phlo/cli/commands/plugin/utils.py
+++ b/src/phlo/cli/commands/plugin/utils.py
@@ -157,18 +157,18 @@ SCAFFOLD_TYPE_MAP = {
 
 
 def run_pip(args: list[str], *, timeout: float = 300) -> None:
-    """Install packages using pip, with uv fallback for uv-managed environments."""
+    """Install packages using uv when available, with pip fallback."""
     operation = args[0] if args else "unknown"
-    if importlib.util.find_spec("pip") is not None:
+    if shutil.which("uv") is not None:
+        command = ["uv", "pip", *args]
+        installer = "uv"
+    elif importlib.util.find_spec("pip") is not None:
         command = [sys.executable, "-m", "pip", *args]
         installer = "pip"
     else:
-        if shutil.which("uv") is None:
-            raise RuntimeError(
-                "pip module is unavailable and 'uv' is not installed; cannot install packages."
-            )
-        command = ["uv", "pip", *args]
-        installer = "uv"
+        raise RuntimeError(
+            "pip module is unavailable and 'uv' is not installed; cannot install packages."
+        )
 
     try:
         logger.info("plugin_pip_command_started", operation=operation, installer=installer)

--- a/src/phlo/cli/commands/services/utils.py
+++ b/src/phlo/cli/commands/services/utils.py
@@ -18,8 +18,9 @@ from phlo.cli.infrastructure.container_backend import select_project_container_b
 from phlo.cli.output import missing_compose_file_error, missing_phlo_project_error, user_error
 from phlo.infrastructure.containers import resolve_container_name as _resolve_container_name
 from phlo.logging import get_logger
-from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
+from phlo.plugins.discovery._service_definition import ServiceDefinition
 from phlo.plugins.discovery.service_manifest import ServiceManifestResolver
+from phlo.plugins.discovery.services import ServiceDiscovery
 from phlo.utils import dedupe_preserve_order
 
 logger = get_logger(__name__)
@@ -403,7 +404,7 @@ def _run_service_hooks(
     if not service_names:
         return
 
-    from phlo.plugins.discovery import ServiceDiscovery
+    from phlo.plugins.discovery.services import ServiceDiscovery
 
     logger.debug(
         "service_hook_execution_started",
@@ -684,7 +685,7 @@ def get_profile_service_names(profile_names: tuple[str, ...]) -> list[str]:
     if not profile_names:
         return []
 
-    from phlo.plugins.discovery import ServiceDiscovery
+    from phlo.plugins.discovery.services import ServiceDiscovery
 
     discovery = ServiceDiscovery()
     service_names: list[str] = []

--- a/src/phlo/plugins/observatory_settings.py
+++ b/src/phlo/plugins/observatory_settings.py
@@ -200,5 +200,12 @@ def get_settings_service() -> SettingsService | InMemorySettingsService:
 
     postgres_settings = get_postgres_settings()
     db_url = postgres_settings.get_postgres_connection_string()
+    psycopg2 = _get_psycopg2()
+    try:
+        with psycopg2.connect(db_url, connect_timeout=1):
+            pass
+    except Exception:
+        logger.warning("observatory_settings_falling_back_to_memory")
+        return InMemorySettingsService()
     logger.debug("observatory_settings_service_initialized", backend="postgres_default")
     return SettingsService(db_url)

--- a/tests/cli/test_cli_plugin.py
+++ b/tests/cli/test_cli_plugin.py
@@ -420,12 +420,33 @@ def test_plugin_update(monkeypatch):
     assert calls == [["install", "--upgrade", "phlo-plugin-registry==2.0.0"]]
 
 
-def test_run_pip_uses_python_pip_when_available(monkeypatch):
-    """Use `python -m pip` when pip module is importable."""
+def test_run_pip_prefers_uv_when_available(monkeypatch):
+    """Use `uv pip` when uv is available."""
     from phlo.cli.commands.plugin.utils import run_pip
 
     calls: list[tuple[list[str], bool, float]] = []
 
+    monkeypatch.setattr("phlo.cli.commands.plugin.utils.shutil.which", lambda _: "/usr/bin/uv")
+    monkeypatch.setattr(
+        "phlo.cli.commands.plugin.utils.importlib.util.find_spec", lambda _: object()
+    )
+    monkeypatch.setattr(
+        "phlo.cli.commands.plugin.utils.subprocess.run",
+        lambda cmd, check, timeout: calls.append((cmd, check, timeout)),
+    )
+
+    run_pip(["install", "demo-plugin"], timeout=12)
+
+    assert calls == [(["uv", "pip", "install", "demo-plugin"], True, 12)]
+
+
+def test_run_pip_uses_python_pip_when_uv_missing(monkeypatch):
+    """Use `python -m pip` when uv is unavailable and pip is importable."""
+    from phlo.cli.commands.plugin.utils import run_pip
+
+    calls: list[tuple[list[str], bool, float]] = []
+
+    monkeypatch.setattr("phlo.cli.commands.plugin.utils.shutil.which", lambda _: None)
     monkeypatch.setattr(
         "phlo.cli.commands.plugin.utils.importlib.util.find_spec", lambda _: object()
     )

--- a/tests/cli/test_cli_services_start.py
+++ b/tests/cli/test_cli_services_start.py
@@ -32,13 +32,31 @@ def test_get_profile_service_names_returns_profile_services(
     )
 
     result = get_profile_service_names(("observability",))
-    assert sorted(result) == ["grafana", "loki", "prometheus"]
+    assert sorted(result) == [
+        "alloy",
+        "clickstack",
+        "grafana",
+        "loki",
+        "postgres-exporter",
+        "prometheus",
+    ]
 
     result = get_profile_service_names(("api",))
-    assert result == ["hasura"]
+    assert sorted(result) == ["hasura", "observatory", "phlo-api", "postgrest"]
 
     result = get_profile_service_names(("observability", "api"))
-    assert sorted(result) == ["grafana", "hasura", "loki", "prometheus"]
+    assert sorted(result) == [
+        "alloy",
+        "clickstack",
+        "grafana",
+        "hasura",
+        "loki",
+        "observatory",
+        "phlo-api",
+        "postgres-exporter",
+        "postgrest",
+        "prometheus",
+    ]
 
     result = get_profile_service_names(())
     assert result == []


### PR DESCRIPTION
## Summary

- completes the Observatory v2 API/read-model/action surface for runtime pages
- gates optional service UI by installed package state and groups package sub-services into one package row
- adds trusted package installation and service add flows from the Services page
- shows stack impact before adding a service, including dependencies that will be added
- improves empty/error copy and runtime refresh behavior across Observatory v2

## Validation

- uv run --project /Users/garethprice/Developer/phlo pytest packages/phlo-api/tests/test_observatory_v2_api.py -q
- uv run --project /Users/garethprice/Developer/phlo python -m ruff check packages/phlo-api/src/phlo_api/observatory_api/v2.py packages/phlo-api/tests/test_observatory_v2_api.py
- npm run lint
- npm run build
- npm test
- live API verification against ../phlo-tests/observatory-qa/minimal-core: pgweb:add succeeded through /api/observatory/v2/actions

## Notes

Opened as draft because this is a broad Observatory slice and should get review against a running Phlo stack before merge.
