### PR TITLE
feat: add efficiency control plane v1

### DIFF
--- a/docs/reference/observatory-v2-contracts.md
+++ b/docs/reference/observatory-v2-contracts.md
@@ -40,6 +40,30 @@ All Observatory v2 endpoints are rooted at `/api/observatory/v2`. They are group
 
 Route parameters that identify assets, tables, services, branches, and checks are stable resource identifiers, not provider URLs or secret-bearing connection strings.
 
+### Efficiency Surface Read Model
+
+Efficiency reports summarize table maintenance and cost-risk signals:
+
+```json
+{
+  "summary": {"tables_scored": 1, "finding_count": 1},
+  "findings": [
+    {
+      "table": "bronze.events",
+      "code": "small_files",
+      "severity": "warning",
+      "message": "bronze.events average file size is 1.0 MiB across 1200 files",
+      "recommended_action": "compact_files",
+      "metrics": {"average_file_mib": 1.0, "file_count": 1200}
+    }
+  ]
+}
+```
+
+Recommended actions are symbolic operation names. The UI must route any action
+through guarded Observatory v2 action contracts rather than executing provider
+commands directly.
+
 ## UI Contributions
 
 A UI contribution describes how one capability appears in Observatory v2.

--- a/src/phlo/efficiency/__init__.py
+++ b/src/phlo/efficiency/__init__.py
@@ -1,0 +1,5 @@
+"""Efficiency scoring public API."""
+
+from phlo.efficiency.model import EfficiencyFinding, TableEfficiencyInput, score_table_efficiency
+
+__all__ = ["EfficiencyFinding", "TableEfficiencyInput", "score_table_efficiency"]

--- a/src/phlo/efficiency/__init__.py
+++ b/src/phlo/efficiency/__init__.py
@@ -1,5 +1,15 @@
 """Efficiency scoring public API."""
 
-from phlo.efficiency.model import EfficiencyFinding, TableEfficiencyInput, score_table_efficiency
+from phlo.efficiency.model import (
+    EfficiencyFinding,
+    TableEfficiencyInput,
+    build_efficiency_report,
+    score_table_efficiency,
+)
 
-__all__ = ["EfficiencyFinding", "TableEfficiencyInput", "score_table_efficiency"]
+__all__ = [
+    "EfficiencyFinding",
+    "TableEfficiencyInput",
+    "build_efficiency_report",
+    "score_table_efficiency",
+]

--- a/src/phlo/efficiency/model.py
+++ b/src/phlo/efficiency/model.py
@@ -37,7 +37,7 @@ class EfficiencyFinding:
             "severity": self.severity,
             "message": self.message,
             "recommended_action": self.recommended_action,
-            "metrics": dict(self.metrics),
+            "metrics": _copy_json_like(self.metrics),
         }
 
 
@@ -109,3 +109,13 @@ def _average_file_mib(table: TableEfficiencyInput) -> float:
     if table.file_count <= 0:
         return 0.0
     return table.total_bytes / table.file_count / BYTES_PER_MIB
+
+
+def _copy_json_like(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _copy_json_like(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_copy_json_like(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_copy_json_like(item) for item in value)
+    return value

--- a/src/phlo/efficiency/model.py
+++ b/src/phlo/efficiency/model.py
@@ -114,8 +114,8 @@ def _average_file_mib(table: TableEfficiencyInput) -> float:
 def _copy_json_like(value: Any) -> Any:
     if isinstance(value, dict):
         return {key: _copy_json_like(item) for key, item in value.items()}
-    if isinstance(value, list):
+    if isinstance(value, list | tuple):
         return [_copy_json_like(item) for item in value]
-    if isinstance(value, tuple):
-        return tuple(_copy_json_like(item) for item in value)
+    if isinstance(value, set):
+        return sorted((_copy_json_like(item) for item in value), key=repr)
     return value

--- a/src/phlo/efficiency/model.py
+++ b/src/phlo/efficiency/model.py
@@ -18,7 +18,7 @@ class TableEfficiencyInput:
     file_count: int
     total_bytes: int
     snapshot_count: int
-    latest_run_seconds: int
+    latest_run_seconds: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,7 +78,10 @@ def score_table_efficiency(table: TableEfficiencyInput) -> list[EfficiencyFindin
             )
         )
 
-    if table.latest_run_seconds >= SLOW_RUN_SECONDS_THRESHOLD:
+    if (
+        table.latest_run_seconds is not None
+        and table.latest_run_seconds >= SLOW_RUN_SECONDS_THRESHOLD
+    ):
         findings.append(
             EfficiencyFinding(
                 table=table.table,

--- a/src/phlo/efficiency/model.py
+++ b/src/phlo/efficiency/model.py
@@ -96,6 +96,15 @@ def score_table_efficiency(table: TableEfficiencyInput) -> list[EfficiencyFindin
     return findings
 
 
+def build_efficiency_report(inputs: list[TableEfficiencyInput]) -> dict[str, Any]:
+    """Build an Observatory-safe efficiency report."""
+    findings = [finding for item in inputs for finding in score_table_efficiency(item)]
+    return {
+        "summary": {"tables_scored": len(inputs), "finding_count": len(findings)},
+        "findings": [finding.to_read_model() for finding in findings],
+    }
+
+
 def _average_file_mib(table: TableEfficiencyInput) -> float:
     if table.file_count <= 0:
         return 0.0

--- a/src/phlo/efficiency/model.py
+++ b/src/phlo/efficiency/model.py
@@ -1,0 +1,99 @@
+"""Efficiency scoring models for table maintenance recommendations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+BYTES_PER_MIB = 1024 * 1024
+SMALL_FILES_FILE_COUNT_THRESHOLD = 500
+SMALL_FILES_AVERAGE_MIB_THRESHOLD = 16
+SNAPSHOT_RETENTION_THRESHOLD = 100
+SLOW_RUN_SECONDS_THRESHOLD = 1800
+
+
+@dataclass(frozen=True, slots=True)
+class TableEfficiencyInput:
+    table: str
+    file_count: int
+    total_bytes: int
+    snapshot_count: int
+    latest_run_seconds: int
+
+
+@dataclass(frozen=True, slots=True)
+class EfficiencyFinding:
+    table: str
+    code: str
+    severity: str
+    message: str
+    recommended_action: str
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "table": self.table,
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "recommended_action": self.recommended_action,
+            "metrics": dict(self.metrics),
+        }
+
+
+def score_table_efficiency(table: TableEfficiencyInput) -> list[EfficiencyFinding]:
+    findings: list[EfficiencyFinding] = []
+    average_file_mib = _average_file_mib(table)
+
+    if (
+        table.file_count >= SMALL_FILES_FILE_COUNT_THRESHOLD
+        and average_file_mib < SMALL_FILES_AVERAGE_MIB_THRESHOLD
+    ):
+        findings.append(
+            EfficiencyFinding(
+                table=table.table,
+                code="small_files",
+                severity="warning",
+                message=(
+                    f"{table.table} average file size is {average_file_mib:.1f} MiB "
+                    f"across {table.file_count} files"
+                ),
+                recommended_action="compact_files",
+                metrics={
+                    "average_file_mib": round(average_file_mib, 1),
+                    "file_count": table.file_count,
+                },
+            )
+        )
+
+    if table.snapshot_count >= SNAPSHOT_RETENTION_THRESHOLD:
+        findings.append(
+            EfficiencyFinding(
+                table=table.table,
+                code="snapshot_retention",
+                severity="warning",
+                message=(f"{table.table} has {table.snapshot_count} snapshots retained"),
+                recommended_action="expire_snapshots",
+                metrics={"snapshot_count": table.snapshot_count},
+            )
+        )
+
+    if table.latest_run_seconds >= SLOW_RUN_SECONDS_THRESHOLD:
+        findings.append(
+            EfficiencyFinding(
+                table=table.table,
+                code="slow_run",
+                severity="warning",
+                message=(f"{table.table} latest run took {table.latest_run_seconds} seconds"),
+                recommended_action="inspect_run_performance",
+                metrics={"latest_run_seconds": table.latest_run_seconds},
+            )
+        )
+
+    return findings
+
+
+def _average_file_mib(table: TableEfficiencyInput) -> float:
+    if table.file_count <= 0:
+        return 0.0
+    return table.total_bytes / table.file_count / BYTES_PER_MIB

--- a/tests/efficiency/test_model.py
+++ b/tests/efficiency/test_model.py
@@ -1,4 +1,5 @@
 from phlo.efficiency import (
+    EfficiencyFinding,
     TableEfficiencyInput,
     build_efficiency_report,
     score_table_efficiency,
@@ -69,6 +70,22 @@ def test_efficiency_finding_serializes_for_observatory() -> None:
         "recommended_action": "compact_files",
         "metrics": {"average_file_mib": 1.0, "file_count": 1200},
     }
+
+
+def test_efficiency_finding_serializes_nested_metrics_without_mutable_leaks() -> None:
+    finding = EfficiencyFinding(
+        table="bronze.events",
+        code="partition_skew",
+        severity="warning",
+        message="bronze.events has hot partitions",
+        recommended_action="rebalance_partitions",
+        metrics={"partitions": {"hot": ["2026-05-22"]}},
+    )
+
+    payload = finding.to_read_model()
+    payload["metrics"]["partitions"]["hot"].append("mutated")
+
+    assert finding.to_read_model()["metrics"]["partitions"]["hot"] == ["2026-05-22"]
 
 
 def test_build_efficiency_report_serializes_findings() -> None:

--- a/tests/efficiency/test_model.py
+++ b/tests/efficiency/test_model.py
@@ -1,4 +1,8 @@
-from phlo.efficiency import TableEfficiencyInput, score_table_efficiency
+from phlo.efficiency import (
+    TableEfficiencyInput,
+    build_efficiency_report,
+    score_table_efficiency,
+)
 
 
 def test_score_table_efficiency_flags_small_files() -> None:
@@ -65,3 +69,19 @@ def test_efficiency_finding_serializes_for_observatory() -> None:
         "recommended_action": "compact_files",
         "metrics": {"average_file_mib": 1.0, "file_count": 1200},
     }
+
+
+def test_build_efficiency_report_serializes_findings() -> None:
+    report = build_efficiency_report(
+        [
+            TableEfficiencyInput(
+                table="bronze.events",
+                file_count=1200,
+                total_bytes=1200 * 1024 * 1024,
+                snapshot_count=8,
+            )
+        ]
+    )
+
+    assert report["summary"] == {"tables_scored": 1, "finding_count": 1}
+    assert report["findings"][0]["code"] == "small_files"

--- a/tests/efficiency/test_model.py
+++ b/tests/efficiency/test_model.py
@@ -32,6 +32,20 @@ def test_score_table_efficiency_flags_stale_snapshots() -> None:
     assert report[0].recommended_action == "expire_snapshots"
 
 
+def test_score_table_efficiency_allows_missing_latest_run_duration() -> None:
+    report = score_table_efficiency(
+        TableEfficiencyInput(
+            table="bronze.events",
+            file_count=10,
+            total_bytes=10 * 128 * 1024 * 1024,
+            snapshot_count=8,
+            latest_run_seconds=None,
+        )
+    )
+
+    assert report == []
+
+
 def test_efficiency_finding_serializes_for_observatory() -> None:
     report = score_table_efficiency(
         TableEfficiencyInput(

--- a/tests/efficiency/test_model.py
+++ b/tests/efficiency/test_model.py
@@ -79,13 +79,22 @@ def test_efficiency_finding_serializes_nested_metrics_without_mutable_leaks() ->
         severity="warning",
         message="bronze.events has hot partitions",
         recommended_action="rebalance_partitions",
-        metrics={"partitions": {"hot": ["2026-05-22"]}},
+        metrics={
+            "partitions": {"hot": ["2026-05-22"]},
+            "checks": ("small_files", "snapshot_retention"),
+            "tags": {"bronze", "quality"},
+        },
     )
 
     payload = finding.to_read_model()
     payload["metrics"]["partitions"]["hot"].append("mutated")
 
     assert finding.to_read_model()["metrics"]["partitions"]["hot"] == ["2026-05-22"]
+    assert finding.to_read_model()["metrics"]["checks"] == [
+        "small_files",
+        "snapshot_retention",
+    ]
+    assert finding.to_read_model()["metrics"]["tags"] == ["bronze", "quality"]
 
 
 def test_build_efficiency_report_serializes_findings() -> None:

--- a/tests/efficiency/test_model.py
+++ b/tests/efficiency/test_model.py
@@ -1,0 +1,53 @@
+from phlo.efficiency import TableEfficiencyInput, score_table_efficiency
+
+
+def test_score_table_efficiency_flags_small_files() -> None:
+    report = score_table_efficiency(
+        TableEfficiencyInput(
+            table="bronze.events",
+            file_count=1200,
+            total_bytes=1200 * 1024 * 1024,
+            snapshot_count=8,
+            latest_run_seconds=120,
+        )
+    )
+
+    assert report[0].code == "small_files"
+    assert report[0].severity == "warning"
+    assert "average file size is 1.0 MiB" in report[0].message
+
+
+def test_score_table_efficiency_flags_stale_snapshots() -> None:
+    report = score_table_efficiency(
+        TableEfficiencyInput(
+            table="bronze.events",
+            file_count=10,
+            total_bytes=10 * 128 * 1024 * 1024,
+            snapshot_count=250,
+            latest_run_seconds=120,
+        )
+    )
+
+    assert report[0].code == "snapshot_retention"
+    assert report[0].recommended_action == "expire_snapshots"
+
+
+def test_efficiency_finding_serializes_for_observatory() -> None:
+    report = score_table_efficiency(
+        TableEfficiencyInput(
+            table="bronze.events",
+            file_count=1200,
+            total_bytes=1200 * 1024 * 1024,
+            snapshot_count=8,
+            latest_run_seconds=120,
+        )
+    )
+
+    assert report[0].to_read_model() == {
+        "table": "bronze.events",
+        "code": "small_files",
+        "severity": "warning",
+        "message": "bronze.events average file size is 1.0 MiB across 1200 files",
+        "recommended_action": "compact_files",
+        "metrics": {"average_file_mib": 1.0, "file_count": 1200},
+    }


### PR DESCRIPTION
## Summary

Adds efficiency scoring and reporting for table maintenance signals, including compact-file style findings, recommended symbolic actions, and browser-safe metrics payloads.

## Validation

- `uv run --locked pytest tests/efficiency -q`
- `uv run --locked ruff check src/phlo/efficiency tests/efficiency`
- `uv run --locked ty check src/phlo/efficiency`
