### PR TITLE
feat: add data product portal v1

### DIFF
--- a/docs/reference/observatory-v2-contracts.md
+++ b/docs/reference/observatory-v2-contracts.md
@@ -73,6 +73,34 @@ The governance surface may include a provider-neutral catalog payload:
 This payload is safe for browser rendering. It must not contain raw credentials,
 private URLs, signed URLs, or generated backend grants.
 
+### Data Product Portal Read Model
+
+The portal read model is a browser-safe list of certified or discoverable data
+products:
+
+```json
+[
+  {
+    "id": "warehouse.customers",
+    "title": "warehouse.customers",
+    "owner": "data-platform",
+    "description": "Customer dimension",
+    "domain": "crm",
+    "classification": "restricted",
+    "certification": "certified",
+    "status": "healthy",
+    "tags": {"domain": "crm", "certification": "certified"},
+    "access_request": {
+      "dataset_id": "warehouse.customers",
+      "policy_ids": ["allow_analyst_dataset_read"]
+    }
+  }
+]
+```
+
+Portal payloads must not expose credentials, raw service URLs, signed URLs, or
+backend-native grant statements.
+
 ## UI Contributions
 
 A UI contribution describes how one capability appears in Observatory v2.

--- a/src/phlo/portal/__init__.py
+++ b/src/phlo/portal/__init__.py
@@ -1,0 +1,5 @@
+"""Data product portal read models."""
+
+from phlo.portal.products import DataProduct, build_data_products
+
+__all__ = ["DataProduct", "build_data_products"]

--- a/src/phlo/portal/__init__.py
+++ b/src/phlo/portal/__init__.py
@@ -1,5 +1,5 @@
 """Data product portal read models."""
 
-from phlo.portal.products import DataProduct, build_data_products
+from phlo.portal.products import DataProduct, build_access_request, build_data_products
 
-__all__ = ["DataProduct", "build_data_products"]
+__all__ = ["DataProduct", "build_access_request", "build_data_products"]

--- a/src/phlo/portal/products.py
+++ b/src/phlo/portal/products.py
@@ -1,0 +1,65 @@
+"""Data product portal read models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from phlo.governance.catalog import GovernanceCatalog, GovernedDataset
+
+
+@dataclass(frozen=True, slots=True)
+class DataProduct:
+    id: str
+    title: str
+    owner: str
+    description: str | None
+    domain: str | None
+    classification: str | None
+    certification: str
+    status: str
+    tags: dict[str, str] = field(default_factory=dict)
+    access_request: dict[str, Any] = field(default_factory=dict)
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "owner": self.owner,
+            "description": self.description,
+            "domain": self.domain,
+            "classification": self.classification,
+            "certification": self.certification,
+            "status": self.status,
+            "tags": dict(self.tags),
+            "access_request": dict(self.access_request),
+        }
+
+
+def _product_from_dataset(dataset: GovernedDataset, status: str) -> DataProduct:
+    certification = dataset.tags.get("certification", "uncertified")
+    return DataProduct(
+        id=dataset.id,
+        title=dataset.id,
+        owner=dataset.owner,
+        description=dataset.description,
+        domain=dataset.tags.get("domain"),
+        classification=dataset.classification,
+        certification=certification,
+        status=status,
+        tags=dict(dataset.tags),
+        access_request={"dataset_id": dataset.id, "policy_ids": list(dataset.policies)},
+    )
+
+
+def build_data_products(
+    *,
+    catalog: GovernanceCatalog,
+    statuses: dict[str, str] | None = None,
+) -> list[DataProduct]:
+    """Build browser-safe data product cards from governance metadata."""
+    status_by_id = statuses or {}
+    return [
+        _product_from_dataset(dataset, status_by_id.get(dataset.id, "unknown"))
+        for dataset in catalog.datasets.values()
+    ]

--- a/src/phlo/portal/products.py
+++ b/src/phlo/portal/products.py
@@ -67,3 +67,13 @@ def build_data_products(
         _product_from_dataset(dataset, status_by_id.get(dataset.id, "unknown"))
         for dataset in catalog.datasets.values()
     ]
+
+
+def build_access_request(*, dataset_id: str, requester: str, reason: str) -> dict[str, str]:
+    """Build a browser-safe access request payload for workflow handoff."""
+    return {
+        "dataset_id": dataset_id,
+        "requester": requester,
+        "reason": reason,
+        "status": "pending",
+    }

--- a/src/phlo/portal/products.py
+++ b/src/phlo/portal/products.py
@@ -22,10 +22,6 @@ class DataProduct:
     access_request: dict[str, Any] = field(default_factory=dict)
 
     def to_read_model(self) -> dict[str, Any]:
-        access_request = {
-            key: list(value) if isinstance(value, list | tuple) else value
-            for key, value in self.access_request.items()
-        }
         return {
             "id": self.id,
             "title": self.title,
@@ -35,9 +31,17 @@ class DataProduct:
             "classification": self.classification,
             "certification": self.certification,
             "status": self.status,
-            "tags": dict(self.tags),
-            "access_request": access_request,
+            "tags": _copy_json_like(self.tags),
+            "access_request": _copy_json_like(self.access_request),
         }
+
+
+def _copy_json_like(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _copy_json_like(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_copy_json_like(item) for item in value]
+    return value
 
 
 def _product_from_dataset(dataset: GovernedDataset, status: str) -> DataProduct:

--- a/src/phlo/portal/products.py
+++ b/src/phlo/portal/products.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -63,13 +64,13 @@ def _product_from_dataset(dataset: GovernedDataset, status: str) -> DataProduct:
 def build_data_products(
     *,
     catalog: GovernanceCatalog,
-    statuses: dict[str, str] | None = None,
+    statuses: Mapping[str, str] | None = None,
 ) -> list[DataProduct]:
     """Build browser-safe data product cards from governance metadata."""
     status_by_id = statuses or {}
     return [
         _product_from_dataset(dataset, status_by_id.get(dataset.id, "unknown"))
-        for dataset in catalog.datasets.values()
+        for dataset in (catalog.datasets[dataset_id] for dataset_id in sorted(catalog.datasets))
     ]
 
 

--- a/src/phlo/portal/products.py
+++ b/src/phlo/portal/products.py
@@ -22,6 +22,10 @@ class DataProduct:
     access_request: dict[str, Any] = field(default_factory=dict)
 
     def to_read_model(self) -> dict[str, Any]:
+        access_request = {
+            key: list(value) if isinstance(value, list | tuple) else value
+            for key, value in self.access_request.items()
+        }
         return {
             "id": self.id,
             "title": self.title,
@@ -32,7 +36,7 @@ class DataProduct:
             "certification": self.certification,
             "status": self.status,
             "tags": dict(self.tags),
-            "access_request": dict(self.access_request),
+            "access_request": access_request,
         }
 
 

--- a/tests/portal/test_data_products.py
+++ b/tests/portal/test_data_products.py
@@ -29,6 +29,22 @@ def test_build_data_products_from_governance_catalog() -> None:
     assert products[0].access_request["policy_ids"] == ["allow_analyst_dataset_read"]
 
 
+def test_build_data_products_returns_deterministic_order() -> None:
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "version": 1,
+            "datasets": [
+                {"id": "z.table", "owner": "platform"},
+                {"id": "a.table", "owner": "platform"},
+            ],
+        }
+    )
+
+    products = build_data_products(catalog=catalog)
+
+    assert [product.id for product in products] == ["a.table", "z.table"]
+
+
 def test_data_product_serialization_is_browser_safe() -> None:
     catalog = GovernanceCatalog.from_dict(
         {

--- a/tests/portal/test_data_products.py
+++ b/tests/portal/test_data_products.py
@@ -57,3 +57,24 @@ def test_data_product_serialization_is_browser_safe() -> None:
         "tags": {"certification": "certified", "domain": "finance"},
         "access_request": {"dataset_id": "gold.revenue", "policy_ids": []},
     }
+
+
+def test_data_product_access_request_policy_ids_are_isolated_between_serializations() -> None:
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "version": 1,
+            "datasets": [
+                {
+                    "id": "gold.customers",
+                    "owner": "crm",
+                    "policies": ["original_policy"],
+                }
+            ],
+        }
+    )
+
+    product = build_data_products(catalog=catalog)[0]
+    payload = product.to_read_model()
+    payload["access_request"]["policy_ids"].append("mutated")
+
+    assert product.to_read_model()["access_request"]["policy_ids"] == ["original_policy"]

--- a/tests/portal/test_data_products.py
+++ b/tests/portal/test_data_products.py
@@ -1,5 +1,5 @@
 from phlo.governance.catalog import GovernanceCatalog
-from phlo.portal.products import build_access_request, build_data_products
+from phlo.portal.products import DataProduct, build_access_request, build_data_products
 
 
 def test_build_data_products_from_governance_catalog() -> None:
@@ -78,6 +78,25 @@ def test_data_product_access_request_policy_ids_are_isolated_between_serializati
     payload["access_request"]["policy_ids"].append("mutated")
 
     assert product.to_read_model()["access_request"]["policy_ids"] == ["original_policy"]
+
+
+def test_data_product_nested_access_request_values_are_isolated_between_serializations() -> None:
+    product = DataProduct(
+        id="gold.customers",
+        title="Gold customers",
+        owner="crm",
+        description=None,
+        domain=None,
+        classification=None,
+        certification="uncertified",
+        status="healthy",
+        access_request={"dataset_id": "x", "approval": {"steps": ["owner"]}},
+    )
+
+    payload = product.to_read_model()
+    payload["access_request"]["approval"]["steps"].append("security")
+
+    assert product.to_read_model()["access_request"]["approval"]["steps"] == ["owner"]
 
 
 def test_build_access_request_payload() -> None:

--- a/tests/portal/test_data_products.py
+++ b/tests/portal/test_data_products.py
@@ -1,5 +1,5 @@
 from phlo.governance.catalog import GovernanceCatalog
-from phlo.portal.products import build_data_products
+from phlo.portal.products import build_access_request, build_data_products
 
 
 def test_build_data_products_from_governance_catalog() -> None:
@@ -78,3 +78,18 @@ def test_data_product_access_request_policy_ids_are_isolated_between_serializati
     payload["access_request"]["policy_ids"].append("mutated")
 
     assert product.to_read_model()["access_request"]["policy_ids"] == ["original_policy"]
+
+
+def test_build_access_request_payload() -> None:
+    payload = build_access_request(
+        dataset_id="warehouse.customers",
+        requester="alice@example.com",
+        reason="Quarterly revenue analysis",
+    )
+
+    assert payload == {
+        "dataset_id": "warehouse.customers",
+        "requester": "alice@example.com",
+        "reason": "Quarterly revenue analysis",
+        "status": "pending",
+    }

--- a/tests/portal/test_data_products.py
+++ b/tests/portal/test_data_products.py
@@ -1,0 +1,59 @@
+from phlo.governance.catalog import GovernanceCatalog
+from phlo.portal.products import build_data_products
+
+
+def test_build_data_products_from_governance_catalog() -> None:
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "version": 1,
+            "datasets": [
+                {
+                    "id": "warehouse.customers",
+                    "owner": "data-platform",
+                    "description": "Customer dimension",
+                    "classification": "restricted",
+                    "tags": {"domain": "crm"},
+                    "policies": ["allow_analyst_dataset_read"],
+                }
+            ],
+        }
+    )
+
+    products = build_data_products(catalog=catalog, statuses={"warehouse.customers": "healthy"})
+
+    assert products[0].id == "warehouse.customers"
+    assert products[0].title == "warehouse.customers"
+    assert products[0].owner == "data-platform"
+    assert products[0].status == "healthy"
+    assert products[0].certification == "uncertified"
+    assert products[0].access_request["policy_ids"] == ["allow_analyst_dataset_read"]
+
+
+def test_data_product_serialization_is_browser_safe() -> None:
+    catalog = GovernanceCatalog.from_dict(
+        {
+            "version": 1,
+            "datasets": [
+                {
+                    "id": "gold.revenue",
+                    "owner": "finance",
+                    "tags": {"certification": "certified", "domain": "finance"},
+                }
+            ],
+        }
+    )
+
+    product = build_data_products(catalog=catalog)[0]
+
+    assert product.to_read_model() == {
+        "id": "gold.revenue",
+        "title": "gold.revenue",
+        "owner": "finance",
+        "description": None,
+        "domain": "finance",
+        "classification": None,
+        "certification": "certified",
+        "status": "unknown",
+        "tags": {"certification": "certified", "domain": "finance"},
+        "access_request": {"dataset_id": "gold.revenue", "policy_ids": []},
+    }


### PR DESCRIPTION
## Summary

Adds a data product portal read model over the governance catalog, including certified product summaries and deterministic access request payloads.

## Stack

This PR targets `GWP/governance-catalog` because the portal model depends on `phlo.governance.catalog`.

## Validation

- `uv run --locked pytest tests/portal -q`
- `uv run --locked ruff check src/phlo/portal tests/portal`
- `uv run --locked ty check src/phlo/portal`
