### PR TITLE
feat: add flow authoring decorators

### DIFF
--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -802,6 +802,68 @@ Use `phlo.quality.rules(...)` when checks can be expressed in Phlo's neutral
 quality vocabulary. Use `phlo.quality.pandera(...)` when you need Pandera-native
 schemas or checks.
 
+## Flow Authoring Decorators
+
+Use these decorators when you want to describe the rest of the flow without
+hand-writing orchestration metadata. They register provider-neutral asset specs
+that adapters can turn into Dagster assets, lineage nodes, catalog entries, or
+operational jobs.
+
+### SQL Transform
+
+```python
+import phlo
+
+@phlo.transform.sql(
+    table="silver.orders",
+    depends_on=["bronze.orders"],
+    materialized="incremental",
+)
+def orders_sql():
+    return """
+    select *
+    from bronze.orders
+    where status != 'cancelled'
+    """
+```
+
+### Publish Surface
+
+```python
+@phlo.publish(
+    table="gold.customer_health",
+    audience=["cs", "sales"],
+    owner="data-platform",
+    freshness_hours=6,
+)
+def customer_health():
+    return "gold.customer_health"
+```
+
+### Operational Observability
+
+```python
+@phlo.observe(
+    table="bronze.events",
+    freshness_hours=2,
+    row_count_change={"warn": 0.3, "fail": 0.6},
+)
+def events_observability():
+    pass
+```
+
+### Repeatable Backfills
+
+```python
+@phlo.backfill(
+    target="silver.orders",
+    partitions={"start": "2026-01-01", "end": "2026-03-31"},
+    mode="replace-partitions",
+)
+def orders_q1_backfill():
+    return orders_sql
+```
+
 ### Built-in Checks
 
 **NullCheck**: Ensure no null values

--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -864,6 +864,60 @@ def orders_q1_backfill():
     return orders_sql
 ```
 
+### Governance Contracts
+
+Use `@phlo.contract` when the ownership, consumer, SLA, PII, or lifecycle
+metadata belongs to the data product rather than one ingestion or quality
+adapter.
+
+```python
+@phlo.contract(
+    table="gold.customer_health",
+    owner="data-platform",
+    consumers=["cs", phlo.Consumer(name="sales", contact="sales@example.com")],
+    pii=True,
+    freshness_hours=6,
+    lifecycle="production",
+)
+def customer_health_contract():
+    pass
+```
+
+### Access Policies
+
+Use `@phlo.access` to declare intended access controls in one place. Catalog,
+warehouse, and policy-engine adapters can translate the same declaration into
+their native grants or policy objects.
+
+```python
+@phlo.access(
+    table="gold.customer_health",
+    roles=["cs_read", "sales_read"],
+    pii_columns=["email"],
+    policy="read",
+)
+def customer_health_access():
+    pass
+```
+
+### Schedules
+
+Use `@phlo.schedule` to declare when a set of static targets should run. The
+`targets` list is the durable contract: it names the assets or jobs an adapter
+should launch. The decorated function is optional dynamic run configuration; it
+can return partition values, tags, or other parameters for that specific run.
+
+```python
+@phlo.schedule(
+    name="daily_customer_health",
+    cron="0 6 * * *",
+    targets=["transform_silver_orders", "publish_gold_customer_health"],
+    timezone="Europe/London",
+)
+def daily_customer_health():
+    return {"partition_date": "2026-05-18"}
+```
+
 ### Built-in Checks
 
 **NullCheck**: Ensure no null values

--- a/src/phlo/__init__.py
+++ b/src/phlo/__init__.py
@@ -117,15 +117,24 @@ _QUALITY_RULE_EXPORTS = {
     "unique",
 }
 _FLOW_EXPORTS = {
+    "access",
     "backfill",
+    "clear_access_policies",
     "clear_backfill_assets",
+    "clear_contract_specs",
     "clear_observe_assets",
     "clear_publish_assets",
+    "clear_schedules",
+    "contract",
+    "get_access_policies",
     "get_backfill_assets",
+    "get_contract_specs",
     "get_observe_assets",
     "get_publish_assets",
+    "get_schedules",
     "observe",
     "publish",
+    "schedule",
 }
 _SUBMODULE_EXPORTS = {"helpers", "ingest", "ingestion", "metrics", "quality", "transform"}
 
@@ -187,28 +196,46 @@ def __getattr__(name: str) -> Any:
         return globals()[name]
     if name in _FLOW_EXPORTS:
         from phlo.flow import (
+            access,
             backfill,
+            clear_access_policies,
             clear_backfill_assets,
+            clear_contract_specs,
             clear_observe_assets,
             clear_publish_assets,
+            clear_schedules,
+            contract,
+            get_access_policies,
             get_backfill_assets,
+            get_contract_specs,
             get_observe_assets,
             get_publish_assets,
+            get_schedules,
             observe,
             publish,
+            schedule,
         )
 
         globals().update(
             {
+                "access": access,
                 "backfill": backfill,
+                "clear_access_policies": clear_access_policies,
                 "clear_backfill_assets": clear_backfill_assets,
+                "clear_contract_specs": clear_contract_specs,
                 "clear_observe_assets": clear_observe_assets,
                 "clear_publish_assets": clear_publish_assets,
+                "clear_schedules": clear_schedules,
+                "contract": contract,
+                "get_access_policies": get_access_policies,
                 "get_backfill_assets": get_backfill_assets,
+                "get_contract_specs": get_contract_specs,
                 "get_observe_assets": get_observe_assets,
                 "get_publish_assets": get_publish_assets,
+                "get_schedules": get_schedules,
                 "observe": observe,
                 "publish": publish,
+                "schedule": schedule,
             }
         )
         return globals()[name]

--- a/src/phlo/__init__.py
+++ b/src/phlo/__init__.py
@@ -116,7 +116,18 @@ _QUALITY_RULE_EXPORTS = {
     "range_between",
     "unique",
 }
-_SUBMODULE_EXPORTS = {"helpers", "ingest", "ingestion", "metrics", "quality"}
+_FLOW_EXPORTS = {
+    "backfill",
+    "clear_backfill_assets",
+    "clear_observe_assets",
+    "clear_publish_assets",
+    "get_backfill_assets",
+    "get_observe_assets",
+    "get_publish_assets",
+    "observe",
+    "publish",
+}
+_SUBMODULE_EXPORTS = {"helpers", "ingest", "ingestion", "metrics", "quality", "transform"}
 
 __all__ = [
     "__version__",
@@ -125,6 +136,7 @@ __all__ = [
     *_INGESTION_EXPORTS,
     *_QUALITY_EXPORTS,
     *_QUALITY_RULE_EXPORTS,
+    *_FLOW_EXPORTS,
 ]
 
 
@@ -170,6 +182,33 @@ def __getattr__(name: str) -> Any:
                 "not_null": not_null,
                 "range_between": range_between,
                 "unique": unique,
+            }
+        )
+        return globals()[name]
+    if name in _FLOW_EXPORTS:
+        from phlo.flow import (
+            backfill,
+            clear_backfill_assets,
+            clear_observe_assets,
+            clear_publish_assets,
+            get_backfill_assets,
+            get_observe_assets,
+            get_publish_assets,
+            observe,
+            publish,
+        )
+
+        globals().update(
+            {
+                "backfill": backfill,
+                "clear_backfill_assets": clear_backfill_assets,
+                "clear_observe_assets": clear_observe_assets,
+                "clear_publish_assets": clear_publish_assets,
+                "get_backfill_assets": get_backfill_assets,
+                "get_observe_assets": get_observe_assets,
+                "get_publish_assets": get_publish_assets,
+                "observe": observe,
+                "publish": publish,
             }
         )
         return globals()[name]

--- a/src/phlo/_flow_authoring.py
+++ b/src/phlo/_flow_authoring.py
@@ -1,0 +1,61 @@
+"""Shared helpers for terse flow authoring decorators."""
+
+from __future__ import annotations
+
+import inspect
+import re
+from collections.abc import Callable, Iterable
+from typing import Any
+
+from phlo.capabilities import AssetSpec, MaterializeResult, RunSpec
+from phlo.capabilities.runtime import RuntimeContext
+from phlo.contracts import SLA, Consumer, normalize_consumers, serialize_consumers, serialize_sla
+
+
+def asset_key(prefix: str, name: str) -> str:
+    """Build a stable asset key from a dotted table or target name."""
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", name).strip("_").lower()
+    return f"{prefix}_{normalized}"
+
+
+def contract_metadata(
+    *,
+    owner: str | None = None,
+    consumers: list[Consumer | str] | None = None,
+    sla: SLA | None = None,
+) -> dict[str, Any]:
+    """Build common owner, consumer, and SLA metadata."""
+    return {
+        "owner": owner,
+        "consumers": serialize_consumers(normalize_consumers(consumers)),
+        "sla": serialize_sla(sla),
+    }
+
+
+def build_run(fn: Callable[..., Any]) -> RunSpec:
+    """Create a generic run spec around a user-authored function."""
+
+    def _run(context: RuntimeContext) -> Iterable[MaterializeResult]:
+        result = _call_with_optional_context(fn, context)
+        yield MaterializeResult(metadata={"result": result}, status="success")
+
+    return RunSpec(fn=_run)
+
+
+def _call_with_optional_context(fn: Callable[..., Any], context: RuntimeContext) -> Any:
+    signature = inspect.signature(fn)
+    required_parameters = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
+    ]
+    if required_parameters:
+        return fn(context)
+    return fn()
+
+
+def append_asset(registry: list[AssetSpec], asset: AssetSpec) -> None:
+    """Register an asset in a module-local registry."""
+    registry.append(asset)

--- a/src/phlo/_flow_authoring.py
+++ b/src/phlo/_flow_authoring.py
@@ -44,6 +44,16 @@ def build_run(fn: Callable[..., Any]) -> RunSpec:
 
 def _call_with_optional_context(fn: Callable[..., Any], context: RuntimeContext) -> Any:
     signature = inspect.signature(fn)
+    unsupported_parameters = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.kind
+        in {
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        }
+    ]
     required_parameters = [
         parameter
         for parameter in signature.parameters.values()
@@ -51,6 +61,11 @@ def _call_with_optional_context(fn: Callable[..., Any], context: RuntimeContext)
         and parameter.kind
         in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
     ]
+    if unsupported_parameters or len(required_parameters) > 1:
+        raise TypeError(
+            f"Decorated function {fn.__qualname__}{signature} must accept either "
+            "no parameters or one context parameter."
+        )
     if required_parameters:
         return fn(context)
     return fn()

--- a/src/phlo/flow.py
+++ b/src/phlo/flow.py
@@ -1,17 +1,63 @@
-"""Terse flow authoring decorators for publish, observe, and backfill assets."""
+"""Terse flow authoring decorators for provider-neutral flow declarations."""
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from phlo._flow_authoring import append_asset, asset_key, build_run, contract_metadata
 from phlo.capabilities import AssetCheckSpec, AssetSpec
-from phlo.contracts import SLA, Consumer
+from phlo.contracts import SLA, Consumer, normalize_consumers, serialize_consumers, serialize_sla
+
+
+@dataclass(frozen=True, slots=True)
+class ContractSpec:
+    """Provider-neutral governance contract declaration for a table."""
+
+    key: str
+    table: str
+    owner: str | None
+    consumers: list[dict[str, Any]]
+    sla: dict[str, Any] | None
+    pii: bool
+    lifecycle: str | None
+    metadata: dict[str, Any]
+    fn: Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class AccessPolicySpec:
+    """Provider-neutral access policy declaration for a table."""
+
+    key: str
+    table: str
+    roles: list[str]
+    pii_columns: list[str]
+    policy: str
+    metadata: dict[str, Any]
+    fn: Callable[..., Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ScheduleSpec:
+    """Provider-neutral schedule declaration for launching static targets."""
+
+    key: str
+    name: str
+    cron: str
+    targets: list[str]
+    timezone: str
+    metadata: dict[str, Any]
+    fn: Callable[..., Any]
+
 
 _PUBLISH_ASSETS: list[AssetSpec] = []
 _OBSERVE_ASSETS: list[AssetSpec] = []
 _BACKFILL_ASSETS: list[AssetSpec] = []
+_CONTRACT_SPECS: list[ContractSpec] = []
+_ACCESS_POLICIES: list[AccessPolicySpec] = []
+_SCHEDULES: list[ScheduleSpec] = []
 
 
 def publish(
@@ -150,6 +196,99 @@ def backfill(
     return _decorator
 
 
+def contract(
+    *,
+    table: str,
+    owner: str | None = None,
+    consumers: list[Consumer | str] | None = None,
+    pii: bool = False,
+    freshness_hours: int | None = None,
+    lifecycle: str | None = None,
+    sla: SLA | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Declare governance ownership, consumer, SLA, and lifecycle metadata."""
+
+    def _decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        effective_sla = sla or (
+            SLA(freshness_hours=freshness_hours) if freshness_hours is not None else None
+        )
+        _CONTRACT_SPECS.append(
+            ContractSpec(
+                key=asset_key("contract", table),
+                table=table,
+                owner=owner,
+                consumers=serialize_consumers(normalize_consumers(consumers)),
+                sla=serialize_sla(effective_sla),
+                pii=pii,
+                lifecycle=lifecycle,
+                metadata=dict(metadata or {}),
+                fn=fn,
+            )
+        )
+        return fn
+
+    return _decorator
+
+
+def access(
+    *,
+    table: str,
+    roles: list[str],
+    pii_columns: list[str] | None = None,
+    policy: str = "read",
+    metadata: dict[str, Any] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Declare intended access policy metadata for a table."""
+
+    def _decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        _ACCESS_POLICIES.append(
+            AccessPolicySpec(
+                key=asset_key("access", table),
+                table=table,
+                roles=list(roles),
+                pii_columns=list(pii_columns or []),
+                policy=policy,
+                metadata=dict(metadata or {}),
+                fn=fn,
+            )
+        )
+        return fn
+
+    return _decorator
+
+
+def schedule(
+    *,
+    name: str,
+    cron: str,
+    targets: list[str],
+    timezone: str = "UTC",
+    metadata: dict[str, Any] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Declare when static targets should run.
+
+    The decorated function is stored as a dynamic parameter hook. Adapters can
+    call it at run time for partition values, config, or tags.
+    """
+
+    def _decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        _SCHEDULES.append(
+            ScheduleSpec(
+                key=asset_key("schedule", name),
+                name=name,
+                cron=cron,
+                targets=list(targets),
+                timezone=timezone,
+                metadata=dict(metadata or {}),
+                fn=fn,
+            )
+        )
+        return fn
+
+    return _decorator
+
+
 def get_publish_assets() -> list[AssetSpec]:
     """Return registered publish asset specs."""
     return list(_PUBLISH_ASSETS)
@@ -180,14 +319,56 @@ def clear_backfill_assets() -> None:
     _BACKFILL_ASSETS.clear()
 
 
+def get_contract_specs() -> list[ContractSpec]:
+    """Return registered governance contract specs."""
+    return list(_CONTRACT_SPECS)
+
+
+def clear_contract_specs() -> None:
+    """Clear registered governance contract specs."""
+    _CONTRACT_SPECS.clear()
+
+
+def get_access_policies() -> list[AccessPolicySpec]:
+    """Return registered access policy specs."""
+    return list(_ACCESS_POLICIES)
+
+
+def clear_access_policies() -> None:
+    """Clear registered access policy specs."""
+    _ACCESS_POLICIES.clear()
+
+
+def get_schedules() -> list[ScheduleSpec]:
+    """Return registered schedule specs."""
+    return list(_SCHEDULES)
+
+
+def clear_schedules() -> None:
+    """Clear registered schedule specs."""
+    _SCHEDULES.clear()
+
+
 __all__ = [
+    "AccessPolicySpec",
+    "ContractSpec",
+    "ScheduleSpec",
+    "access",
     "backfill",
+    "clear_access_policies",
     "clear_backfill_assets",
+    "clear_contract_specs",
     "clear_observe_assets",
     "clear_publish_assets",
+    "clear_schedules",
+    "contract",
+    "get_access_policies",
     "get_backfill_assets",
+    "get_contract_specs",
     "get_observe_assets",
     "get_publish_assets",
+    "get_schedules",
     "observe",
     "publish",
+    "schedule",
 ]

--- a/src/phlo/flow.py
+++ b/src/phlo/flow.py
@@ -1,0 +1,193 @@
+"""Terse flow authoring decorators for publish, observe, and backfill assets."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from phlo._flow_authoring import append_asset, asset_key, build_run, contract_metadata
+from phlo.capabilities import AssetCheckSpec, AssetSpec
+from phlo.contracts import SLA, Consumer
+
+_PUBLISH_ASSETS: list[AssetSpec] = []
+_OBSERVE_ASSETS: list[AssetSpec] = []
+_BACKFILL_ASSETS: list[AssetSpec] = []
+
+
+def publish(
+    *,
+    table: str,
+    audience: list[str] | None = None,
+    owner: str | None = None,
+    freshness_hours: int | None = None,
+    depends_on: list[str] | None = None,
+    group: str = "publish",
+    consumers: list[Consumer | str] | None = None,
+    sla: SLA | None = None,
+    description: str | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Mark a curated table as a publishable data-product surface."""
+
+    def _decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        append_asset(
+            _PUBLISH_ASSETS,
+            AssetSpec(
+                key=asset_key("publish", table),
+                group=group,
+                description=description or fn.__doc__,
+                kinds={"publish", "data_product"},
+                tags={"provider": "core", "asset_type": "publish"},
+                metadata={
+                    "table": table,
+                    "audience": list(audience or []),
+                    "freshness_hours": freshness_hours,
+                    **contract_metadata(owner=owner, consumers=consumers, sla=sla),
+                },
+                deps=list(depends_on or []),
+                run=build_run(fn),
+            ),
+        )
+        return fn
+
+    return _decorator
+
+
+def observe(
+    *,
+    table: str,
+    freshness_hours: int | None = None,
+    row_count_change: dict[str, float] | None = None,
+    depends_on: list[str] | None = None,
+    group: str = "observe",
+    description: str | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Register operational health checks for a table or asset."""
+
+    def _decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        key = asset_key("observe", table)
+        checks: list[AssetCheckSpec] = []
+        if freshness_hours is not None:
+            checks.append(
+                AssetCheckSpec(
+                    name="freshness_hours",
+                    asset_key=key,
+                    fn=None,
+                    blocking=False,
+                    description=f"Warn when {table} is older than {freshness_hours} hours.",
+                    severity="warning",
+                    tags={"check_type": "freshness"},
+                )
+            )
+        if row_count_change is not None:
+            checks.append(
+                AssetCheckSpec(
+                    name="row_count_change",
+                    asset_key=key,
+                    fn=None,
+                    blocking=False,
+                    description=f"Watch row-count movement for {table}.",
+                    severity="warning",
+                    tags={"check_type": "volume"},
+                )
+            )
+
+        append_asset(
+            _OBSERVE_ASSETS,
+            AssetSpec(
+                key=key,
+                group=group,
+                description=description or fn.__doc__,
+                kinds={"observe", "operational_check"},
+                tags={"provider": "core", "asset_type": "observe"},
+                metadata={
+                    "table": table,
+                    "freshness_hours": freshness_hours,
+                    "row_count_change": dict(row_count_change or {}),
+                },
+                deps=list(depends_on or []),
+                run=build_run(fn),
+                checks=checks,
+            ),
+        )
+        return fn
+
+    return _decorator
+
+
+def backfill(
+    *,
+    target: str,
+    partitions: dict[str, Any],
+    mode: str = "replace-partitions",
+    depends_on: list[str] | None = None,
+    group: str = "backfill",
+    owner: str | None = None,
+    description: str | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Register a repeatable backfill job."""
+
+    def _decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        append_asset(
+            _BACKFILL_ASSETS,
+            AssetSpec(
+                key=asset_key("backfill", target),
+                group=group,
+                description=description or fn.__doc__,
+                kinds={"backfill"},
+                tags={"provider": "core", "asset_type": "backfill", "mode": mode},
+                metadata={
+                    "target": target,
+                    "partitions": dict(partitions),
+                    "mode": mode,
+                    "owner": owner,
+                },
+                deps=list(depends_on or []),
+                run=build_run(fn),
+            ),
+        )
+        return fn
+
+    return _decorator
+
+
+def get_publish_assets() -> list[AssetSpec]:
+    """Return registered publish asset specs."""
+    return list(_PUBLISH_ASSETS)
+
+
+def clear_publish_assets() -> None:
+    """Clear registered publish asset specs."""
+    _PUBLISH_ASSETS.clear()
+
+
+def get_observe_assets() -> list[AssetSpec]:
+    """Return registered observe asset specs."""
+    return list(_OBSERVE_ASSETS)
+
+
+def clear_observe_assets() -> None:
+    """Clear registered observe asset specs."""
+    _OBSERVE_ASSETS.clear()
+
+
+def get_backfill_assets() -> list[AssetSpec]:
+    """Return registered backfill asset specs."""
+    return list(_BACKFILL_ASSETS)
+
+
+def clear_backfill_assets() -> None:
+    """Clear registered backfill asset specs."""
+    _BACKFILL_ASSETS.clear()
+
+
+__all__ = [
+    "backfill",
+    "clear_backfill_assets",
+    "clear_observe_assets",
+    "clear_publish_assets",
+    "get_backfill_assets",
+    "get_observe_assets",
+    "get_publish_assets",
+    "observe",
+    "publish",
+]

--- a/src/phlo/transform.py
+++ b/src/phlo/transform.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 
 from phlo._flow_authoring import append_asset, asset_key, build_run, contract_metadata
@@ -25,7 +26,7 @@ def sql(
     """Register a SQL transform asset."""
 
     def _decorator(fn: Callable[..., str]) -> Callable[..., str]:
-        sql_text = fn()
+        sql_text = _static_sql_text(fn)
         append_asset(
             _TRANSFORM_ASSETS,
             AssetSpec(
@@ -52,6 +53,20 @@ def sql(
         return fn
 
     return _decorator
+
+
+def _static_sql_text(fn: Callable[..., str]) -> str | None:
+    signature = inspect.signature(fn)
+    required_parameters = [
+        parameter
+        for parameter in signature.parameters.values()
+        if parameter.default is inspect.Parameter.empty
+        and parameter.kind
+        in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
+    ]
+    if required_parameters:
+        return None
+    return fn()
 
 
 def get_transform_assets() -> list[AssetSpec]:

--- a/src/phlo/transform.py
+++ b/src/phlo/transform.py
@@ -62,7 +62,11 @@ def _static_sql_text(fn: Callable[..., str]) -> str | None:
         for parameter in signature.parameters.values()
         if parameter.default is inspect.Parameter.empty
         and parameter.kind
-        in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
+        in {
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }
     ]
     if required_parameters:
         return None

--- a/src/phlo/transform.py
+++ b/src/phlo/transform.py
@@ -1,0 +1,67 @@
+"""Provider-neutral transformation authoring decorators."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from phlo._flow_authoring import append_asset, asset_key, build_run, contract_metadata
+from phlo.capabilities import AssetSpec
+from phlo.contracts import SLA, Consumer
+
+_TRANSFORM_ASSETS: list[AssetSpec] = []
+
+
+def sql(
+    *,
+    table: str,
+    depends_on: list[str] | None = None,
+    materialized: str = "table",
+    group: str = "transform",
+    owner: str | None = None,
+    consumers: list[Consumer | str] | None = None,
+    sla: SLA | None = None,
+    description: str | None = None,
+) -> Callable[[Callable[..., str]], Callable[..., str]]:
+    """Register a SQL transform asset."""
+
+    def _decorator(fn: Callable[..., str]) -> Callable[..., str]:
+        sql_text = fn()
+        append_asset(
+            _TRANSFORM_ASSETS,
+            AssetSpec(
+                key=asset_key("transform", table),
+                group=group,
+                description=description or fn.__doc__,
+                kinds={"sql", "transform"},
+                tags={
+                    "provider": "core",
+                    "asset_type": "transform",
+                    "transform_type": "sql",
+                    "materialized": materialized,
+                },
+                metadata={
+                    "table": table,
+                    "sql": sql_text,
+                    "materialized": materialized,
+                    **contract_metadata(owner=owner, consumers=consumers, sla=sla),
+                },
+                deps=list(depends_on or []),
+                run=build_run(fn),
+            ),
+        )
+        return fn
+
+    return _decorator
+
+
+def get_transform_assets() -> list[AssetSpec]:
+    """Return registered transform asset specs."""
+    return list(_TRANSFORM_ASSETS)
+
+
+def clear_transform_assets() -> None:
+    """Clear registered transform asset specs."""
+    _TRANSFORM_ASSETS.clear()
+
+
+__all__ = ["clear_transform_assets", "get_transform_assets", "sql"]

--- a/tests/plugins/test_flow_authoring_decorators.py
+++ b/tests/plugins/test_flow_authoring_decorators.py
@@ -150,6 +150,97 @@ def test_backfill_registers_repeatable_backfill_job() -> None:
     assert assets[0].metadata["mode"] == "replace-partitions"
 
 
+def test_contract_registers_governance_contract() -> None:
+    """Contract should declare ownership and lifecycle metadata once."""
+    import phlo
+
+    phlo.clear_contract_specs()
+
+    @phlo.contract(
+        table="gold.customer_health",
+        owner="data-platform",
+        consumers=["cs", Consumer(name="sales", contact="sales@example.com")],
+        pii=True,
+        freshness_hours=6,
+        lifecycle="production",
+    )
+    def customer_health_contract() -> None:
+        return None
+
+    contracts = phlo.get_contract_specs()
+
+    assert customer_health_contract() is None
+    assert len(contracts) == 1
+    assert contracts[0].key == "contract_gold_customer_health"
+    assert contracts[0].table == "gold.customer_health"
+    assert contracts[0].owner == "data-platform"
+    assert contracts[0].pii is True
+    assert contracts[0].lifecycle == "production"
+    assert contracts[0].consumers == [
+        {"name": "cs", "contact": None, "usage": None},
+        {"name": "sales", "contact": "sales@example.com", "usage": None},
+    ]
+    assert contracts[0].sla == {
+        "freshness_hours": 6,
+        "quality_threshold": 1.0,
+        "max_failures": None,
+        "notify": None,
+    }
+
+
+def test_access_registers_access_policy() -> None:
+    """Access should declare intended access policy for a table."""
+    import phlo
+
+    phlo.clear_access_policies()
+
+    @phlo.access(
+        table="gold.customer_health",
+        roles=["cs_read", "sales_read"],
+        pii_columns=["email"],
+        policy="read",
+    )
+    def customer_health_access() -> None:
+        return None
+
+    policies = phlo.get_access_policies()
+
+    assert customer_health_access() is None
+    assert len(policies) == 1
+    assert policies[0].key == "access_gold_customer_health"
+    assert policies[0].table == "gold.customer_health"
+    assert policies[0].roles == ["cs_read", "sales_read"]
+    assert policies[0].pii_columns == ["email"]
+    assert policies[0].policy == "read"
+
+
+def test_schedule_registers_static_targets_and_dynamic_parameters() -> None:
+    """Schedule targets should be static while the function returns run parameters."""
+    import phlo
+
+    phlo.clear_schedules()
+
+    @phlo.schedule(
+        name="daily_customer_health",
+        cron="0 6 * * *",
+        targets=["transform_silver_orders", "publish_gold_customer_health"],
+        timezone="Europe/London",
+    )
+    def daily_customer_health() -> dict[str, str]:
+        return {"partition_date": "2026-05-18"}
+
+    schedules = phlo.get_schedules()
+
+    assert daily_customer_health() == {"partition_date": "2026-05-18"}
+    assert len(schedules) == 1
+    assert schedules[0].key == "schedule_daily_customer_health"
+    assert schedules[0].name == "daily_customer_health"
+    assert schedules[0].cron == "0 6 * * *"
+    assert schedules[0].targets == ["transform_silver_orders", "publish_gold_customer_health"]
+    assert schedules[0].timezone == "Europe/London"
+    assert schedules[0].fn() == {"partition_date": "2026-05-18"}
+
+
 def test_top_level_exports_lazy_load_new_authoring_surfaces() -> None:
     """Top-level phlo exports should expose the new decorators lazily."""
     import phlo
@@ -165,4 +256,7 @@ def test_top_level_exports_lazy_load_new_authoring_surfaces() -> None:
     assert callable(phlo.publish)
     assert callable(phlo.observe)
     assert callable(phlo.backfill)
+    assert callable(phlo.contract)
+    assert callable(phlo.access)
+    assert callable(phlo.schedule)
     assert callable(phlo.transform.sql)

--- a/tests/plugins/test_flow_authoring_decorators.py
+++ b/tests/plugins/test_flow_authoring_decorators.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 from phlo.contracts import SLA, Consumer
+from phlo.helpers.testing import FakeRuntimeContext
 
 pytestmark = pytest.mark.core_regression
 
@@ -55,6 +56,29 @@ def test_transform_sql_registers_provider_neutral_asset() -> None:
         "max_failures": None,
         "notify": None,
     }
+
+
+def test_transform_sql_defers_context_aware_sql_rendering() -> None:
+    """Context-aware SQL transforms should not execute during decoration."""
+    import phlo
+
+    transform = importlib.import_module("phlo.transform")
+    transform.clear_transform_assets()
+
+    @phlo.transform.sql(table="silver.orders_daily")
+    def orders_sql(context: FakeRuntimeContext) -> str:
+        return f"select * from bronze.orders where ds = '{context.partition_key}'"
+
+    assets = transform.get_transform_assets()
+
+    assert orders_sql(FakeRuntimeContext(partition_key="2026-05-18")) == (
+        "select * from bronze.orders where ds = '2026-05-18'"
+    )
+    assert len(assets) == 1
+    assert assets[0].metadata["sql"] is None
+    assert assets[0].run is not None
+    results = list(assets[0].run.fn(FakeRuntimeContext(partition_key="2026-05-18")))
+    assert results[0].metadata["result"] == "select * from bronze.orders where ds = '2026-05-18'"
 
 
 def test_publish_registers_data_product_surface() -> None:

--- a/tests/plugins/test_flow_authoring_decorators.py
+++ b/tests/plugins/test_flow_authoring_decorators.py
@@ -81,6 +81,43 @@ def test_transform_sql_defers_context_aware_sql_rendering() -> None:
     assert results[0].metadata["result"] == "select * from bronze.orders where ds = '2026-05-18'"
 
 
+def test_transform_sql_does_not_call_required_keyword_only_functions() -> None:
+    """Required keyword-only SQL parameters should not be treated as static SQL."""
+    import phlo
+
+    transform = importlib.import_module("phlo.transform")
+    transform.clear_transform_assets()
+
+    @phlo.transform.sql(table="silver.orders_daily")
+    def orders_sql(*, ds: str) -> str:
+        return f"select * from bronze.orders where ds = '{ds}'"
+
+    assets = transform.get_transform_assets()
+
+    assert orders_sql(ds="2026-05-18") == "select * from bronze.orders where ds = '2026-05-18'"
+    assert len(assets) == 1
+    assert assets[0].metadata["sql"] is None
+
+
+def test_flow_run_rejects_unsupported_callable_signatures() -> None:
+    """Runtime execution should fail clearly for ambiguous decorator callables."""
+    from phlo._flow_authoring import build_run
+
+    def needs_two_parameters(context: FakeRuntimeContext, extra: str) -> str:
+        return f"{context.partition_key}:{extra}"
+
+    def needs_keyword_only_parameter(*, ds: str) -> str:
+        return ds
+
+    for fn in [needs_two_parameters, needs_keyword_only_parameter]:
+        run = build_run(fn)
+
+        with pytest.raises(
+            TypeError, match="must accept either no parameters or one context parameter"
+        ):
+            list(run.fn(FakeRuntimeContext(partition_key="2026-05-18")))
+
+
 def test_publish_registers_data_product_surface() -> None:
     """Publish should mark curated tables as data-product surfaces."""
     import phlo

--- a/tests/plugins/test_flow_authoring_decorators.py
+++ b/tests/plugins/test_flow_authoring_decorators.py
@@ -1,0 +1,168 @@
+"""Tests for terse flow authoring decorators."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+from phlo.contracts import SLA, Consumer
+
+pytestmark = pytest.mark.core_regression
+
+
+def test_transform_sql_registers_provider_neutral_asset() -> None:
+    """SQL transforms should register asset specs with the returned SQL text."""
+    import phlo
+
+    transform = importlib.import_module("phlo.transform")
+    transform.clear_transform_assets()
+
+    @phlo.transform.sql(
+        table="silver.orders",
+        depends_on=["bronze.orders"],
+        materialized="incremental",
+        owner="data-platform",
+        consumers=[Consumer(name="analytics")],
+        sla=SLA(freshness_hours=4),
+    )
+    def orders_sql() -> str:
+        return "select * from bronze.orders"
+
+    assets = transform.get_transform_assets()
+
+    assert orders_sql() == "select * from bronze.orders"
+    assert len(assets) == 1
+    assert assets[0].key == "transform_silver_orders"
+    assert assets[0].deps == ["bronze.orders"]
+    assert assets[0].kinds == {"sql", "transform"}
+    assert assets[0].tags == {
+        "asset_type": "transform",
+        "provider": "core",
+        "transform_type": "sql",
+        "materialized": "incremental",
+    }
+    assert assets[0].metadata["table"] == "silver.orders"
+    assert assets[0].metadata["sql"] == "select * from bronze.orders"
+    assert assets[0].metadata["owner"] == "data-platform"
+    assert assets[0].metadata["consumers"] == [
+        {"name": "analytics", "contact": None, "usage": None}
+    ]
+    assert assets[0].metadata["sla"] == {
+        "freshness_hours": 4,
+        "quality_threshold": 1.0,
+        "max_failures": None,
+        "notify": None,
+    }
+
+
+def test_publish_registers_data_product_surface() -> None:
+    """Publish should mark curated tables as data-product surfaces."""
+    import phlo
+
+    phlo.clear_publish_assets()
+
+    @phlo.publish(
+        table="gold.customer_health",
+        audience=["cs", "sales"],
+        owner="revops",
+        freshness_hours=6,
+        depends_on=["silver.customers"],
+    )
+    def customer_health() -> str:
+        return "gold.customer_health"
+
+    assets = phlo.get_publish_assets()
+
+    assert customer_health() == "gold.customer_health"
+    assert len(assets) == 1
+    assert assets[0].key == "publish_gold_customer_health"
+    assert assets[0].deps == ["silver.customers"]
+    assert assets[0].kinds == {"publish", "data_product"}
+    assert assets[0].tags["asset_type"] == "publish"
+    assert assets[0].metadata["table"] == "gold.customer_health"
+    assert assets[0].metadata["audience"] == ["cs", "sales"]
+    assert assets[0].metadata["freshness_hours"] == 6
+    assert assets[0].metadata["owner"] == "revops"
+
+
+def test_observe_registers_operational_check_surface() -> None:
+    """Observe should register operational health checks separately from quality rules."""
+    import phlo
+
+    phlo.clear_observe_assets()
+
+    @phlo.observe(
+        table="bronze.events",
+        freshness_hours=2,
+        row_count_change={"warn": 0.3, "fail": 0.6},
+        depends_on=["bronze.events"],
+    )
+    def events_observability() -> None:
+        return None
+
+    assets = phlo.get_observe_assets()
+
+    assert events_observability() is None
+    assert len(assets) == 1
+    assert assets[0].key == "observe_bronze_events"
+    assert assets[0].deps == ["bronze.events"]
+    assert assets[0].kinds == {"observe", "operational_check"}
+    assert assets[0].tags["asset_type"] == "observe"
+    assert assets[0].metadata["table"] == "bronze.events"
+    assert assets[0].metadata["freshness_hours"] == 2
+    assert assets[0].metadata["row_count_change"] == {"warn": 0.3, "fail": 0.6}
+    assert [check.name for check in assets[0].checks] == [
+        "freshness_hours",
+        "row_count_change",
+    ]
+
+
+def test_backfill_registers_repeatable_backfill_job() -> None:
+    """Backfill should capture partition window and write policy metadata."""
+    import phlo
+
+    phlo.clear_backfill_assets()
+
+    @phlo.backfill(
+        target="silver.orders",
+        partitions={"start": "2026-01-01", "end": "2026-03-31"},
+        mode="replace-partitions",
+        depends_on=["bronze.orders"],
+    )
+    def orders_q1_backfill() -> str:
+        return "orders_sql"
+
+    assets = phlo.get_backfill_assets()
+
+    assert orders_q1_backfill() == "orders_sql"
+    assert len(assets) == 1
+    assert assets[0].key == "backfill_silver_orders"
+    assert assets[0].deps == ["bronze.orders"]
+    assert assets[0].kinds == {"backfill"}
+    assert assets[0].tags["asset_type"] == "backfill"
+    assert assets[0].metadata["target"] == "silver.orders"
+    assert assets[0].metadata["partitions"] == {
+        "start": "2026-01-01",
+        "end": "2026-03-31",
+    }
+    assert assets[0].metadata["mode"] == "replace-partitions"
+
+
+def test_top_level_exports_lazy_load_new_authoring_surfaces() -> None:
+    """Top-level phlo exports should expose the new decorators lazily."""
+    import phlo
+
+    for name in [
+        "phlo.transform",
+        "phlo.publish",
+        "phlo.observe",
+        "phlo.backfill",
+    ]:
+        sys.modules.pop(name, None)
+
+    assert callable(phlo.publish)
+    assert callable(phlo.observe)
+    assert callable(phlo.backfill)
+    assert callable(phlo.transform.sql)


### PR DESCRIPTION
## Summary
- add provider-neutral flow authoring decorators for transform SQL, publish surfaces, operational observability, repeatable backfills, governance contracts, access policies, and schedules
- expose the new decorators through lazy top-level phlo exports
- document the schedule model as static targets plus optional dynamic run parameters

## Tests
- uv run pytest tests/plugins -v
- uv run ruff check src/phlo/flow.py src/phlo/__init__.py tests/plugins/test_flow_authoring_decorators.py
- uv run ruff format --check src/phlo/flow.py src/phlo/__init__.py tests/plugins/test_flow_authoring_decorators.py