### PR TITLE
chore(release): phlo 0.11.0 + 12 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,74 @@
 # Changelog
 
+## [phlo 0.11.0 + 12 packages] - 2026-06-11
+
+### Added
+- phlo: derive governance surface from declarations (#522)
+- phlo: deepen observatory lakehouse experience (#527)
+- phlo: decouple agent workflow capabilities (#531)
+- phlo: add Iceberg 1.11 compatibility checks
+- phlo: add agent observability operation context
+- phlo: add logical relation references (#543)
+- phlo: add dialect-aware synthetic key helper (#544)
+- phlo: add typed workflow settings (#546)
+- phlo: add partitioned SQL ingestion helper (#549)
+- phlo: bridge dbt lineage into Python assets (#550)
+- phlo: add Trino DataFrame read helpers (#551)
+- phlo: improve workflow author ergonomics (#552)
+- phlo: make logs command package-selectable (#553)
+- phlo-api: deepen observatory lakehouse experience (#527)
+- phlo-api: decouple agent workflow capabilities (#531)
+- phlo-api: add Iceberg 1.11 compatibility checks
+- phlo-api: add agent observability operation context
+- phlo-dagster: decouple agent workflow capabilities (#531)
+- phlo-dbt: improve workflow author ergonomics (#552)
+- phlo-dlt: decouple agent workflow capabilities (#531)
+- phlo-dlt: add partitioned SQL ingestion helper (#549)
+- phlo-dlt: improve workflow author ergonomics (#552)
+- phlo-iceberg: add Iceberg 1.11 compatibility checks
+- phlo-mcp: decouple agent workflow capabilities (#531)
+- phlo-mcp: add agent observability operation context
+- phlo-nessie: add Iceberg 1.11 compatibility checks
+- phlo-observatory: deepen observatory lakehouse experience (#527)
+- phlo-sling: decouple agent workflow capabilities (#531)
+- phlo-trino: add Iceberg 1.11 compatibility checks
+- phlo-trino: add Trino DataFrame read helpers (#551)
+- phlo-trino: improve workflow author ergonomics (#552)
+
+### Changed
+- phlo: centralize schema migration planning (#524)
+- phlo: centralize plugin lifecycle registry (#526)
+- phlo: centralize capability family registry (#525)
+- phlo-api: centralize plugin lifecycle registry (#526)
+- phlo-api: centralize capability family registry (#525)
+- phlo-dagster: centralize capability family registry (#525)
+- phlo-dlt: centralize plugin lifecycle registry (#526)
+- phlo-iceberg: centralize schema migration planning (#524)
+- phlo-mcp: centralize capability family registry (#525)
+
+### Fixed
+- phlo: harden setup onboarding flow (#529)
+- phlo: diagnose duplicate dagster assets (#545)
+- phlo: include node properties in package data (#554)
+- phlo: align package-owned port defaults (#555)
+- phlo: discover project assets consistently (#556)
+- phlo-api: align package-owned port defaults (#555)
+- phlo-dagster: harden setup onboarding flow (#529)
+- phlo-dagster: diagnose duplicate dagster assets (#545)
+- phlo-dagster: align package-owned port defaults (#555)
+- phlo-dagster: discover project assets consistently (#556)
+- phlo-dbt: discover project assets consistently (#556)
+- phlo-minio: align package-owned port defaults (#555)
+- phlo-nessie: align package-owned port defaults (#555)
+- phlo-observatory: align package-owned port defaults (#555)
+- phlo-postgres: align package-owned port defaults (#555)
+- phlo-trino: include node properties in package data (#554)
+- phlo-trino: align package-owned port defaults (#555)
+
+### Contributors
+Thanks to our contributors for this release:
+- @iamgp (74 commits)
+
 ## Unreleased
 
 ### Added

--- a/packages/phlo-api/pyproject.toml
+++ b/packages/phlo-api/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 description = "Phlo API - Backend service exposing Phlo internals to Observatory"
 name = "phlo-api"
 requires-python = ">=3.11"
-version = "0.5.0"
+version = "0.6.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/pyproject.toml
+++ b/packages/phlo-dagster/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Dagster service plugin for Phlo"
 name = "phlo-dagster"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.5.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dagster/src/phlo_dagster/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "authorize_daemon_run",
     "create_daemon_principal",
 ]
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/packages/phlo-dbt/pyproject.toml
+++ b/packages/phlo-dbt/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 description = "dbt integration capability plugin for Phlo"
 name = "phlo-dbt"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.5.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-dlt/pyproject.toml
+++ b/packages/phlo-dlt/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 description = "DLT ingestion engine capability plugin for Phlo"
 name = "phlo-dlt"
 requires-python = ">=3.11"
-version = "0.5.0"
+version = "0.6.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-iceberg/pyproject.toml
+++ b/packages/phlo-iceberg/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Iceberg table-store capability plugin for Phlo"
 name = "phlo-iceberg"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.5.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-mcp/pyproject.toml
+++ b/packages/phlo-mcp/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "MCP server for Phlo observability and lakehouse operations"
 name = "phlo-mcp"
 requires-python = ">=3.11"
-version = "0.2.0"
+version = "0.3.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-mcp/src/phlo_mcp/__init__.py
+++ b/packages/phlo-mcp/src/phlo_mcp/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/packages/phlo-minio/pyproject.toml
+++ b/packages/phlo-minio/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "MinIO service plugin for Phlo"
 name = "phlo-minio"
 requires-python = ">=3.11"
-version = "0.3.3"
+version = "0.3.4"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-nessie/pyproject.toml
+++ b/packages/phlo-nessie/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Nessie service plugin for Phlo"
 name = "phlo-nessie"
 requires-python = ">=3.11"
-version = "0.3.3"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/pyproject.toml
+++ b/packages/phlo-observatory/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = ["phlo>=0.1.0"]
 description = "Phlo Observatory - Data platform UI (bundled with phlo core)"
 name = "phlo-observatory"
 requires-python = ">=3.11"
-version = "0.5.0"
+version = "0.6.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-observatory/src/phlo_observatory/__init__.py
+++ b/packages/phlo-observatory/src/phlo_observatory/__init__.py
@@ -64,4 +64,4 @@ __all__ = [
     "get_settings",
     "get_settings_service",
 ]
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/packages/phlo-postgres/pyproject.toml
+++ b/packages/phlo-postgres/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Postgres service plugin for Phlo"
 name = "phlo-postgres"
 requires-python = ">=3.11"
-version = "0.3.1"
+version = "0.3.2"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-postgres/src/phlo_postgres/__init__.py
+++ b/packages/phlo-postgres/src/phlo_postgres/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "PostgresSettings",
     "get_settings",
 ]
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/packages/phlo-sling/pyproject.toml
+++ b/packages/phlo-sling/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = "Sling replication ingestion provider for Phlo"
 name = "phlo-sling"
 requires-python = ">=3.11"
-version = "0.5.0"
+version = "0.6.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/pyproject.toml
+++ b/packages/phlo-trino/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
 description = "Trino service plugin for Phlo"
 name = "phlo-trino"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.4.0"
 
 [[project.authors]]
 email = "team@phlo.dev"

--- a/packages/phlo-trino/src/phlo_trino/__init__.py
+++ b/packages/phlo-trino/src/phlo_trino/__init__.py
@@ -32,4 +32,4 @@ __all__ = [
     "TrinoSettings",
     "get_settings",
 ]
-__version__ = "0.3.2"
+__version__ = "0.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ description = "Lakehouse platform"
 name = "phlo"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.10.0"
+version = "0.11.0"
 
 [project.entry-points."phlo.plugins.quality"]
 

--- a/src/phlo/cli/__init__.py
+++ b/src/phlo/cli/__init__.py
@@ -16,4 +16,4 @@ Examples:
     phlo workflow create --type ingestion --domain weather
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/src/phlo/plugins/__init__.py
+++ b/src/phlo/plugins/__init__.py
@@ -284,4 +284,4 @@ __all__ = [
     "PluginRegistry",
 ]
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/uv.lock
+++ b/uv.lock
@@ -3042,7 +3042,7 @@ wheels = [
 
 [[package]]
 name = "phlo"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
@@ -3306,7 +3306,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-api"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/phlo-api" }
 dependencies = [
     { name = "anyio" },
@@ -3436,7 +3436,7 @@ provides-extras = ["dev", "quality"]
 
 [[package]]
 name = "phlo-dagster"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/phlo-dagster" }
 dependencies = [
     { name = "dagster-graphql" },
@@ -3482,7 +3482,7 @@ provides-extras = ["alerting", "dev", "iceberg", "nessie", "observatory"]
 
 [[package]]
 name = "phlo-dbt"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/phlo-dbt" }
 dependencies = [
     { name = "dbt-core" },
@@ -3550,7 +3550,7 @@ provides-extras = ["dev", "minio"]
 
 [[package]]
 name = "phlo-dlt"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/phlo-dlt" }
 dependencies = [
     { name = "dlt" },
@@ -3636,7 +3636,7 @@ provides-extras = ["dev", "postgres"]
 
 [[package]]
 name = "phlo-iceberg"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/phlo-iceberg" }
 dependencies = [
     { name = "pandera" },
@@ -3732,7 +3732,7 @@ provides-extras = ["dev", "observatory"]
 
 [[package]]
 name = "phlo-mcp"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/phlo-mcp" }
 dependencies = [
     { name = "httpx" },
@@ -3762,7 +3762,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-minio"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "packages/phlo-minio" }
 dependencies = [
     { name = "phlo" },
@@ -3786,7 +3786,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-nessie"
-version = "0.3.3"
+version = "0.4.0"
 source = { editable = "packages/phlo-nessie" }
 dependencies = [
     { name = "marshmallow" },
@@ -3852,7 +3852,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-observatory"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/phlo-observatory" }
 dependencies = [
     { name = "phlo" },
@@ -4027,7 +4027,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-postgres"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "packages/phlo-postgres" }
 dependencies = [
     { name = "phlo" },
@@ -4135,7 +4135,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-sling"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/phlo-sling" }
 dependencies = [
     { name = "phlo" },
@@ -4257,7 +4257,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "phlo-trino"
-version = "0.3.2"
+version = "0.4.0"
 source = { editable = "packages/phlo-trino" }
 dependencies = [
     { name = "pandas" },


### PR DESCRIPTION
## Release summary

## [phlo 0.11.0 + 12 packages] - 2026-06-11

### Added
- phlo: derive governance surface from declarations (#522)
- phlo: deepen observatory lakehouse experience (#527)
- phlo: decouple agent workflow capabilities (#531)
- phlo: add Iceberg 1.11 compatibility checks
- phlo: add agent observability operation context
- phlo: add logical relation references (#543)
- phlo: add dialect-aware synthetic key helper (#544)
- phlo: add typed workflow settings (#546)
- phlo: add partitioned SQL ingestion helper (#549)
- phlo: bridge dbt lineage into Python assets (#550)
- phlo: add Trino DataFrame read helpers (#551)
- phlo: improve workflow author ergonomics (#552)
- phlo: make logs command package-selectable (#553)
- phlo-api: deepen observatory lakehouse experience (#527)
- phlo-api: decouple agent workflow capabilities (#531)
- phlo-api: add Iceberg 1.11 compatibility checks
- phlo-api: add agent observability operation context
- phlo-dagster: decouple agent workflow capabilities (#531)
- phlo-dbt: improve workflow author ergonomics (#552)
- phlo-dlt: decouple agent workflow capabilities (#531)
- phlo-dlt: add partitioned SQL ingestion helper (#549)
- phlo-dlt: improve workflow author ergonomics (#552)
- phlo-iceberg: add Iceberg 1.11 compatibility checks
- phlo-mcp: decouple agent workflow capabilities (#531)
- phlo-mcp: add agent observability operation context
- phlo-nessie: add Iceberg 1.11 compatibility checks
- phlo-observatory: deepen observatory lakehouse experience (#527)
- phlo-sling: decouple agent workflow capabilities (#531)
- phlo-trino: add Iceberg 1.11 compatibility checks
- phlo-trino: add Trino DataFrame read helpers (#551)
- phlo-trino: improve workflow author ergonomics (#552)

### Changed
- phlo: centralize schema migration planning (#524)
- phlo: centralize plugin lifecycle registry (#526)
- phlo: centralize capability family registry (#525)
- phlo-api: centralize plugin lifecycle registry (#526)
- phlo-api: centralize capability family registry (#525)
- phlo-dagster: centralize capability family registry (#525)
- phlo-dlt: centralize plugin lifecycle registry (#526)
- phlo-iceberg: centralize schema migration planning (#524)
- phlo-mcp: centralize capability family registry (#525)

### Fixed
- phlo: harden setup onboarding flow (#529)
- phlo: diagnose duplicate dagster assets (#545)
- phlo: include node properties in package data (#554)
- phlo: align package-owned port defaults (#555)
- phlo: discover project assets consistently (#556)
- phlo-api: align package-owned port defaults (#555)
- phlo-dagster: harden setup onboarding flow (#529)
- phlo-dagster: diagnose duplicate dagster assets (#545)
- phlo-dagster: align package-owned port defaults (#555)
- phlo-dagster: discover project assets consistently (#556)
- phlo-dbt: discover project assets consistently (#556)
- phlo-minio: align package-owned port defaults (#555)
- phlo-nessie: align package-owned port defaults (#555)
- phlo-observatory: align package-owned port defaults (#555)
- phlo-postgres: align package-owned port defaults (#555)
- phlo-trino: include node properties in package data (#554)
- phlo-trino: align package-owned port defaults (#555)

### Contributors
Thanks to our contributors for this release:
- @iamgp (74 commits)

## Maintainer checklist
- [ ] Review version bump
- [ ] Review changelog
- [ ] Merge to cut the release