### PR TITLE
feat: add managed live tables v1

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -122,6 +122,7 @@ references, desired target lag, refresh mode, and quality gate names.
 @phlo.live_table(
     name="bronze.orders",
     query="select * from raw.orders",
+    mode="full",
 )
 def bronze_orders():
     pass

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -112,6 +112,29 @@ In the default bundled stack, Nessie is the versioned catalog provider for this 
 Profiles without a versioned catalog still work, but they do not get branch/promotion
 semantics.
 
+### Managed Live Tables
+
+`phlo.live_table(...)` declares a managed table that Phlo can refresh from one
+or more upstream sources. V1 records the table name, SQL query, source table
+references, desired target lag, refresh mode, and quality gate names.
+
+```python
+@phlo.live_table(
+    name="silver.orders",
+    query="select * from bronze.orders",
+    sources=["bronze.orders"],
+    target_lag="15 minutes",
+    mode="incremental",
+    quality=["not_null:order_id"],
+)
+def silver_orders():
+    pass
+```
+
+Live table declarations are provider-neutral. Execution providers can compile
+them into Dagster assets, dbt models, Trino SQL jobs, or Iceberg maintenance
+flows.
+
 ### 2. Decorator-Driven Development
 
 Phlo reduces boilerplate through powerful decorators that auto-generate Dagster assets.

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -120,6 +120,14 @@ references, desired target lag, refresh mode, and quality gate names.
 
 ```python
 @phlo.live_table(
+    name="bronze.orders",
+    query="select * from raw.orders",
+)
+def bronze_orders():
+    pass
+
+
+@phlo.live_table(
     name="silver.orders",
     query="select * from bronze.orders",
     sources=["bronze.orders"],
@@ -131,9 +139,9 @@ def silver_orders():
     pass
 ```
 
-Live table declarations are provider-neutral. Execution providers can compile
-them into Dagster assets, dbt models, Trino SQL jobs, or Iceberg maintenance
-flows.
+Live table declarations are provider-neutral. These declarations are designed to
+be consumed by future execution providers that can compile them into Dagster
+assets, dbt models, Trino SQL jobs, or Iceberg maintenance flows.
 
 ### 2. Decorator-Driven Development
 

--- a/docs/reference/phlo-api.md
+++ b/docs/reference/phlo-api.md
@@ -120,6 +120,28 @@ Observatory v2 endpoints live under `/api/observatory/v2`. They are provider-neu
 
 See [Observatory v2 Contracts](observatory-v2-contracts.md) for the capability contribution model and browser-safety rules.
 
+### Live Table Read Model
+
+The live table read model contains the declaration plan returned by
+`phlo.live.plan_live_tables()`:
+
+```json
+[
+  {
+    "name": "silver.orders",
+    "query": "select * from bronze.orders",
+    "sources": ["bronze.orders"],
+    "target_lag": "15 minutes",
+    "mode": "incremental",
+    "quality": ["not_null:order_id"],
+    "metadata": {}
+  }
+]
+```
+
+The query text is user-authored SQL and must be treated as project metadata, not
+as a browser-executable command.
+
 ## Key Features
 
 ### 1. Read-Only Query Guardrails

--- a/docs/reference/phlo-api.md
+++ b/docs/reference/phlo-api.md
@@ -128,6 +128,15 @@ The live table read model contains the declaration plan returned by
 ```json
 [
   {
+    "name": "bronze.orders",
+    "query": "select * from raw.orders",
+    "sources": [],
+    "target_lag": null,
+    "mode": "full",
+    "quality": [],
+    "metadata": {}
+  },
+  {
     "name": "silver.orders",
     "query": "select * from bronze.orders",
     "sources": ["bronze.orders"],

--- a/src/phlo/__init__.py
+++ b/src/phlo/__init__.py
@@ -136,7 +136,8 @@ _FLOW_EXPORTS = {
     "publish",
     "schedule",
 }
-_SUBMODULE_EXPORTS = {"helpers", "ingest", "ingestion", "metrics", "quality", "transform"}
+_LIVE_EXPORTS = {"live_table"}
+_SUBMODULE_EXPORTS = {"helpers", "ingest", "ingestion", "live", "metrics", "quality", "transform"}
 
 __all__ = [
     "__version__",
@@ -146,6 +147,7 @@ __all__ = [
     *_QUALITY_EXPORTS,
     *_QUALITY_RULE_EXPORTS,
     *_FLOW_EXPORTS,
+    *_LIVE_EXPORTS,
 ]
 
 
@@ -238,6 +240,11 @@ def __getattr__(name: str) -> Any:
                 "schedule": schedule,
             }
         )
+        return globals()[name]
+    if name in _LIVE_EXPORTS:
+        from phlo.live import live_table
+
+        globals().update({"live_table": live_table})
         return globals()[name]
     if name in _QUALITY_EXPORTS:
         from phlo.quality import (

--- a/src/phlo/live.py
+++ b/src/phlo/live.py
@@ -61,7 +61,16 @@ def get_live_tables() -> list[LiveTableSpec]:
 
 def plan_live_tables() -> list[dict[str, Any]]:
     """Return live tables in dependency order and validate source references."""
-    by_name = {spec.name: spec for spec in _LIVE_TABLES}
+    by_name: dict[str, LiveTableSpec] = {}
+    duplicates: set[str] = set()
+    for spec in _LIVE_TABLES:
+        if spec.name in by_name:
+            duplicates.add(spec.name)
+        by_name[spec.name] = spec
+    if duplicates:
+        names = ", ".join(sorted(duplicates))
+        raise ValueError(f"Duplicate live table declarations: {names}")
+
     planned: list[LiveTableSpec] = []
     visiting: set[str] = set()
     visited: set[str] = set()

--- a/src/phlo/live.py
+++ b/src/phlo/live.py
@@ -1,0 +1,64 @@
+"""Managed live table declarations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+_SUPPORTED_MODES = {"incremental", "full"}
+_LIVE_TABLES: list[LiveTableSpec] = []
+
+
+@dataclass(frozen=True, slots=True)
+class LiveTableSpec:
+    name: str
+    query: str
+    sources: tuple[str, ...]
+    target_lag: str | None
+    mode: str
+    quality: tuple[str, ...]
+    metadata: dict[str, Any]
+    fn: Callable[..., Any]
+
+
+def live_table(
+    *,
+    name: str,
+    query: str,
+    sources: list[str] | tuple[str, ...] | None = None,
+    target_lag: str | None = None,
+    mode: str = "incremental",
+    quality: list[str] | tuple[str, ...] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Declare a managed table that Phlo can refresh from upstream sources."""
+    if mode not in _SUPPORTED_MODES:
+        raise ValueError(f"Unsupported live table mode: {mode}")
+
+    def _decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        _LIVE_TABLES.append(
+            LiveTableSpec(
+                name=name,
+                query=query,
+                sources=tuple(sources or ()),
+                target_lag=target_lag,
+                mode=mode,
+                quality=tuple(quality or ()),
+                metadata=dict(metadata or {}),
+                fn=fn,
+            )
+        )
+        return fn
+
+    return _decorator
+
+
+def get_live_tables() -> list[LiveTableSpec]:
+    """Return registered live table declarations."""
+    return list(_LIVE_TABLES)
+
+
+def clear_live_tables() -> None:
+    """Clear live table declarations for tests and reloads."""
+    _LIVE_TABLES.clear()

--- a/src/phlo/live.py
+++ b/src/phlo/live.py
@@ -61,16 +61,7 @@ def get_live_tables() -> list[LiveTableSpec]:
 
 def plan_live_tables() -> list[dict[str, Any]]:
     """Return live tables in dependency order and validate source references."""
-    by_name: dict[str, LiveTableSpec] = {}
-    duplicates: set[str] = set()
-    for spec in _LIVE_TABLES:
-        if spec.name in by_name:
-            duplicates.add(spec.name)
-        by_name[spec.name] = spec
-    if duplicates:
-        names = ", ".join(sorted(duplicates))
-        raise ValueError(f"Duplicate live table declarations: {names}")
-
+    by_name = _live_tables_by_name(_LIVE_TABLES)
     planned: list[LiveTableSpec] = []
     visiting: set[str] = set()
     visited: set[str] = set()
@@ -101,7 +92,7 @@ def plan_live_tables() -> list[dict[str, Any]]:
             "target_lag": spec.target_lag,
             "mode": spec.mode,
             "quality": list(spec.quality),
-            "metadata": dict(spec.metadata),
+            "metadata": _copy_json_like(spec.metadata),
         }
         for spec in planned
     ]
@@ -110,3 +101,24 @@ def plan_live_tables() -> list[dict[str, Any]]:
 def clear_live_tables() -> None:
     """Clear live table declarations for tests and reloads."""
     _LIVE_TABLES.clear()
+
+
+def _live_tables_by_name(specs: list[LiveTableSpec]) -> dict[str, LiveTableSpec]:
+    by_name: dict[str, LiveTableSpec] = {}
+    duplicates: set[str] = set()
+    for spec in specs:
+        if spec.name in by_name:
+            duplicates.add(spec.name)
+        by_name[spec.name] = spec
+    if duplicates:
+        names = ", ".join(sorted(duplicates))
+        raise ValueError(f"Duplicate live table declarations: {names}")
+    return by_name
+
+
+def _copy_json_like(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _copy_json_like(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_copy_json_like(item) for item in value]
+    return value

--- a/src/phlo/live.py
+++ b/src/phlo/live.py
@@ -59,6 +59,45 @@ def get_live_tables() -> list[LiveTableSpec]:
     return list(_LIVE_TABLES)
 
 
+def plan_live_tables() -> list[dict[str, Any]]:
+    """Return live tables in dependency order and validate source references."""
+    by_name = {spec.name: spec for spec in _LIVE_TABLES}
+    planned: list[LiveTableSpec] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(spec: LiveTableSpec) -> None:
+        if spec.name in visited:
+            return
+        if spec.name in visiting:
+            raise ValueError(f"Live table dependency cycle includes {spec.name}")
+        visiting.add(spec.name)
+        for source in spec.sources:
+            if source in by_name:
+                visit(by_name[source])
+            elif "." in source:
+                raise ValueError(f"{spec.name} depends on unknown live table source {source}")
+        visiting.remove(spec.name)
+        visited.add(spec.name)
+        planned.append(spec)
+
+    for spec in _LIVE_TABLES:
+        visit(spec)
+
+    return [
+        {
+            "name": spec.name,
+            "query": spec.query,
+            "sources": list(spec.sources),
+            "target_lag": spec.target_lag,
+            "mode": spec.mode,
+            "quality": list(spec.quality),
+            "metadata": dict(spec.metadata),
+        }
+        for spec in planned
+    ]
+
+
 def clear_live_tables() -> None:
     """Clear live table declarations for tests and reloads."""
     _LIVE_TABLES.clear()

--- a/tests/live/test_live_table_api.py
+++ b/tests/live/test_live_table_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 import phlo
-from phlo.live import clear_live_tables, get_live_tables
+from phlo.live import clear_live_tables, get_live_tables, plan_live_tables
 
 
 @pytest.fixture(autouse=True)
@@ -41,3 +41,42 @@ def test_live_table_rejects_invalid_mode() -> None:
         assert "Unsupported live table mode: streaming" in str(exc)
     else:
         raise AssertionError("Expected invalid mode to fail")
+
+
+def test_plan_live_tables_orders_dependencies() -> None:
+    clear_live_tables()
+
+    @phlo.live_table(name="bronze.orders", query="select 1", mode="full")
+    def bronze_orders() -> None:
+        return None
+
+    @phlo.live_table(
+        name="silver.orders",
+        query="select * from bronze.orders",
+        sources=["bronze.orders"],
+    )
+    def silver_orders() -> None:
+        return None
+
+    plan = plan_live_tables()
+
+    assert [item["name"] for item in plan] == ["bronze.orders", "silver.orders"]
+
+
+def test_plan_live_tables_rejects_missing_source() -> None:
+    clear_live_tables()
+
+    @phlo.live_table(
+        name="silver.orders",
+        query="select * from bronze.orders",
+        sources=["bronze.orders"],
+    )
+    def silver_orders() -> None:
+        return None
+
+    try:
+        plan_live_tables()
+    except ValueError as exc:
+        assert "silver.orders depends on unknown live table source bronze.orders" in str(exc)
+    else:
+        raise AssertionError("Expected missing source to fail")

--- a/tests/live/test_live_table_api.py
+++ b/tests/live/test_live_table_api.py
@@ -80,3 +80,22 @@ def test_plan_live_tables_rejects_missing_source() -> None:
         assert "silver.orders depends on unknown live table source bronze.orders" in str(exc)
     else:
         raise AssertionError("Expected missing source to fail")
+
+
+def test_plan_live_tables_rejects_duplicate_names() -> None:
+    @phlo.live_table(name="silver.orders", query="select 1")
+    def silver_orders_v1() -> None:
+        return None
+
+    @phlo.live_table(name="silver.orders", query="select 2")
+    def silver_orders_v2() -> None:
+        return None
+
+    assert [spec.fn for spec in get_live_tables()] == [silver_orders_v1, silver_orders_v2]
+
+    try:
+        plan_live_tables()
+    except ValueError as exc:
+        assert "Duplicate live table declarations: silver.orders" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate live table names to fail")

--- a/tests/live/test_live_table_api.py
+++ b/tests/live/test_live_table_api.py
@@ -1,0 +1,38 @@
+import phlo
+from phlo.live import clear_live_tables, get_live_tables
+
+
+def test_live_table_decorator_records_managed_table_spec() -> None:
+    clear_live_tables()
+
+    @phlo.live_table(
+        name="silver.orders",
+        query="select * from bronze.orders",
+        sources=["bronze.orders"],
+        target_lag="15 minutes",
+        mode="incremental",
+        quality=["not_null:order_id"],
+    )
+    def silver_orders() -> None:
+        return None
+
+    spec = get_live_tables()[0]
+
+    assert spec.name == "silver.orders"
+    assert spec.query == "select * from bronze.orders"
+    assert spec.sources == ("bronze.orders",)
+    assert spec.target_lag == "15 minutes"
+    assert spec.mode == "incremental"
+    assert spec.quality == ("not_null:order_id",)
+    assert spec.fn is silver_orders
+
+
+def test_live_table_rejects_invalid_mode() -> None:
+    clear_live_tables()
+
+    try:
+        phlo.live_table(name="silver.orders", query="select 1", mode="streaming")
+    except ValueError as exc:
+        assert "Unsupported live table mode: streaming" in str(exc)
+    else:
+        raise AssertionError("Expected invalid mode to fail")

--- a/tests/live/test_live_table_api.py
+++ b/tests/live/test_live_table_api.py
@@ -99,3 +99,18 @@ def test_plan_live_tables_rejects_duplicate_names() -> None:
         assert "Duplicate live table declarations: silver.orders" in str(exc)
     else:
         raise AssertionError("Expected duplicate live table names to fail")
+
+
+def test_plan_live_tables_deep_copies_metadata() -> None:
+    @phlo.live_table(
+        name="silver.orders",
+        query="select 1",
+        metadata={"owner": {"teams": ["analytics"]}},
+    )
+    def silver_orders() -> None:
+        return None
+
+    plan = plan_live_tables()
+    plan[0]["metadata"]["owner"]["teams"].append("mutated")
+
+    assert plan_live_tables()[0]["metadata"]["owner"]["teams"] == ["analytics"]

--- a/tests/live/test_live_table_api.py
+++ b/tests/live/test_live_table_api.py
@@ -1,10 +1,17 @@
+import pytest
+
 import phlo
 from phlo.live import clear_live_tables, get_live_tables
 
 
-def test_live_table_decorator_records_managed_table_spec() -> None:
+@pytest.fixture(autouse=True)
+def clean_live_tables() -> None:
+    clear_live_tables()
+    yield
     clear_live_tables()
 
+
+def test_live_table_decorator_records_managed_table_spec() -> None:
     @phlo.live_table(
         name="silver.orders",
         query="select * from bronze.orders",
@@ -28,8 +35,6 @@ def test_live_table_decorator_records_managed_table_spec() -> None:
 
 
 def test_live_table_rejects_invalid_mode() -> None:
-    clear_live_tables()
-
     try:
         phlo.live_table(name="silver.orders", query="select 1", mode="streaming")
     except ValueError as exc:


### PR DESCRIPTION
## Summary

Adds managed live table declarations, registry isolation helpers, dependency-order planning, duplicate-name validation, and API/docs coverage for live table refresh plans.

## Validation

- `uv run --locked pytest tests/live tests/plugins/test_public_api_exports.py -q`
- `uv run --locked ruff check src/phlo/live.py tests/live tests/plugins/test_public_api_exports.py`
- `uv run --locked ty check src/phlo/live.py`
