### PR TITLE
docs: update phlo documentation for 0.10.0

### DIFF
--- a/docs/blog/data-engineering-fundamentals/01-what-is-data-engineering.md
+++ b/docs/blog/data-engineering-fundamentals/01-what-is-data-engineering.md
@@ -48,12 +48,12 @@ graph LR
 
 | Layer | Goal | Phlo Building Blocks |
 | --- | --- | --- |
-| Ingestion | Pull source data reliably | `phlo_ingestion`, DLT, staging + merge |
+| Ingestion | Pull source data reliably | `phlo.ingest.dlt`, DLT, staging + merge |
 | Storage | Transactional open tables | Apache Iceberg + MinIO |
 | Versioning | Isolated change flow | Nessie branches/tags |
 | Orchestration | Deterministic execution | Dagster assets via `phlo materialize` |
 | Transformation | Business logic in SQL | dbt project in `workflows/transforms/dbt` |
-| Quality + Ops | Confidence and response | Pandera, `phlo_quality`, logs, metrics, lineage |
+| Quality + Ops | Confidence and response | Pandera, `phlo.quality.pandera`, logs, metrics, lineage |
 
 ## First Contact with the CLI
 
@@ -78,7 +78,7 @@ phlo --version
 You should see something like this:
 
 ```text
-phlo, version 0.7.x
+phlo, version 0.10.0
 ```
 
 ```bash
@@ -124,9 +124,9 @@ Phlo helps by making those decisions explicit in code and commands.
 
 For example, this is not just syntax:
 
-- `unique_key` in `phlo_ingestion` is a deduplication decision.
+- `unique_key` in `phlo.ingest.dlt` is a deduplication decision.
 - `merge_strategy` is a correctness-vs-throughput decision.
-- `blocking` checks in `phlo_quality` are a risk decision.
+- `blocking` checks in `phlo.quality.pandera` are a risk decision.
 - `phlo backfill --parallel N` is a source-pressure decision.
 
 When you treat those as product decisions, your data system becomes much easier to operate.

--- a/docs/blog/data-engineering-fundamentals/03-ingestion-foundations-with-dlt.md
+++ b/docs/blog/data-engineering-fundamentals/03-ingestion-foundations-with-dlt.md
@@ -4,7 +4,7 @@
 
 ## What You'll Learn
 
-- How `phlo_ingestion` turns a source function into a managed asset
+- How `phlo.ingest.dlt` turns a source function into a managed asset
 - Why two-step ingestion (stage then merge) improves reliability
 - How to choose `merge` vs `append`
 - How partition keys affect replay and idempotency
@@ -44,11 +44,11 @@ Put that in `workflows/schemas/orders.py`, then import it into your ingestion mo
 A simplified workflow example:
 
 ```python
+import phlo
 from dlt.sources.rest_api import rest_api
-from phlo_dlt import phlo_ingestion
 from workflows.schemas.orders import RawOrders
 
-@phlo_ingestion(
+@phlo.ingest.dlt(
     table_name="orders",
     unique_key="id",
     group="commerce",
@@ -95,7 +95,8 @@ Use `merge` when source rows can be resent or corrected.
 Use `append` when source rows are immutable events and duplicates are acceptable only if replayed intentionally.
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     table_name="raw_clickstream",
     unique_key="event_id",
     group="events",
@@ -193,11 +194,11 @@ A practical ingestion function should include:
 Illustrative pattern:
 
 ```python
+import phlo
 from dlt.sources.rest_api import rest_api
-from phlo_dlt import phlo_ingestion
 from workflows.schemas.orders import RawOrders
 
-@phlo_ingestion(
+@phlo.ingest.dlt(
     table_name="orders",
     unique_key="id",
     group="commerce",
@@ -515,7 +516,7 @@ Debug patterns: [Troubleshooting](../../operations/troubleshooting.md)
 
 ## Summary
 
-`phlo_ingestion` is not just syntactic sugar. It encodes a repeatable ingestion contract with partitioning, schema, and merge behaviour built in.
+`phlo.ingest.dlt` is not just syntactic sugar. It encodes a repeatable ingestion contract with partitioning, schema, and merge behaviour built in.
 
 ## Next Steps
 

--- a/docs/blog/data-engineering-fundamentals/07-quality-checks-with-pandera-and-phlo-pandera.md
+++ b/docs/blog/data-engineering-fundamentals/07-quality-checks-with-pandera-and-phlo-pandera.md
@@ -5,7 +5,7 @@
 ## What You'll Learn
 
 - How Pandera schemas define enforceable contracts
-- How `phlo_quality` generates asset checks
+- How `phlo.quality.pandera` generates asset checks
 - When to block downstream runs vs warn
 - How to validate schemas and workflow files from CLI
 
@@ -38,9 +38,10 @@ class RawOrders(PhloSchema):
 ## Add Declarative Quality Checks
 
 ```python
-from phlo.quality import phlo_quality, NullCheck, RangeCheck, FreshnessCheck, CustomSQLCheck
+import phlo
+from phlo.quality import NullCheck, RangeCheck, FreshnessCheck, CustomSQLCheck
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.fct_orders",
     checks=[
         NullCheck(columns=["order_id", "customer_id", "total_amount"]),
@@ -85,9 +86,10 @@ Use this policy in early production:
 Not every check needs zero tolerance. Use `allow_threshold` for soft quality gates:
 
 ```python
-from phlo.quality import phlo_quality, NullCheck, RangeCheck, UniqueCheck, FreshnessCheck
+import phlo
+from phlo.quality import NullCheck, RangeCheck, UniqueCheck, FreshnessCheck
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="bronze.customer_data",
     checks=[
         NullCheck(columns=["phone", "address"], allow_threshold=0.05),

--- a/docs/blog/data-engineering-fundamentals/README.md
+++ b/docs/blog/data-engineering-fundamentals/README.md
@@ -16,9 +16,9 @@ transformation, quality, observability, and extension design.
 By the end, you will be able to:
 
 - Design a clean ingestion-to-serving data flow
-- Use `phlo_dlt.decorator.phlo_ingestion` for repeatable loads
+- Use `phlo.ingest.dlt` for repeatable loads
 - Run SQL transformations with dbt in `workflows/transforms/dbt`
-- Validate quality with Pandera and `phlo.quality.phlo_quality`
+- Validate quality with Pandera and `phlo.quality.pandera`
 - Track pipeline health with status, logs, metrics, and lineage
 - Debug incidents using a repeatable response checklist
 - Extend the platform with plugins and Observatory extensions
@@ -48,7 +48,7 @@ Then run the blog commands from your working project directory (for example `/pa
 | --- | --- | --- | --- |
 | 1 | [What Data Engineering Really Is](01-what-is-data-engineering.md) | Core concepts, layers, responsibilities | 18 min |
 | 2 | [Build Your First Phlo Project](02-build-your-first-phlo-project.md) | Project setup, services, first run | 22 min |
-| 3 | [Ingestion Foundations with DLT](03-ingestion-foundations-with-dlt.md) | `phlo_ingestion`, merge strategies, partitions | 24 min |
+| 3 | [Ingestion Foundations with DLT](03-ingestion-foundations-with-dlt.md) | `phlo.ingest.dlt`, merge strategies, partitions | 24 min |
 | 4 | [Iceberg and Nessie for Reliable Tables](04-iceberg-and-nessie-for-reliable-tables.md) | Table format, branching, catalog tooling | 22 min |
 | 5 | [Orchestration with Dagster Assets](05-orchestration-with-dagster-assets.md) | Materialization, backfills, scheduling mindset | 24 min |
 | 6 | [Transformations with dbt](06-transformations-with-dbt.md) | Medallion models, tests, publish configs | 24 min |

--- a/docs/errors/PHLO-001.md
+++ b/docs/errors/PHLO-001.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-This error occurs when Dagster cannot discover your asset definitions. Phlo uses Python decorators like `@phlo_ingestion` to define assets, and Dagster needs to be able to find and load these definitions.
+This error occurs when Dagster cannot discover your asset definitions. Phlo uses Python decorators like `phlo.ingest.dlt(...)` to define assets, and Dagster needs to be able to find and load these definitions.
 
 ## Common Causes
 
@@ -15,7 +15,7 @@ This error occurs when Dagster cannot discover your asset definitions. Phlo uses
    - `PHLO_WORKFLOWS_PATH` points to the wrong location
 
 2. **Incorrect decorator usage**
-   - Missing `@phlo_ingestion` or `@phlo_quality` decorator
+   - Missing `phlo.ingest.dlt(...)` or `phlo.quality.pandera(...)` decorator
    - Decorator applied to a non-function object
 
 3. **Import errors in asset module**
@@ -71,7 +71,7 @@ Ensure you're using the decorator correctly:
 import phlo
 from workflows.schemas.weather import WeatherObservations
 
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )
@@ -98,14 +98,15 @@ workflows/ingestion/weather/observations.py
 
 ```python
 def weather_observations(partition: str):
-    # Missing @phlo_ingestion decorator
+    # Missing phlo.ingest.dlt(...) decorator
     return fetch_weather_data(partition)
 ```
 
 ### ✅ Correct: Decorator applied
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )

--- a/docs/errors/PHLO-002.md
+++ b/docs/errors/PHLO-002.md
@@ -34,6 +34,7 @@ Check that your `unique_key` matches a field in your schema:
 
 ```python
 # schemas/weather.py
+import phlo
 from pandera import DataFrameModel, Field
 
 class WeatherObservations(DataFrameModel):
@@ -43,7 +44,7 @@ class WeatherObservations(DataFrameModel):
     timestamp: datetime
 
 # ingestion/weather.py
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",  # ✅ Matches schema field
     validation_schema=WeatherObservations,
 )
@@ -94,7 +95,8 @@ unique_key="observation_id"
 ### ❌ Incorrect: Typo in unique_key
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_idd",  # ❌ Typo: extra 'd'
     validation_schema=WeatherObservations,
 )
@@ -105,7 +107,8 @@ def weather_observations(partition: str):
 ### ✅ Correct: Exact match
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",  # ✅ Matches schema field exactly
     validation_schema=WeatherObservations,
 )
@@ -116,12 +119,13 @@ def weather_observations(partition: str):
 ### ❌ Incorrect: Field not in schema
 
 ```python
+import phlo
 class WeatherObservations(DataFrameModel):
     station_id: str
     temperature: float
     # ❌ No observation_id field
 
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",  # ❌ Field doesn't exist
     validation_schema=WeatherObservations,
 )
@@ -132,12 +136,13 @@ def weather_observations(partition: str):
 ### ✅ Correct: All fields defined
 
 ```python
+import phlo
 class WeatherObservations(DataFrameModel):
     observation_id: str = Field(nullable=False)  # ✅ Unique key field defined
     station_id: str
     temperature: float
 
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",  # ✅ Field exists in schema
     validation_schema=WeatherObservations,
 )
@@ -209,7 +214,7 @@ def weather_observations(partition: str):
    # ingestion/weather.py
    from workflows.schemas.weather import WeatherObservations, UNIQUE_KEY
 
-   @phlo_ingestion(
+   @phlo.ingest.dlt(
        unique_key=UNIQUE_KEY,  # ✅ Use constant to avoid typos
        validation_schema=WeatherObservations,
    )

--- a/docs/errors/PHLO-003.md
+++ b/docs/errors/PHLO-003.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-This error occurs when the `cron` schedule expression provided to the `@phlo_ingestion` decorator is invalid or malformed. Phlo validates cron expressions to ensure assets are scheduled correctly.
+This error occurs when the `cron` schedule expression provided to the `phlo.ingest.dlt(...)` decorator is invalid or malformed. Phlo validates cron expressions to ensure assets are scheduled correctly.
 
 ## Common Causes
 
@@ -46,7 +46,8 @@ This error occurs when the `cron` schedule expression provided to the `@phlo_ing
 Ensure your cron expression has 5 fields with valid values:
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
     cron="0 */1 * * *",  # ✅ Valid: Every hour at minute 0
@@ -105,7 +106,7 @@ cron=0 */1 * * *  # SyntaxError!
 ### ❌ Incorrect: Wrong number of fields
 
 ```python
-@phlo_ingestion(
+@phlo.ingest.dlt(
     cron="0 */1 * *",  # ❌ Only 4 fields (need 5)
     ...
 )
@@ -114,7 +115,7 @@ cron=0 */1 * * *  # SyntaxError!
 ### ✅ Correct: 5 fields
 
 ```python
-@phlo_ingestion(
+@phlo.ingest.dlt(
     cron="0 */1 * * *",  # ✅ All 5 fields present
     ...
 )
@@ -123,7 +124,7 @@ cron=0 */1 * * *  # SyntaxError!
 ### ❌ Incorrect: Invalid hour value
 
 ```python
-@phlo_ingestion(
+@phlo.ingest.dlt(
     cron="0 25 * * *",  # ❌ Hour 25 is invalid (max is 23)
     ...
 )
@@ -132,7 +133,7 @@ cron=0 */1 * * *  # SyntaxError!
 ### ✅ Correct: Valid hour value
 
 ```python
-@phlo_ingestion(
+@phlo.ingest.dlt(
     cron="0 23 * * *",  # ✅ Hour 23 is valid (11 PM)
     ...
 )
@@ -141,7 +142,7 @@ cron=0 */1 * * *  # SyntaxError!
 ### ❌ Incorrect: Invalid step value
 
 ```python
-@phlo_ingestion(
+@phlo.ingest.dlt(
     cron="*/0 * * * *",  # ❌ Step value 0 is invalid
     ...
 )
@@ -150,7 +151,7 @@ cron=0 */1 * * *  # SyntaxError!
 ### ✅ Correct: Valid step value
 
 ```python
-@phlo_ingestion(
+@phlo.ingest.dlt(
     cron="*/5 * * * *",  # ✅ Every 5 minutes
     ...
 )
@@ -258,7 +259,7 @@ cron="0 0 L * *"       # Last day of month (if supported)
    # ingestion.py
    from config import HOURLY
 
-   @phlo_ingestion(
+   @phlo.ingest.dlt(
        cron=HOURLY,  # ✅ Use constant
        ...
    )
@@ -286,7 +287,7 @@ cron="0 0 L * *"       # Last day of month (if supported)
 3. **Document schedule rationale**
 
    ```python
-   @phlo_ingestion(
+   @phlo.ingest.dlt(
        unique_key="observation_id",
        validation_schema=WeatherObservations,
        cron="0 */1 * * *",  # Run hourly to match API update frequency
@@ -312,7 +313,7 @@ cron="0 0 L * *"       # Last day of month (if supported)
        """Generate daily cron expression."""
        return f"{minute} {hour} * * *"
 
-   @phlo_ingestion(
+   @phlo.ingest.dlt(
        cron=hourly(minute=0),  # ✅ Type-safe schedule builder
        ...
    )

--- a/docs/errors/PHLO-004.md
+++ b/docs/errors/PHLO-004.md
@@ -89,7 +89,8 @@ class WeatherObservations(pa.DataFrameModel):
 Pre-process data to fix known issues:
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )
@@ -194,7 +195,7 @@ class SensorReadings(pa.DataFrameModel):
 2. **Use `allow_threshold` for gradual enforcement**
 
    ```python
-   @phlo_quality(
+   @phlo.quality.pandera(
        validation_schema=WeatherObservations,
        allow_threshold=0.95,  # Allow up to 5% failures
    )

--- a/docs/errors/PHLO-005.md
+++ b/docs/errors/PHLO-005.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-This error occurs when the `validation_schema` parameter is not provided to the `@phlo_ingestion` or `@phlo_quality` decorator. Phlo requires a Pandera schema to validate data and derive Iceberg table schemas.
+This error occurs when the `validation_schema` parameter is not provided to the `phlo.ingest.dlt(...)` or `phlo.quality.pandera(...)` decorator. Phlo requires a Pandera schema to validate data and derive Iceberg table schemas.
 
 ## Common Causes
 
@@ -31,18 +31,18 @@ This error occurs when the `validation_schema` parameter is not provided to the 
 ### Solution 1: Add the validation_schema parameter
 
 ```python
-from phlo_dlt.decorator import phlo_ingestion
+import phlo
 from workflows.schemas.weather import WeatherObservations
 
 # ❌ Missing validation_schema
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",
 )
 def weather_observations(partition: str):
     pass
 
 # ✅ Schema provided
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )
@@ -93,7 +93,8 @@ from workflows.schemas.weather import WeatherObservations
 ### ❌ Incorrect: No schema
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
 )
 def weather_observations(partition: str):
@@ -103,7 +104,8 @@ def weather_observations(partition: str):
 ### ❌ Incorrect: Typo in parameter name
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
     schema=WeatherObservations,  # ❌ Wrong parameter name
 )
@@ -114,7 +116,8 @@ def weather_observations(partition: str):
 ### ✅ Correct: Schema provided
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )
@@ -127,7 +130,7 @@ def weather_observations(partition: str):
 1. **Check decorator parameters**
 
    ```bash
-   grep -n "phlo_ingestion\|phlo_quality" workflows/ingestion/weather/observations.py
+   grep -n "phlo.ingest.dlt\|phlo.quality.pandera" workflows/ingestion/weather/observations.py
    ```
 
 2. **Verify schema import**

--- a/docs/errors/PHLO-006.md
+++ b/docs/errors/PHLO-006.md
@@ -53,6 +53,7 @@ except requests.exceptions.RequestException as e:
 Add retry logic for transient failures:
 
 ```python
+import phlo
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
@@ -73,7 +74,7 @@ def create_session_with_retries():
     return session
 
 # Use in asset
-@phlo_ingestion(...)
+@phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
 def weather_observations(partition: str):
     session = create_session_with_retries()
     response = session.get(f"https://api.weather.com/observations/{partition}")
@@ -85,6 +86,7 @@ def weather_observations(partition: str):
 Ensure API credentials are valid:
 
 ```python
+import phlo
 import os
 
 def validate_api_credentials():
@@ -116,7 +118,7 @@ def validate_api_credentials():
             ]
         )
 
-@phlo_ingestion(...)
+@phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
 def weather_observations(partition: str):
     validate_api_credentials()
     # ... fetch data
@@ -127,7 +129,8 @@ def weather_observations(partition: str):
 Wrap data fetching in try/except with detailed logging:
 
 ```python
-@phlo_ingestion(...)
+import phlo
+@phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
 def weather_observations(partition: str, context):
     try:
         context.log.info(f"Fetching data for partition: {partition}")
@@ -184,7 +187,8 @@ def weather_observations(partition: str, context):
 ### ❌ Incorrect: No error handling
 
 ```python
-@phlo_ingestion(...)
+import phlo
+@phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
 def weather_observations(partition: str):
     # ❌ No error handling - will fail silently
     response = requests.get(f"https://api.weather.com/obs/{partition}")
@@ -194,7 +198,8 @@ def weather_observations(partition: str):
 ### ✅ Correct: Comprehensive error handling
 
 ```python
-@phlo_ingestion(...)
+import phlo
+@phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
 def weather_observations(partition: str, context):
     try:
         context.log.info(f"Fetching data for {partition}")
@@ -305,6 +310,8 @@ def weather_observations(partition: str, context):
 1. **Implement health checks**
 
    ```python
+   import phlo
+
    def check_api_health():
        try:
            response = requests.get("https://api.example.com/health", timeout=5)
@@ -312,7 +319,7 @@ def weather_observations(partition: str, context):
        except:
            return False
 
-   @phlo_ingestion(...)
+   @phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
    def weather_observations(partition: str):
        if not check_api_health():
            raise PhloIngestionError(
@@ -326,8 +333,9 @@ def weather_observations(partition: str, context):
 
    ```python
    from dagster import MetadataValue
+   import phlo
 
-   @phlo_ingestion(...)
+   @phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
    def weather_observations(partition: str, context):
        start_time = time.time()
 
@@ -356,11 +364,12 @@ def weather_observations(partition: str, context):
 3. **Use circuit breaker pattern**
 
    ```python
+   import phlo
    from pybreaker import CircuitBreaker
 
    breaker = CircuitBreaker(fail_max=5, timeout_duration=60)
 
-   @phlo_ingestion(...)
+   @phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
    def weather_observations(partition: str):
        @breaker
        def fetch():

--- a/docs/errors/PHLO-300.md
+++ b/docs/errors/PHLO-300.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-This error occurs when a DLT (Data Load Tool) pipeline execution fails. Phlo uses DLT via the `@phlo_ingestion` decorator for data ingestion, and this error wraps DLT-specific failures including source errors, destination write failures, and schema evolution conflicts.
+This error occurs when a DLT (Data Load Tool) pipeline execution fails. Phlo uses DLT via the `phlo.ingest.dlt(...)` decorator for data ingestion, and this error wraps DLT-specific failures including source errors, destination write failures, and schema evolution conflicts.
 
 ## Common Causes
 
@@ -99,7 +99,8 @@ WEATHER_API_KEY=your-api-key
 ### ❌ Incorrect: No error context in ingestion
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )
@@ -111,7 +112,8 @@ def weather_observations(partition: str):
 ### ✅ Correct: Source with error handling
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )
@@ -197,7 +199,7 @@ def weather_observations(partition: str):
 2. **Use DLT retry configuration**
 
    ```python
-   @phlo_ingestion(
+   @phlo.ingest.dlt(
        unique_key="observation_id",
        validation_schema=WeatherObservations,
    )
@@ -217,7 +219,7 @@ def weather_observations(partition: str):
 
    ```python
    # Prevent unexpected schema evolution
-   @phlo_ingestion(
+   @phlo.ingest.dlt(
        unique_key="observation_id",
        validation_schema=WeatherObservations,  # Schema acts as a contract
    )

--- a/docs/errors/PHLO-301.md
+++ b/docs/errors/PHLO-301.md
@@ -6,7 +6,7 @@
 
 ## Description
 
-This error occurs when a DLT source cannot produce data. The source function — the data-fetching logic inside a `@phlo_ingestion` asset — fails before data reaches the DLT pipeline. This is distinct from [PHLO-300](./PHLO-300.md), which covers pipeline-level failures; PHLO-301 is specific to the data source itself.
+This error occurs when a DLT source cannot produce data. The source function — the data-fetching logic inside a `phlo.ingest.dlt(...)` asset — fails before data reaches the DLT pipeline. This is distinct from [PHLO-300](./PHLO-300.md), which covers pipeline-level failures; PHLO-301 is specific to the data source itself.
 
 ## Common Causes
 
@@ -69,10 +69,11 @@ if not api_key:
 ### Solution 3: Handle rate limiting
 
 ```python
+import phlo
 import time
 import requests
 
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )
@@ -97,7 +98,8 @@ def weather_observations(partition: str):
 ### Solution 4: Validate response format
 
 ```python
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,
 )
@@ -127,7 +129,8 @@ def weather_observations(partition: str):
 ### ❌ Incorrect: No source validation
 
 ```python
-@phlo_ingestion(...)
+import phlo
+@phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
 def weather_observations(partition: str):
     return requests.get(f"https://api.weather.com/{partition}").json()
 ```
@@ -135,7 +138,8 @@ def weather_observations(partition: str):
 ### ✅ Correct: Source with validation and error handling
 
 ```python
-@phlo_ingestion(...)
+import phlo
+@phlo.ingest.dlt(table_name="weather_observations", unique_key="observation_id", group="weather")
 def weather_observations(partition: str, context):
     context.log.info(f"Fetching from weather API for {partition}")
 

--- a/docs/errors/PHLO-402.md
+++ b/docs/errors/PHLO-402.md
@@ -223,7 +223,7 @@ table.append(df)  # ✅ Columns match table schema
    ```
 
 2. **Use Phlo decorators**
-   - `@phlo_ingestion` handles schema alignment and writes automatically
+   - `phlo.ingest.dlt(...)` handles schema alignment and writes automatically
    - Validation runs before writes, catching mismatches early
 
 3. **Monitor storage capacity**

--- a/docs/errors/README.md
+++ b/docs/errors/README.md
@@ -67,7 +67,7 @@ Mismatch between decorator configuration and Pandera schema.
 
 ```python
 # Verify unique_key matches schema field
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",  # Must match schema field exactly
     validation_schema=WeatherObservations,
 )
@@ -93,7 +93,7 @@ Invalid or malformed cron schedule expression.
 
 ```python
 # Use standard 5-field cron format
-@phlo_ingestion(
+@phlo.ingest.dlt(
     cron="0 */1 * * *",  # minute hour day month weekday
     ...
 )
@@ -146,7 +146,7 @@ Validation schema not provided to decorator.
 ```python
 from workflows.schemas.weather import WeatherObservations
 
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="observation_id",
     validation_schema=WeatherObservations,  # ✅ Required
 )
@@ -502,7 +502,8 @@ raise PhloSchemaError(
 Use Dagster context for logging:
 
 ```python
-@phlo_ingestion(...)
+import phlo
+@phlo.ingest.dlt(table_name="my_asset", unique_key="id", group="examples")
 def my_asset(partition: str, context):
     try:
         data = fetch_data(partition)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -15,6 +15,84 @@ Complete guide to installing and setting up Phlo on your system.
 - **8GB RAM**: Minimum for running all services
 - **20GB disk space**: For Docker volumes and data
 
+## Windows via WSL
+
+Phlo works best on Windows when you run it inside a WSL 2 Linux distribution and keep your project files on the Linux filesystem, for example under `~/projects`, instead of `/mnt/c/...`.
+
+From an elevated PowerShell terminal on Windows:
+
+```powershell
+wsl --install -d Ubuntu-24.04
+wsl --set-default-version 2
+wsl --update
+```
+
+Restart if Windows asks you to, then open Ubuntu and prepare the Linux environment:
+
+```bash
+sudo apt update
+sudo apt install -y build-essential ca-certificates curl git python3 python3-venv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+exec $SHELL
+uv python install 3.12
+```
+
+Install Docker Engine inside Ubuntu/WSL:
+
+```bash
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo service docker start
+```
+
+Allow your WSL user to run Docker without `sudo`, then restart your Ubuntu shell:
+
+```bash
+sudo usermod -aG docker $USER
+exit
+```
+
+Reopen Ubuntu and verify Docker from inside WSL:
+
+```bash
+docker version
+docker compose version
+```
+
+If your organization already standardizes on Docker Desktop, that also works: install Docker Desktop on Windows, enable the WSL 2 backend, enable integration for your Ubuntu distribution, then run the same Phlo commands from inside Ubuntu.
+
+Now create and run Phlo from inside Ubuntu:
+
+```bash
+mkdir -p ~/projects
+cd ~/projects
+uv venv
+source .venv/bin/activate
+uv pip install "phlo[defaults]"
+phlo init my-project --template csv-batch
+cd my-project
+phlo services init
+phlo services start
+phlo services status
+```
+
+Open browser UIs from Windows with the same localhost ports, for example http://localhost:10006 for Dagster.
+
+Troubleshooting tips:
+
+- If Docker commands fail inside Ubuntu, run `sudo service docker start`, then check your user is in the `docker` group with `groups`.
+- If file watching or installs feel slow, move the project from `/mnt/c/...` into the WSL filesystem.
+- If ports are busy on Windows, edit the `env:` ports in `phlo.yaml`, then rerun `phlo services init`.
+
 ## Quick Install
 
 ```bash

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -76,15 +76,14 @@ uv pip install -e .
 Open `workflows/ingestion/csv/events.py`. The important part is the Phlo ingestion decorator:
 
 ```python
+import phlo
 from pathlib import Path
 
 import pandas as pd
-
-from phlo_dlt.decorator import phlo_ingestion
 from workflows.schemas.csv import EventsSchema
 
 
-@phlo_ingestion(
+@phlo.ingest.dlt(
     table_name="events",
     unique_key="id",
     validation_schema=EventsSchema,

--- a/docs/guides/developer-guide.md
+++ b/docs/guides/developer-guide.md
@@ -213,8 +213,13 @@ Phlo works with any DLT source. Common patterns:
 
 ```python
 from dlt.sources.rest_api import rest_api
+import phlo
 
-@phlo.ingest.dlt(...)
+@phlo.ingest.dlt(
+    table_name="api_events",
+    unique_key="id",
+    group="api",
+)
 def api_data(partition_date: str):
     return rest_api(
         client={
@@ -244,6 +249,7 @@ def api_data(partition_date: str):
 
 ```python
 import dlt
+import phlo
 
 @dlt.source
 def my_source(start_date: str):
@@ -254,7 +260,11 @@ def my_source(start_date: str):
             yield record
     return events
 
-@phlo.ingest.dlt(...)
+@phlo.ingest.dlt(
+    table_name="custom_events",
+    unique_key="id",
+    group="api",
+)
 def custom_data(partition_date: str):
     return my_source(start_date=partition_date)
 ```
@@ -263,8 +273,13 @@ def custom_data(partition_date: str):
 
 ```python
 from dlt.sources.filesystem import filesystem
+import phlo
 
-@phlo.ingest.dlt(...)
+@phlo.ingest.dlt(
+    table_name="file_events",
+    unique_key="id",
+    group="files",
+)
 def file_data(partition_date: str):
     return filesystem(
         bucket_url=f"s3://bucket/data/{partition_date}",
@@ -276,9 +291,14 @@ def file_data(partition_date: str):
 
 ```python
 import dlt
+import phlo
 from sqlalchemy import create_engine
 
-@phlo.ingest.dlt(...)
+@phlo.ingest.dlt(
+    table_name="sql_events",
+    unique_key="id",
+    group="sql",
+)
 def sql_data(partition_date: str):
     @dlt.resource
     def query():
@@ -298,8 +318,8 @@ def sql_data(partition_date: str):
 @phlo.ingest.dlt(
     table_name="logs",
     unique_key="id",
+    group="observability",
     merge_strategy="append",  # Insert-only
-    ...
 )
 def logs(partition_date: str):
     # Good for: immutable event streams, logs
@@ -312,9 +332,9 @@ def logs(partition_date: str):
 @phlo.ingest.dlt(
     table_name="users",
     unique_key="user_id",
+    group="identity",
     merge_strategy="merge",
     merge_config={"deduplication_method": "last"},  # Keep most recent
-    ...
 )
 def users(partition_date: str):
     # Good for: dimension tables, user profiles
@@ -349,7 +369,14 @@ merge_config={"deduplication_method": "hash"}
 Phlo uses daily partitioning by default:
 
 ```python
-@phlo.ingest.dlt(...)
+import phlo
+from dlt.sources.rest_api import rest_api
+
+@phlo.ingest.dlt(
+    table_name="events",
+    unique_key="id",
+    group="api",
+)
 def my_data(partition_date: str):
     # partition_date is automatically provided by Dagster
     # Format: "YYYY-MM-DD"
@@ -537,7 +564,7 @@ FactEvents = dbt_model_to_pandera(_dbt_model_path, "fct_events")
 - 50% less code to maintain
 - No schema drift between dbt and Pandera
 - dbt data_tests automatically become Pandera Field constraints
-- Works seamlessly with `@phlo_quality` decorator
+- Works seamlessly with `phlo.quality.pandera(...)` decorator
 
 #### Step 1: Define Schema in dbt YAML
 
@@ -626,16 +653,17 @@ FactEvents = dbt_model_to_pandera(
 
 The generated schema automatically inherits from `PhloSchema` and includes all constraints from dbt tests.
 
-#### Step 3: Use with @phlo_quality
+#### Step 3: Use with phlo.quality.pandera(...)
 
 The generated schema works seamlessly with quality checks:
 
 ```python
 # workflows/quality/events.py
-from phlo.quality import phlo_quality, SchemaCheck
+import phlo
+from phlo.quality import SchemaCheck
 from workflows.schemas.events import FactEvents
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         SchemaCheck(schema=FactEvents)  # Uses auto-generated schema
@@ -750,7 +778,7 @@ class FactDailyEventMetrics(PhloSchema):
 
 Pandera types automatically convert to Iceberg types:
 
-```python
+```text
 # Pandera → Iceberg mapping:
 str → StringType()
 int → LongType()
@@ -1072,7 +1100,8 @@ ChecksumReconciliationCheck(
 **Multiple tables**:
 
 ```python
-@phlo_quality(
+import phlo
+@phlo.quality.pandera(
     table="bronze.events",
     checks=[
         CustomSQLCheck(
@@ -1094,6 +1123,7 @@ def referential_integrity():
 **Conditional checks**:
 
 ```python
+import phlo
 import pandas as pd
 from datetime import datetime
 from phlo_pandera.checks import QualityCheck, QualityCheckResult
@@ -1116,7 +1146,7 @@ class ConditionalCheck(QualityCheck):
             message=f"Validated {len(df)} rows"
         )
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="bronze.events",
     checks=[ConditionalCheck()]
 )
@@ -1371,6 +1401,7 @@ Create custom Dagster resources:
 ```python
 # workflows/resources/custom.py
 from dagster import ConfigurableResource
+import phlo
 
 class MyAPIResource(ConfigurableResource):
     api_key: str
@@ -1381,7 +1412,11 @@ class MyAPIResource(ConfigurableResource):
         pass
 
 # Usage in asset:
-@phlo.ingest.dlt(...)
+@phlo.ingest.dlt(
+    table_name="resource_events",
+    unique_key="id",
+    group="api",
+)
 def my_data(context, my_api: MyAPIResource):
     data = my_api.fetch_data("/events")
     return data
@@ -1410,7 +1445,16 @@ def file_sensor(context):
 ### Conditional Execution
 
 ```python
-@phlo.ingest.dlt(...)
+from datetime import datetime
+
+import phlo
+from dlt.sources.rest_api import rest_api
+
+@phlo.ingest.dlt(
+    table_name="conditional_events",
+    unique_key="id",
+    group="api",
+)
 def conditional_data(context):
     # Skip on weekends
     if datetime.now().weekday() >= 5:
@@ -1443,7 +1487,12 @@ def my_data(partition_date: str):
 Let Phlo handle retries, but add custom handling where needed:
 
 ```python
+import phlo
+
 @phlo.ingest.dlt(
+    table_name="robust_events",
+    unique_key="id",
+    group="api",
     max_retries=3,
     retry_delay_seconds=30,
     max_runtime_seconds=3600

--- a/docs/guides/developer-workflow.md
+++ b/docs/guides/developer-workflow.md
@@ -32,8 +32,8 @@ phlo services start
 
 ### 3. Build workflows
 
-- define ingestion with package-backed decorators such as `phlo_dlt.phlo_ingestion` or `phlo_sling.phlo_sling_replication`
-- define validation with `phlo_pandera.phlo_pandera` or the lazy `phlo.quality` public API when `phlo-pandera` is installed
+- define ingestion with package-backed decorators such as `phlo.ingest.dlt` or `phlo_sling.phlo_sling_replication`
+- define validation with `phlo.quality.pandera` or the lazy `phlo.quality` public API when `phlo-pandera` is installed
 - define transforms with dbt
 - keep schemas under `workflows/schemas/`
 

--- a/docs/guides/operations-contracts.md
+++ b/docs/guides/operations-contracts.md
@@ -185,7 +185,7 @@ class CsvIngester(BaseIngester):
 ### phlo-dlt
 
 The `phlo-dlt` package provides a DLT-based ingester that wraps DLT pipelines behind
-`BaseIngester`. The `@phlo_ingestion` decorator constructs a `BaseIngester` subclass
+`BaseIngester`. The `phlo.ingest.dlt(...)` decorator constructs a `BaseIngester` subclass
 and wires it to the orchestrator via capability specs.
 
 ### phlo-dbt

--- a/docs/operations/release-management.md
+++ b/docs/operations/release-management.md
@@ -17,8 +17,8 @@ Phlo has two ReleaseX channels:
 
 | Branch | Channel | Version shape | Purpose |
 |---|---|---:|---|
-| `main` | stable | `0.8.3` | Normal public releases |
-| `beta` | beta | `0.8.3b1` | Prerelease validation, workshops, and release candidates |
+| `main` | stable | `0.10.0` | Normal public releases |
+| `beta` | beta | `0.10.0b1` | Prerelease validation, workshops, and release candidates |
 
 Beta releases sync selected workspace package versions into the root `defaults` and
 `core-services` extras. This matters because `phlo[defaults]` must resolve the
@@ -85,7 +85,7 @@ git push origin beta
 
 2. Let the `Release` workflow run on the push to `beta`.
 3. Review the beta release PR against `beta`.
-4. Confirm the version set uses beta versions, for example `phlo 0.8.3b1`.
+4. Confirm the version set uses beta versions, for example `phlo 0.10.0b1`.
 5. Confirm the root extras point at selected beta package versions.
 6. Merge the beta release PR.
 7. Confirm the beta tag is created and the publish job uploads or skips expected artifacts.
@@ -97,10 +97,10 @@ Prefer exact beta pins over broad prerelease resolution:
 uv venv /tmp/phlo-beta-check
 source /tmp/phlo-beta-check/bin/activate
 uv pip install --prerelease explicit \
-  "phlo[defaults]==0.8.3b1" \
-  "phlo-dagster==0.3.3b1" \
-  "phlo-dlt==0.3.3b1" \
-  "phlo-iceberg==0.3.3b1"
+  "phlo[defaults]==0.10.0b1" \
+  "phlo-dagster==0.4.0b1" \
+  "phlo-dlt==0.5.0b1" \
+  "phlo-iceberg==0.4.0b1"
 phlo --version
 ```
 
@@ -141,7 +141,7 @@ There are two recovery paths:
 For the `Release` workflow, provide the version tag, with or without `v`:
 
 ```text
-v0.8.3
+v0.10.0
 ```
 
 The publish job checks PyPI and removes artifacts that already exist before it calls `uv publish`, so rerunning after a partial publish is expected to be safe.
@@ -166,8 +166,8 @@ If ReleaseX updates the release PR but does not create the tag after merge:
 git fetch origin
 git checkout main
 git pull --ff-only
-git tag -a v0.8.3 -m "v0.8.3"
-git push origin v0.8.3
+git tag -a v0.10.0 -m "v0.10.0"
+git push origin v0.10.0
 ```
 
 4. Watch the `Release` workflow publish job.

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -12,6 +12,62 @@ For environment-specific setup of external surfaces such as Hasura, PostgREST, o
 
 Use the generated Python Reference in the pymdx site when you need symbol-level docstring and API reference for package modules.
 
+## Current Versions
+
+These versions come from the current package manifests.
+
+| Package | Version | Description |
+| ------- | ------- | ----------- |
+| `phlo` | `0.10.0` | Lakehouse platform |
+| `phlo-alerting` | `0.3.0` | Alerting destinations and hooks for Phlo |
+| `phlo-alloy` | `0.2.3` | alloy service plugin for Phlo |
+| `phlo-api` | `0.5.0` | Phlo API - Backend service exposing Phlo internals to Observatory |
+| `phlo-clickhouse` | `0.4.0` | ClickHouse service and resource plugin for Phlo |
+| `phlo-clickstack` | `0.3.1` | clickstack service plugin for Phlo |
+| `phlo-core-plugins` | `0.2.4` | Core plugin package for Phlo |
+| `phlo-dagster` | `0.4.0` | Dagster service plugin for Phlo |
+| `phlo-dbt` | `0.4.0` | dbt integration capability plugin for Phlo |
+| `phlo-delta` | `0.4.0` | Delta Lake table-store capability plugin for Phlo |
+| `phlo-dlt` | `0.5.0` | DLT ingestion engine capability plugin for Phlo |
+| `phlo-grafana` | `0.2.4` | grafana service plugin for Phlo |
+| `phlo-hasura` | `0.2.6` | hasura service plugin for Phlo |
+| `phlo-iceberg` | `0.4.0` | Iceberg table-store capability plugin for Phlo |
+| `phlo-lineage` | `0.3.3` | Lineage tracking and visualization for Phlo |
+| `phlo-loki` | `0.2.4` | loki service plugin for Phlo |
+| `phlo-mcp` | `0.2.0` | MCP server for Phlo observability and lakehouse operations |
+| `phlo-minio` | `0.3.3` | MinIO service plugin for Phlo |
+| `phlo-nessie` | `0.3.3` | Nessie service plugin for Phlo |
+| `phlo-oauth2-proxy` | `0.2.0` | oauth2-proxy service plugin for Phlo |
+| `phlo-observatory` | `0.5.0` | Phlo Observatory - Data platform UI (bundled with phlo core) |
+| `phlo-observatory-example` | `0.2.3` | Example Observatory extension plugin |
+| `phlo-openmetadata` | `0.4.0` | OpenMetadata integration for Phlo |
+| `phlo-otel` | `0.2.3` | OpenTelemetry traces and metrics for Phlo |
+| `phlo-pandera` | `0.5.0` | Quality checks and schema utilities for Phlo |
+| `phlo-pgweb` | `0.2.3` | pgweb service plugin for Phlo |
+| `phlo-postgres` | `0.3.1` | Postgres service plugin for Phlo |
+| `phlo-postgrest` | `0.2.5` | postgrest service plugin for Phlo |
+| `phlo-prometheus` | `0.2.4` | prometheus service plugin for Phlo |
+| `phlo-rustfs` | `0.3.0` | RustFS service plugin for Phlo |
+| `phlo-sling` | `0.5.0` | Sling replication ingestion provider for Phlo |
+| `phlo-superset` | `0.2.5` | superset service plugin for Phlo |
+| `phlo-testing` | `0.3.0` | Testing utilities for Phlo |
+| `phlo-traefik` | `0.2.3` | Traefik service plugin for Phlo |
+| `phlo-trino` | `0.3.2` | Trino service plugin for Phlo |
+
+## Historical Releases
+
+Use the current version table for new installations. For older deployments, read
+the docs from the matching git tag so examples, package versions, and migration
+notes match the installed code.
+
+| Release | Notes |
+| ------- | ----- |
+| `v0.10.0` | Current stable release. Adds provider-neutral decorators and flow authoring decorators. |
+| `v0.9.0` | Previous stable release before the May 2026 decorator APIs. |
+| `v0.8.3` | Stable release after the 0.8.1 beta series and 0.8.2 publish recovery. |
+| `v0.8.2` | Stable release that required manual tag recovery during publishing. |
+| `v0.8.0` and earlier | Historical releases. Prefer upgrading before following current docs. |
+
 ## Complete Package Index
 
 ### Core Framework (1 package)
@@ -259,17 +315,20 @@ uv pip install "phlo[defaults]" \
 
 ## Package Versioning
 
-All packages share synchronized versioning with the core phlo package. Always keep packages at the same version to ensure compatibility.
+Phlo packages are versioned independently. Install compatible packages from the
+same current release set instead of forcing every package to the same version.
+The table at the top of this page is the authoritative set for the current
+release.
 
 ```bash
 # Check installed versions
 pip list | grep phlo
 
-# Example output:
-# phlo              0.7.8
-# phlo-dagster      0.7.8
-# phlo-dbt          0.7.8
-# phlo-dlt          0.7.8
+# Example output for the current release set:
+# phlo              0.10.0
+# phlo-dagster      0.4.0
+# phlo-dbt          0.4.0
+# phlo-dlt          0.5.0
 ```
 
 ---

--- a/docs/packages/phlo-core-plugins.md
+++ b/docs/packages/phlo-core-plugins.md
@@ -34,9 +34,10 @@ pip install phlo-core-plugins
 ### Quality Check Usage
 
 ```python
-from phlo.quality import NullCheck, RangeCheck, UniqueCheck, phlo_quality
+import phlo
+from phlo.quality import NullCheck, RangeCheck, UniqueCheck
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="bronze.users",
     checks=[
         NullCheck(columns=["id"]),
@@ -57,18 +58,19 @@ def validate_users():
 ### Source Connector Usage
 
 ```python
-from phlo.ingestion import phlo_ingestion
+import phlo
+from dlt.sources.rest_api import rest_api
 
-@phlo_ingestion(
-    name="api_data",
-    source="rest_api",  # Uses rest_api connector
-    destination="bronze.api_data"
+@phlo.ingest.dlt(
+    table_name="api_data",
+    unique_key="id",
+    group="api",
 )
 def ingest_api():
-    return {
-        "client": {"base_url": "https://api.example.com"},
-        "resources": ["users", "events"]
-    }
+    return rest_api(
+        client={"base_url": "https://api.example.com"},
+        resources=[{"name": "users", "endpoint": {"path": "users"}}],
+    )
 ```
 
 ## Detailed Plugin Reference

--- a/docs/packages/phlo-dagster.md
+++ b/docs/packages/phlo-dagster.md
@@ -55,7 +55,7 @@ Capability providers are auto-loaded through the plugin system:
 
 - Asset specs from `phlo.plugins.assets` (for example phlo-dlt, phlo-dbt)
 - Resource specs from `phlo.plugins.resources` (for example phlo-iceberg, phlo-trino)
-- Check specs from `@phlo_quality` and other packages
+- Check specs from `phlo.quality.pandera(...)` and other packages
 
 ### Versioned catalogs and WAP
 

--- a/docs/packages/phlo-dlt.md
+++ b/docs/packages/phlo-dlt.md
@@ -4,7 +4,7 @@ DLT (Data Load Tool) ingestion engine for Phlo.
 
 ## Overview
 
-`phlo-dlt` provides the `@phlo_ingestion` decorator for defining data ingestion pipelines using DLT. It materializes data into the active `table_store` with schema evolution and full lineage tracking.
+`phlo-dlt` provides the `phlo.ingest.dlt(...)` decorator for defining data ingestion pipelines using DLT. It materializes data into the active `table_store` with schema evolution and full lineage tracking.
 Schema validation is supplied by installed quality-provider capabilities such as `phlo-pandera`;
 `phlo-dlt` does not depend on a specific quality provider.
 
@@ -45,7 +45,7 @@ Note: Additional configuration for table storage comes from the active table_sto
 
 ```mermaid
 flowchart LR
-    ingestion["@phlo_ingestion"]
+    ingestion["phlo.ingest.dlt(...)"]
     emitter[IngestionEventEmitter]
     hookbus[HookBus]
     plugins["Alerting, Metrics, Lineage plugins"]
@@ -58,10 +58,11 @@ flowchart LR
 ### Basic Ingestion
 
 ```python
-from phlo import ingestion
+import phlo
+from phlo.contracts import Consumer, SLA
 from workflows.schemas.events import EventSchema
 
-@ingestion.phlo_ingestion(
+@phlo.ingest.dlt(
     table_name="events",
     unique_key="id",
     validation_schema=EventSchema,
@@ -85,11 +86,19 @@ def api_events(partition_date: str):
     )
 ```
 
-Or import directly from the package:
+The `phlo.ingestion(...)` compatibility alias still exists for older workflows, but
+new code should use the provider-neutral `phlo.ingest.dlt(...)` API.
 
 ```python
-from phlo_dlt import phlo_ingestion
-from phlo.contracts import Consumer, SLA
+import phlo
+
+@phlo.ingest.dlt(
+    table_name="legacy_events",
+    unique_key="id",
+    group="api",
+)
+def legacy_events():
+    ...
 ```
 
 ### Decorator Options
@@ -119,19 +128,28 @@ from phlo.contracts import Consumer, SLA
 ### Merge Strategies
 
 ```python
+import phlo
+
 # Default merge with deduplication
-@phlo_ingestion(
+@phlo.ingest.dlt(
     table_name="events",
     unique_key="id",
+    group="api",
     merge_strategy="merge",
     merge_config={"deduplication_method": "last"}  # or "first", "hash"
 )
+def merge_events():
+    ...
 
 # Append-only (no deduplication)
-@phlo_ingestion(
+@phlo.ingest.dlt(
     table_name="events",
+    unique_key="id",
+    group="api",
     merge_strategy="append"
 )
+def append_events():
+    ...
 ```
 
 When `table_schema` is omitted, the active `table_store` provider must implement
@@ -140,7 +158,10 @@ schema derivation from `validation_schema` (for example Iceberg provider convers
 ### Selecting a Table Store
 
 ```python
-@ingestion.phlo_ingestion(
+import phlo
+from workflows.schemas.events import EventSchema
+
+@phlo.ingest.dlt(
     table_name="events",
     unique_key="id",
     validation_schema=EventSchema,

--- a/docs/packages/phlo-lineage.md
+++ b/docs/packages/phlo-lineage.md
@@ -34,7 +34,7 @@ Auto-wired when `LINEAGE_DB_URL` is set:
 | Feature               | How It Works                                                  |
 | --------------------- | ------------------------------------------------------------- |
 | **Hook Registration** | Receives `lineage.edges` events via HookBus                   |
-| **Event Capture**     | Automatically captures lineage from `@phlo_ingestion` and dbt |
+| **Event Capture**     | Automatically captures lineage from `phlo.ingest.dlt(...)`/`phlo.ingest.sling(...)` and dbt |
 | **Row ID Injection**  | `_phlo_row_id` column auto-injected during ingestion          |
 
 > **Note:** If `LINEAGE_DB_URL` is not configured, lineage events are logged but not persisted.

--- a/docs/packages/phlo-pandera.md
+++ b/docs/packages/phlo-pandera.md
@@ -4,7 +4,7 @@ Data quality checks and validation for Phlo.
 
 ## Overview
 
-`phlo-pandera` enables defining and executing data quality checks using the `@phlo_pandera` decorator. Checks emit capability specs that adapters translate into orchestrator-native checks.
+`phlo-pandera` enables defining and executing data quality checks using the `phlo.quality.pandera(...)` decorator. Checks emit capability specs that adapters translate into orchestrator-native checks.
 
 ## Installation
 
@@ -34,7 +34,7 @@ phlo plugin install quality
 ### Event Flow
 
 ```
-@phlo_pandera → QualityEventEmitter → quality.result → [Alerting, Metrics, OpenMetadata]
+phlo.quality.pandera(...) → QualityEventEmitter → quality.result → [Alerting, Metrics, OpenMetadata]
 ```
 
 ## Usage
@@ -42,10 +42,11 @@ phlo plugin install quality
 ### Defining Checks
 
 ```python
+import phlo
 from phlo.contracts import Consumer, SLA
-from phlo_pandera import phlo_pandera, NullCheck, UniqueCheck, RangeCheck
+from phlo.quality import NullCheck, UniqueCheck, RangeCheck
 
-@phlo_pandera(
+@phlo.quality.pandera(
     table="bronze.users",
     checks=[
         NullCheck(columns=["id"]),
@@ -114,7 +115,7 @@ checks = checks_from_contract(
 import pandera as pa
 from pandera.typing import Series
 
-from phlo import ingestion
+import phlo
 
 class UserSchema(pa.DataFrameModel):
     id: Series[str] = pa.Field(nullable=False, unique=True)
@@ -126,7 +127,7 @@ class UserSchema(pa.DataFrameModel):
         coerce = True
 
 # Use with ingestion decorator for automatic validation
-@ingestion.phlo_ingestion(
+@phlo.ingest.dlt(
     table_name="users",
     validation_schema=UserSchema,
     # ...

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -105,7 +105,7 @@ phlo minio               # MinIO client and admin helpers
 phlo postgres            # PostgreSQL shell and maintenance
 phlo trino               # Trino shell and queries
 phlo dbt                 # dbt compile/run/test helpers
-phlo publishing          # dbt publishing layer
+phlo dbt publishing      # dbt publishing layer
 phlo metrics             # Metrics summary (built-in)
 phlo alerts              # Alerting rules
 phlo openmetadata        # OpenMetadata catalog
@@ -507,7 +507,7 @@ phlo services list --json
 
 ```bash
 phlo services list --json
-# Error: Failed to discover services. Verify service plugins are installed and run `phlo plugins list` for diagnostics.
+# Error: Failed to discover services. Verify service plugins are installed and run `phlo plugin list` for diagnostics.
 ```
 
 ### phlo services ports
@@ -854,7 +854,7 @@ phlo plugin install PLUGIN_NAME [OPTIONS]
 phlo plugin install phlo-superset
 
 # Install specific version
-phlo plugin install phlo-superset==0.2.0
+phlo plugin install phlo-superset==0.2.5
 ```
 
 ### phlo plugin info
@@ -2019,7 +2019,7 @@ Hasura GraphQL engine management.
 
 **Installation**: `phlo plugin install phlo-hasura`
 
-### phlo publishing
+### phlo dbt publishing
 
 dbt publishing layer management.
 

--- a/docs/reference/common-errors.md
+++ b/docs/reference/common-errors.md
@@ -41,7 +41,7 @@ KeyError: 'observation_id'
 
 ```python
 # Check your decorator
-@phlo_ingestion(
+@phlo.ingest.dlt(
     unique_key="id",  # Must match a field in validation_schema
     validation_schema=MySchema,
     ...
@@ -71,7 +71,7 @@ ValueError: Invalid cron expression: 'every hour'
 
 ```python
 # Use standard cron format: minute hour day month weekday
-@phlo_ingestion(
+@phlo.ingest.dlt(
     cron="0 */1 * * *",  # Every hour at minute 0
     # NOT: cron="every hour"
     ...
@@ -139,7 +139,7 @@ ValueError: Missing required schema parameter (`validation_schema` or `table_sch
 
 ```python
 # Add validation_schema (recommended)
-@phlo_ingestion(
+@phlo.ingest.dlt(
     table_name="my_table",
     unique_key="id",
     validation_schema=MySchema,  # Add this
@@ -391,7 +391,8 @@ MySchema.validate(test_data)  # Fails fast if schema is wrong
 
 ```python
 # unique_key must match schema field exactly
-@phlo_ingestion(
+import phlo
+@phlo.ingest.dlt(
     unique_key="id",  # Must match field name below
     validation_schema=MySchema,
 )

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -231,7 +231,7 @@ class GitHubConnector(SourceConnectorPlugin):
 
 **Inherits:** `Plugin`, `ABC`, `Generic[TQualityCheck]`
 
-Factory for custom data quality checks that integrate with the `@phlo_pandera` decorator.
+Factory for custom data quality checks that integrate with the `phlo.quality.pandera(...)` decorator.
 
 ### Abstract methods
 

--- a/docs/reference/plugin-architecture.md
+++ b/docs/reference/plugin-architecture.md
@@ -15,8 +15,8 @@ Provider plugins supply the core primitives that other packages depend on:
 | Plugin Type | Entry Point | Purpose | Package |
 |-------------|-------------|---------|---------|
 | `orchestrators` | `phlo.plugins.orchestrators` | Orchestration runtime (Dagster) | phlo-dagster |
-| `quality_providers` | `phlo.plugins.quality_providers` | Quality primitives (@phlo_quality, checks) | phlo-pandera |
-| `ingestion_providers` | `phlo.plugins.ingestion_providers` | Ingestion primitives (@phlo_ingestion) | phlo-dlt |
+| `quality_providers` | `phlo.plugins.quality_providers` | Quality primitives (phlo.quality.pandera(...), checks) | phlo-pandera |
+| `ingestion_providers` | `phlo.plugins.ingestion_providers` | Ingestion primitives (phlo.ingest.dlt(...)) | phlo-dlt |
 | `transformation_providers` | `phlo.plugins.transformation_providers` | Transformation primitives (dbt assets) | phlo-dbt |
 | `resource_providers` | `phlo.plugins.resources` | Infrastructure resources (DB, storage) | phlo-trino, phlo-postgres, phlo-iceberg, phlo-delta |
 | `asset_providers` | `phlo.plugins.assets` | Asset spec generation | phlo-dbt, phlo-dlt |
@@ -156,11 +156,11 @@ sequenceDiagram
     REG->>IP: DLTIngestionProvider
     REG->>TP: DbtTransformationProvider
 
-    D->>P: import phlo.ingestion
+    D->>P: import phlo
     P->>IP: get_decorator()
-    IP-->>P: @phlo_ingestion
+    IP-->>P: phlo.ingest.dlt(...)
 
-    D->>P: @phlo_ingestion<br/>def load_users(): ...
+    D->>P: phlo.ingest.dlt(...)<br/>def load_users(): ...
     P->>DA: build_definitions()
     DA-->>P: Dagster Assets
 
@@ -186,7 +186,7 @@ class QualityProviderPlugin(Plugin, ABC):
 
     @abstractmethod
     def get_decorator(self) -> Callable:
-        """Returns @phlo_quality or equivalent."""
+        """Returns phlo.quality.pandera(...) or equivalent."""
 
     @abstractmethod
     def get_check_classes(self) -> dict[str, type]:
@@ -207,7 +207,7 @@ from phlo.plugins.discovery import discover_plugins, get_quality_provider
 
 discover_plugins()
 provider = get_quality_provider("pandera")
-phlo_quality = provider.get_decorator()
+pandera = provider.get_decorator()
 ```
 
 ## Related Documentation

--- a/docs/reference/quality-checks-catalog.md
+++ b/docs/reference/quality-checks-catalog.md
@@ -1,10 +1,10 @@
 # Quality Checks Catalog
 
-Comprehensive reference for all quality check types available in the `@phlo_quality` framework.
+Comprehensive reference for all quality check types available in the `phlo.quality.pandera(...)` framework.
 
 ## Overview
 
-Phlo's declarative quality framework reduces quality check boilerplate by 70-80% through the `@phlo_quality` decorator and reusable check classes. Instead of writing verbose asset checks with custom SQL and validation logic, you define quality checks declaratively using pre-built check types.
+Phlo's declarative quality framework reduces quality check boilerplate by 70-80% through the `phlo.quality.pandera(...)` decorator and reusable check classes. Instead of writing verbose asset checks with custom SQL and validation logic, you define quality checks declaratively using pre-built check types.
 
 **Key Benefits:**
 
@@ -35,9 +35,10 @@ Phlo's declarative quality framework reduces quality check boilerplate by 70-80%
 ## Basic Example
 
 ```python
-from phlo.quality import phlo_quality, NullCheck, RangeCheck, UniqueCheck
+import phlo
+from phlo.quality import NullCheck, RangeCheck, UniqueCheck
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.events",
     checks=[
         NullCheck(columns=["event_id", "event_type"]),
@@ -81,9 +82,9 @@ Verifies that specified columns contain no null values.
 **Example:**
 
 ```python
-from phlo.quality import NullCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import NullCheck
+@phlo.quality.pandera(
     table="bronze.weather_observations",
     checks=[
         # Strict: no nulls allowed
@@ -134,9 +135,9 @@ Verifies that specified columns have unique value combinations (no duplicates).
 **Example:**
 
 ```python
-from phlo.quality import UniqueCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import UniqueCheck
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         # Single column uniqueness
@@ -192,9 +193,9 @@ Verifies that numeric column values fall within a specified range.
 **Example:**
 
 ```python
-from phlo.quality import RangeCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import RangeCheck
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         # Both bounds
@@ -255,9 +256,9 @@ Verifies that string column values match a regular expression pattern.
 **Example:**
 
 ```python
-from phlo.quality import PatternCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import PatternCheck
+@phlo.quality.pandera(
     table="raw.user_profile",
     checks=[
         # GitHub username pattern
@@ -331,9 +332,9 @@ Verifies that the table row count meets expectations.
 **Example:**
 
 ```python
-from phlo.quality import CountCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import CountCheck
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         # At least 1 row (ensure partition not empty)
@@ -390,9 +391,9 @@ Verifies that data is fresh (not stale) by checking the maximum timestamp.
 **Example:**
 
 ```python
-from phlo.quality import FreshnessCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import FreshnessCheck
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         # Data should be less than 24 hours old
@@ -446,10 +447,10 @@ Verifies that a DataFrame matches a Pandera schema with type-safe validation.
 **Example:**
 
 ```python
+import phlo
 import pandera as pa
 from pandera.typing import Series
-from phlo.quality import SchemaCheck, phlo_quality
-
+from phlo.quality import SchemaCheck
 # Define Pandera schema
 class WeatherObservations(pa.DataFrameModel):
     station_id: Series[str] = pa.Field(nullable=False)
@@ -461,7 +462,7 @@ class WeatherObservations(pa.DataFrameModel):
         strict = True
         coerce = True
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="bronze.weather_observations",
     checks=[
         SchemaCheck(schema=WeatherObservations),
@@ -515,9 +516,9 @@ Executes arbitrary SQL to validate data using custom business logic.
 **Example:**
 
 ```python
-from phlo.quality import CustomSQLCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import CustomSQLCheck
+@phlo.quality.pandera(
     table="silver.fct_weather_observations",
     checks=[
         # Cross-column validation
@@ -591,9 +592,9 @@ Compares row counts between source and target tables to detect data loss or dupl
 **Example:**
 
 ```python
-from phlo.quality import ReconciliationCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import ReconciliationCheck
+@phlo.quality.pandera(
     table="gold.fct_github_events",
     checks=[
         # Exact row count match (1:1 transformation)
@@ -675,9 +676,9 @@ Verifies that computed aggregates in a target table match the expected computati
 **Example:**
 
 ```python
-from phlo.quality import AggregateConsistencyCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import AggregateConsistencyCheck
+@phlo.quality.pandera(
     table="gold.fct_daily_github_metrics",
     checks=[
         # Verify total_events matches source count
@@ -758,9 +759,9 @@ Verifies that source and target tables have matching keys to catch missing or ex
 **Example:**
 
 ```python
-from phlo.quality import KeyParityCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import KeyParityCheck
+@phlo.quality.pandera(
     table="gold.dim_customers",
     checks=[
         # Verify all customer IDs present
@@ -835,9 +836,10 @@ Efficiently validates multiple aggregates in a single query to reduce source tab
 **Example:**
 
 ```python
-from phlo.quality import AggregateSpec, MultiAggregateConsistencyCheck, phlo_quality
+import phlo
+from phlo.quality import AggregateSpec, MultiAggregateConsistencyCheck
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="gold.fct_daily_metrics",
     checks=[
         MultiAggregateConsistencyCheck(
@@ -889,7 +891,7 @@ Performs row-level hash comparison between source and target tables to detect da
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `source_table` | `str` | Required | Fully qualified source table name |
-| `target_table` | `str` | Required | Fully qualified target table name (usually same as @phlo_quality table) |
+| `target_table` | `str` | Required | Fully qualified target table name (usually same as phlo.quality.pandera(...) table) |
 | `key_columns` | `list[str]` | Required | Primary key columns for alignment |
 | `columns` | `list[str] \| None` | `None` | Columns to hash (None = all non-key columns) |
 | `partition_column` | `str` | `"_phlo_partition_date"` | Partition filtering column |
@@ -909,9 +911,9 @@ Performs row-level hash comparison between source and target tables to detect da
 **Example:**
 
 ```python
-from phlo.quality import ChecksumReconciliationCheck, phlo_quality
-
-@phlo_quality(
+import phlo
+from phlo.quality import ChecksumReconciliationCheck
+@phlo.quality.pandera(
     table="gold.dim_products",
     checks=[
         # Full row-level comparison
@@ -976,9 +978,9 @@ Sample hash mismatches: ['product-123', 'product-456', ...]
 
 ---
 
-## Decision Guide: @phlo_quality vs dbt tests vs pytest
+## Decision Guide: phlo.quality.pandera(...) vs dbt tests vs pytest
 
-### Use @phlo_quality when:
+### Use phlo.quality.pandera(...) when:
 
 - You're working in Python workflows (Dagster, Airflow, Prefect)
 - You need rich metadata and diagnostics (sample rows, detailed failures)
@@ -1015,8 +1017,8 @@ models:
             - order_id
             - item_id
 
-# Use @phlo_quality for external tables and cross-layer validation
-@phlo_quality(
+# Use phlo.quality.pandera(...) for external tables and cross-layer validation
+@phlo.quality.pandera(
     table="iceberg.gold.fct_orders",
     checks=[
         ReconciliationCheck(
@@ -1043,7 +1045,7 @@ Begin with basic checks and add more as you discover issues:
 
 ```python
 # Week 1: Basic checks
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         NullCheck(columns=["event_id"]),
@@ -1052,7 +1054,7 @@ Begin with basic checks and add more as you discover issues:
 )
 
 # Week 2: Add range validation after investigating failures
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         NullCheck(columns=["event_id", "timestamp"]),
@@ -1084,7 +1086,7 @@ Group related checks together:
 
 ```python
 # Bronze layer: Basic structure
-@phlo_quality(
+@phlo.quality.pandera(
     table="bronze.raw_events",
     checks=[
         CountCheck(min_rows=1),
@@ -1094,7 +1096,7 @@ Group related checks together:
 )
 
 # Silver layer: Business logic
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         UniqueCheck(columns=["event_id"]),
@@ -1105,7 +1107,7 @@ Group related checks together:
 )
 
 # Gold layer: Reconciliation
-@phlo_quality(
+@phlo.quality.pandera(
     table="gold.fct_daily_metrics",
     checks=[
         ReconciliationCheck(source_table="silver.fct_events"),
@@ -1126,14 +1128,14 @@ Not all checks should block downstream assets:
 
 ```python
 # Critical: Block downstream if failed
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.dim_customers",
     checks=[UniqueCheck(columns=["customer_id"])],
     blocking=True,  # Block downstream
 )
 
 # Non-critical: Warn but don't block
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[FreshnessCheck(timestamp_column="created_at", max_age_hours=48)],
     blocking=False,  # Warn only
@@ -1146,7 +1148,7 @@ Let phlo automatically scope checks to partitions:
 
 ```python
 # Partition-aware (recommended for incremental tables)
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[...],
     partition_aware=True,  # Default
@@ -1154,7 +1156,7 @@ Let phlo automatically scope checks to partitions:
 )
 
 # Full table scan (use sparingly)
-@phlo_quality(
+@phlo.quality.pandera(
     table="gold.dim_products",  # Slowly changing dimension
     checks=[...],
     full_table=True,  # Check entire table
@@ -1167,7 +1169,7 @@ Add reconciliation checks at aggregation boundaries:
 
 ```python
 # Ensure gold layer matches silver layer
-@phlo_quality(
+@phlo.quality.pandera(
     table="gold.fct_daily_metrics",
     checks=[
         ReconciliationCheck(source_table="silver.fct_events"),
@@ -1187,7 +1189,8 @@ Add reconciliation checks at aggregation boundaries:
 Use docstrings to explain why checks exist:
 
 ```python
-@phlo_quality(
+import phlo
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         RangeCheck(column="event_value", min_value=0, max_value=100),
@@ -1233,9 +1236,10 @@ ChecksumReconciliationCheck(
 Use `SchemaCheck` with other checks for comprehensive validation:
 
 ```python
+import phlo
 from workflows.schemas.events import EventsSchema
 
-@phlo_quality(
+@phlo.quality.pandera(
     table="silver.fct_events",
     checks=[
         SchemaCheck(schema=EventsSchema),  # Type validation


### PR DESCRIPTION
## Summary

- update source documentation for the phlo 0.10.0 release and current subpackage versions
- document the provider-neutral decorator APIs and flow authoring decorators introduced after v0.9.0
- correct stale version guidance, release recovery examples, package-version guidance, and decorator examples

## Validation

- npm run build in /Users/garethprice/Developer/phlo-website/web-next
- uv run pytest tests/codemods/test_decorators_2026_05.py tests/plugins/test_provider_neutral_ingest_api.py tests/plugins/test_provider_neutral_quality_api.py tests/plugins/test_flow_authoring_decorators.py tests/cli/test_cli_plugin.py -q
- package version table checked against all current pyproject.toml files
- scans for stale current-version strings and legacy public decorator examples

## Notes

- docs/repo-intent.html was already untracked and was left out of this PR
- ignored docs/plans material is not included
