### PR TITLE
chore(release): phlo 0.10.0 + 7 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [phlo 0.10.0 + 7 packages] - 2026-05-18
+
+### Added
+- phlo: complete Observatory v2 runtime flows (#510)
+- phlo: add provider-neutral decorator APIs (#512)
+- phlo: add flow authoring decorators (#513)
+- phlo-api: complete Observatory v2 runtime flows (#510)
+- phlo-clickhouse: complete Observatory v2 runtime flows (#510)
+- phlo-dlt: add provider-neutral decorator APIs (#512)
+- phlo-observatory: complete Observatory v2 runtime flows (#510)
+- phlo-pandera: add provider-neutral decorator APIs (#512)
+- phlo-rustfs: complete Observatory v2 runtime flows (#510)
+- phlo-sling: add provider-neutral decorator APIs (#512)
+
+### Contributors
+Thanks to our contributors for this release:
+- @iamgp (10 commits)
+
 ## [phlo 0.9.0 + 11 packages] - 2026-05-16
 
 ### Added

--- a/packages/phlo-api/pyproject.toml
+++ b/packages/phlo-api/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 description = "Phlo API - Backend service exposing Phlo internals to Observatory"
 name = "phlo-api"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.5.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-clickhouse/pyproject.toml
+++ b/packages/phlo-clickhouse/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "ClickHouse service and resource plugin for Phlo"
 name = "phlo-clickhouse"
 requires-python = ">=3.11"
-version = "0.3.1"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dlt/pyproject.toml
+++ b/packages/phlo-dlt/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 description = "DLT ingestion engine capability plugin for Phlo"
 name = "phlo-dlt"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.5.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/pyproject.toml
+++ b/packages/phlo-observatory/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["phlo>=0.1.0"]
 description = "Phlo Observatory - Data platform UI (bundled with phlo core)"
 name = "phlo-observatory"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.5.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/src/phlo_observatory/__init__.py
+++ b/packages/phlo-observatory/src/phlo_observatory/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "get_settings",
     "get_settings_service",
 ]
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/packages/phlo-pandera/pyproject.toml
+++ b/packages/phlo-pandera/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Quality checks and schema utilities for Phlo"
 name = "phlo-pandera"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.5.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-rustfs/pyproject.toml
+++ b/packages/phlo-rustfs/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "RustFS service plugin for Phlo"
 name = "phlo-rustfs"
 requires-python = ">=3.11"
-version = "0.2.4"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-rustfs/src/phlo_rustfs/__init__.py
+++ b/packages/phlo-rustfs/src/phlo_rustfs/__init__.py
@@ -22,4 +22,4 @@ from phlo_rustfs.plugin import RustfsServicePlugin
 from phlo_rustfs.settings import RustfsSettings, get_settings
 
 __all__ = ["RustfsServicePlugin", "RustfsSettings", "get_settings"]
-__version__ = "0.2.4"
+__version__ = "0.3.0"

--- a/packages/phlo-sling/pyproject.toml
+++ b/packages/phlo-sling/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Sling replication ingestion provider for Phlo"
 name = "phlo-sling"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.5.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.9.0"
+version = "0.10.0"
 
 [project.entry-points."phlo.plugins.quality"]
 

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -307,4 +307,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3042,7 +3042,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "asyncpg" },
@@ -3284,7 +3284,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-api"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/phlo-api" }
 dependencies = [
     { name = "anyio" },
@@ -3324,7 +3324,7 @@ provides-extras = ["dev", "lineage"]
 
 [[package]]
 name = "phlo-clickhouse"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/phlo-clickhouse" }
 dependencies = [
     { name = "clickhouse-connect" },
@@ -3528,7 +3528,7 @@ provides-extras = ["dev", "minio"]
 
 [[package]]
 name = "phlo-dlt"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/phlo-dlt" }
 dependencies = [
     { name = "dlt" },
@@ -3830,7 +3830,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-observatory"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/phlo-observatory" }
 dependencies = [
     { name = "phlo" },
@@ -3947,7 +3947,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-pandera"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/phlo-pandera" }
 dependencies = [
     { name = "click" },
@@ -4089,7 +4089,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-rustfs"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "packages/phlo-rustfs" }
 dependencies = [
     { name = "phlo" },
@@ -4113,7 +4113,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-sling"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/phlo-sling" }
 dependencies = [
     { name = "phlo" },


### PR DESCRIPTION
## Release summary

## [phlo 0.10.0 + 7 packages] - 2026-05-18

### Added
- phlo: complete Observatory v2 runtime flows (#510)
- phlo: add provider-neutral decorator APIs (#512)
- phlo: add flow authoring decorators (#513)
- phlo-api: complete Observatory v2 runtime flows (#510)
- phlo-clickhouse: complete Observatory v2 runtime flows (#510)
- phlo-dlt: add provider-neutral decorator APIs (#512)
- phlo-observatory: complete Observatory v2 runtime flows (#510)
- phlo-pandera: add provider-neutral decorator APIs (#512)
- phlo-rustfs: complete Observatory v2 runtime flows (#510)
- phlo-sling: add provider-neutral decorator APIs (#512)

### Contributors
Thanks to our contributors for this release:
- @iamgp (10 commits)

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release