### PR TITLE
refactor: centralize schema migration planning

### DIFF
--- a/packages/phlo-delta/src/phlo_delta/schema_migrator.py
+++ b/packages/phlo-delta/src/phlo_delta/schema_migrator.py
@@ -21,10 +21,15 @@ from typing import Any, cast
 
 import pyarrow as pa
 
-from phlo.capabilities.schema import default_classify_change, worst_classification
-from phlo.capabilities.specs import NormalizedSchema, SchemaChange, SchemaMigrationPlan
+from phlo.capabilities.specs import FieldSpec, NormalizedSchema, SchemaChange, SchemaMigrationPlan
 from phlo.hooks.emitters import SchemaMigrationEventContext, SchemaMigrationEventEmitter
 from phlo.logging import get_logger
+from phlo.schema_migration.planning import (
+    SchemaMigrationInstructions,
+    SchemaPlanningPolicy,
+    classify_schema_change,
+    plan_schema_migration,
+)
 from phlo_delta.tables import _default_storage_options, _resolve_table_uri
 
 logger = get_logger(__name__)
@@ -41,14 +46,10 @@ _ARROW_TYPE_MAP: dict[pa.DataType, str] = {
 }
 # Mapping of PyArrow data types to canonical dtype strings.
 
-_WIDEN_PAIRS: set[tuple[str, str]] = {
-    ("int32", "int64"),
-    ("float32", "float64"),
-    ("int32", "float64"),
-    ("int64", "float64"),
-    ("date", "timestamptz"),
-}
-# Set of valid type widening pairs for schema evolution.
+DELTA_SCHEMA_POLICY = SchemaPlanningPolicy(
+    change_classifications={"drop": "warning", "rename": "safe"},
+    recommendations={"drop": "Dropped columns are recoverable via Delta Lake time travel."},
+)
 
 
 def _arrow_type_to_dtype(arrow_type: pa.DataType) -> str:
@@ -186,13 +187,15 @@ class DeltaSchemaMigrator:
             # Returns: "safe"
 
         """
-        if change_type == "rename":
-            return "safe"
-        if change_type == "drop":
-            return "warning"
-        return default_classify_change(change_type, **details)
+        return classify_schema_change(change_type, policy=DELTA_SCHEMA_POLICY, **details)
 
-    def diff_schema(self, *, table_name: str, desired: NormalizedSchema) -> SchemaMigrationPlan:
+    def diff_schema(
+        self,
+        *,
+        table_name: str,
+        desired: NormalizedSchema,
+        instructions: SchemaMigrationInstructions | None = None,
+    ) -> SchemaMigrationPlan:
         """Compare *desired* schema against current Delta table schema.
 
         Analyzes differences between the desired schema and the existing
@@ -226,92 +229,22 @@ class DeltaSchemaMigrator:
         dt = DeltaTable(table_uri, storage_options=opts)
         current_schema = cast(Any, dt.schema()).to_pyarrow()
 
-        current_fields: dict[str, tuple[str, bool]] = {}
+        current_fields: list[FieldSpec] = []
         for field in current_schema:
-            current_fields[field.name] = (_arrow_type_to_dtype(field.type), field.nullable)
-
-        desired_fields: dict[str, tuple[str, bool]] = {}
-        for f in desired.fields:
-            desired_fields[f.name] = (f.dtype, f.nullable)
-
-        changes: list[SchemaChange] = []
-
-        for name, (dtype, nullable) in desired_fields.items():
-            if name not in current_fields:
-                cls = self.classify_change("add", nullable=nullable, has_default=False)
-                changes.append(
-                    SchemaChange(
-                        field_name=name,
-                        change_type="add",
-                        new_value=dtype,
-                        classification=cls,
-                    )
+            current_fields.append(
+                FieldSpec(
+                    name=field.name,
+                    dtype=_arrow_type_to_dtype(field.type),
+                    nullable=field.nullable,
                 )
+            )
 
-        for name in current_fields:
-            if name not in desired_fields:
-                cls = self.classify_change("drop")
-                changes.append(
-                    SchemaChange(
-                        field_name=name,
-                        change_type="drop",
-                        old_value=current_fields[name][0],
-                        classification=cls,
-                    )
-                )
-
-        for name in current_fields.keys() & desired_fields.keys():
-            cur_dtype, cur_nullable = current_fields[name]
-            des_dtype, des_nullable = desired_fields[name]
-
-            if cur_dtype != des_dtype:
-                if (cur_dtype, des_dtype) in _WIDEN_PAIRS:
-                    change_type = "widen_type"
-                else:
-                    change_type = "narrow_type"
-                cls = self.classify_change(change_type)
-                changes.append(
-                    SchemaChange(
-                        field_name=name,
-                        change_type=change_type,
-                        old_value=cur_dtype,
-                        new_value=des_dtype,
-                        classification=cls,
-                    )
-                )
-
-            if cur_nullable != des_nullable:
-                if des_nullable and not cur_nullable:
-                    change_type = "nullability_relaxed"
-                else:
-                    change_type = "nullability_tightened"
-                cls = self.classify_change(change_type)
-                changes.append(
-                    SchemaChange(
-                        field_name=name,
-                        change_type=change_type,
-                        old_value=str(cur_nullable),
-                        new_value=str(des_nullable),
-                        classification=cls,
-                    )
-                )
-
-        classifications = [c.classification for c in changes]
-        overall = worst_classification(classifications)
-        requires_approval = overall == "breaking"
-
-        recommendations: list[str] = []
-        if requires_approval:
-            recommendations.append("Breaking changes detected — requires explicit approval.")
-        if any(c.change_type == "drop" for c in changes):
-            recommendations.append("Dropped columns are recoverable via Delta Lake time travel.")
-
-        plan = SchemaMigrationPlan(
+        plan = plan_schema_migration(
             table_name=table_name,
-            changes=changes,
-            classification=overall,
-            recommendations=recommendations,
-            requires_approval=requires_approval,
+            current=NormalizedSchema(fields=current_fields),
+            desired=desired,
+            policy=DELTA_SCHEMA_POLICY,
+            instructions=instructions,
         )
 
         emitter = SchemaMigrationEventEmitter(
@@ -319,9 +252,9 @@ class DeltaSchemaMigrator:
         )
         emitter.emit(
             status="planned",
-            classification=overall,
-            change_count=len(changes),
-            changes=[asdict(c) for c in changes],
+            classification=plan.classification,
+            change_count=len(plan.changes),
+            changes=[asdict(c) for c in plan.changes],
         )
 
         return plan

--- a/packages/phlo-iceberg/src/phlo_iceberg/schema_migrator.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/schema_migrator.py
@@ -70,10 +70,15 @@ from pyiceberg.types import (
 
 from dataclasses import asdict
 
-from phlo.capabilities.schema import default_classify_change, worst_classification
-from phlo.capabilities.specs import NormalizedSchema, SchemaChange, SchemaMigrationPlan
+from phlo.capabilities.specs import FieldSpec, NormalizedSchema, SchemaChange, SchemaMigrationPlan
 from phlo.hooks.emitters import SchemaMigrationEventContext, SchemaMigrationEventEmitter
 from phlo.logging import get_logger
+from phlo.schema_migration.planning import (
+    SchemaMigrationInstructions,
+    SchemaPlanningPolicy,
+    classify_schema_change,
+    plan_schema_migration,
+)
 from phlo_iceberg.catalog import get_catalog
 from phlo_iceberg.settings import get_settings
 
@@ -93,14 +98,6 @@ _ICEBERG_TYPE_MAP: dict[type[IcebergType], str] = {
     DecimalType: "decimal",
 }
 
-_WIDEN_PAIRS: set[tuple[str, str]] = {
-    ("int32", "int64"),
-    ("float32", "float64"),
-    ("int32", "float64"),
-    ("int64", "float64"),
-    ("date", "timestamptz"),
-}
-
 _SYSTEM_METADATA_FIELDS = {
     "_dlt_load_id",
     "_dlt_id",
@@ -109,6 +106,11 @@ _SYSTEM_METADATA_FIELDS = {
     "_phlo_partition_date",
     "_phlo_run_id",
 }
+
+ICEBERG_SCHEMA_POLICY = SchemaPlanningPolicy(
+    change_classifications={"drop": "warning", "rename": "safe"},
+    recommendations={"drop": "Dropped columns are recoverable via Iceberg snapshot rollback."},
+)
 
 
 def _iceberg_type_to_dtype(iceberg_type: IcebergType) -> str:
@@ -240,13 +242,15 @@ class IcebergSchemaMigrator:
                 assert migrator.classify_change("add", nullable=False, has_default=False) == "breaking"
 
         """
-        if change_type == "rename":
-            return "safe"
-        if change_type == "drop":
-            return "warning"
-        return default_classify_change(change_type, **details)
+        return classify_schema_change(change_type, policy=ICEBERG_SCHEMA_POLICY, **details)
 
-    def diff_schema(self, *, table_name: str, desired: NormalizedSchema) -> SchemaMigrationPlan:
+    def diff_schema(
+        self,
+        *,
+        table_name: str,
+        desired: NormalizedSchema,
+        instructions: SchemaMigrationInstructions | None = None,
+    ) -> SchemaMigrationPlan:
         """Compare desired schema against current table schema.
 
         Detects all differences between the desired schema and the current
@@ -301,97 +305,24 @@ class IcebergSchemaMigrator:
         table = catalog.load_table(table_name)
         current_schema = table.schema()
 
-        current_fields: dict[str, tuple[str, bool]] = {}
+        current_fields: list[FieldSpec] = []
         for f in current_schema.fields:
             if f.name in _SYSTEM_METADATA_FIELDS:
                 continue
-            current_fields[f.name] = (_iceberg_type_to_dtype(f.field_type), f.required is False)
-
-        desired_fields: dict[str, tuple[str, bool]] = {}
-        for f in desired.fields:
-            desired_fields[f.name] = (f.dtype, f.nullable)
-
-        changes: list[SchemaChange] = []
-
-        # Added fields
-        for name, (dtype, nullable) in desired_fields.items():
-            if name not in current_fields:
-                cls = self.classify_change("add", nullable=nullable, has_default=False)
-                changes.append(
-                    SchemaChange(
-                        field_name=name,
-                        change_type="add",
-                        new_value=dtype,
-                        classification=cls,
-                    )
+            current_fields.append(
+                FieldSpec(
+                    name=f.name,
+                    dtype=_iceberg_type_to_dtype(f.field_type),
+                    nullable=f.required is False,
                 )
+            )
 
-        # Dropped fields
-        for name in current_fields:
-            if name not in desired_fields:
-                cls = self.classify_change("drop")
-                changes.append(
-                    SchemaChange(
-                        field_name=name,
-                        change_type="drop",
-                        old_value=current_fields[name][0],
-                        classification=cls,
-                    )
-                )
-
-        # Type and nullability changes on common fields
-        for name in current_fields.keys() & desired_fields.keys():
-            cur_dtype, cur_nullable = current_fields[name]
-            des_dtype, des_nullable = desired_fields[name]
-
-            if cur_dtype != des_dtype:
-                if (cur_dtype, des_dtype) in _WIDEN_PAIRS:
-                    change_type = "widen_type"
-                else:
-                    change_type = "narrow_type"
-                cls = self.classify_change(change_type)
-                changes.append(
-                    SchemaChange(
-                        field_name=name,
-                        change_type=change_type,
-                        old_value=cur_dtype,
-                        new_value=des_dtype,
-                        classification=cls,
-                    )
-                )
-
-            if cur_nullable != des_nullable:
-                if des_nullable and not cur_nullable:
-                    change_type = "nullability_relaxed"
-                else:
-                    change_type = "nullability_tightened"
-                cls = self.classify_change(change_type)
-                changes.append(
-                    SchemaChange(
-                        field_name=name,
-                        change_type=change_type,
-                        old_value=str(cur_nullable),
-                        new_value=str(des_nullable),
-                        classification=cls,
-                    )
-                )
-
-        classifications = [c.classification for c in changes]
-        overall = worst_classification(classifications)
-        requires_approval = overall == "breaking"
-
-        recommendations: list[str] = []
-        if requires_approval:
-            recommendations.append("Breaking changes detected — requires explicit approval.")
-        if any(c.change_type == "drop" for c in changes):
-            recommendations.append("Dropped columns are recoverable via Iceberg snapshot rollback.")
-
-        plan = SchemaMigrationPlan(
+        plan = plan_schema_migration(
             table_name=table_name,
-            changes=changes,
-            classification=overall,
-            recommendations=recommendations,
-            requires_approval=requires_approval,
+            current=NormalizedSchema(fields=current_fields),
+            desired=desired,
+            policy=ICEBERG_SCHEMA_POLICY,
+            instructions=instructions,
         )
 
         emitter = SchemaMigrationEventEmitter(
@@ -399,9 +330,9 @@ class IcebergSchemaMigrator:
         )
         emitter.emit(
             status="planned",
-            classification=overall,
-            change_count=len(changes),
-            changes=[asdict(c) for c in changes],
+            classification=plan.classification,
+            change_count=len(plan.changes),
+            changes=[asdict(c) for c in plan.changes],
         )
 
         return plan

--- a/src/phlo/cli/commands/schema_migrate.py
+++ b/src/phlo/cli/commands/schema_migrate.py
@@ -24,6 +24,7 @@ from rich.table import Table
 from phlo.capabilities import (
     FieldSpec,
     NormalizedSchema,
+    SchemaMigrationPlan,
     configured_capability_name,
     get_capability_registry,
     list_capabilities,
@@ -31,6 +32,13 @@ from phlo.capabilities import (
 )
 from phlo.cli.commands import schema_migrate_contracts
 from phlo.logging import get_logger
+from phlo.schema_migration.instructions import (
+    MigrationInstructionError,
+    resolve_migration_instructions,
+)
+from phlo.schema_migration.planning import (
+    SchemaMigrationPlanningError,
+)
 
 console = Console()
 logger = get_logger(__name__)
@@ -188,6 +196,53 @@ def _resolve_desired_schema(table_name: str, schema_class: str | None) -> tuple[
 
     desired = extractor.extract(native_schema)
     return migrator, desired, native_schema
+
+
+def _build_migration_plan(
+    *,
+    table_name: str,
+    schema_class: str | None,
+    migration_file: Path | None,
+    rename: tuple[str, ...],
+) -> tuple[Any, SchemaMigrationPlan]:
+    """Resolve the selected migrator and build a plan from CLI inputs."""
+    try:
+        instructions = resolve_migration_instructions(
+            table_name=table_name,
+            migration_file=migration_file,
+            rename_flags=rename,
+        )
+    except MigrationInstructionError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    migrator, desired, _ = _resolve_desired_schema(table_name, schema_class)
+    try:
+        plan = migrator.diff_schema(
+            table_name=table_name,
+            desired=desired,
+            instructions=instructions,
+        )
+    except SchemaMigrationPlanningError as exc:
+        raise click.ClickException(str(exc)) from exc
+    return migrator, plan
+
+
+def _ensure_plan_supported(migrator: Any, plan: SchemaMigrationPlan) -> None:
+    """Refuse to apply unsupported explicit change types."""
+    if not hasattr(migrator, "supported_changes"):
+        return
+    supported = migrator.supported_changes()
+    unsupported = sorted(
+        {change.change_type for change in plan.changes if change.change_type not in supported}
+    )
+    if not unsupported:
+        return
+    rendered = ", ".join(unsupported)
+    raise click.ClickException(
+        "Schema migration plan contains unsupported change type(s) for the selected "
+        f"schema migrator: {rendered}. Use a provider that supports them, or change the "
+        "migration YAML/CLI flags."
+    )
 
 
 def _select_default_table_store_name() -> str | None:
@@ -411,8 +466,25 @@ def schema_migrate_group() -> None:
 @click.option(
     "--schema-class", default=None, help="Pandera schema class name (auto-detected if omitted)"
 )
+@click.option(
+    "--migration-file",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+    help="Migration instruction YAML (default: .phlo/migrations/<table>.yaml)",
+)
+@click.option(
+    "--rename",
+    multiple=True,
+    help="Explicit rename instruction in old_name=new_name form. May be repeated.",
+)
 @click.option("--format", "fmt", type=click.Choice(["table", "json"]), default="table")
-def diff(table_name: str, schema_class: str | None, fmt: str) -> None:
+def diff(
+    table_name: str,
+    schema_class: str | None,
+    migration_file: Path | None,
+    rename: tuple[str, ...],
+    fmt: str,
+) -> None:
     """Show pending schema changes between quality schema and storage table.
 
     Examples:
@@ -420,18 +492,22 @@ def diff(table_name: str, schema_class: str | None, fmt: str) -> None:
         phlo schema-migrate diff warehouse.customers --schema-class CustomerSchema
         phlo schema-migrate diff warehouse.customers --format json
     """
-    migrator, desired, _ = _resolve_desired_schema(table_name, schema_class)
-    plan = migrator.diff_schema(table_name=table_name, desired=desired)
+    _, migration_plan = _build_migration_plan(
+        table_name=table_name,
+        schema_class=schema_class,
+        migration_file=migration_file,
+        rename=rename,
+    )
 
     if fmt == "json":
-        click.echo(json.dumps(asdict(plan), indent=2))
+        click.echo(json.dumps(asdict(migration_plan), indent=2))
         return
 
-    if not plan.changes:
+    if not migration_plan.changes:
         console.print(f"[green]No schema changes detected for {table_name}[/green]")
         return
 
-    _render_plan(plan)
+    _render_plan(migration_plan)
 
 
 @schema_migrate_group.command()
@@ -439,15 +515,36 @@ def diff(table_name: str, schema_class: str | None, fmt: str) -> None:
 @click.option(
     "--schema-class", default=None, help="Pandera schema class name (auto-detected if omitted)"
 )
+@click.option(
+    "--migration-file",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+    help="Migration instruction YAML (default: .phlo/migrations/<table>.yaml)",
+)
+@click.option(
+    "--rename",
+    multiple=True,
+    help="Explicit rename instruction in old_name=new_name form. May be repeated.",
+)
 @click.option("--format", "fmt", type=click.Choice(["table", "json"]), default="table")
-def plan(table_name: str, schema_class: str | None, fmt: str) -> None:
+def plan(
+    table_name: str,
+    schema_class: str | None,
+    migration_file: Path | None,
+    rename: tuple[str, ...],
+    fmt: str,
+) -> None:
     """Generate a migration plan for a table.
 
     Examples:
         phlo schema-migrate plan warehouse.customers
     """
-    migrator, desired, _ = _resolve_desired_schema(table_name, schema_class)
-    migration_plan = migrator.diff_schema(table_name=table_name, desired=desired)
+    _, migration_plan = _build_migration_plan(
+        table_name=table_name,
+        schema_class=schema_class,
+        migration_file=migration_file,
+        rename=rename,
+    )
 
     if fmt == "json":
         click.echo(json.dumps(asdict(migration_plan), indent=2))
@@ -470,9 +567,27 @@ def plan(table_name: str, schema_class: str | None, fmt: str) -> None:
 @click.option(
     "--schema-class", default=None, help="Pandera schema class name (auto-detected if omitted)"
 )
+@click.option(
+    "--migration-file",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+    help="Migration instruction YAML (default: .phlo/migrations/<table>.yaml)",
+)
+@click.option(
+    "--rename",
+    multiple=True,
+    help="Explicit rename instruction in old_name=new_name form. May be repeated.",
+)
 @click.option("--yes", is_flag=True, help="Auto-approve breaking changes")
 @click.option("--dry-run", is_flag=True, help="Show what would be applied without executing")
-def apply(table_name: str, schema_class: str | None, yes: bool, dry_run: bool) -> None:
+def apply(
+    table_name: str,
+    schema_class: str | None,
+    migration_file: Path | None,
+    rename: tuple[str, ...],
+    yes: bool,
+    dry_run: bool,
+) -> None:
     """Apply schema migration to a storage table.
 
     Safe changes are applied automatically. Breaking changes require
@@ -483,13 +598,18 @@ def apply(table_name: str, schema_class: str | None, yes: bool, dry_run: bool) -
         phlo schema-migrate apply warehouse.customers --yes
         phlo schema-migrate apply warehouse.customers --dry-run
     """
-    migrator, desired, _ = _resolve_desired_schema(table_name, schema_class)
-    migration_plan = migrator.diff_schema(table_name=table_name, desired=desired)
+    migrator, migration_plan = _build_migration_plan(
+        table_name=table_name,
+        schema_class=schema_class,
+        migration_file=migration_file,
+        rename=rename,
+    )
 
     if not migration_plan.changes:
         console.print(f"[green]No migration needed for {table_name}[/green]")
         return
 
+    _ensure_plan_supported(migrator, migration_plan)
     _render_plan(migration_plan)
 
     if dry_run:

--- a/src/phlo/cli/commands/schema_migrate_contracts.py
+++ b/src/phlo/cli/commands/schema_migrate_contracts.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import yaml
 
+from phlo.schema_migration.instructions import default_migration_instruction_path
+
 CONTRACT_VERSION = 1
 MIGRATION_SCAFFOLD_VERSION = 1
 
@@ -28,7 +30,7 @@ def default_contract_path(table_name: str) -> Path:
 
 def default_scaffold_yaml_path(table_name: str) -> Path:
     """Return default scaffold YAML path for a table."""
-    return Path(".phlo/migrations") / f"{table_to_artifact_stem(table_name)}.yaml"
+    return default_migration_instruction_path(table_name)
 
 
 def list_recent_contract_paths(
@@ -122,6 +124,7 @@ def build_scaffold_payload(
         "classification": migration_plan.classification,
         "requires_approval": migration_plan.requires_approval,
         "recommendations": list(migration_plan.recommendations),
+        "renames": {},
         "context": {
             "table_store": contract.get("table_store"),
             "schema_migrator": contract.get("schema_migrator"),

--- a/src/phlo/cli/commands/schema_registry_cli.py
+++ b/src/phlo/cli/commands/schema_registry_cli.py
@@ -11,9 +11,9 @@ from rich.table import Table
 
 from phlo.capabilities.schema import CLASSIFICATION_ORDER
 from phlo.logging import get_logger
+from phlo.schema_migration.planning import plan_schema_migration
 from phlo.schema_registry import (
     SchemaRegistry,
-    check_compatibility,
     deserialize_schema,
     resolve_registry_db_url,
 )
@@ -83,7 +83,7 @@ def check(table: str, fail_on: str) -> None:
 
     current = deserialize_schema(snapshots[0].schema_json)
     previous = deserialize_schema(snapshots[1].schema_json)
-    plan = check_compatibility(previous, current, table_name=table)
+    plan = plan_schema_migration(table_name=table, current=previous, desired=current)
 
     classification_colors = {"safe": "green", "warning": "yellow", "breaking": "red"}
     color = classification_colors.get(plan.classification, "white")

--- a/src/phlo/helpers/__init__.py
+++ b/src/phlo/helpers/__init__.py
@@ -146,13 +146,10 @@ from phlo.helpers.references import (
     reference_required_field_gaps,
 )
 from phlo.helpers.schema import (
-    assert_schema_compatible,
-    compare_schemas,
     normalized_schema,
     schema_field_map,
     schema_from_arrow,
     schema_from_dataframe,
-    suggest_schema_migration,
 )
 from phlo.helpers.sql import (
     apply_where,
@@ -243,7 +240,6 @@ __all__ = [
     "assert_materialize_result",
     "assert_no_reference_gap",
     "assert_reference_unique",
-    "assert_schema_compatible",
     "assert_valid_transition",
     "audit_event",
     "bitemporal_predicate",
@@ -257,7 +253,6 @@ __all__ = [
     "collect_errors",
     "collect_workflow_evidence",
     "compare_partitions",
-    "compare_schemas",
     "connection_from_url",
     "correction_chain",
     "create_api_view",
@@ -358,7 +353,6 @@ __all__ = [
     "schema_from_dataframe",
     "stage_path_for_run",
     "state_transition_counts",
-    "suggest_schema_migration",
     "supersession_key",
     "table_exists",
     "table_ref_sql",

--- a/src/phlo/helpers/schema.py
+++ b/src/phlo/helpers/schema.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from phlo.capabilities import FieldSpec, NormalizedSchema, SchemaChange, SchemaMigrationPlan
-from phlo.capabilities.schema import default_classify_change, worst_classification
+from phlo.capabilities import FieldSpec, NormalizedSchema
 from phlo.exceptions import PhloConfigError
 
 
@@ -56,76 +55,3 @@ def schema_from_arrow(schema: Any) -> NormalizedSchema:
 def schema_field_map(schema: NormalizedSchema) -> dict[str, FieldSpec]:
     """Return fields keyed by name."""
     return {field.name: field for field in schema.fields}
-
-
-def compare_schemas(
-    current: NormalizedSchema,
-    desired: NormalizedSchema,
-    *,
-    table_name: str = "<unknown>",
-) -> SchemaMigrationPlan:
-    """Compare two normalized schemas and classify changes."""
-    current_fields = schema_field_map(current)
-    desired_fields = schema_field_map(desired)
-    changes: list[SchemaChange] = []
-
-    for name, field in desired_fields.items():
-        old = current_fields.get(name)
-        if old is None:
-            classification = default_classify_change(
-                "add",
-                nullable=field.nullable,
-                has_default=field.default is not None,
-            )
-            changes.append(SchemaChange(name, "add", None, field.dtype, classification))
-            continue
-        if old.dtype != field.dtype:
-            classification = default_classify_change("type_change")
-            changes.append(
-                SchemaChange(name, "type_change", old.dtype, field.dtype, classification)
-            )
-        if old.nullable != field.nullable:
-            change_type = "nullability_relaxed" if field.nullable else "nullability_tightened"
-            classification = default_classify_change(change_type)
-            changes.append(
-                SchemaChange(
-                    name, change_type, str(old.nullable), str(field.nullable), classification
-                )
-            )
-
-    for name, field in current_fields.items():
-        if name not in desired_fields:
-            changes.append(SchemaChange(name, "drop", field.dtype, None, "warning"))
-
-    classification = worst_classification([change.classification for change in changes])
-    return SchemaMigrationPlan(
-        table_name=table_name,
-        changes=changes,
-        classification=classification,
-        requires_approval=classification == "breaking",
-        recommendations=suggest_schema_migration(changes),
-    )
-
-
-def suggest_schema_migration(changes: list[SchemaChange]) -> list[str]:
-    """Return human-readable migration recommendations."""
-    recommendations: list[str] = []
-    if any(change.change_type == "add" for change in changes):
-        recommendations.append("Add nullable/defaulted columns before tightening constraints.")
-    if any(change.change_type == "drop" for change in changes):
-        recommendations.append(
-            "Review dropped columns and confirm downstream consumers are migrated."
-        )
-    if any(change.classification == "breaking" for change in changes):
-        recommendations.append("Apply breaking changes only after approval or on a staging branch.")
-    return recommendations
-
-
-def assert_schema_compatible(current: NormalizedSchema, desired: NormalizedSchema) -> None:
-    """Raise when the desired schema contains breaking changes."""
-    plan = compare_schemas(current, desired)
-    if plan.requires_approval:
-        raise PhloConfigError(
-            message="Schema changes require approval",
-            suggestions=[f"{change.field_name}: {change.change_type}" for change in plan.changes],
-        )

--- a/src/phlo/helpers/schema.py
+++ b/src/phlo/helpers/schema.py
@@ -1,4 +1,4 @@
-"""Normalized schema construction and comparison helpers."""
+"""Normalized schema construction helpers."""
 
 from __future__ import annotations
 

--- a/src/phlo/schema_migration/__init__.py
+++ b/src/phlo/schema_migration/__init__.py
@@ -1,0 +1,27 @@
+"""Schema migration planning primitives."""
+
+from phlo.schema_migration.instructions import (
+    MigrationInstructionError,
+    default_migration_instruction_path,
+    resolve_migration_instructions,
+)
+from phlo.schema_migration.planning import (
+    GENERIC_SCHEMA_POLICY,
+    SchemaMigrationInstructions,
+    SchemaMigrationPlanningError,
+    SchemaPlanningPolicy,
+    classify_schema_change,
+    plan_schema_migration,
+)
+
+__all__ = [
+    "GENERIC_SCHEMA_POLICY",
+    "MigrationInstructionError",
+    "SchemaMigrationInstructions",
+    "SchemaMigrationPlanningError",
+    "SchemaPlanningPolicy",
+    "classify_schema_change",
+    "default_migration_instruction_path",
+    "plan_schema_migration",
+    "resolve_migration_instructions",
+]

--- a/src/phlo/schema_migration/instructions.py
+++ b/src/phlo/schema_migration/instructions.py
@@ -1,0 +1,96 @@
+"""Load human-authored schema migration instructions."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+from phlo.schema_migration.planning import SchemaMigrationInstructions
+
+
+class MigrationInstructionError(ValueError):
+    """Raised when migration instruction files or flags are invalid."""
+
+
+def default_migration_instruction_path(table_name: str) -> Path:
+    """Return the default migration instruction file for a table."""
+    return Path(".phlo/migrations") / f"{_table_to_artifact_stem(table_name)}.yaml"
+
+
+def resolve_migration_instructions(
+    *,
+    table_name: str,
+    migration_file: Path | None,
+    rename_flags: tuple[str, ...],
+) -> SchemaMigrationInstructions:
+    """Merge migration instructions from YAML and CLI rename flags."""
+    yaml_path = migration_file or default_migration_instruction_path(table_name)
+    renames = _load_migration_yaml_renames(yaml_path, table_name)
+
+    for value in rename_flags:
+        old_name, new_name = _parse_rename_flag(value)
+        existing = renames.get(old_name)
+        if existing is not None and existing != new_name:
+            raise MigrationInstructionError(
+                f"Conflicting rename instruction for {old_name}: "
+                f"YAML maps it to {existing}, CLI maps it to {new_name}. "
+                "Sort out the YAML or CLI flags and rerun."
+            )
+        renames[old_name] = new_name
+
+    return SchemaMigrationInstructions(renames=renames)
+
+
+def _table_to_artifact_stem(table_name: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "_", table_name.strip())
+    return sanitized.replace(".", "__")
+
+
+def _parse_rename_flag(value: str) -> tuple[str, str]:
+    if "=" not in value:
+        raise MigrationInstructionError("Use old_name=new_name.")
+    old_name, new_name = (part.strip() for part in value.split("=", 1))
+    if not old_name or not new_name:
+        raise MigrationInstructionError("Use old_name=new_name with non-empty field names.")
+    return old_name, new_name
+
+
+def _load_migration_yaml_renames(path: Path, table_name: str) -> dict[str, str]:
+    if not path.exists():
+        return {}
+
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise MigrationInstructionError(f"Failed to parse migration file {path}: {exc}") from exc
+    except OSError as exc:
+        raise MigrationInstructionError(f"Failed to read migration file {path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise MigrationInstructionError(f"Migration file root must be an object: {path}")
+    payload_table = payload.get("table_name")
+    if payload_table is not None and payload_table != table_name:
+        raise MigrationInstructionError(
+            f"Migration file table mismatch: expected '{table_name}', found '{payload_table}'."
+        )
+
+    raw_renames = payload.get("renames", {})
+    if raw_renames is None:
+        return {}
+    if not isinstance(raw_renames, dict):
+        raise MigrationInstructionError(f"Migration file renames must be a mapping: {path}")
+
+    renames: dict[str, str] = {}
+    for old_name, new_name in raw_renames.items():
+        if not isinstance(old_name, str) or not isinstance(new_name, str):
+            raise MigrationInstructionError(f"Migration file renames must map strings: {path}")
+        old_name = old_name.strip()
+        new_name = new_name.strip()
+        if not old_name or not new_name:
+            raise MigrationInstructionError(
+                f"Migration file renames require non-empty field names: {path}"
+            )
+        renames[old_name] = new_name
+    return renames

--- a/src/phlo/schema_migration/planning.py
+++ b/src/phlo/schema_migration/planning.py
@@ -1,0 +1,276 @@
+"""Shared schema migration planning over normalized schemas."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from phlo.capabilities.schema import default_classify_change, worst_classification
+from phlo.capabilities.specs import FieldSpec, NormalizedSchema, SchemaChange, SchemaMigrationPlan
+
+_WIDEN_PAIRS = {
+    ("int32", "int64"),
+    ("float32", "float64"),
+    ("int32", "float64"),
+    ("int64", "float64"),
+    ("date", "timestamptz"),
+}
+
+
+class SchemaMigrationPlanningError(ValueError):
+    """Raised when explicit migration instructions are invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaPlanningPolicy:
+    """Provider-specific risk and recommendation overrides for neutral changes."""
+
+    change_classifications: Mapping[str, str] = field(default_factory=dict)
+    recommendations: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaMigrationInstructions:
+    """Explicit human-authored schema migration instructions."""
+
+    renames: Mapping[str, str] = field(default_factory=dict)
+
+
+GENERIC_SCHEMA_POLICY = SchemaPlanningPolicy()
+
+
+def plan_schema_migration(
+    *,
+    table_name: str,
+    current: NormalizedSchema,
+    desired: NormalizedSchema,
+    policy: SchemaPlanningPolicy = GENERIC_SCHEMA_POLICY,
+    instructions: SchemaMigrationInstructions | None = None,
+) -> SchemaMigrationPlan:
+    """Compare two normalized schemas and produce a migration plan."""
+    instructions = instructions or SchemaMigrationInstructions()
+    current_fields = _field_map(current)
+    desired_fields = _field_map(desired)
+    renames = dict(instructions.renames)
+    _validate_renames(renames, current_fields=current_fields, desired_fields=desired_fields)
+
+    changes: list[SchemaChange] = []
+    renamed_sources = set(renames)
+    renamed_targets = set(renames.values())
+
+    for old_name, new_name in _ordered_renames(renames):
+        changes.append(
+            SchemaChange(
+                field_name=old_name,
+                change_type="rename",
+                old_value=old_name,
+                new_value=new_name,
+                classification=_classify("rename", policy),
+            )
+        )
+        _append_field_mutation_changes(
+            changes,
+            field_name=new_name,
+            current_field=current_fields[old_name],
+            desired_field=desired_fields[new_name],
+            policy=policy,
+        )
+
+    for name, desired_field in desired_fields.items():
+        if name in renamed_targets:
+            continue
+        if name not in current_fields:
+            changes.append(
+                SchemaChange(
+                    field_name=name,
+                    change_type="add",
+                    new_value=desired_field.dtype,
+                    classification=_classify(
+                        "add",
+                        policy,
+                        nullable=desired_field.nullable,
+                        has_default=desired_field.default is not None,
+                    ),
+                )
+            )
+
+    for name, current_field in current_fields.items():
+        if name in renamed_sources:
+            continue
+        if name not in desired_fields:
+            changes.append(
+                SchemaChange(
+                    field_name=name,
+                    change_type="drop",
+                    old_value=current_field.dtype,
+                    classification=_classify("drop", policy),
+                )
+            )
+
+    for name in current_fields.keys() & desired_fields.keys():
+        if name in renamed_sources or name in renamed_targets:
+            continue
+        current_field = current_fields[name]
+        desired_field = desired_fields[name]
+        _append_field_mutation_changes(
+            changes,
+            field_name=name,
+            current_field=current_field,
+            desired_field=desired_field,
+            policy=policy,
+        )
+
+    classification = worst_classification([change.classification for change in changes])
+    return SchemaMigrationPlan(
+        table_name=table_name,
+        changes=changes,
+        classification=classification,
+        recommendations=_recommendations(changes, classification, policy),
+        requires_approval=classification == "breaking",
+    )
+
+
+def _field_map(schema: NormalizedSchema) -> dict[str, FieldSpec]:
+    fields: dict[str, FieldSpec] = {}
+    for schema_field in schema.fields:
+        if schema_field.name in fields:
+            raise SchemaMigrationPlanningError(
+                f"Schema contains duplicate field name '{schema_field.name}'."
+            )
+        fields[schema_field.name] = schema_field
+    return fields
+
+
+def _classify(change_type: str, policy: SchemaPlanningPolicy, **details: object) -> str:
+    override = policy.change_classifications.get(change_type)
+    if override is not None:
+        return override
+    return default_classify_change(change_type, **details)
+
+
+def classify_schema_change(
+    change_type: str,
+    *,
+    policy: SchemaPlanningPolicy = GENERIC_SCHEMA_POLICY,
+    **details: object,
+) -> str:
+    """Classify a schema change through the same policy used for planning."""
+    return _classify(change_type, policy, **details)
+
+
+def _append_field_mutation_changes(
+    changes: list[SchemaChange],
+    *,
+    field_name: str,
+    current_field: FieldSpec,
+    desired_field: FieldSpec,
+    policy: SchemaPlanningPolicy,
+) -> None:
+    if current_field.dtype != desired_field.dtype:
+        change_type = (
+            "widen_type"
+            if (current_field.dtype, desired_field.dtype) in _WIDEN_PAIRS
+            else "narrow_type"
+        )
+        changes.append(
+            SchemaChange(
+                field_name=field_name,
+                change_type=change_type,
+                old_value=current_field.dtype,
+                new_value=desired_field.dtype,
+                classification=_classify(change_type, policy),
+            )
+        )
+
+    if current_field.nullable != desired_field.nullable:
+        change_type = (
+            "nullability_relaxed"
+            if desired_field.nullable and not current_field.nullable
+            else "nullability_tightened"
+        )
+        changes.append(
+            SchemaChange(
+                field_name=field_name,
+                change_type=change_type,
+                old_value=str(current_field.nullable),
+                new_value=str(desired_field.nullable),
+                classification=_classify(change_type, policy),
+            )
+        )
+
+
+def _recommendations(
+    changes: list[SchemaChange],
+    classification: str,
+    policy: SchemaPlanningPolicy,
+) -> list[str]:
+    recommendations: list[str] = []
+    if classification == "breaking":
+        recommendations.append("Breaking changes detected - requires explicit approval.")
+    for change in changes:
+        recommendation = policy.recommendations.get(change.change_type)
+        if recommendation and recommendation not in recommendations:
+            recommendations.append(recommendation)
+    return recommendations
+
+
+def _validate_renames(
+    renames: Mapping[str, str],
+    *,
+    current_fields: Mapping[str, FieldSpec],
+    desired_fields: Mapping[str, FieldSpec],
+) -> None:
+    seen_targets: dict[str, str] = {}
+    for old_name, new_name in renames.items():
+        if not old_name or not new_name:
+            raise SchemaMigrationPlanningError("Rename instructions require non-empty field names.")
+        if old_name not in current_fields:
+            raise SchemaMigrationPlanningError(
+                f"Rename instruction {old_name} -> {new_name} is invalid: "
+                f"current schema has no field '{old_name}'."
+            )
+        if new_name not in desired_fields:
+            raise SchemaMigrationPlanningError(
+                f"Rename instruction {old_name} -> {new_name} is invalid: "
+                f"desired schema has no field '{new_name}'."
+            )
+        previous_source = seen_targets.get(new_name)
+        if previous_source is not None:
+            raise SchemaMigrationPlanningError(
+                f"Invalid rename instructions: multiple rename sources "
+                f"('{previous_source}', '{old_name}') target '{new_name}'."
+            )
+        seen_targets[new_name] = old_name
+
+    renamed_sources = set(renames)
+    for old_name, new_name in renames.items():
+        if new_name in current_fields and new_name not in renamed_sources:
+            raise SchemaMigrationPlanningError(
+                f"Rename instruction {old_name} -> {new_name} is invalid: "
+                f"target field '{new_name}' already exists in current schema."
+            )
+
+
+def _ordered_renames(renames: Mapping[str, str]) -> list[tuple[str, str]]:
+    ordered: list[tuple[str, str]] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(old_name: str) -> None:
+        if old_name in visited:
+            return
+        if old_name in visiting:
+            raise SchemaMigrationPlanningError(
+                "Cyclic rename instructions are not executable without an intermediate field name."
+            )
+        visiting.add(old_name)
+        new_name = renames[old_name]
+        if new_name in renames:
+            visit(new_name)
+        visiting.remove(old_name)
+        visited.add(old_name)
+        ordered.append((old_name, new_name))
+
+    for old_name in sorted(renames):
+        visit(old_name)
+    return ordered

--- a/src/phlo/schema_migration/planning.py
+++ b/src/phlo/schema_migration/planning.py
@@ -58,7 +58,7 @@ def plan_schema_migration(
     renamed_sources = set(renames)
     renamed_targets = set(renames.values())
 
-    for old_name, new_name in _ordered_renames(renames):
+    for old_name, new_name in sorted(renames.items()):
         changes.append(
             SchemaChange(
                 field_name=old_name,
@@ -224,6 +224,11 @@ def _validate_renames(
     for old_name, new_name in renames.items():
         if not old_name or not new_name:
             raise SchemaMigrationPlanningError("Rename instructions require non-empty field names.")
+        if old_name == new_name:
+            raise SchemaMigrationPlanningError(
+                f"Rename instruction {old_name} -> {new_name} is invalid: "
+                "source and target are identical."
+            )
         if old_name not in current_fields:
             raise SchemaMigrationPlanningError(
                 f"Rename instruction {old_name} -> {new_name} is invalid: "
@@ -242,35 +247,9 @@ def _validate_renames(
             )
         seen_targets[new_name] = old_name
 
-    renamed_sources = set(renames)
     for old_name, new_name in renames.items():
-        if new_name in current_fields and new_name not in renamed_sources:
+        if new_name in current_fields:
             raise SchemaMigrationPlanningError(
                 f"Rename instruction {old_name} -> {new_name} is invalid: "
                 f"target field '{new_name}' already exists in current schema."
             )
-
-
-def _ordered_renames(renames: Mapping[str, str]) -> list[tuple[str, str]]:
-    ordered: list[tuple[str, str]] = []
-    visiting: set[str] = set()
-    visited: set[str] = set()
-
-    def visit(old_name: str) -> None:
-        if old_name in visited:
-            return
-        if old_name in visiting:
-            raise SchemaMigrationPlanningError(
-                "Cyclic rename instructions are not executable without an intermediate field name."
-            )
-        visiting.add(old_name)
-        new_name = renames[old_name]
-        if new_name in renames:
-            visit(new_name)
-        visiting.remove(old_name)
-        visited.add(old_name)
-        ordered.append((old_name, new_name))
-
-    for old_name in sorted(renames):
-        visit(old_name)
-    return ordered

--- a/src/phlo/schema_registry.py
+++ b/src/phlo/schema_registry.py
@@ -11,8 +11,7 @@ from pathlib import Path
 import psycopg2
 import ulid
 
-from phlo.capabilities.schema import default_classify_change, worst_classification
-from phlo.capabilities.specs import FieldSpec, NormalizedSchema, SchemaChange, SchemaMigrationPlan
+from phlo.capabilities.specs import FieldSpec, NormalizedSchema
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
@@ -22,14 +21,6 @@ _REGISTRY_DB_KEYS = (
     "PHLO_LINEAGE_DB_URL",
     "DAGSTER_PG_DB_CONNECTION_STRING",
 )
-
-_WIDEN_PAIRS = {
-    ("int32", "int64"),
-    ("float32", "float64"),
-    ("int32", "float64"),
-    ("int64", "float64"),
-    ("date", "timestamptz"),
-}
 
 
 def resolve_registry_db_url() -> str | None:
@@ -174,93 +165,6 @@ class SchemaRegistry:
             )
             for r in rows
         ]
-
-
-def check_compatibility(
-    previous: NormalizedSchema,
-    current: NormalizedSchema,
-    table_name: str = "unknown",
-) -> SchemaMigrationPlan:
-    """Compare two schemas and classify changes.
-
-    Breaking: column drops, type narrowings, nullability tightening
-    Safe: adds, widenings, nullability relaxed
-    """
-    prev_fields = {f.name: f for f in previous.fields}
-    curr_fields = {f.name: f for f in current.fields}
-    changes: list[SchemaChange] = []
-
-    for name in prev_fields:
-        if name not in curr_fields:
-            changes.append(
-                SchemaChange(
-                    field_name=name,
-                    change_type="drop",
-                    old_value=prev_fields[name].dtype,
-                    classification=default_classify_change("drop"),
-                )
-            )
-
-    for name in curr_fields:
-        if name not in prev_fields:
-            f = curr_fields[name]
-            classification = default_classify_change(
-                "add", nullable=f.nullable, has_default=f.default is not None
-            )
-            changes.append(
-                SchemaChange(
-                    field_name=name,
-                    change_type="add",
-                    new_value=f.dtype,
-                    classification=classification,
-                )
-            )
-
-    for name in prev_fields:
-        if name not in curr_fields:
-            continue
-        prev_f = prev_fields[name]
-        curr_f = curr_fields[name]
-
-        if prev_f.dtype != curr_f.dtype:
-            if (prev_f.dtype, curr_f.dtype) in _WIDEN_PAIRS:
-                change_type = "widen_type"
-            else:
-                change_type = "narrow_type"
-            changes.append(
-                SchemaChange(
-                    field_name=name,
-                    change_type=change_type,
-                    old_value=prev_f.dtype,
-                    new_value=curr_f.dtype,
-                    classification=default_classify_change(change_type),
-                )
-            )
-
-        if prev_f.nullable != curr_f.nullable:
-            if prev_f.nullable and not curr_f.nullable:
-                null_change_type = "nullability_tightened"
-            else:
-                null_change_type = "nullability_relaxed"
-            changes.append(
-                SchemaChange(
-                    field_name=name,
-                    change_type=null_change_type,
-                    old_value=str(prev_f.nullable),
-                    new_value=str(curr_f.nullable),
-                    classification=default_classify_change(null_change_type),
-                )
-            )
-
-    classifications = [c.classification for c in changes]
-    overall = worst_classification(classifications)
-
-    return SchemaMigrationPlan(
-        table_name=table_name,
-        changes=changes,
-        classification=overall,
-        requires_approval=overall == "breaking",
-    )
 
 
 def deserialize_schema(schema_json: str) -> NormalizedSchema:

--- a/src/phlo/schema_registry.py
+++ b/src/phlo/schema_registry.py
@@ -1,4 +1,8 @@
-"""Schema registry for tracking schema evolution and detecting breaking changes."""
+"""Schema snapshot registry.
+
+Compatibility checking previously provided by check_compatibility() now lives in
+the schema migration planner rather than this registry module.
+"""
 
 from __future__ import annotations
 

--- a/tests/cli/test_cli_schema_migrate.py
+++ b/tests/cli/test_cli_schema_migrate.py
@@ -20,6 +20,7 @@ from phlo.capabilities.specs import (
 )
 from phlo.cli.commands import schema_migrate as schema_migrate_commands
 from phlo.cli.main import cli
+from phlo.schema_migration.planning import SchemaMigrationInstructions
 
 
 def test_schema_migrate_history_renders_timestamp_ms(monkeypatch) -> None:
@@ -283,8 +284,245 @@ def test_schema_migrate_scaffold_yaml_reads_contract(monkeypatch) -> None:
         payload = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
         assert payload["table_name"] == "warehouse.customers"
         assert payload["classification"] == "safe"
+        assert payload["renames"] == {}
         assert payload["operations"][0]["change_type"] == "add"
         assert payload["operations"][0]["operation_id"]
+
+
+def test_schema_migrate_plan_passes_yaml_and_cli_renames(monkeypatch) -> None:
+    """Plan reads default migration YAML and additive CLI rename flags."""
+
+    class FakeExtractor:
+        def extract(self, native_schema: object) -> NormalizedSchema:
+            return NormalizedSchema(fields=[FieldSpec(name="email", dtype="string")])
+
+    class FakeMigrator:
+        def diff_schema(
+            self,
+            *,
+            table_name: str,
+            desired: NormalizedSchema,
+            instructions: SchemaMigrationInstructions | None = None,
+        ) -> SchemaMigrationPlan:
+            assert table_name == "warehouse.customers"
+            assert instructions is not None
+            assert instructions.renames == {
+                "customer_email": "email",
+                "surname": "last_name",
+            }
+            return SchemaMigrationPlan(
+                table_name=table_name,
+                changes=[
+                    SchemaChange(
+                        field_name="customer_email",
+                        change_type="rename",
+                        old_value="customer_email",
+                        new_value="email",
+                        classification="safe",
+                    )
+                ],
+                classification="safe",
+            )
+
+    class CustomerSchema:
+        pass
+
+    monkeypatch.setattr(schema_migrate_commands, "_resolve_extractor", lambda: FakeExtractor())
+    monkeypatch.setattr(schema_migrate_commands, "_resolve_migrator", lambda: FakeMigrator())
+    monkeypatch.setattr(
+        schema_migrate_commands,
+        "_find_native_schema",
+        lambda table_name, schema_class: CustomerSchema,
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        migration_path = Path(".phlo/migrations/warehouse__customers.yaml")
+        migration_path.parent.mkdir(parents=True, exist_ok=True)
+        migration_path.write_text(
+            yaml.safe_dump(
+                {
+                    "table_name": "warehouse.customers",
+                    "renames": {"customer_email": "email"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "schema-migrate",
+                "plan",
+                "warehouse.customers",
+                "--rename",
+                "surname=last_name",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert "rename" in result.output
+
+
+def test_schema_migrate_rename_conflict_tells_user_to_sort_yaml_or_cli(monkeypatch) -> None:
+    """Conflicting YAML/CLI rename instructions fail before planning."""
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        migration_path = Path(".phlo/migrations/warehouse__customers.yaml")
+        migration_path.parent.mkdir(parents=True, exist_ok=True)
+        migration_path.write_text(
+            yaml.safe_dump(
+                {
+                    "table_name": "warehouse.customers",
+                    "renames": {"customer_email": "email"},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = runner.invoke(
+            cli,
+            [
+                "schema-migrate",
+                "diff",
+                "warehouse.customers",
+                "--rename",
+                "customer_email=primary_email",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "Sort out the YAML or CLI flags" in result.output
+
+
+def test_schema_migrate_apply_refuses_rename_when_migrator_does_not_support_it(
+    monkeypatch,
+) -> None:
+    """Apply stops when the selected migrator cannot execute an explicit rename."""
+
+    class FakeExtractor:
+        def extract(self, native_schema: object) -> NormalizedSchema:
+            return NormalizedSchema(fields=[FieldSpec(name="email", dtype="string")])
+
+    class FakeMigrator:
+        def supported_changes(self) -> set[str]:
+            return {"add", "drop"}
+
+        def diff_schema(
+            self,
+            *,
+            table_name: str,
+            desired: NormalizedSchema,
+            instructions: SchemaMigrationInstructions | None = None,
+        ) -> SchemaMigrationPlan:
+            return SchemaMigrationPlan(
+                table_name=table_name,
+                changes=[
+                    SchemaChange(
+                        field_name="customer_email",
+                        change_type="rename",
+                        old_value="customer_email",
+                        new_value="email",
+                        classification="safe",
+                    )
+                ],
+                classification="safe",
+            )
+
+        def apply_plan(
+            self, *, plan: SchemaMigrationPlan, approved: bool = False
+        ) -> dict[str, object]:
+            raise AssertionError("apply_plan should not run for unsupported rename")
+
+    class CustomerSchema:
+        pass
+
+    monkeypatch.setattr(schema_migrate_commands, "_resolve_extractor", lambda: FakeExtractor())
+    monkeypatch.setattr(schema_migrate_commands, "_resolve_migrator", lambda: FakeMigrator())
+    monkeypatch.setattr(
+        schema_migrate_commands,
+        "_find_native_schema",
+        lambda table_name, schema_class: CustomerSchema,
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "schema-migrate",
+                "apply",
+                "warehouse.customers",
+                "--rename",
+                "customer_email=email",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "unsupported change type" in result.output
+    assert "rename" in result.output
+
+
+def test_schema_migrate_apply_dry_run_refuses_unsupported_rename(monkeypatch) -> None:
+    """Dry-run still answers whether the selected migrator can apply the plan."""
+
+    class FakeExtractor:
+        def extract(self, native_schema: object) -> NormalizedSchema:
+            return NormalizedSchema(fields=[FieldSpec(name="email", dtype="string")])
+
+    class FakeMigrator:
+        def supported_changes(self) -> set[str]:
+            return {"add", "drop"}
+
+        def diff_schema(
+            self,
+            *,
+            table_name: str,
+            desired: NormalizedSchema,
+            instructions: SchemaMigrationInstructions | None = None,
+        ) -> SchemaMigrationPlan:
+            return SchemaMigrationPlan(
+                table_name=table_name,
+                changes=[
+                    SchemaChange(
+                        field_name="customer_email",
+                        change_type="rename",
+                        old_value="customer_email",
+                        new_value="email",
+                        classification="safe",
+                    )
+                ],
+                classification="safe",
+            )
+
+    class CustomerSchema:
+        pass
+
+    monkeypatch.setattr(schema_migrate_commands, "_resolve_extractor", lambda: FakeExtractor())
+    monkeypatch.setattr(schema_migrate_commands, "_resolve_migrator", lambda: FakeMigrator())
+    monkeypatch.setattr(
+        schema_migrate_commands,
+        "_find_native_schema",
+        lambda table_name, schema_class: CustomerSchema,
+    )
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli,
+            [
+                "schema-migrate",
+                "apply",
+                "warehouse.customers",
+                "--rename",
+                "customer_email=email",
+                "--dry-run",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "unsupported change type" in result.output
+    assert "Dry run" not in result.output
 
 
 def test_schema_migrate_scaffold_yaml_is_deterministic(monkeypatch) -> None:

--- a/tests/data/test_schema_migration_planning.py
+++ b/tests/data/test_schema_migration_planning.py
@@ -1,0 +1,250 @@
+"""Tests for the shared schema migration planner."""
+
+from __future__ import annotations
+
+import pytest
+
+from phlo.capabilities.specs import FieldSpec, NormalizedSchema
+from phlo.schema_migration.instructions import (
+    MigrationInstructionError,
+    resolve_migration_instructions,
+)
+from phlo.schema_migration.planning import (
+    SchemaMigrationInstructions,
+    SchemaMigrationPlanningError,
+    SchemaPlanningPolicy,
+    plan_schema_migration,
+)
+
+
+def _schema(*fields: tuple[str, str, bool]) -> NormalizedSchema:
+    return NormalizedSchema(
+        fields=[
+            FieldSpec(name=name, dtype=dtype, nullable=nullable) for name, dtype, nullable in fields
+        ]
+    )
+
+
+def test_plan_schema_migration_detects_neutral_changes() -> None:
+    current = _schema(
+        ("id", "int32", False),
+        ("email", "string", True),
+        ("legacy", "string", True),
+        ("score", "int64", True),
+    )
+    desired = _schema(
+        ("id", "int64", False),
+        ("email", "string", False),
+        ("created_at", "timestamptz", True),
+        ("score", "int32", True),
+    )
+
+    plan = plan_schema_migration(table_name="raw.users", current=current, desired=desired)
+
+    changes = {(change.field_name, change.change_type): change for change in plan.changes}
+    assert changes[("id", "widen_type")].classification == "safe"
+    assert changes[("email", "nullability_tightened")].classification == "breaking"
+    assert changes[("created_at", "add")].classification == "safe"
+    assert changes[("legacy", "drop")].classification == "breaking"
+    assert changes[("score", "narrow_type")].classification == "breaking"
+    assert plan.classification == "breaking"
+    assert plan.requires_approval is True
+
+
+def test_policy_overrides_change_classification_and_recommendations() -> None:
+    current = _schema(("legacy", "string", True))
+    desired = _schema()
+    policy = SchemaPlanningPolicy(
+        change_classifications={"drop": "warning"},
+        recommendations={"drop": "Dropped columns are recoverable via snapshots."},
+    )
+
+    plan = plan_schema_migration(
+        table_name="raw.users",
+        current=current,
+        desired=desired,
+        policy=policy,
+    )
+
+    assert plan.classification == "warning"
+    assert plan.requires_approval is False
+    assert plan.changes[0].classification == "warning"
+    assert plan.recommendations == ["Dropped columns are recoverable via snapshots."]
+
+
+def test_explicit_rename_consumes_drop_and_add() -> None:
+    current = _schema(("customer_email", "string", True), ("id", "int64", False))
+    desired = _schema(("email", "string", True), ("id", "int64", False))
+
+    plan = plan_schema_migration(
+        table_name="raw.customers",
+        current=current,
+        desired=desired,
+        instructions=SchemaMigrationInstructions(renames={"customer_email": "email"}),
+    )
+
+    assert [(change.field_name, change.change_type) for change in plan.changes] == [
+        ("customer_email", "rename")
+    ]
+    assert plan.changes[0].old_value == "customer_email"
+    assert plan.changes[0].new_value == "email"
+    assert plan.classification == "warning"
+
+
+def test_explicit_rename_still_detects_type_and_nullability_changes() -> None:
+    current = _schema(("customer_id", "int32", True))
+    desired = _schema(("id", "int64", False))
+
+    plan = plan_schema_migration(
+        table_name="raw.customers",
+        current=current,
+        desired=desired,
+        instructions=SchemaMigrationInstructions(renames={"customer_id": "id"}),
+    )
+
+    assert [(change.field_name, change.change_type) for change in plan.changes] == [
+        ("customer_id", "rename"),
+        ("id", "widen_type"),
+        ("id", "nullability_tightened"),
+    ]
+
+
+def test_invalid_rename_instruction_raises() -> None:
+    current = _schema(("customer_email", "string", True))
+    desired = _schema(("email", "string", True))
+
+    with pytest.raises(SchemaMigrationPlanningError, match="current schema has no field"):
+        plan_schema_migration(
+            table_name="raw.customers",
+            current=current,
+            desired=desired,
+            instructions=SchemaMigrationInstructions(renames={"missing": "email"}),
+        )
+
+
+def test_duplicate_rename_target_raises() -> None:
+    current = _schema(("customer_email", "string", True), ("contact_email", "string", True))
+    desired = _schema(("email", "string", True))
+
+    with pytest.raises(SchemaMigrationPlanningError, match="multiple rename sources"):
+        plan_schema_migration(
+            table_name="raw.customers",
+            current=current,
+            desired=desired,
+            instructions=SchemaMigrationInstructions(
+                renames={"customer_email": "email", "contact_email": "email"}
+            ),
+        )
+
+
+def test_rename_to_existing_current_field_raises_unless_target_is_renamed_away() -> None:
+    current = _schema(("old_email", "string", True), ("email", "string", True))
+    desired = _schema(("email", "string", True), ("primary_email", "string", True))
+
+    with pytest.raises(SchemaMigrationPlanningError, match="already exists in current schema"):
+        plan_schema_migration(
+            table_name="raw.customers",
+            current=current,
+            desired=desired,
+            instructions=SchemaMigrationInstructions(renames={"old_email": "email"}),
+        )
+
+    plan = plan_schema_migration(
+        table_name="raw.customers",
+        current=current,
+        desired=desired,
+        instructions=SchemaMigrationInstructions(
+            renames={"old_email": "email", "email": "primary_email"}
+        ),
+    )
+
+    assert [(change.field_name, change.new_value) for change in plan.changes] == [
+        ("email", "primary_email"),
+        ("old_email", "email"),
+    ]
+
+
+def test_chained_renames_are_ordered_before_dependents() -> None:
+    current = _schema(
+        ("account_id", "int64", False),
+        ("customer_id", "int64", False),
+        ("id", "int64", False),
+    )
+    desired = _schema(
+        ("customer_id", "int64", False),
+        ("id", "int64", False),
+        ("legacy_id", "int64", False),
+    )
+
+    plan = plan_schema_migration(
+        table_name="raw.customers",
+        current=current,
+        desired=desired,
+        instructions=SchemaMigrationInstructions(
+            renames={
+                "account_id": "customer_id",
+                "customer_id": "id",
+                "id": "legacy_id",
+            }
+        ),
+    )
+
+    assert [(change.field_name, change.new_value) for change in plan.changes] == [
+        ("id", "legacy_id"),
+        ("customer_id", "id"),
+        ("account_id", "customer_id"),
+    ]
+
+
+def test_cyclic_rename_instructions_raise() -> None:
+    current = _schema(("a", "string", True), ("b", "string", True))
+    desired = _schema(("a", "string", True), ("b", "string", True))
+
+    with pytest.raises(SchemaMigrationPlanningError, match="Cyclic rename"):
+        plan_schema_migration(
+            table_name="raw.customers",
+            current=current,
+            desired=desired,
+            instructions=SchemaMigrationInstructions(renames={"a": "b", "b": "a"}),
+        )
+
+
+def test_duplicate_field_names_raise() -> None:
+    current = _schema(("id", "int64", False), ("id", "string", True))
+    desired = _schema(("id", "int64", False))
+
+    with pytest.raises(SchemaMigrationPlanningError, match="duplicate field name"):
+        plan_schema_migration(table_name="raw.customers", current=current, desired=desired)
+
+
+def test_resolve_migration_instructions_merges_yaml_and_cli_renames(tmp_path) -> None:
+    migration_file = tmp_path / "warehouse__customers.yaml"
+    migration_file.write_text(
+        "table_name: warehouse.customers\nrenames:\n  customer_email: email\n",
+        encoding="utf-8",
+    )
+
+    instructions = resolve_migration_instructions(
+        table_name="warehouse.customers",
+        migration_file=migration_file,
+        rename_flags=("surname=last_name",),
+    )
+
+    assert instructions == SchemaMigrationInstructions(
+        renames={"customer_email": "email", "surname": "last_name"}
+    )
+
+
+def test_resolve_migration_instructions_rejects_yaml_cli_conflicts(tmp_path) -> None:
+    migration_file = tmp_path / "warehouse__customers.yaml"
+    migration_file.write_text(
+        "table_name: warehouse.customers\nrenames:\n  customer_email: email\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(MigrationInstructionError, match="Sort out the YAML or CLI flags"):
+        resolve_migration_instructions(
+            table_name="warehouse.customers",
+            migration_file=migration_file,
+            rename_flags=("customer_email=primary_email",),
+        )

--- a/tests/data/test_schema_migration_planning.py
+++ b/tests/data/test_schema_migration_planning.py
@@ -137,7 +137,7 @@ def test_duplicate_rename_target_raises() -> None:
         )
 
 
-def test_rename_to_existing_current_field_raises_unless_target_is_renamed_away() -> None:
+def test_rename_to_existing_current_field_raises() -> None:
     current = _schema(("old_email", "string", True), ("email", "string", True))
     desired = _schema(("email", "string", True), ("primary_email", "string", True))
 
@@ -149,22 +149,8 @@ def test_rename_to_existing_current_field_raises_unless_target_is_renamed_away()
             instructions=SchemaMigrationInstructions(renames={"old_email": "email"}),
         )
 
-    plan = plan_schema_migration(
-        table_name="raw.customers",
-        current=current,
-        desired=desired,
-        instructions=SchemaMigrationInstructions(
-            renames={"old_email": "email", "email": "primary_email"}
-        ),
-    )
 
-    assert [(change.field_name, change.new_value) for change in plan.changes] == [
-        ("email", "primary_email"),
-        ("old_email", "email"),
-    ]
-
-
-def test_chained_renames_are_ordered_before_dependents() -> None:
+def test_chained_renames_raise() -> None:
     current = _schema(
         ("account_id", "int64", False),
         ("customer_id", "int64", False),
@@ -176,31 +162,39 @@ def test_chained_renames_are_ordered_before_dependents() -> None:
         ("legacy_id", "int64", False),
     )
 
-    plan = plan_schema_migration(
-        table_name="raw.customers",
-        current=current,
-        desired=desired,
-        instructions=SchemaMigrationInstructions(
-            renames={
-                "account_id": "customer_id",
-                "customer_id": "id",
-                "id": "legacy_id",
-            }
-        ),
-    )
-
-    assert [(change.field_name, change.new_value) for change in plan.changes] == [
-        ("id", "legacy_id"),
-        ("customer_id", "id"),
-        ("account_id", "customer_id"),
-    ]
+    with pytest.raises(SchemaMigrationPlanningError, match="already exists in current schema"):
+        plan_schema_migration(
+            table_name="raw.customers",
+            current=current,
+            desired=desired,
+            instructions=SchemaMigrationInstructions(
+                renames={
+                    "account_id": "customer_id",
+                    "customer_id": "id",
+                    "id": "legacy_id",
+                }
+            ),
+        )
 
 
-def test_cyclic_rename_instructions_raise() -> None:
+def test_no_op_rename_instruction_raises() -> None:
+    current = _schema(("id", "string", True))
+    desired = _schema(("id", "string", True))
+
+    with pytest.raises(SchemaMigrationPlanningError, match="source and target are identical"):
+        plan_schema_migration(
+            table_name="raw.customers",
+            current=current,
+            desired=desired,
+            instructions=SchemaMigrationInstructions(renames={"id": "id"}),
+        )
+
+
+def test_cyclic_rename_instructions_raise_as_existing_targets() -> None:
     current = _schema(("a", "string", True), ("b", "string", True))
     desired = _schema(("a", "string", True), ("b", "string", True))
 
-    with pytest.raises(SchemaMigrationPlanningError, match="Cyclic rename"):
+    with pytest.raises(SchemaMigrationPlanningError, match="already exists in current schema"):
         plan_schema_migration(
             table_name="raw.customers",
             current=current,

--- a/tests/data/test_schema_registry.py
+++ b/tests/data/test_schema_registry.py
@@ -12,7 +12,6 @@ from phlo.schema_registry import (
     SchemaRegistry,
     _canonical_schema_json,
     _schema_hash,
-    check_compatibility,
     deserialize_schema,
 )
 
@@ -49,80 +48,6 @@ class TestSchemaHash:
         c1 = _canonical_schema_json(_schema(("id", "int64", False)))
         c2 = _canonical_schema_json(_schema(("id", "string", False)))
         assert _schema_hash(c1) != _schema_hash(c2)
-
-
-class TestCheckCompatibility:
-    def test_drop_is_breaking(self) -> None:
-        previous = _schema(("id", "int64", False), ("name", "string", True))
-        current = _schema(("id", "int64", False))
-        plan = check_compatibility(previous, current, table_name="t")
-        assert plan.classification == "breaking"
-        assert plan.requires_approval is True
-        assert any(c.change_type == "drop" for c in plan.changes)
-
-    def test_add_nullable_is_safe(self) -> None:
-        previous = _schema(("id", "int64", False))
-        current = _schema(("id", "int64", False), ("email", "string", True))
-        plan = check_compatibility(previous, current, table_name="t")
-        assert plan.classification == "safe"
-        assert plan.requires_approval is False
-
-    def test_add_non_nullable_is_breaking(self) -> None:
-        previous = _schema(("id", "int64", False))
-        current = _schema(("id", "int64", False), ("email", "string", False))
-        plan = check_compatibility(previous, current, table_name="t")
-        assert plan.classification == "breaking"
-        assert plan.requires_approval is True
-
-    def test_add_non_nullable_with_default_is_warning(self) -> None:
-        previous = _schema(("id", "int64", False))
-        current = NormalizedSchema(
-            fields=[
-                FieldSpec(name="id", dtype="int64", nullable=False),
-                FieldSpec(
-                    name="email", dtype="string", nullable=False, default="unknown@example.com"
-                ),
-            ]
-        )
-        plan = check_compatibility(previous, current, table_name="t")
-        assert plan.classification == "warning"
-        add_change = next(c for c in plan.changes if c.change_type == "add")
-        assert add_change.classification == "warning"
-
-    def test_widen_type_is_safe(self) -> None:
-        previous = _schema(("val", "int32", True))
-        current = _schema(("val", "int64", True))
-        plan = check_compatibility(previous, current, table_name="t")
-        assert plan.classification == "safe"
-        assert any(c.change_type == "widen_type" for c in plan.changes)
-
-    def test_narrow_type_is_breaking(self) -> None:
-        previous = _schema(("val", "int64", True))
-        current = _schema(("val", "int32", True))
-        plan = check_compatibility(previous, current, table_name="t")
-        assert plan.classification == "breaking"
-        assert any(c.change_type == "narrow_type" for c in plan.changes)
-
-    def test_nullability_tightened_is_breaking(self) -> None:
-        previous = _schema(("id", "int64", True))
-        current = _schema(("id", "int64", False))
-        plan = check_compatibility(previous, current, table_name="t")
-        assert plan.classification == "breaking"
-        assert any(c.change_type == "nullability_tightened" for c in plan.changes)
-
-    def test_nullability_relaxed_is_safe(self) -> None:
-        previous = _schema(("id", "int64", False))
-        current = _schema(("id", "int64", True))
-        plan = check_compatibility(previous, current, table_name="t")
-        assert plan.classification == "safe"
-        assert any(c.change_type == "nullability_relaxed" for c in plan.changes)
-
-    def test_no_changes(self) -> None:
-        schema = _schema(("id", "int64", False), ("name", "string", True))
-        plan = check_compatibility(schema, schema, table_name="t")
-        assert plan.classification == "safe"
-        assert plan.changes == []
-        assert plan.requires_approval is False
 
 
 class TestDeserializeSchema:

--- a/tests/unit/helpers/test_helpers_core.py
+++ b/tests/unit/helpers/test_helpers_core.py
@@ -15,7 +15,6 @@ from phlo.helpers import (
     build_backfill_plan,
     classify_columns,
     compare_partitions,
-    compare_schemas,
     connection_from_url,
     expected_partitions,
     flatten_json_records,
@@ -47,6 +46,7 @@ from phlo.helpers import (
     where_and,
 )
 from phlo.helpers.tables import load_table_schema, merge_batch
+from phlo.schema_migration.planning import plan_schema_migration
 
 
 def test_connection_helpers_redact_and_render_profiles() -> None:
@@ -98,7 +98,7 @@ def test_table_and_schema_helpers() -> None:
             FieldSpec("email", "string", nullable=True),
         ]
     )
-    plan = compare_schemas(current, desired, table_name="raw.users")
+    plan = plan_schema_migration(table_name="raw.users", current=current, desired=desired)
     assert plan.classification == "safe"
     assert [change.change_type for change in plan.changes] == ["add"]
 


### PR DESCRIPTION
## Summary

Centralizes schema migration planning behind the new `phlo.schema_migration` package and removes duplicated provider diff logic from the Iceberg and Delta adapters.

## What changed

- Added shared schema migration planning primitives for neutral schema diffs, explicit rename instructions, provider policy overrides, and recommendation generation.
- Added domain-level migration instruction loading for YAML files and repeatable CLI `--rename old=new` flags.
- Updated `schema-migrate diff`, `plan`, and `apply` to use one planning path instead of duplicating instruction resolution in each command.
- Made `apply --dry-run` validate provider support before printing dry-run output.
- Updated Iceberg and Delta migrators to delegate diff planning and classification through the shared policy-based planner.
- Removed older duplicate compatibility helpers from schema registry/helper surfaces.

## Validation

- `uv run pytest tests/data/test_schema_migration_planning.py tests/data/test_schema_migration.py tests/data/test_schema_registry.py tests/data/test_schema_migrate_contracts.py tests/cli/test_cli_schema_migrate.py tests/unit/helpers/test_helpers_core.py packages/phlo-iceberg/tests/test_schema_migrator.py packages/phlo-delta/tests -q` -> `128 passed, 1 deselected`
- `uv run ruff check src/phlo/schema_migration src/phlo/cli/commands/schema_migrate.py src/phlo/cli/commands/schema_migrate_contracts.py packages/phlo-iceberg/src/phlo_iceberg/schema_migrator.py packages/phlo-delta/src/phlo_delta/schema_migrator.py tests/data/test_schema_migration_planning.py tests/cli/test_cli_schema_migrate.py`
- `git diff --check`
- `uv run ty check ...` exited 0 with existing warnings in tests around dynamic module attributes, monkeypatched methods, and possible `None` access.