### PR TITLE
feat: add ai operator assistant context v1

### DIFF
--- a/docs/reference/phlo-api.md
+++ b/docs/reference/phlo-api.md
@@ -123,7 +123,8 @@ See [Observatory v2 Contracts](observatory-v2-contracts.md) for the capability c
 ## Assistant Context Payloads
 
 Assistant context payloads are deterministic, sanitized summaries for AI tools.
-They do not execute actions and do not include credentials.
+They do not execute actions, redact supported credential patterns, and should
+not be used for raw secrets.
 
 ```json
 {

--- a/docs/reference/phlo-api.md
+++ b/docs/reference/phlo-api.md
@@ -120,6 +120,25 @@ Observatory v2 endpoints live under `/api/observatory/v2`. They are provider-neu
 
 See [Observatory v2 Contracts](observatory-v2-contracts.md) for the capability contribution model and browser-safety rules.
 
+## Assistant Context Payloads
+
+Assistant context payloads are deterministic, sanitized summaries for AI tools.
+They do not execute actions and do not include credentials.
+
+```json
+{
+  "kind": "phlo.assistant.context.v1",
+  "payload": {
+    "title": "Quality failure",
+    "facts": {"table": "silver.orders", "check": "not_null(order_id)"},
+    "suggested_actions": ["inspect_quality_check", "open_lineage"]
+  }
+}
+```
+
+Suggested actions are symbolic names. Tools must route any mutation or provider
+operation through guarded Phlo action contracts.
+
 ## Key Features
 
 ### 1. Read-Only Query Guardrails

--- a/src/phlo/assistant/__init__.py
+++ b/src/phlo/assistant/__init__.py
@@ -1,0 +1,5 @@
+"""Assistant public API."""
+
+from phlo.assistant.context import AssistantContextBundle, build_incident_context
+
+__all__ = ["AssistantContextBundle", "build_incident_context"]

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -22,14 +22,6 @@ _KEY_VALUE_SECRET_RE = re.compile(
     rf"""\b({_SECRET_NAME_PATTERN})\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)""",
     re.IGNORECASE,
 )
-_SECRET_KEY_RE = re.compile(
-    r"^(?:password|passwd|token|access[_-]?token|refresh[_-]?token|"
-    r"auth[_-]?token|session[_-]?token|client[_-]?secret|secret[_-]?key|"
-    r"secret|api[_-]?key|credential|authorization|"
-    r"private[_-]?key(?:[_-].*)?|signing[_-]?key(?:[_-].*)?|"
-    r"encryption[_-]?key(?:[_-].*)?)$",
-    re.IGNORECASE,
-)
 
 
 def _redact(value: str) -> str:
@@ -37,6 +29,22 @@ def _redact(value: str) -> str:
     value = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", value)
     value = _AUTHORIZATION_BEARER_RE.sub(r"\1\2 <redacted>", value)
     return _BEARER_RE.sub(r"\1 <redacted>", value)
+
+
+def _is_secret_key(key: str) -> bool:
+    parts = [part for part in re.split(r"[_-]+", key.lower()) if part]
+    if not parts:
+        return False
+    if key.lower() == "authorization":
+        return True
+    if any(part in {"password", "passwd", "token", "credential"} for part in parts):
+        return True
+    pairs = set(zip(parts, parts[1:], strict=False))
+    if ("api", "key") in pairs or ("client", "secret") in pairs:
+        return True
+    if "secret" in parts and "key" in parts:
+        return True
+    return any((prefix, "key") in pairs for prefix in ("private", "signing", "encryption"))
 
 
 def _redact_value(value: Any, *, secret_key: bool = False) -> Any:
@@ -70,7 +78,7 @@ def _redact_facts(facts: Mapping[str, Any]) -> dict[str, Any]:
             redacted_key = f"{redacted_key} ({collisions[redacted_key]})"
         redacted[redacted_key] = _redact_value(
             value,
-            secret_key=_SECRET_KEY_RE.fullmatch(raw_key) is not None,
+            secret_key=_is_secret_key(raw_key),
         )
     return redacted
 

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -18,7 +18,7 @@ _KEY_VALUE_SECRET_RE = re.compile(
     re.IGNORECASE,
 )
 _SECRET_KEY_RE = re.compile(
-    r"^(?:password|passwd|token|access[_-]?token|refresh[_-]?token|secret|api[_-]?key|credential|authorization)$",
+    r"^(?:password|passwd|token|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|client[_-]?secret|secret|api[_-]?key|credential|authorization|private[_-]?key|signing[_-]?key|encryption[_-]?key)$",
     re.IGNORECASE,
 )
 
@@ -41,7 +41,11 @@ def _redact_value(value: Any, *, secret_key: bool = False) -> Any:
         return [_redact_value(item) for item in value]
     if isinstance(value, tuple):
         return [_redact_value(item) for item in value]
-    return value
+    if isinstance(value, set):
+        return sorted((_redact_value(item) for item in value), key=repr)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return _redact(str(value))
 
 
 def _redact_facts(facts: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -50,6 +50,10 @@ class AssistantContextBundle:
             "suggested_actions": [_redact(action) for action in self.suggested_actions],
         }
 
+    def to_mcp_payload(self) -> dict[str, Any]:
+        """Serialize context for MCP tools without granting execution privileges."""
+        return {"kind": "phlo.assistant.context.v1", "payload": self.to_read_model()}
+
     def to_prompt(self) -> str:
         payload = self.to_read_model()
         facts = payload["facts"]

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -7,13 +7,13 @@ from dataclasses import dataclass, field
 from typing import Any
 
 _DSN_RE = re.compile(r"^[a-z][a-z0-9+.-]*://\S+$", re.IGNORECASE)
-_TOKEN_RE = re.compile(r"token=\S+")
+_TOKEN_RE = re.compile(r"(token)=\S+", re.IGNORECASE)
 
 
 def _redact(value: str) -> str:
     if _DSN_RE.fullmatch(value):
         return "<redacted-dsn>"
-    return _TOKEN_RE.sub("token=<redacted>", value)
+    return _TOKEN_RE.sub(r"\1=<redacted>", value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,12 +30,14 @@ class AssistantContextBundle:
         }
 
     def to_prompt(self) -> str:
+        payload = self.to_read_model()
+        facts = payload["facts"]
         lines = [
-            f"Incident: {self.title}",
+            f"Incident: {payload['title']}",
             "Facts:",
-            *(f"- {key}: {self.facts[key]}" for key in sorted(self.facts)),
+            *(f"- {key}: {facts[key]}" for key in sorted(facts)),
             "Suggested actions:",
-            *(f"- {action}" for action in self.suggested_actions),
+            *(f"- {action}" for action in payload["suggested_actions"]),
         ]
         return "\n".join(lines)
 

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -28,9 +28,9 @@ class AssistantContextBundle:
 
     def to_read_model(self) -> dict[str, Any]:
         return {
-            "title": self.title,
+            "title": _redact(self.title),
             "facts": {key: _redact(value) for key, value in self.facts.items()},
-            "suggested_actions": list(self.suggested_actions),
+            "suggested_actions": [_redact(action) for action in self.suggested_actions],
         }
 
     def to_prompt(self) -> str:

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -15,7 +15,7 @@ _AUTHORIZATION_BEARER_RE = re.compile(
 )
 _BEARER_RE = re.compile(r"\b(bearer)\b\s+\S+", re.IGNORECASE)
 _KEY_VALUE_SECRET_RE = re.compile(
-    r"""\b([\w-]*(?:password|passwd|token|secret|api[_-]?key|credential)[\w-]*)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)""",
+    r"""\b([\w-]*(?:password|passwd|token|secret|api[_-]?key|credential|private[_-]?key|signing[_-]?key|encryption[_-]?key)[\w-]*)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)""",
     re.IGNORECASE,
 )
 _SECRET_KEY_RE = re.compile(

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -9,8 +9,8 @@ from math import isfinite
 from typing import Any
 
 _DSN_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://\S+", re.IGNORECASE)
-_AUTHORIZATION_BEARER_RE = re.compile(
-    r"\b(authorization)(\s*:?\s+bearer)\s+\S+",
+_AUTHORIZATION_SCHEME_RE = re.compile(
+    r"\b(authorization)(\s*:?\s+(?:basic|bearer))\s+\S+",
     re.IGNORECASE,
 )
 _BEARER_RE = re.compile(r"\b(bearer)\b\s+\S+", re.IGNORECASE)
@@ -27,12 +27,13 @@ _KEY_VALUE_SECRET_RE = re.compile(
 def _redact(value: str) -> str:
     value = _DSN_RE.sub("<redacted-dsn>", value)
     value = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", value)
-    value = _AUTHORIZATION_BEARER_RE.sub(r"\1\2 <redacted>", value)
+    value = _AUTHORIZATION_SCHEME_RE.sub(r"\1\2 <redacted>", value)
     return _BEARER_RE.sub(r"\1 <redacted>", value)
 
 
 def _is_secret_key(key: str) -> bool:
-    parts = [part for part in re.split(r"[_-]+", key.lower()) if part]
+    normalized_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key)
+    parts = [part for part in re.split(r"[_-]+", normalized_key.lower()) if part]
     if not parts:
         return False
     if key.lower() == "authorization":

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -23,6 +23,17 @@ _KEY_VALUE_SECRET_RE = re.compile(
     rf"""\b({_SECRET_NAME_PATTERN})\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)""",
     re.IGNORECASE,
 )
+_CAMEL_CASE_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
+_KEY_SEPARATOR_RE = re.compile(r"[_-]+")
+_DESCRIPTIVE_SUFFIXES = {"count", "label", "name"}
+_SECRET_PARTS = {"password", "passwd", "token", "credential"}
+_SECRET_PAIRS = {
+    ("api", "key"),
+    ("client", "secret"),
+    ("private", "key"),
+    ("signing", "key"),
+    ("encryption", "key"),
+}
 
 
 def _redact(value: str) -> str:
@@ -39,22 +50,24 @@ def _redact(value: str) -> str:
 
 
 def _is_secret_key(key: str) -> bool:
-    normalized_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key)
-    parts = [part for part in re.split(r"[_-]+", normalized_key.lower()) if part]
+    parts = _key_parts(key)
     if not parts:
         return False
-    if parts[-1] in {"count", "label", "name"}:
+    if parts[-1] in _DESCRIPTIVE_SUFFIXES:
         return False
     if key.lower() == "authorization":
         return True
-    if any(part in {"password", "passwd", "token", "credential"} for part in parts):
+    if any(part in _SECRET_PARTS for part in parts):
         return True
     pairs = set(zip(parts, parts[1:], strict=False))
-    if ("api", "key") in pairs or ("client", "secret") in pairs:
-        return True
     if "secret" in parts and "key" in parts:
         return True
-    return any((prefix, "key") in pairs for prefix in ("private", "signing", "encryption"))
+    return bool(pairs & _SECRET_PAIRS)
+
+
+def _key_parts(key: str) -> list[str]:
+    normalized_key = _CAMEL_CASE_BOUNDARY_RE.sub(r"\1_\2", key)
+    return [part for part in _KEY_SEPARATOR_RE.split(normalized_key.lower()) if part]
 
 
 def _redact_value(value: Any, *, secret_key: bool = False) -> Any:

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -25,22 +26,34 @@ def _redact(value: str) -> str:
     return _BEARER_RE.sub(r"\1 <redacted>", value)
 
 
-def _redact_facts(facts: dict[str, str]) -> dict[str, str]:
-    redacted: dict[str, str] = {}
+def _redact_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _redact(value)
+    if isinstance(value, Mapping):
+        return _redact_facts(value)
+    if isinstance(value, list):
+        return [_redact_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_value(item) for item in value]
+    return value
+
+
+def _redact_facts(facts: Mapping[str, Any]) -> dict[str, Any]:
+    redacted: dict[str, Any] = {}
     collisions: dict[str, int] = {}
     for key, value in facts.items():
-        redacted_key = _redact(key)
+        redacted_key = _redact(str(key))
         if redacted_key in redacted:
             collisions[redacted_key] = collisions.get(redacted_key, 1) + 1
             redacted_key = f"{redacted_key} ({collisions[redacted_key]})"
-        redacted[redacted_key] = _redact(value)
+        redacted[redacted_key] = _redact_value(value)
     return redacted
 
 
 @dataclass(frozen=True, slots=True)
 class AssistantContextBundle:
     title: str
-    facts: dict[str, str] = field(default_factory=dict)
+    facts: dict[str, Any] = field(default_factory=dict)
     suggested_actions: tuple[str, ...] = ()
 
     def to_read_model(self) -> dict[str, Any]:
@@ -70,7 +83,7 @@ class AssistantContextBundle:
 def build_incident_context(
     *,
     title: str,
-    facts: dict[str, str],
+    facts: dict[str, Any],
     suggested_actions: list[str] | tuple[str, ...],
 ) -> AssistantContextBundle:
     return AssistantContextBundle(

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -17,6 +17,10 @@ _KEY_VALUE_SECRET_RE = re.compile(
     r"""\b([\w-]*(?:password|passwd|token|secret|api[_-]?key|credential)[\w-]*)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)""",
     re.IGNORECASE,
 )
+_SECRET_KEY_RE = re.compile(
+    r"^(?:password|passwd|token|access[_-]?token|refresh[_-]?token|secret|api[_-]?key|credential|authorization)$",
+    re.IGNORECASE,
+)
 
 
 def _redact(value: str) -> str:
@@ -26,7 +30,9 @@ def _redact(value: str) -> str:
     return _BEARER_RE.sub(r"\1 <redacted>", value)
 
 
-def _redact_value(value: Any) -> Any:
+def _redact_value(value: Any, *, secret_key: bool = False) -> Any:
+    if secret_key:
+        return "<redacted>"
     if isinstance(value, str):
         return _redact(value)
     if isinstance(value, Mapping):
@@ -42,11 +48,15 @@ def _redact_facts(facts: Mapping[str, Any]) -> dict[str, Any]:
     redacted: dict[str, Any] = {}
     collisions: dict[str, int] = {}
     for key, value in facts.items():
-        redacted_key = _redact(str(key))
+        raw_key = str(key)
+        redacted_key = _redact(raw_key)
         if redacted_key in redacted:
             collisions[redacted_key] = collisions.get(redacted_key, 1) + 1
             redacted_key = f"{redacted_key} ({collisions[redacted_key]})"
-        redacted[redacted_key] = _redact_value(value)
+        redacted[redacted_key] = _redact_value(
+            value,
+            secret_key=_SECRET_KEY_RE.fullmatch(raw_key) is not None,
+        )
     return redacted
 
 

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from math import isfinite
 from typing import Any
 
 _DSN_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://\S+", re.IGNORECASE)
@@ -43,6 +44,8 @@ def _redact_value(value: Any, *, secret_key: bool = False) -> Any:
         return [_redact_value(item) for item in value]
     if isinstance(value, set):
         return sorted((_redact_value(item) for item in value), key=repr)
+    if isinstance(value, float) and not isfinite(value):
+        return str(value)
     if value is None or isinstance(value, (bool, int, float)):
         return value
     return _redact(str(value))

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -27,7 +27,12 @@ _KEY_VALUE_SECRET_RE = re.compile(
 
 def _redact(value: str) -> str:
     value = _DSN_RE.sub("<redacted-dsn>", value)
-    value = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", value)
+    value = _KEY_VALUE_SECRET_RE.sub(
+        lambda match: (
+            f"{match.group(1)}=<redacted>" if _is_secret_key(match.group(1)) else match.group(0)
+        ),
+        value,
+    )
     value = _AUTHORIZATION_SCHEME_RE.sub(r"\1\2 <redacted>", value)
     value = _BEARER_RE.sub(r"\1 <redacted>", value)
     return _BASIC_RE.sub(r"\1 <redacted>", value)

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -14,6 +14,7 @@ _AUTHORIZATION_SCHEME_RE = re.compile(
     re.IGNORECASE,
 )
 _BEARER_RE = re.compile(r"\b(bearer)\b\s+\S+", re.IGNORECASE)
+_BASIC_RE = re.compile(r"\b(basic)\b\s+\S+", re.IGNORECASE)
 _SECRET_NAME_PATTERN = (
     r"[\w-]*(?:password|passwd|token|secret|api[_-]?key|credential|"
     r"private[_-]?key|signing[_-]?key|encryption[_-]?key)[\w-]*"
@@ -28,13 +29,16 @@ def _redact(value: str) -> str:
     value = _DSN_RE.sub("<redacted-dsn>", value)
     value = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", value)
     value = _AUTHORIZATION_SCHEME_RE.sub(r"\1\2 <redacted>", value)
-    return _BEARER_RE.sub(r"\1 <redacted>", value)
+    value = _BEARER_RE.sub(r"\1 <redacted>", value)
+    return _BASIC_RE.sub(r"\1 <redacted>", value)
 
 
 def _is_secret_key(key: str) -> bool:
     normalized_key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key)
     parts = [part for part in re.split(r"[_-]+", normalized_key.lower()) if part]
     if not parts:
+        return False
+    if parts[-1] in {"count", "label", "name"}:
         return False
     if key.lower() == "authorization":
         return True

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -1,0 +1,53 @@
+"""Assistant context bundle models."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+_DSN_RE = re.compile(r"^[a-z][a-z0-9+.-]*://\S+$", re.IGNORECASE)
+_TOKEN_RE = re.compile(r"token=\S+")
+
+
+def _redact(value: str) -> str:
+    if _DSN_RE.fullmatch(value):
+        return "<redacted-dsn>"
+    return _TOKEN_RE.sub("token=<redacted>", value)
+
+
+@dataclass(frozen=True, slots=True)
+class AssistantContextBundle:
+    title: str
+    facts: dict[str, str] = field(default_factory=dict)
+    suggested_actions: tuple[str, ...] = ()
+
+    def to_read_model(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "facts": {key: _redact(value) for key, value in self.facts.items()},
+            "suggested_actions": list(self.suggested_actions),
+        }
+
+    def to_prompt(self) -> str:
+        lines = [
+            f"Incident: {self.title}",
+            "Facts:",
+            *(f"- {key}: {self.facts[key]}" for key in sorted(self.facts)),
+            "Suggested actions:",
+            *(f"- {action}" for action in self.suggested_actions),
+        ]
+        return "\n".join(lines)
+
+
+def build_incident_context(
+    *,
+    title: str,
+    facts: dict[str, str],
+    suggested_actions: list[str] | tuple[str, ...],
+) -> AssistantContextBundle:
+    return AssistantContextBundle(
+        title=title,
+        facts=dict(facts),
+        suggested_actions=tuple(suggested_actions),
+    )

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -7,9 +7,13 @@ from dataclasses import dataclass, field
 from typing import Any
 
 _DSN_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://\S+", re.IGNORECASE)
-_AUTHORIZATION_RE = re.compile(r"\b(authorization|bearer)\b\s+\S+", re.IGNORECASE)
+_AUTHORIZATION_BEARER_RE = re.compile(
+    r"\b(authorization)(\s*:?\s+bearer)\s+\S+",
+    re.IGNORECASE,
+)
+_BEARER_RE = re.compile(r"\b(bearer)\b\s+\S+", re.IGNORECASE)
 _KEY_VALUE_SECRET_RE = re.compile(
-    r"\b([\w-]*(?:password|passwd|token|secret|api[_-]?key|credential)[\w-]*)\b\s*[:=]\s*[^\s,;]+",
+    r"""\b([\w-]*(?:password|passwd|token|secret|api[_-]?key|credential)[\w-]*)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)""",
     re.IGNORECASE,
 )
 
@@ -17,7 +21,8 @@ _KEY_VALUE_SECRET_RE = re.compile(
 def _redact(value: str) -> str:
     value = _DSN_RE.sub("<redacted-dsn>", value)
     value = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", value)
-    return _AUTHORIZATION_RE.sub(r"\1 <redacted>", value)
+    value = _AUTHORIZATION_BEARER_RE.sub(r"\1\2 <redacted>", value)
+    return _BEARER_RE.sub(r"\1 <redacted>", value)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -6,17 +6,16 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-_DSN_RE = re.compile(r"^[a-z][a-z0-9+.-]*://\S+$", re.IGNORECASE)
+_DSN_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://\S+", re.IGNORECASE)
 _AUTHORIZATION_RE = re.compile(r"\b(authorization|bearer)\b\s+\S+", re.IGNORECASE)
 _KEY_VALUE_SECRET_RE = re.compile(
-    r"\b(password|passwd|token|secret|api_key|apikey|credential)\b\s*[:=]\s*[^\s,;]+",
+    r"\b([\w-]*(?:password|passwd|token|secret|api[_-]?key|credential)[\w-]*)\b\s*[:=]\s*[^\s,;]+",
     re.IGNORECASE,
 )
 
 
 def _redact(value: str) -> str:
-    if _DSN_RE.fullmatch(value):
-        return "<redacted-dsn>"
+    value = _DSN_RE.sub("<redacted-dsn>", value)
     value = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", value)
     return _AUTHORIZATION_RE.sub(r"\1 <redacted>", value)
 

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -7,13 +7,18 @@ from dataclasses import dataclass, field
 from typing import Any
 
 _DSN_RE = re.compile(r"^[a-z][a-z0-9+.-]*://\S+$", re.IGNORECASE)
-_TOKEN_RE = re.compile(r"(token)=\S+", re.IGNORECASE)
+_AUTHORIZATION_RE = re.compile(r"\b(authorization|bearer)\b\s+\S+", re.IGNORECASE)
+_KEY_VALUE_SECRET_RE = re.compile(
+    r"\b(password|passwd|token|secret|api_key|apikey|credential)\b\s*[:=]\s*[^\s,;]+",
+    re.IGNORECASE,
+)
 
 
 def _redact(value: str) -> str:
     if _DSN_RE.fullmatch(value):
         return "<redacted-dsn>"
-    return _TOKEN_RE.sub(r"\1=<redacted>", value)
+    value = _KEY_VALUE_SECRET_RE.sub(lambda match: f"{match.group(1)}=<redacted>", value)
+    return _AUTHORIZATION_RE.sub(r"\1 <redacted>", value)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -25,6 +25,18 @@ def _redact(value: str) -> str:
     return _BEARER_RE.sub(r"\1 <redacted>", value)
 
 
+def _redact_facts(facts: dict[str, str]) -> dict[str, str]:
+    redacted: dict[str, str] = {}
+    collisions: dict[str, int] = {}
+    for key, value in facts.items():
+        redacted_key = _redact(key)
+        if redacted_key in redacted:
+            collisions[redacted_key] = collisions.get(redacted_key, 1) + 1
+            redacted_key = f"{redacted_key} ({collisions[redacted_key]})"
+        redacted[redacted_key] = _redact(value)
+    return redacted
+
+
 @dataclass(frozen=True, slots=True)
 class AssistantContextBundle:
     title: str
@@ -34,7 +46,7 @@ class AssistantContextBundle:
     def to_read_model(self) -> dict[str, Any]:
         return {
             "title": _redact(self.title),
-            "facts": {key: _redact(value) for key, value in self.facts.items()},
+            "facts": _redact_facts(self.facts),
             "suggested_actions": [_redact(action) for action in self.suggested_actions],
         }
 

--- a/src/phlo/assistant/context.py
+++ b/src/phlo/assistant/context.py
@@ -14,12 +14,20 @@ _AUTHORIZATION_BEARER_RE = re.compile(
     re.IGNORECASE,
 )
 _BEARER_RE = re.compile(r"\b(bearer)\b\s+\S+", re.IGNORECASE)
+_SECRET_NAME_PATTERN = (
+    r"[\w-]*(?:password|passwd|token|secret|api[_-]?key|credential|"
+    r"private[_-]?key|signing[_-]?key|encryption[_-]?key)[\w-]*"
+)
 _KEY_VALUE_SECRET_RE = re.compile(
-    r"""\b([\w-]*(?:password|passwd|token|secret|api[_-]?key|credential|private[_-]?key|signing[_-]?key|encryption[_-]?key)[\w-]*)\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)""",
+    rf"""\b({_SECRET_NAME_PATTERN})\b\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\s,;]+)""",
     re.IGNORECASE,
 )
 _SECRET_KEY_RE = re.compile(
-    r"^(?:password|passwd|token|access[_-]?token|refresh[_-]?token|auth[_-]?token|session[_-]?token|client[_-]?secret|secret|api[_-]?key|credential|authorization|private[_-]?key|signing[_-]?key|encryption[_-]?key)$",
+    r"^(?:password|passwd|token|access[_-]?token|refresh[_-]?token|"
+    r"auth[_-]?token|session[_-]?token|client[_-]?secret|secret[_-]?key|"
+    r"secret|api[_-]?key|credential|authorization|"
+    r"private[_-]?key(?:[_-].*)?|signing[_-]?key(?:[_-].*)?|"
+    r"encryption[_-]?key(?:[_-].*)?)$",
     re.IGNORECASE,
 )
 

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -32,6 +32,24 @@ def test_read_model_redacts_token_case_insensitively() -> None:
     assert payload["facts"]["error"] == "Token=<redacted> failed"
 
 
+def test_read_model_redacts_password_like_values_and_bearer_tokens() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "error": "password=hunter2 failed",
+            "auth": "Bearer deadbeef",
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"]["error"] == "password=<redacted> failed"
+    assert payload["facts"]["auth"] == "Bearer <redacted>"
+    assert "hunter2" not in str(payload)
+    assert "deadbeef" not in str(payload)
+
+
 def test_assistant_context_to_prompt_is_deterministic() -> None:
     bundle = AssistantContextBundle(
         title="Quality failure",
@@ -65,3 +83,22 @@ def test_assistant_context_to_prompt_redacts_secret_like_values() -> None:
     assert "<redacted-dsn>" in prompt
     assert "abc123" not in prompt
     assert "user:pass" not in prompt
+
+
+def test_assistant_context_to_prompt_redacts_password_like_values_and_bearer_tokens() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "auth": "Bearer deadbeef",
+            "error": "password=hunter2 failed",
+        },
+        suggested_actions=(),
+    )
+
+    assert bundle.to_prompt() == (
+        "Incident: Incident\n"
+        "Facts:\n"
+        "- auth: Bearer <redacted>\n"
+        "- error: password=<redacted> failed\n"
+        "Suggested actions:"
+    )

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -161,12 +161,41 @@ def test_read_model_preserves_structured_fact_values_and_redacts_nested_strings(
         "checks": ["not_null(order_id)", "token=<redacted>"],
         "metadata": {
             "owner": "analytics",
-            "password": "password=<redacted>",
+            "password": "<redacted>",
             "attempts": [1, 2],
         },
     }
     assert "abc123" not in str(payload)
     assert "hunter2" not in str(payload)
+
+
+def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "metadata": {
+                "password": "hunter2",
+                "api_key": "abc123",
+                "nested": {"refresh_token": "deadbeef"},
+                "owner": "analytics",
+            },
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"] == {
+        "metadata": {
+            "password": "<redacted>",
+            "api_key": "<redacted>",
+            "nested": {"refresh_token": "<redacted>"},
+            "owner": "analytics",
+        },
+    }
+    assert "hunter2" not in str(payload)
+    assert "abc123" not in str(payload)
+    assert "deadbeef" not in str(payload)
 
 
 def test_assistant_context_to_prompt_is_deterministic() -> None:
@@ -338,6 +367,30 @@ def test_assistant_context_to_prompt_preserves_structured_fact_values() -> None:
         "- failed_rows: 12\n"
         "Suggested actions:"
     )
+    assert "abc123" not in prompt
+
+
+def test_assistant_context_to_prompt_redacts_values_for_nested_secret_like_keys() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "metadata": {
+                "password": "hunter2",
+                "api_key": "abc123",
+            },
+        },
+        suggested_actions=(),
+    )
+
+    prompt = bundle.to_prompt()
+
+    assert prompt == (
+        "Incident: Incident\n"
+        "Facts:\n"
+        "- metadata: {'password': '<redacted>', 'api_key': '<redacted>'}\n"
+        "Suggested actions:"
+    )
+    assert "hunter2" not in prompt
     assert "abc123" not in prompt
 
 

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -120,6 +120,23 @@ def test_read_model_redacts_authorization_bearer_and_quoted_secret_values() -> N
     assert "key with spaces" not in str(payload)
 
 
+def test_read_model_redacts_embedded_key_material_values() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={"error": "private_key=PRIVATE signing_key=SIGN encryption_key=ENC"},
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"]["error"] == (
+        "private_key=<redacted> signing_key=<redacted> encryption_key=<redacted>"
+    )
+    assert "PRIVATE" not in str(payload)
+    assert "SIGN" not in str(payload)
+    assert "ENC" not in str(payload)
+
+
 def test_read_model_redacts_secret_like_fact_keys_and_preserves_collisions() -> None:
     bundle = AssistantContextBundle(
         title="Incident",
@@ -358,6 +375,26 @@ def test_assistant_context_to_prompt_redacts_authorization_bearer_and_quoted_sec
     assert "cafebabe" not in prompt
     assert "hunter two" not in prompt
     assert "key with spaces" not in prompt
+
+
+def test_assistant_context_to_prompt_redacts_embedded_key_material_values() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={"error": "private_key=PRIVATE signing_key=SIGN encryption_key=ENC"},
+        suggested_actions=(),
+    )
+
+    prompt = bundle.to_prompt()
+
+    assert prompt == (
+        "Incident: Incident\n"
+        "Facts:\n"
+        "- error: private_key=<redacted> signing_key=<redacted> encryption_key=<redacted>\n"
+        "Suggested actions:"
+    )
+    assert "PRIVATE" not in prompt
+    assert "SIGN" not in prompt
+    assert "ENC" not in prompt
 
 
 def test_assistant_context_to_prompt_redacts_secret_like_fact_keys() -> None:

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -1,4 +1,5 @@
 import json
+import math
 from datetime import UTC, datetime
 from decimal import Decimal
 
@@ -459,6 +460,25 @@ def test_assistant_context_mcp_payload_is_json_serializable() -> None:
     }
     assert "s3cr3t" not in str(payload)
     assert "abc123" not in str(payload)
+
+
+def test_assistant_context_mcp_payload_serializes_non_finite_floats_strictly() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={"metric": math.nan, "upper": math.inf, "lower": -math.inf},
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_mcp_payload()
+
+    assert json.loads(json.dumps(payload, allow_nan=False)) == {
+        "kind": "phlo.assistant.context.v1",
+        "payload": {
+            "title": "Incident",
+            "facts": {"metric": "nan", "upper": "inf", "lower": "-inf"},
+            "suggested_actions": [],
+        },
+    }
 
 
 def test_assistant_context_serializes_mcp_payload() -> None:

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -123,14 +123,21 @@ def test_read_model_redacts_authorization_bearer_and_quoted_secret_values() -> N
 def test_read_model_redacts_authorization_basic_values() -> None:
     bundle = AssistantContextBundle(
         title="Incident",
-        facts={"authorization_header": "Authorization: Basic dXNlcjpwYXNz"},
+        facts={
+            "authorization_header": "Authorization: Basic dXNlcjpwYXNz",
+            "auth": "Basic YmFyOmJheg==",
+            "error": "upstream returned Basic dXNlcjpwYXNz",
+        },
         suggested_actions=(),
     )
 
     payload = bundle.to_read_model()
 
     assert payload["facts"]["authorization_header"] == "Authorization: Basic <redacted>"
+    assert payload["facts"]["auth"] == "Basic <redacted>"
+    assert payload["facts"]["error"] == "upstream returned Basic <redacted>"
     assert "dXNlcjpwYXNz" not in str(payload)
+    assert "YmFyOmJheg==" not in str(payload)
 
 
 def test_read_model_redacts_embedded_key_material_values() -> None:
@@ -281,6 +288,30 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
     assert "deadbeef" not in str(payload)
 
 
+def test_read_model_preserves_descriptive_secret_metadata_labels() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "metadata": {
+                "token_count": 7,
+                "api_key_label": "Stripe API key",
+                "secret_name": "warehouse credential",
+            },
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"] == {
+        "metadata": {
+            "token_count": 7,
+            "api_key_label": "Stripe API key",
+            "secret_name": "warehouse credential",
+        },
+    }
+
+
 def test_read_model_serializes_common_metadata_values() -> None:
     bundle = AssistantContextBundle(
         title="Incident",
@@ -429,7 +460,11 @@ def test_assistant_context_to_prompt_redacts_authorization_bearer_and_quoted_sec
 def test_assistant_context_to_prompt_redacts_authorization_basic_values() -> None:
     bundle = AssistantContextBundle(
         title="Incident",
-        facts={"authorization_header": "Authorization: Basic dXNlcjpwYXNz"},
+        facts={
+            "authorization_header": "Authorization: Basic dXNlcjpwYXNz",
+            "auth": "Basic YmFyOmJheg==",
+            "error": "upstream returned Basic dXNlcjpwYXNz",
+        },
         suggested_actions=(),
     )
 
@@ -438,10 +473,13 @@ def test_assistant_context_to_prompt_redacts_authorization_basic_values() -> Non
     assert prompt == (
         "Incident: Incident\n"
         "Facts:\n"
+        "- auth: Basic <redacted>\n"
         "- authorization_header: Authorization: Basic <redacted>\n"
+        "- error: upstream returned Basic <redacted>\n"
         "Suggested actions:"
     )
     assert "dXNlcjpwYXNz" not in prompt
+    assert "YmFyOmJheg==" not in prompt
 
 
 def test_assistant_context_to_prompt_redacts_embedded_key_material_values() -> None:

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -72,6 +72,25 @@ def test_read_model_redacts_embedded_dsns_and_compound_token_keys() -> None:
     assert "ghi" not in str(payload)
 
 
+def test_read_model_redacts_title_and_suggested_actions() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident token=titleSecret",
+        facts={},
+        suggested_actions=("rotate password=actionSecret", "notify Bearer actionBearer"),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["title"] == "Incident token=<redacted>"
+    assert payload["suggested_actions"] == [
+        "rotate password=<redacted>",
+        "notify Bearer <redacted>",
+    ]
+    assert "titleSecret" not in str(payload)
+    assert "actionSecret" not in str(payload)
+    assert "actionBearer" not in str(payload)
+
+
 def test_assistant_context_to_prompt_is_deterministic() -> None:
     bundle = AssistantContextBundle(
         title="Quality failure",
@@ -143,3 +162,24 @@ def test_assistant_context_to_prompt_redacts_embedded_dsns_and_compound_token_ke
         "- tokens: access_token=<redacted> refresh_token=<redacted> api-key=<redacted>\n"
         "Suggested actions:"
     )
+
+
+def test_assistant_context_to_prompt_redacts_title_and_suggested_actions() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident token=titleSecret",
+        facts={},
+        suggested_actions=("rotate password=actionSecret", "notify Bearer actionBearer"),
+    )
+
+    prompt = bundle.to_prompt()
+
+    assert prompt == (
+        "Incident: Incident token=<redacted>\n"
+        "Facts:\n"
+        "Suggested actions:\n"
+        "- rotate password=<redacted>\n"
+        "- notify Bearer <redacted>"
+    )
+    assert "titleSecret" not in prompt
+    assert "actionSecret" not in prompt
+    assert "actionBearer" not in prompt

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -120,6 +120,19 @@ def test_read_model_redacts_authorization_bearer_and_quoted_secret_values() -> N
     assert "key with spaces" not in str(payload)
 
 
+def test_read_model_redacts_authorization_basic_values() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={"authorization_header": "Authorization: Basic dXNlcjpwYXNz"},
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"]["authorization_header"] == "Authorization: Basic <redacted>"
+    assert "dXNlcjpwYXNz" not in str(payload)
+
+
 def test_read_model_redacts_embedded_key_material_values() -> None:
     bundle = AssistantContextBundle(
         title="Incident",
@@ -211,6 +224,9 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
                 "aws_secret_access_key": "aws-secret",
                 "github_token_value": "ghp_123",
                 "service_api_key_value": "api-secret",
+                "apiKey": "camel-api",
+                "clientSecret": "camel-secret",
+                "accessToken": "camel-token",
                 "nested": {"refresh_token": "deadbeef"},
                 "owner": "analytics",
             },
@@ -237,6 +253,9 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
             "aws_secret_access_key": "<redacted>",
             "github_token_value": "<redacted>",
             "service_api_key_value": "<redacted>",
+            "apiKey": "<redacted>",
+            "clientSecret": "<redacted>",
+            "accessToken": "<redacted>",
             "nested": {"refresh_token": "<redacted>"},
             "owner": "analytics",
         },
@@ -256,6 +275,9 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
     assert "aws-secret" not in str(payload)
     assert "ghp_123" not in str(payload)
     assert "api-secret" not in str(payload)
+    assert "camel-api" not in str(payload)
+    assert "camel-secret" not in str(payload)
+    assert "camel-token" not in str(payload)
     assert "deadbeef" not in str(payload)
 
 
@@ -402,6 +424,24 @@ def test_assistant_context_to_prompt_redacts_authorization_bearer_and_quoted_sec
     assert "cafebabe" not in prompt
     assert "hunter two" not in prompt
     assert "key with spaces" not in prompt
+
+
+def test_assistant_context_to_prompt_redacts_authorization_basic_values() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={"authorization_header": "Authorization: Basic dXNlcjpwYXNz"},
+        suggested_actions=(),
+    )
+
+    prompt = bundle.to_prompt()
+
+    assert prompt == (
+        "Incident: Incident\n"
+        "Facts:\n"
+        "- authorization_header: Authorization: Basic <redacted>\n"
+        "Suggested actions:"
+    )
+    assert "dXNlcjpwYXNz" not in prompt
 
 
 def test_assistant_context_to_prompt_redacts_embedded_key_material_values() -> None:

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -137,6 +137,38 @@ def test_read_model_redacts_secret_like_fact_keys_and_preserves_collisions() -> 
     assert "def456" not in str(payload)
 
 
+def test_read_model_preserves_structured_fact_values_and_redacts_nested_strings() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "failed_rows": 12,
+            "has_failures": True,
+            "checks": ["not_null(order_id)", "token=abc123"],
+            "metadata": {
+                "owner": "analytics",
+                "password": "password=hunter2",
+                "attempts": (1, 2),
+            },
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"] == {
+        "failed_rows": 12,
+        "has_failures": True,
+        "checks": ["not_null(order_id)", "token=<redacted>"],
+        "metadata": {
+            "owner": "analytics",
+            "password": "password=<redacted>",
+            "attempts": [1, 2],
+        },
+    }
+    assert "abc123" not in str(payload)
+    assert "hunter2" not in str(payload)
+
+
 def test_assistant_context_to_prompt_is_deterministic() -> None:
     bundle = AssistantContextBundle(
         title="Quality failure",
@@ -285,6 +317,28 @@ def test_assistant_context_to_prompt_redacts_secret_like_fact_keys() -> None:
     )
     assert "abc123" not in prompt
     assert "def456" not in prompt
+
+
+def test_assistant_context_to_prompt_preserves_structured_fact_values() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "failed_rows": 12,
+            "checks": ["not_null(order_id)", "token=abc123"],
+        },
+        suggested_actions=(),
+    )
+
+    prompt = bundle.to_prompt()
+
+    assert prompt == (
+        "Incident: Incident\n"
+        "Facts:\n"
+        "- checks: ['not_null(order_id)', 'token=<redacted>']\n"
+        "- failed_rows: 12\n"
+        "Suggested actions:"
+    )
+    assert "abc123" not in prompt
 
 
 def test_assistant_context_serializes_mcp_payload() -> None:

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -20,6 +20,18 @@ def test_build_incident_context_redacts_secret_like_values() -> None:
     assert payload["suggested_actions"] == ["inspect_quality_check", "open_lineage"]
 
 
+def test_read_model_redacts_token_case_insensitively() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={"error": "Token=abc123 failed"},
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"]["error"] == "Token=<redacted> failed"
+
+
 def test_assistant_context_to_prompt_is_deterministic() -> None:
     bundle = AssistantContextBundle(
         title="Quality failure",
@@ -35,3 +47,21 @@ def test_assistant_context_to_prompt_is_deterministic() -> None:
         "Suggested actions:\n"
         "- inspect_quality_check"
     )
+
+
+def test_assistant_context_to_prompt_redacts_secret_like_values() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "error": "TOKEN=abc123",
+            "dsn": "postgresql://user:pass@localhost/db",
+        },
+        suggested_actions=(),
+    )
+
+    prompt = bundle.to_prompt()
+
+    assert "TOKEN=<redacted>" in prompt
+    assert "<redacted-dsn>" in prompt
+    assert "abc123" not in prompt
+    assert "user:pass" not in prompt

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -115,6 +115,28 @@ def test_read_model_redacts_authorization_bearer_and_quoted_secret_values() -> N
     assert "key with spaces" not in str(payload)
 
 
+def test_read_model_redacts_secret_like_fact_keys_and_preserves_collisions() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "token=abc123": "failed",
+            "token=def456": "retry",
+            "table": "silver.orders",
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"] == {
+        "token=<redacted>": "failed",
+        "token=<redacted> (2)": "retry",
+        "table": "silver.orders",
+    }
+    assert "abc123" not in str(payload)
+    assert "def456" not in str(payload)
+
+
 def test_assistant_context_to_prompt_is_deterministic() -> None:
     bundle = AssistantContextBundle(
         title="Quality failure",
@@ -238,3 +260,28 @@ def test_assistant_context_to_prompt_redacts_authorization_bearer_and_quoted_sec
     assert "cafebabe" not in prompt
     assert "hunter two" not in prompt
     assert "key with spaces" not in prompt
+
+
+def test_assistant_context_to_prompt_redacts_secret_like_fact_keys() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "token=abc123": "failed",
+            "token=def456": "retry",
+            "table": "silver.orders",
+        },
+        suggested_actions=(),
+    )
+
+    prompt = bundle.to_prompt()
+
+    assert prompt == (
+        "Incident: Incident\n"
+        "Facts:\n"
+        "- table: silver.orders\n"
+        "- token=<redacted>: failed\n"
+        "- token=<redacted> (2): retry\n"
+        "Suggested actions:"
+    )
+    assert "abc123" not in prompt
+    assert "def456" not in prompt

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -1,0 +1,37 @@
+from phlo.assistant import AssistantContextBundle, build_incident_context
+
+
+def test_build_incident_context_redacts_secret_like_values() -> None:
+    bundle = build_incident_context(
+        title="Quality failure",
+        facts={
+            "table": "silver.orders",
+            "error": "token=abc123 failed not_null(order_id)",
+            "dsn": "postgresql://user:pass@localhost/db",
+        },
+        suggested_actions=["inspect_quality_check", "open_lineage"],
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["title"] == "Quality failure"
+    assert payload["facts"]["error"] == "token=<redacted> failed not_null(order_id)"
+    assert payload["facts"]["dsn"] == "<redacted-dsn>"
+    assert payload["suggested_actions"] == ["inspect_quality_check", "open_lineage"]
+
+
+def test_assistant_context_to_prompt_is_deterministic() -> None:
+    bundle = AssistantContextBundle(
+        title="Quality failure",
+        facts={"table": "silver.orders", "check": "not_null(order_id)"},
+        suggested_actions=("inspect_quality_check",),
+    )
+
+    assert bundle.to_prompt() == (
+        "Incident: Quality failure\n"
+        "Facts:\n"
+        "- check: not_null(order_id)\n"
+        "- table: silver.orders\n"
+        "Suggested actions:\n"
+        "- inspect_quality_check"
+    )

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -312,6 +312,22 @@ def test_read_model_preserves_descriptive_secret_metadata_labels() -> None:
     }
 
 
+def test_read_model_preserves_embedded_descriptive_metadata_labels() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "summary": 'token_count=7 api_key_label="Stripe API key" secret_name=warehouse',
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"]["summary"] == (
+        'token_count=7 api_key_label="Stripe API key" secret_name=warehouse'
+    )
+
+
 def test_read_model_serializes_common_metadata_values() -> None:
     bundle = AssistantContextBundle(
         title="Incident",

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -206,6 +206,11 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
                 "signing_key_id": "signing-id",
                 "encryption_key_arn": "encryption-arn",
                 "secret_key": "django-secret",
+                "db_password": "db-pass",
+                "stripe_secret_key": "sk_live_123",
+                "aws_secret_access_key": "aws-secret",
+                "github_token_value": "ghp_123",
+                "service_api_key_value": "api-secret",
                 "nested": {"refresh_token": "deadbeef"},
                 "owner": "analytics",
             },
@@ -227,6 +232,11 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
             "signing_key_id": "<redacted>",
             "encryption_key_arn": "<redacted>",
             "secret_key": "<redacted>",
+            "db_password": "<redacted>",
+            "stripe_secret_key": "<redacted>",
+            "aws_secret_access_key": "<redacted>",
+            "github_token_value": "<redacted>",
+            "service_api_key_value": "<redacted>",
             "nested": {"refresh_token": "<redacted>"},
             "owner": "analytics",
         },
@@ -241,6 +251,11 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
     assert "signing-id" not in str(payload)
     assert "encryption-arn" not in str(payload)
     assert "django-secret" not in str(payload)
+    assert "db-pass" not in str(payload)
+    assert "sk_live_123" not in str(payload)
+    assert "aws-secret" not in str(payload)
+    assert "ghp_123" not in str(payload)
+    assert "api-secret" not in str(payload)
     assert "deadbeef" not in str(payload)
 
 

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -285,3 +285,42 @@ def test_assistant_context_to_prompt_redacts_secret_like_fact_keys() -> None:
     )
     assert "abc123" not in prompt
     assert "def456" not in prompt
+
+
+def test_assistant_context_serializes_mcp_payload() -> None:
+    bundle = AssistantContextBundle(
+        title="Quality failure",
+        facts={"table": "silver.orders"},
+        suggested_actions=("inspect_quality_check",),
+    )
+
+    assert bundle.to_mcp_payload() == {
+        "kind": "phlo.assistant.context.v1",
+        "payload": {
+            "title": "Quality failure",
+            "facts": {"table": "silver.orders"},
+            "suggested_actions": ["inspect_quality_check"],
+        },
+    }
+
+
+def test_assistant_context_mcp_payload_uses_redacted_read_model() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident token=titleSecret",
+        facts={"dsn": "postgresql://user:pass@localhost/db"},
+        suggested_actions=("notify Bearer actionBearer",),
+    )
+
+    payload = bundle.to_mcp_payload()
+
+    assert payload == {
+        "kind": "phlo.assistant.context.v1",
+        "payload": {
+            "title": "Incident token=<redacted>",
+            "facts": {"dsn": "<redacted-dsn>"},
+            "suggested_actions": ["notify Bearer <redacted>"],
+        },
+    }
+    assert "titleSecret" not in str(payload)
+    assert "user:pass" not in str(payload)
+    assert "actionBearer" not in str(payload)

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -202,6 +202,10 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
                 "auth_token": "auth123",
                 "session_token": "session123",
                 "private_key": "private123",
+                "private_key_pem": "private-pem",
+                "signing_key_id": "signing-id",
+                "encryption_key_arn": "encryption-arn",
+                "secret_key": "django-secret",
                 "nested": {"refresh_token": "deadbeef"},
                 "owner": "analytics",
             },
@@ -219,6 +223,10 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
             "auth_token": "<redacted>",
             "session_token": "<redacted>",
             "private_key": "<redacted>",
+            "private_key_pem": "<redacted>",
+            "signing_key_id": "<redacted>",
+            "encryption_key_arn": "<redacted>",
+            "secret_key": "<redacted>",
             "nested": {"refresh_token": "<redacted>"},
             "owner": "analytics",
         },
@@ -229,6 +237,10 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
     assert "auth123" not in str(payload)
     assert "session123" not in str(payload)
     assert "private123" not in str(payload)
+    assert "private-pem" not in str(payload)
+    assert "signing-id" not in str(payload)
+    assert "encryption-arn" not in str(payload)
+    assert "django-secret" not in str(payload)
     assert "deadbeef" not in str(payload)
 
 

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -1,3 +1,7 @@
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+
 from phlo.assistant import AssistantContextBundle, build_incident_context
 
 
@@ -176,6 +180,10 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
             "metadata": {
                 "password": "hunter2",
                 "api_key": "abc123",
+                "client_secret": "s3cr3t",
+                "auth_token": "auth123",
+                "session_token": "session123",
+                "private_key": "private123",
                 "nested": {"refresh_token": "deadbeef"},
                 "owner": "analytics",
             },
@@ -189,13 +197,41 @@ def test_read_model_redacts_values_for_nested_secret_like_keys() -> None:
         "metadata": {
             "password": "<redacted>",
             "api_key": "<redacted>",
+            "client_secret": "<redacted>",
+            "auth_token": "<redacted>",
+            "session_token": "<redacted>",
+            "private_key": "<redacted>",
             "nested": {"refresh_token": "<redacted>"},
             "owner": "analytics",
         },
     }
     assert "hunter2" not in str(payload)
     assert "abc123" not in str(payload)
+    assert "s3cr3t" not in str(payload)
+    assert "auth123" not in str(payload)
+    assert "session123" not in str(payload)
+    assert "private123" not in str(payload)
     assert "deadbeef" not in str(payload)
+
+
+def test_read_model_serializes_common_metadata_values() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "when": datetime(2026, 5, 22, 9, 30, tzinfo=UTC),
+            "ratio": Decimal("0.25"),
+            "tags": {"bronze", "quality"},
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"] == {
+        "when": "2026-05-22 09:30:00+00:00",
+        "ratio": "0.25",
+        "tags": ["bronze", "quality"],
+    }
 
 
 def test_assistant_context_to_prompt_is_deterministic() -> None:
@@ -392,6 +428,37 @@ def test_assistant_context_to_prompt_redacts_values_for_nested_secret_like_keys(
     )
     assert "hunter2" not in prompt
     assert "abc123" not in prompt
+
+
+def test_assistant_context_mcp_payload_is_json_serializable() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "when": datetime(2026, 5, 22, 9, 30, tzinfo=UTC),
+            "ratio": Decimal("0.25"),
+            "tags": {"bronze", "quality"},
+            "oauth": {"client_secret": "s3cr3t", "auth_token": "abc123"},
+        },
+        suggested_actions=("inspect_quality_check",),
+    )
+
+    payload = bundle.to_mcp_payload()
+
+    assert json.loads(json.dumps(payload)) == {
+        "kind": "phlo.assistant.context.v1",
+        "payload": {
+            "title": "Incident",
+            "facts": {
+                "when": "2026-05-22 09:30:00+00:00",
+                "ratio": "0.25",
+                "tags": ["bronze", "quality"],
+                "oauth": {"client_secret": "<redacted>", "auth_token": "<redacted>"},
+            },
+            "suggested_actions": ["inspect_quality_check"],
+        },
+    }
+    assert "s3cr3t" not in str(payload)
+    assert "abc123" not in str(payload)
 
 
 def test_assistant_context_serializes_mcp_payload() -> None:

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -50,6 +50,28 @@ def test_read_model_redacts_password_like_values_and_bearer_tokens() -> None:
     assert "deadbeef" not in str(payload)
 
 
+def test_read_model_redacts_embedded_dsns_and_compound_token_keys() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "connection": "connect failed: postgresql://user:pass@localhost/db timeout",
+            "tokens": "access_token=abc refresh_token=def api-key=ghi",
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"]["connection"] == "connect failed: <redacted-dsn> timeout"
+    assert payload["facts"]["tokens"] == (
+        "access_token=<redacted> refresh_token=<redacted> api-key=<redacted>"
+    )
+    assert "user:pass" not in str(payload)
+    assert "abc" not in str(payload)
+    assert "def" not in str(payload)
+    assert "ghi" not in str(payload)
+
+
 def test_assistant_context_to_prompt_is_deterministic() -> None:
     bundle = AssistantContextBundle(
         title="Quality failure",
@@ -100,5 +122,24 @@ def test_assistant_context_to_prompt_redacts_password_like_values_and_bearer_tok
         "Facts:\n"
         "- auth: Bearer <redacted>\n"
         "- error: password=<redacted> failed\n"
+        "Suggested actions:"
+    )
+
+
+def test_assistant_context_to_prompt_redacts_embedded_dsns_and_compound_token_keys() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "connection": "connect failed: postgresql://user:pass@localhost/db timeout",
+            "tokens": "access_token=abc refresh_token=def api-key=ghi",
+        },
+        suggested_actions=(),
+    )
+
+    assert bundle.to_prompt() == (
+        "Incident: Incident\n"
+        "Facts:\n"
+        "- connection: connect failed: <redacted-dsn> timeout\n"
+        "- tokens: access_token=<redacted> refresh_token=<redacted> api-key=<redacted>\n"
         "Suggested actions:"
     )

--- a/tests/assistant/test_context.py
+++ b/tests/assistant/test_context.py
@@ -91,6 +91,30 @@ def test_read_model_redacts_title_and_suggested_actions() -> None:
     assert "actionBearer" not in str(payload)
 
 
+def test_read_model_redacts_authorization_bearer_and_quoted_secret_values() -> None:
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "authorization_header": "Authorization Bearer deadbeef",
+            "authorization_colon": "Authorization: Bearer cafebabe",
+            "quoted_secret": 'password="hunter two" failed',
+            "quoted_secret_colon": "api-key: 'key with spaces'",
+        },
+        suggested_actions=(),
+    )
+
+    payload = bundle.to_read_model()
+
+    assert payload["facts"]["authorization_header"] == "Authorization Bearer <redacted>"
+    assert payload["facts"]["authorization_colon"] == "Authorization: Bearer <redacted>"
+    assert payload["facts"]["quoted_secret"] == "password=<redacted> failed"
+    assert payload["facts"]["quoted_secret_colon"] == "api-key=<redacted>"
+    assert "deadbeef" not in str(payload)
+    assert "cafebabe" not in str(payload)
+    assert "hunter two" not in str(payload)
+    assert "key with spaces" not in str(payload)
+
+
 def test_assistant_context_to_prompt_is_deterministic() -> None:
     bundle = AssistantContextBundle(
         title="Quality failure",
@@ -183,3 +207,34 @@ def test_assistant_context_to_prompt_redacts_title_and_suggested_actions() -> No
     assert "titleSecret" not in prompt
     assert "actionSecret" not in prompt
     assert "actionBearer" not in prompt
+
+
+def test_assistant_context_to_prompt_redacts_authorization_bearer_and_quoted_secret_values() -> (
+    None
+):
+    bundle = AssistantContextBundle(
+        title="Incident",
+        facts={
+            "authorization_header": "Authorization Bearer deadbeef",
+            "authorization_colon": "Authorization: Bearer cafebabe",
+            "quoted_secret": 'password="hunter two" failed',
+            "quoted_secret_colon": "api-key: 'key with spaces'",
+        },
+        suggested_actions=(),
+    )
+
+    prompt = bundle.to_prompt()
+
+    assert prompt == (
+        "Incident: Incident\n"
+        "Facts:\n"
+        "- authorization_colon: Authorization: Bearer <redacted>\n"
+        "- authorization_header: Authorization Bearer <redacted>\n"
+        "- quoted_secret: password=<redacted> failed\n"
+        "- quoted_secret_colon: api-key=<redacted>\n"
+        "Suggested actions:"
+    )
+    assert "deadbeef" not in prompt
+    assert "cafebabe" not in prompt
+    assert "hunter two" not in prompt
+    assert "key with spaces" not in prompt


### PR DESCRIPTION
## Summary

Adds sanitized assistant context bundles, deterministic prompts, MCP payload serialization, strict JSON-safe structured facts, and redaction coverage for common credential-bearing strings and keys.

## Validation

- `uv run --locked pytest tests/assistant -q`
- `uv run --locked ruff check src/phlo/assistant tests/assistant`
- `uv run --locked ty check src/phlo/assistant`
