### PR TITLE
feat: add federated access registry v1

### DIFF
--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -412,6 +412,28 @@ Notes:
 - `PHLO_DEFAULT_REF` is required for ref-dependent endpoints unless the resolved `query_engine` capability exposes `default_ref`.
 - `PHLO_API_DISCOVERY_SCHEMAS` is optional only when table discovery can use request `branch`/`preferred_schema` values or `query_engine` capability metadata such as `discovery_schemas`.
 
+## Federation Registry
+
+Federated access is configured through `.phlo/federation.yaml`:
+
+```yaml
+version: 1
+connections:
+  - id: crm-postgres
+    type: postgres
+    jdbc_url: jdbc:postgresql://crm.internal:5432/app
+    secret_ref: PHLO_CRM_POSTGRES_PASSWORD
+datasets:
+  - id: crm.public.accounts
+    connection_id: crm-postgres
+    remote_name: public.accounts
+    mode: query
+```
+
+Connection credentials are referenced by environment variable name and are not
+returned in Observatory read models. `mode: query` means the dataset remains in
+the source system and is accessed through a federation provider such as Trino.
+
 ### dbt Runtime Configuration
 
 Generated dbt profile settings:

--- a/src/phlo/federation/__init__.py
+++ b/src/phlo/federation/__init__.py
@@ -1,0 +1,5 @@
+"""Federated access registry models."""
+
+from phlo.federation.registry import ExternalConnection, FederationRegistry, ForeignDataset
+
+__all__ = ["ExternalConnection", "FederationRegistry", "ForeignDataset"]

--- a/src/phlo/federation/registry.py
+++ b/src/phlo/federation/registry.py
@@ -1,0 +1,83 @@
+"""Provider-neutral federation registry models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalConnection:
+    id: str
+    type: str
+    jdbc_url: str
+    secret_ref: str
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ForeignDataset:
+    id: str
+    connection_id: str
+    remote_name: str
+    mode: str = "query"
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "connection_id": self.connection_id,
+            "remote_name": self.remote_name,
+            "mode": self.mode,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class FederationRegistry:
+    version: int
+    connections: dict[str, ExternalConnection]
+    datasets: dict[str, ForeignDataset]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FederationRegistry:
+        connections: dict[str, ExternalConnection] = {}
+        for raw in data.get("connections", []):
+            connection_id = str(raw["id"])
+            connections[connection_id] = ExternalConnection(
+                id=connection_id,
+                type=str(raw["type"]),
+                jdbc_url=str(raw["jdbc_url"]),
+                secret_ref=str(raw["secret_ref"]),
+            )
+
+        datasets: dict[str, ForeignDataset] = {}
+        for raw in data.get("datasets", []):
+            dataset_id = str(raw["id"])
+            connection_id = str(raw["connection_id"])
+            if connection_id not in connections:
+                raise ValueError(
+                    f"Foreign dataset {dataset_id} references unknown connection {connection_id}"
+                )
+            datasets[dataset_id] = ForeignDataset(
+                id=dataset_id,
+                connection_id=connection_id,
+                remote_name=str(raw["remote_name"]),
+                mode=str(raw.get("mode", "query")),
+            )
+
+        return cls(
+            version=int(data.get("version", 1)),
+            connections=connections,
+            datasets=datasets,
+        )
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "connections": [connection.to_read_model() for connection in self.connections.values()],
+            "datasets": [dataset.to_read_model() for dataset in self.datasets.values()],
+        }

--- a/src/phlo/federation/registry.py
+++ b/src/phlo/federation/registry.py
@@ -82,6 +82,11 @@ class FederationRegistry:
     def to_read_model(self) -> dict[str, Any]:
         return {
             "version": self.version,
-            "connections": [connection.to_read_model() for connection in self.connections.values()],
-            "datasets": [dataset.to_read_model() for dataset in self.datasets.values()],
+            "connections": [
+                self.connections[connection_id].to_read_model()
+                for connection_id in sorted(self.connections)
+            ],
+            "datasets": [
+                self.datasets[dataset_id].to_read_model() for dataset_id in sorted(self.datasets)
+            ],
         }

--- a/src/phlo/federation/registry.py
+++ b/src/phlo/federation/registry.py
@@ -47,6 +47,8 @@ class FederationRegistry:
         connections: dict[str, ExternalConnection] = {}
         for raw in data.get("connections", []):
             connection_id = str(raw["id"])
+            if connection_id in connections:
+                raise ValueError(f"Duplicate federation connection id: {connection_id}")
             connections[connection_id] = ExternalConnection(
                 id=connection_id,
                 type=str(raw["type"]),
@@ -57,6 +59,8 @@ class FederationRegistry:
         datasets: dict[str, ForeignDataset] = {}
         for raw in data.get("datasets", []):
             dataset_id = str(raw["id"])
+            if dataset_id in datasets:
+                raise ValueError(f"Duplicate foreign dataset id: {dataset_id}")
             connection_id = str(raw["connection_id"])
             if connection_id not in connections:
                 raise ValueError(

--- a/tests/federation/test_registry.py
+++ b/tests/federation/test_registry.py
@@ -1,0 +1,97 @@
+from phlo.federation.registry import FederationRegistry
+
+
+def test_registry_parses_connections_and_datasets() -> None:
+    registry = FederationRegistry.from_dict(
+        {
+            "version": 1,
+            "connections": [
+                {
+                    "id": "crm",
+                    "type": "postgres",
+                    "jdbc_url": "jdbc:postgresql://crm.example.com:5432/app",
+                    "secret_ref": "secret/data/crm",
+                }
+            ],
+            "datasets": [
+                {
+                    "id": "crm.public.accounts",
+                    "connection_id": "crm",
+                    "remote_name": "public.accounts",
+                    "mode": "query",
+                }
+            ],
+        }
+    )
+
+    connection = registry.connections["crm"]
+    dataset = registry.datasets["crm.public.accounts"]
+
+    assert registry.version == 1
+    assert connection.type == "postgres"
+    assert connection.jdbc_url == "jdbc:postgresql://crm.example.com:5432/app"
+    assert connection.secret_ref == "secret/data/crm"
+    assert dataset.connection_id == "crm"
+    assert dataset.remote_name == "public.accounts"
+    assert dataset.mode == "query"
+
+
+def test_registry_rejects_unknown_connection() -> None:
+    try:
+        FederationRegistry.from_dict(
+            {
+                "version": 1,
+                "connections": [],
+                "datasets": [
+                    {
+                        "id": "crm.public.accounts",
+                        "connection_id": "missing",
+                        "remote_name": "public.accounts",
+                    }
+                ],
+            }
+        )
+    except ValueError as exc:
+        assert (
+            str(exc) == "Foreign dataset crm.public.accounts references unknown connection missing"
+        )
+    else:
+        raise AssertionError("Expected unknown connection to fail")
+
+
+def test_registry_read_model_redacts_connection_details() -> None:
+    registry = FederationRegistry.from_dict(
+        {
+            "version": 1,
+            "connections": [
+                {
+                    "id": "crm",
+                    "type": "postgres",
+                    "jdbc_url": "jdbc:postgresql://crm.example.com:5432/app",
+                    "secret_ref": "secret/data/crm",
+                }
+            ],
+            "datasets": [
+                {
+                    "id": "crm.public.accounts",
+                    "connection_id": "crm",
+                    "remote_name": "public.accounts",
+                }
+            ],
+        }
+    )
+
+    payload = registry.to_read_model()
+
+    assert payload == {
+        "version": 1,
+        "connections": [{"id": "crm", "type": "postgres"}],
+        "datasets": [
+            {
+                "id": "crm.public.accounts",
+                "connection_id": "crm",
+                "remote_name": "public.accounts",
+                "mode": "query",
+            }
+        ],
+    }

--- a/tests/federation/test_registry.py
+++ b/tests/federation/test_registry.py
@@ -59,6 +59,67 @@ def test_registry_rejects_unknown_connection() -> None:
         raise AssertionError("Expected unknown connection to fail")
 
 
+def test_registry_rejects_duplicate_connection_ids() -> None:
+    try:
+        FederationRegistry.from_dict(
+            {
+                "version": 1,
+                "connections": [
+                    {
+                        "id": "crm-postgres",
+                        "type": "postgres",
+                        "jdbc_url": "jdbc:postgresql://primary.example.com:5432/app",
+                        "secret_ref": "secret/data/crm-primary",
+                    },
+                    {
+                        "id": "crm-postgres",
+                        "type": "postgres",
+                        "jdbc_url": "jdbc:postgresql://replica.example.com:5432/app",
+                        "secret_ref": "secret/data/crm-replica",
+                    },
+                ],
+                "datasets": [],
+            }
+        )
+    except ValueError as exc:
+        assert str(exc) == "Duplicate federation connection id: crm-postgres"
+    else:
+        raise AssertionError("Expected duplicate connection id to fail")
+
+
+def test_registry_rejects_duplicate_dataset_ids() -> None:
+    try:
+        FederationRegistry.from_dict(
+            {
+                "version": 1,
+                "connections": [
+                    {
+                        "id": "crm",
+                        "type": "postgres",
+                        "jdbc_url": "jdbc:postgresql://crm.example.com:5432/app",
+                        "secret_ref": "secret/data/crm",
+                    }
+                ],
+                "datasets": [
+                    {
+                        "id": "crm.public.accounts",
+                        "connection_id": "crm",
+                        "remote_name": "public.accounts",
+                    },
+                    {
+                        "id": "crm.public.accounts",
+                        "connection_id": "crm",
+                        "remote_name": "public.accounts_archive",
+                    },
+                ],
+            }
+        )
+    except ValueError as exc:
+        assert str(exc) == "Duplicate foreign dataset id: crm.public.accounts"
+    else:
+        raise AssertionError("Expected duplicate dataset id to fail")
+
+
 def test_registry_read_model_redacts_connection_details() -> None:
     registry = FederationRegistry.from_dict(
         {

--- a/tests/federation/test_registry.py
+++ b/tests/federation/test_registry.py
@@ -156,3 +156,34 @@ def test_registry_read_model_redacts_connection_details() -> None:
             }
         ],
     }
+
+
+def test_registry_read_model_is_deterministic() -> None:
+    registry = FederationRegistry.from_dict(
+        {
+            "version": 1,
+            "connections": [
+                {
+                    "id": "z",
+                    "type": "postgres",
+                    "jdbc_url": "jdbc:postgresql://z.example.com:5432/app",
+                    "secret_ref": "secret/data/z",
+                },
+                {
+                    "id": "a",
+                    "type": "postgres",
+                    "jdbc_url": "jdbc:postgresql://a.example.com:5432/app",
+                    "secret_ref": "secret/data/a",
+                },
+            ],
+            "datasets": [
+                {"id": "z.remote", "connection_id": "z", "remote_name": "public.z"},
+                {"id": "a.remote", "connection_id": "a", "remote_name": "public.a"},
+            ],
+        }
+    )
+
+    payload = registry.to_read_model()
+
+    assert [connection["id"] for connection in payload["connections"]] == ["a", "z"]
+    assert [dataset["id"] for dataset in payload["datasets"]] == ["a.remote", "z.remote"]


### PR DESCRIPTION
## Summary

Adds a federated access registry model for external sources, replica declarations, duplicate-id validation, and redacted browser-safe connection summaries.

## Validation

- `uv run --locked pytest tests/federation -q`
- `uv run --locked ruff check src/phlo/federation tests/federation`
- `uv run --locked ty check src/phlo/federation`
