### PR TITLE
feat: add data sharing manifests v1

### DIFF
--- a/docs/reference/observatory-v2-contracts.md
+++ b/docs/reference/observatory-v2-contracts.md
@@ -73,6 +73,24 @@ The governance surface may include a provider-neutral catalog payload:
 This payload is safe for browser rendering. It must not contain raw credentials,
 private URLs, signed URLs, or generated backend grants.
 
+### Sharing Surface Read Model
+
+Sharing manifests describe governed read-only data shares:
+
+```json
+{
+  "version": 1,
+  "share_id": "partner-revenue",
+  "title": "Partner Revenue Share",
+  "datasets": [{"id": "gold.revenue", "mode": "read"}],
+  "recipients": [{"id": "partner-a", "type": "partner"}]
+}
+```
+
+V1 sharing manifests are declarative. Delivery adapters for Delta Sharing,
+Iceberg REST catalogs, signed exports, or partner-specific distribution must
+consume the manifest through explicit provider packages.
+
 ## UI Contributions
 
 A UI contribution describes how one capability appears in Observatory v2.

--- a/docs/reference/observatory-v2-contracts.md
+++ b/docs/reference/observatory-v2-contracts.md
@@ -35,7 +35,7 @@ All Observatory v2 endpoints are rooted at `/api/observatory/v2`. They are group
 | Data and assets | `assets`, `assets/{asset_id}`, `tables`, `table-preview/{table_id}`, `query`, `saved-queries`, `stage-diff`, `row-journey/{table_id}/{row_id}` | Expose provider-neutral asset, table, query, diff, and row provenance read models. |
 | Quality and logs | `quality`, `quality/{check_id}`, `logs`, `logs/facets` | Support quality triage and evidence inspection. |
 | Branches and changes | `branches`, `branches/{branch_name}`, `branches/actions` | Describe branch state and execute guarded branch operations. |
-| Capability surfaces | `storage`, `observability`, `governance`, `catalog`, `apis`, `bi` | Allow packages to contribute specialized operator surfaces without hardcoding provider APIs in the UI. |
+| Capability surfaces | `storage`, `observability`, `governance`, `catalog`, `sharing`, `apis`, `bi` | Allow packages to contribute specialized operator surfaces without hardcoding provider APIs in the UI. |
 | Extensions and settings | `extensions`, `extensions/{extension_id}`, `settings`, `search`, `actions` | Expose extension inventory, global search, settings state, and generic guarded actions. |
 
 Route parameters that identify assets, tables, services, branches, and checks are stable resource identifiers, not provider URLs or secret-bearing connection strings.
@@ -121,6 +121,7 @@ Prefer existing Observatory v2 surfaces before introducing new ones:
 - `Observability`
 - `Governance`
 - `Catalog`
+- `Sharing`
 - `APIs`
 - `BI`
 - `Services`

--- a/src/phlo/sharing/__init__.py
+++ b/src/phlo/sharing/__init__.py
@@ -1,0 +1,5 @@
+"""Data sharing public API."""
+
+from phlo.sharing.manifest import ShareDataset, ShareManifest, ShareRecipient
+
+__all__ = ["ShareDataset", "ShareManifest", "ShareRecipient"]

--- a/src/phlo/sharing/manifest.py
+++ b/src/phlo/sharing/manifest.py
@@ -1,0 +1,69 @@
+"""Data sharing manifest models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from phlo.governance.catalog import GovernanceCatalog
+
+
+@dataclass(frozen=True, slots=True)
+class ShareDataset:
+    id: str
+    mode: str = "read"
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {"id": self.id, "mode": self.mode}
+
+
+@dataclass(frozen=True, slots=True)
+class ShareRecipient:
+    id: str
+    type: str
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {"id": self.id, "type": self.type}
+
+
+@dataclass(frozen=True, slots=True)
+class ShareManifest:
+    version: int
+    share_id: str
+    title: str | None
+    datasets: tuple[ShareDataset, ...]
+    recipients: tuple[ShareRecipient, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], *, catalog: GovernanceCatalog) -> ShareManifest:
+        datasets: list[ShareDataset] = []
+        for raw in data.get("datasets", []):
+            dataset_id = str(raw["id"])
+            mode = str(raw.get("mode", "read"))
+            if mode != "read":
+                raise ValueError(f"Shares are read-only in v1: {dataset_id} requested {mode}")
+            if dataset_id not in catalog.datasets:
+                raise ValueError(f"Share references unknown governed dataset: {dataset_id}")
+            datasets.append(ShareDataset(id=dataset_id, mode=mode))
+
+        recipients = tuple(
+            ShareRecipient(id=str(raw["id"]), type=str(raw["type"]))
+            for raw in data.get("recipients", [])
+        )
+
+        return cls(
+            version=int(data.get("version", 1)),
+            share_id=str(data["share_id"]),
+            title=data.get("title"),
+            datasets=tuple(datasets),
+            recipients=recipients,
+        )
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "share_id": self.share_id,
+            "title": self.title,
+            "datasets": [dataset.to_read_model() for dataset in self.datasets],
+            "recipients": [recipient.to_read_model() for recipient in self.recipients],
+        }

--- a/src/phlo/sharing/manifest.py
+++ b/src/phlo/sharing/manifest.py
@@ -13,6 +13,10 @@ class ShareDataset:
     id: str
     mode: str = "read"
 
+    def __post_init__(self) -> None:
+        if self.mode != "read":
+            raise ValueError(f"Shares are read-only in v1: {self.id} requested {self.mode}")
+
     def to_read_model(self) -> dict[str, Any]:
         return {"id": self.id, "mode": self.mode}
 

--- a/src/phlo/sharing/manifest.py
+++ b/src/phlo/sharing/manifest.py
@@ -41,26 +41,32 @@ class ShareManifest:
     @classmethod
     def from_dict(cls, data: dict[str, Any], *, catalog: GovernanceCatalog) -> ShareManifest:
         datasets: list[ShareDataset] = []
+        seen_dataset_ids: set[str] = set()
         for raw in data.get("datasets", []):
             dataset_id = str(raw["id"])
             mode = str(raw.get("mode", "read"))
-            if mode != "read":
-                raise ValueError(f"Shares are read-only in v1: {dataset_id} requested {mode}")
+            if dataset_id in seen_dataset_ids:
+                raise ValueError(f"Duplicate shared dataset id: {dataset_id}")
             if dataset_id not in catalog.datasets:
                 raise ValueError(f"Share references unknown governed dataset: {dataset_id}")
+            seen_dataset_ids.add(dataset_id)
             datasets.append(ShareDataset(id=dataset_id, mode=mode))
 
-        recipients = tuple(
-            ShareRecipient(id=str(raw["id"]), type=str(raw["type"]))
-            for raw in data.get("recipients", [])
-        )
+        recipients: list[ShareRecipient] = []
+        seen_recipient_ids: set[str] = set()
+        for raw in data.get("recipients", []):
+            recipient_id = str(raw["id"])
+            if recipient_id in seen_recipient_ids:
+                raise ValueError(f"Duplicate share recipient id: {recipient_id}")
+            seen_recipient_ids.add(recipient_id)
+            recipients.append(ShareRecipient(id=recipient_id, type=str(raw["type"])))
 
         return cls(
             version=int(data.get("version", 1)),
             share_id=str(data["share_id"]),
             title=data.get("title"),
             datasets=tuple(datasets),
-            recipients=recipients,
+            recipients=tuple(recipients),
         )
 
     def to_read_model(self) -> dict[str, Any]:

--- a/tests/sharing/test_manifest.py
+++ b/tests/sharing/test_manifest.py
@@ -1,0 +1,57 @@
+from phlo.governance.catalog import GovernanceCatalog
+from phlo.sharing import ShareManifest
+
+
+def _catalog() -> GovernanceCatalog:
+    return GovernanceCatalog.from_dict(
+        {"version": 1, "datasets": [{"id": "gold.revenue", "owner": "finance"}]}
+    )
+
+
+def test_share_manifest_parses_read_only_share() -> None:
+    manifest = ShareManifest.from_dict(
+        {
+            "version": 1,
+            "share_id": "partner-revenue",
+            "title": "Partner Revenue Share",
+            "datasets": [{"id": "gold.revenue", "mode": "read"}],
+            "recipients": [{"id": "partner-a", "type": "partner"}],
+        },
+        catalog=_catalog(),
+    )
+
+    assert manifest.share_id == "partner-revenue"
+    assert manifest.datasets[0].id == "gold.revenue"
+    assert manifest.recipients[0].id == "partner-a"
+
+
+def test_share_manifest_rejects_write_mode() -> None:
+    try:
+        ShareManifest.from_dict(
+            {
+                "share_id": "bad-share",
+                "datasets": [{"id": "gold.revenue", "mode": "write"}],
+                "recipients": [{"id": "partner-a", "type": "partner"}],
+            },
+            catalog=_catalog(),
+        )
+    except ValueError as exc:
+        assert "Shares are read-only in v1: gold.revenue requested write" in str(exc)
+    else:
+        raise AssertionError("Expected write mode to fail")
+
+
+def test_share_manifest_rejects_unknown_dataset() -> None:
+    try:
+        ShareManifest.from_dict(
+            {
+                "share_id": "bad-share",
+                "datasets": [{"id": "gold.unknown", "mode": "read"}],
+                "recipients": [{"id": "partner-a", "type": "partner"}],
+            },
+            catalog=_catalog(),
+        )
+    except ValueError as exc:
+        assert "Share references unknown governed dataset: gold.unknown" in str(exc)
+    else:
+        raise AssertionError("Expected unknown dataset to fail")

--- a/tests/sharing/test_manifest.py
+++ b/tests/sharing/test_manifest.py
@@ -85,3 +85,41 @@ def test_share_manifest_rejects_unknown_dataset() -> None:
         assert "Share references unknown governed dataset: gold.unknown" in str(exc)
     else:
         raise AssertionError("Expected unknown dataset to fail")
+
+
+def test_share_manifest_rejects_duplicate_dataset_ids() -> None:
+    try:
+        ShareManifest.from_dict(
+            {
+                "share_id": "partner-revenue",
+                "datasets": [
+                    {"id": "gold.revenue"},
+                    {"id": "gold.revenue"},
+                ],
+                "recipients": [{"id": "partner-a", "type": "partner"}],
+            },
+            catalog=_catalog(),
+        )
+    except ValueError as exc:
+        assert "Duplicate shared dataset id: gold.revenue" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate dataset to fail")
+
+
+def test_share_manifest_rejects_duplicate_recipient_ids() -> None:
+    try:
+        ShareManifest.from_dict(
+            {
+                "share_id": "partner-revenue",
+                "datasets": [{"id": "gold.revenue"}],
+                "recipients": [
+                    {"id": "partner-a", "type": "partner"},
+                    {"id": "partner-a", "type": "partner"},
+                ],
+            },
+            catalog=_catalog(),
+        )
+    except ValueError as exc:
+        assert "Duplicate share recipient id: partner-a" in str(exc)
+    else:
+        raise AssertionError("Expected duplicate recipient to fail")

--- a/tests/sharing/test_manifest.py
+++ b/tests/sharing/test_manifest.py
@@ -25,6 +25,27 @@ def test_share_manifest_parses_read_only_share() -> None:
     assert manifest.recipients[0].id == "partner-a"
 
 
+def test_share_manifest_serializes_browser_safe_payload() -> None:
+    manifest = ShareManifest.from_dict(
+        {
+            "version": 1,
+            "share_id": "partner-revenue",
+            "title": "Partner Revenue Share",
+            "datasets": [{"id": "gold.revenue", "mode": "read"}],
+            "recipients": [{"id": "partner-a", "type": "partner"}],
+        },
+        catalog=_catalog(),
+    )
+
+    assert manifest.to_read_model() == {
+        "version": 1,
+        "share_id": "partner-revenue",
+        "title": "Partner Revenue Share",
+        "datasets": [{"id": "gold.revenue", "mode": "read"}],
+        "recipients": [{"id": "partner-a", "type": "partner"}],
+    }
+
+
 def test_share_manifest_rejects_write_mode() -> None:
     try:
         ShareManifest.from_dict(

--- a/tests/sharing/test_manifest.py
+++ b/tests/sharing/test_manifest.py
@@ -1,5 +1,5 @@
 from phlo.governance.catalog import GovernanceCatalog
-from phlo.sharing import ShareManifest
+from phlo.sharing import ShareDataset, ShareManifest
 
 
 def _catalog() -> GovernanceCatalog:
@@ -35,6 +35,15 @@ def test_share_manifest_rejects_write_mode() -> None:
             },
             catalog=_catalog(),
         )
+    except ValueError as exc:
+        assert "Shares are read-only in v1: gold.revenue requested write" in str(exc)
+    else:
+        raise AssertionError("Expected write mode to fail")
+
+
+def test_share_dataset_rejects_write_mode() -> None:
+    try:
+        ShareDataset(id="gold.revenue", mode="write")
     except ValueError as exc:
         assert "Shares are read-only in v1: gold.revenue requested write" in str(exc)
     else:


### PR DESCRIPTION
## Summary

Adds declarative read-only data sharing manifests, recipients, dataset share validation, read model serialization, and Observatory contract docs for sharing surfaces.

## Stack

This PR targets `GWP/governance-catalog` because the sharing tests and read model consume governance catalog data structures.

## Validation

- `uv run --locked pytest tests/sharing -q`
- `uv run --locked ruff check src/phlo/sharing tests/sharing`
- `uv run --locked ty check src/phlo/sharing`
