### PR TITLE
feat: add governance catalog v1

### DIFF
--- a/docs/reference/canonical-rbac.md
+++ b/docs/reference/canonical-rbac.md
@@ -8,6 +8,24 @@ behavior, or backend support boundaries.
 
 ## Overview
 
+## Governance Catalog Relationship
+
+The governance catalog is the metadata source for dataset ownership,
+classification, governed tags, row-filter intent, column-mask intent, and
+policy references. Canonical RBAC remains the enforcement-source format for
+roles and allow rules.
+
+Use this split:
+
+- governance catalog: describes what a dataset is and how it should be treated
+- canonical RBAC: describes who can perform canonical actions
+- backend compilers: translate canonical RBAC into Trino, PostgreSQL, Hasura,
+  MinIO, and Nessie artifacts
+
+V1 governance catalog entries can reference RBAC `policy_id` values through the
+dataset `policies` list. This keeps the browser and operator views connected to
+the policy files without duplicating allow rules in two places.
+
 The canonical RBAC workflow centers on two files under `.phlo/authorization/`:
 
 - `roles.yaml`: role definitions, inheritance, and subject-to-role assignments

--- a/docs/reference/canonical-rbac.md
+++ b/docs/reference/canonical-rbac.md
@@ -8,24 +8,6 @@ behavior, or backend support boundaries.
 
 ## Overview
 
-## Governance Catalog Relationship
-
-The governance catalog is the metadata source for dataset ownership,
-classification, governed tags, row-filter intent, column-mask intent, and
-policy references. Canonical RBAC remains the enforcement-source format for
-roles and allow rules.
-
-Use this split:
-
-- governance catalog: describes what a dataset is and how it should be treated
-- canonical RBAC: describes who can perform canonical actions
-- backend compilers: translate canonical RBAC into Trino, PostgreSQL, Hasura,
-  MinIO, and Nessie artifacts
-
-V1 governance catalog entries can reference RBAC `policy_id` values through the
-dataset `policies` list. This keeps the browser and operator views connected to
-the policy files without duplicating allow rules in two places.
-
 The canonical RBAC workflow centers on two files under `.phlo/authorization/`:
 
 - `roles.yaml`: role definitions, inheritance, and subject-to-role assignments
@@ -48,6 +30,24 @@ Typical flow:
 4. run `phlo authz plan`
 5. run `phlo authz sync`
 6. run `phlo authz verify`
+
+## Governance Catalog Relationship
+
+The governance catalog is the metadata source for dataset ownership,
+classification, governed tags, row-filter intent, column-mask intent, and
+policy references. Canonical RBAC remains the enforcement-source format for
+roles and allow rules.
+
+Use this split:
+
+- governance catalog: describes what a dataset is and how it should be treated
+- canonical RBAC: describes who can perform canonical actions
+- backend compilers: translate canonical RBAC into Trino, PostgreSQL, Hasura,
+  MinIO, and Nessie artifacts
+
+V1 governance catalog entries can reference RBAC `policy_id` values through the
+dataset `policies` list. This keeps the browser and operator views connected to
+the policy files without duplicating allow rules in two places.
 
 ## Configuration Layout
 

--- a/docs/reference/observatory-v2-contracts.md
+++ b/docs/reference/observatory-v2-contracts.md
@@ -60,7 +60,7 @@ The governance surface may include a provider-neutral catalog payload:
       "row_filters": [
         {
           "name": "region_scope",
-          "expression": "region = current_setting('phlo.region')",
+          "expression": "region == request.region",
           "applies_to_roles": ["regional_analyst"]
         }
       ],

--- a/docs/reference/observatory-v2-contracts.md
+++ b/docs/reference/observatory-v2-contracts.md
@@ -40,6 +40,39 @@ All Observatory v2 endpoints are rooted at `/api/observatory/v2`. They are group
 
 Route parameters that identify assets, tables, services, branches, and checks are stable resource identifiers, not provider URLs or secret-bearing connection strings.
 
+### Governance Surface Read Model
+
+The governance surface may include a provider-neutral catalog payload:
+
+```json
+{
+  "version": 1,
+  "datasets": [
+    {
+      "id": "warehouse.customers",
+      "owner": "data-platform",
+      "description": "Customer dimension",
+      "classification": "restricted",
+      "tags": {"domain": "crm", "privacy": "restricted"},
+      "columns": [
+        {"name": "email", "classification": "personal", "mask": "email", "tags": {}}
+      ],
+      "row_filters": [
+        {
+          "name": "region_scope",
+          "expression": "region = current_setting('phlo.region')",
+          "applies_to_roles": ["regional_analyst"]
+        }
+      ],
+      "policies": ["allow_analyst_dataset_read"]
+    }
+  ]
+}
+```
+
+This payload is safe for browser rendering. It must not contain raw credentials,
+private URLs, signed URLs, or generated backend grants.
+
 ## UI Contributions
 
 A UI contribution describes how one capability appears in Observatory v2.

--- a/src/phlo/__init__.py
+++ b/src/phlo/__init__.py
@@ -118,6 +118,7 @@ _QUALITY_RULE_EXPORTS = {
 }
 _FLOW_EXPORTS = {
     "access",
+    "access_policy",
     "backfill",
     "clear_access_policies",
     "clear_backfill_assets",
@@ -197,6 +198,7 @@ def __getattr__(name: str) -> Any:
     if name in _FLOW_EXPORTS:
         from phlo.flow import (
             access,
+            access_policy,
             backfill,
             clear_access_policies,
             clear_backfill_assets,
@@ -219,6 +221,7 @@ def __getattr__(name: str) -> Any:
         globals().update(
             {
                 "access": access,
+                "access_policy": access_policy,
                 "backfill": backfill,
                 "clear_access_policies": clear_access_policies,
                 "clear_backfill_assets": clear_backfill_assets,

--- a/src/phlo/flow.py
+++ b/src/phlo/flow.py
@@ -37,6 +37,10 @@ class AccessPolicySpec:
     policy: str
     metadata: dict[str, Any]
     fn: Callable[..., Any]
+    tags: dict[str, str] | None = None
+    classification: str | None = None
+    row_filter: str | None = None
+    column_masks: dict[str, str] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -231,13 +235,17 @@ def contract(
     return _decorator
 
 
-def access(
+def access_policy(
     *,
     table: str,
     roles: list[str],
     pii_columns: list[str] | None = None,
-    policy: str = "read",
+    policy: str = "mask",
     metadata: dict[str, Any] | None = None,
+    tags: dict[str, str] | None = None,
+    classification: str | None = None,
+    row_filter: str | None = None,
+    column_masks: dict[str, str] | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Declare intended access policy metadata for a table."""
 
@@ -251,11 +259,42 @@ def access(
                 policy=policy,
                 metadata=dict(metadata or {}),
                 fn=fn,
+                tags=dict(tags or {}),
+                classification=classification,
+                row_filter=row_filter,
+                column_masks=dict(column_masks or {}),
             )
         )
         return fn
 
     return _decorator
+
+
+def access(
+    *,
+    table: str,
+    roles: list[str],
+    pii_columns: list[str] | None = None,
+    policy: str = "read",
+    metadata: dict[str, Any] | None = None,
+    tags: dict[str, str] | None = None,
+    classification: str | None = None,
+    row_filter: str | None = None,
+    column_masks: dict[str, str] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Declare intended access policy metadata for a table."""
+
+    return access_policy(
+        table=table,
+        roles=roles,
+        pii_columns=pii_columns,
+        policy=policy,
+        metadata=metadata,
+        tags=tags,
+        classification=classification,
+        row_filter=row_filter,
+        column_masks=column_masks,
+    )
 
 
 def schedule(
@@ -349,15 +388,27 @@ def clear_schedules() -> None:
     _SCHEDULES.clear()
 
 
+def clear_flow_declarations() -> None:
+    """Clear all registered flow declarations."""
+    clear_publish_assets()
+    clear_observe_assets()
+    clear_backfill_assets()
+    clear_contract_specs()
+    clear_access_policies()
+    clear_schedules()
+
+
 __all__ = [
     "AccessPolicySpec",
     "ContractSpec",
     "ScheduleSpec",
     "access",
+    "access_policy",
     "backfill",
     "clear_access_policies",
     "clear_backfill_assets",
     "clear_contract_specs",
+    "clear_flow_declarations",
     "clear_observe_assets",
     "clear_publish_assets",
     "clear_schedules",

--- a/src/phlo/governance/__init__.py
+++ b/src/phlo/governance/__init__.py
@@ -1,0 +1,5 @@
+"""Governance catalog public API."""
+
+from phlo.governance.catalog import GovernanceCatalog, GovernedColumn, GovernedDataset, RowFilter
+
+__all__ = ["GovernedColumn", "GovernedDataset", "GovernanceCatalog", "RowFilter"]

--- a/src/phlo/governance/catalog.py
+++ b/src/phlo/governance/catalog.py
@@ -2,8 +2,18 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    return tuple(str(item) for item in value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -11,7 +21,10 @@ class GovernedColumn:
     name: str
     classification: str | None = None
     mask: str | None = None
-    tags: dict[str, str] = field(default_factory=dict)
+    tags: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
 
     def to_read_model(self) -> dict[str, Any]:
         return {
@@ -42,10 +55,16 @@ class GovernedDataset:
     owner: str
     description: str | None = None
     classification: str | None = None
-    tags: dict[str, str] = field(default_factory=dict)
-    columns: dict[str, GovernedColumn] = field(default_factory=dict)
+    tags: Mapping[str, str] = field(default_factory=dict)
+    columns: Mapping[str, GovernedColumn] = field(default_factory=dict)
     row_filters: tuple[RowFilter, ...] = ()
     policies: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
+        object.__setattr__(self, "columns", MappingProxyType(dict(self.columns)))
+        object.__setattr__(self, "row_filters", tuple(self.row_filters))
+        object.__setattr__(self, "policies", _string_tuple(self.policies))
 
     def to_read_model(self) -> dict[str, Any]:
         return {
@@ -66,7 +85,10 @@ class GovernedDataset:
 @dataclass(frozen=True, slots=True)
 class GovernanceCatalog:
     version: int
-    datasets: dict[str, GovernedDataset]
+    datasets: Mapping[str, GovernedDataset]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "datasets", MappingProxyType(dict(self.datasets)))
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> GovernanceCatalog:
@@ -89,7 +111,7 @@ class GovernanceCatalog:
                 RowFilter(
                     name=str(row_filter["name"]),
                     expression=str(row_filter["expression"]),
-                    applies_to_roles=tuple(row_filter.get("applies_to_roles", ())),
+                    applies_to_roles=_string_tuple(row_filter.get("applies_to_roles")),
                 )
                 for row_filter in raw.get("row_filters", [])
             )
@@ -101,7 +123,7 @@ class GovernanceCatalog:
                 tags=dict(raw.get("tags", {})),
                 columns=columns,
                 row_filters=row_filters,
-                policies=tuple(raw.get("policies", ())),
+                policies=_string_tuple(raw.get("policies")),
             )
         return cls(version=int(data.get("version", 1)), datasets=datasets)
 

--- a/src/phlo/governance/catalog.py
+++ b/src/phlo/governance/catalog.py
@@ -54,8 +54,11 @@ class GovernedDataset:
             "description": self.description,
             "classification": self.classification,
             "tags": dict(self.tags),
-            "columns": [column.to_read_model() for column in self.columns.values()],
-            "row_filters": [row_filter.to_read_model() for row_filter in self.row_filters],
+            "columns": [self.columns[name].to_read_model() for name in sorted(self.columns)],
+            "row_filters": [
+                row_filter.to_read_model()
+                for row_filter in sorted(self.row_filters, key=lambda item: item.name)
+            ],
             "policies": list(self.policies),
         }
 
@@ -108,5 +111,7 @@ class GovernanceCatalog:
     def to_read_model(self) -> dict[str, Any]:
         return {
             "version": self.version,
-            "datasets": [dataset.to_read_model() for dataset in self.datasets.values()],
+            "datasets": [
+                self.datasets[dataset_id].to_read_model() for dataset_id in sorted(self.datasets)
+            ],
         }

--- a/src/phlo/governance/catalog.py
+++ b/src/phlo/governance/catalog.py
@@ -1,0 +1,112 @@
+"""Provider-neutral governance catalog models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class GovernedColumn:
+    name: str
+    classification: str | None = None
+    mask: str | None = None
+    tags: dict[str, str] = field(default_factory=dict)
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "classification": self.classification,
+            "mask": self.mask,
+            "tags": dict(self.tags),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class RowFilter:
+    name: str
+    expression: str
+    applies_to_roles: tuple[str, ...] = ()
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "expression": self.expression,
+            "applies_to_roles": list(self.applies_to_roles),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GovernedDataset:
+    id: str
+    owner: str
+    description: str | None = None
+    classification: str | None = None
+    tags: dict[str, str] = field(default_factory=dict)
+    columns: dict[str, GovernedColumn] = field(default_factory=dict)
+    row_filters: tuple[RowFilter, ...] = ()
+    policies: tuple[str, ...] = ()
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "owner": self.owner,
+            "description": self.description,
+            "classification": self.classification,
+            "tags": dict(self.tags),
+            "columns": [column.to_read_model() for column in self.columns.values()],
+            "row_filters": [row_filter.to_read_model() for row_filter in self.row_filters],
+            "policies": list(self.policies),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class GovernanceCatalog:
+    version: int
+    datasets: dict[str, GovernedDataset]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> GovernanceCatalog:
+        datasets: dict[str, GovernedDataset] = {}
+        for raw in data.get("datasets", []):
+            dataset_id = str(raw["id"])
+            if dataset_id in datasets:
+                raise ValueError(f"Duplicate dataset id: {dataset_id}")
+            raw_columns = raw.get("columns", {})
+            columns = {
+                name: GovernedColumn(
+                    name=name,
+                    classification=column.get("classification"),
+                    mask=column.get("mask"),
+                    tags=dict(column.get("tags", {})),
+                )
+                for name, column in raw_columns.items()
+            }
+            row_filters = tuple(
+                RowFilter(
+                    name=str(row_filter["name"]),
+                    expression=str(row_filter["expression"]),
+                    applies_to_roles=tuple(row_filter.get("applies_to_roles", ())),
+                )
+                for row_filter in raw.get("row_filters", [])
+            )
+            datasets[dataset_id] = GovernedDataset(
+                id=dataset_id,
+                owner=str(raw["owner"]),
+                description=raw.get("description"),
+                classification=raw.get("classification"),
+                tags=dict(raw.get("tags", {})),
+                columns=columns,
+                row_filters=row_filters,
+                policies=tuple(raw.get("policies", ())),
+            )
+        return cls(version=int(data.get("version", 1)), datasets=datasets)
+
+    def dataset(self, dataset_id: str) -> GovernedDataset:
+        return self.datasets[dataset_id]
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "datasets": [dataset.to_read_model() for dataset in self.datasets.values()],
+        }

--- a/tests/governance/test_catalog.py
+++ b/tests/governance/test_catalog.py
@@ -90,3 +90,33 @@ def test_catalog_serializes_browser_safe_governance_view() -> None:
             }
         ],
     }
+
+
+def test_catalog_read_model_is_deterministic() -> None:
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "version": 1,
+            "datasets": [
+                {
+                    "id": "z.table",
+                    "owner": "platform",
+                    "columns": {"z": {}, "a": {}},
+                    "row_filters": [
+                        {"name": "z_filter", "expression": "z = true"},
+                        {"name": "a_filter", "expression": "a = true"},
+                    ],
+                },
+                {"id": "a.table", "owner": "platform"},
+            ],
+        }
+    )
+
+    payload = catalog.to_read_model()
+
+    assert [dataset["id"] for dataset in payload["datasets"]] == ["a.table", "z.table"]
+    z_table = payload["datasets"][1]
+    assert [column["name"] for column in z_table["columns"]] == ["a", "z"]
+    assert [row_filter["name"] for row_filter in z_table["row_filters"]] == [
+        "a_filter",
+        "z_filter",
+    ]

--- a/tests/governance/test_catalog.py
+++ b/tests/governance/test_catalog.py
@@ -1,0 +1,92 @@
+from phlo.governance.catalog import GovernanceCatalog
+
+
+def test_catalog_parses_governed_dataset_with_tags_and_masks() -> None:
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "version": 1,
+            "datasets": [
+                {
+                    "id": "warehouse.customers",
+                    "owner": "data-platform",
+                    "description": "Customer dimension",
+                    "tags": {"domain": "crm", "privacy": "restricted"},
+                    "classification": "restricted",
+                    "columns": {
+                        "email": {"classification": "personal", "mask": "email"},
+                        "region": {"classification": "internal"},
+                    },
+                    "row_filters": [
+                        {
+                            "name": "region_scope",
+                            "expression": "region = current_setting('phlo.region')",
+                            "applies_to_roles": ["regional_analyst"],
+                        }
+                    ],
+                    "policies": ["allow_analyst_dataset_read"],
+                }
+            ],
+        }
+    )
+
+    dataset = catalog.dataset("warehouse.customers")
+
+    assert dataset.owner == "data-platform"
+    assert dataset.tags["privacy"] == "restricted"
+    assert dataset.columns["email"].mask == "email"
+    assert dataset.row_filters[0].applies_to_roles == ("regional_analyst",)
+    assert dataset.policies == ("allow_analyst_dataset_read",)
+
+
+def test_catalog_rejects_duplicate_dataset_ids() -> None:
+    try:
+        GovernanceCatalog.from_dict(
+            {
+                "version": 1,
+                "datasets": [
+                    {"id": "warehouse.customers", "owner": "team-a"},
+                    {"id": "warehouse.customers", "owner": "team-b"},
+                ],
+            }
+        )
+    except ValueError as exc:
+        assert "Duplicate dataset id: warehouse.customers" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate dataset id to fail")
+
+
+def test_catalog_serializes_browser_safe_governance_view() -> None:
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "version": 1,
+            "datasets": [
+                {
+                    "id": "warehouse.customers",
+                    "owner": "data-platform",
+                    "tags": {"privacy": "restricted"},
+                    "columns": {"email": {"classification": "personal", "mask": "email"}},
+                    "policies": ["allow_analyst_dataset_read"],
+                }
+            ],
+        }
+    )
+
+    payload = catalog.to_read_model()
+
+    assert payload == {
+        "version": 1,
+        "datasets": [
+            {
+                "id": "warehouse.customers",
+                "owner": "data-platform",
+                "description": None,
+                "classification": None,
+                "tags": {"privacy": "restricted"},
+                "columns": [
+                    {"name": "email", "classification": "personal", "mask": "email", "tags": {}}
+                ],
+                "row_filters": [],
+                "policies": ["allow_analyst_dataset_read"],
+            }
+        ],
+    }

--- a/tests/governance/test_catalog.py
+++ b/tests/governance/test_catalog.py
@@ -1,3 +1,5 @@
+from typing import Any, cast
+
 from phlo.governance.catalog import GovernanceCatalog
 
 
@@ -90,6 +92,63 @@ def test_catalog_serializes_browser_safe_governance_view() -> None:
             }
         ],
     }
+
+
+def test_catalog_normalizes_scalar_string_sequences() -> None:
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "datasets": [
+                {
+                    "id": "warehouse.customers",
+                    "owner": "data-platform",
+                    "row_filters": [
+                        {
+                            "name": "region_scope",
+                            "expression": "region == request.region",
+                            "applies_to_roles": "regional_analyst",
+                        }
+                    ],
+                    "policies": "allow_analyst_dataset_read",
+                }
+            ],
+        }
+    )
+
+    dataset = catalog.dataset("warehouse.customers")
+
+    assert dataset.row_filters[0].applies_to_roles == ("regional_analyst",)
+    assert dataset.policies == ("allow_analyst_dataset_read",)
+
+
+def test_catalog_returns_defensive_immutable_models() -> None:
+    raw_tags = {"privacy": "restricted"}
+    raw_columns = {"email": {"tags": {"pii": "true"}}}
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "datasets": [
+                {
+                    "id": "warehouse.customers",
+                    "owner": "data-platform",
+                    "tags": raw_tags,
+                    "columns": raw_columns,
+                }
+            ],
+        }
+    )
+    raw_tags["privacy"] = "public"
+    raw_columns["email"]["tags"]["pii"] = "false"
+
+    dataset = catalog.dataset("warehouse.customers")
+
+    assert dataset.tags["privacy"] == "restricted"
+    assert dataset.columns["email"].tags["pii"] == "true"
+
+    try:
+        cast(Any, dataset.tags)["privacy"] = "public"
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Expected dataset tags to be immutable")
 
 
 def test_catalog_read_model_is_deterministic() -> None:

--- a/tests/governance/test_flow_access_policy_metadata.py
+++ b/tests/governance/test_flow_access_policy_metadata.py
@@ -3,23 +3,26 @@ import phlo.flow as flow
 
 def test_access_policy_records_governance_metadata() -> None:
     flow.clear_flow_declarations()
+    try:
 
-    @flow.access_policy(
-        table="warehouse.customers",
-        roles=["analyst"],
-        pii_columns=["email"],
-        policy="mask-pii",
-        tags={"privacy": "restricted"},
-        classification="restricted",
-        row_filter="region = current_setting('phlo.region')",
-        column_masks={"email": "email"},
-    )
-    def customers_policy() -> None:
-        return None
+        @flow.access_policy(
+            table="warehouse.customers",
+            roles=["analyst"],
+            pii_columns=["email"],
+            policy="mask-pii",
+            tags={"privacy": "restricted"},
+            classification="restricted",
+            row_filter="region = current_setting('phlo.region')",
+            column_masks={"email": "email"},
+        )
+        def customers_policy() -> None:
+            return None
 
-    policy = flow.get_access_policies()[0]
+        policy = flow.get_access_policies()[0]
 
-    assert policy.tags == {"privacy": "restricted"}
-    assert policy.classification == "restricted"
-    assert policy.row_filter == "region = current_setting('phlo.region')"
-    assert policy.column_masks == {"email": "email"}
+        assert policy.tags == {"privacy": "restricted"}
+        assert policy.classification == "restricted"
+        assert policy.row_filter == "region = current_setting('phlo.region')"
+        assert policy.column_masks == {"email": "email"}
+    finally:
+        flow.clear_flow_declarations()

--- a/tests/governance/test_flow_access_policy_metadata.py
+++ b/tests/governance/test_flow_access_policy_metadata.py
@@ -1,0 +1,25 @@
+import phlo.flow as flow
+
+
+def test_access_policy_records_governance_metadata() -> None:
+    flow.clear_flow_declarations()
+
+    @flow.access_policy(
+        table="warehouse.customers",
+        roles=["analyst"],
+        pii_columns=["email"],
+        policy="mask-pii",
+        tags={"privacy": "restricted"},
+        classification="restricted",
+        row_filter="region = current_setting('phlo.region')",
+        column_masks={"email": "email"},
+    )
+    def customers_policy() -> None:
+        return None
+
+    policy = flow.get_access_policies()[0]
+
+    assert policy.tags == {"privacy": "restricted"}
+    assert policy.classification == "restricted"
+    assert policy.row_filter == "region = current_setting('phlo.region')"
+    assert policy.column_masks == {"email": "email"}

--- a/tests/plugins/test_public_api_exports.py
+++ b/tests/plugins/test_public_api_exports.py
@@ -248,6 +248,16 @@ def test_plugins_module_imports_without_psycopg2(monkeypatch: pytest.MonkeyPatch
     assert plugins.SettingsService.__name__ == "SettingsService"
 
 
+def test_top_level_phlo_exports_access_policy_decorator() -> None:
+    """The public flow access policy decorator should resolve from top-level phlo."""
+    import phlo
+    import phlo.flow
+
+    assert "access_policy" in phlo.__all__
+    assert callable(phlo.access_policy)
+    assert phlo.access_policy is phlo.flow.access_policy
+
+
 def test_settings_service_raises_clear_error_without_psycopg2(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Adds a provider-neutral governance catalog read model for datasets, columns, row filters, and access policies. Also captures governance metadata on flow access policies and exports the access policy decorator through the public API.

## Validation

- `uv run --locked pytest tests/governance tests/plugins/test_public_api_exports.py -q`
- `uv run --locked ruff check src/phlo/governance tests/governance tests/plugins/test_public_api_exports.py`
- `uv run --locked ty check src/phlo/governance`
