### PR TITLE
refactor: centralize capability family registry

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -89,10 +89,10 @@ def configured_minio_object_store(minio_service, monkeypatch):
     from phlo_minio.plugin import MinioResourceProvider
     from phlo_minio.settings import get_settings as get_minio_settings
 
-    from phlo.capabilities import register_object_store, resolve_capability
+    from phlo.capabilities import register_capability, resolve_capability
 
     get_minio_settings.cache_clear()
-    register_object_store(MinioResourceProvider().get_object_stores()[0])
+    register_capability("object_store", MinioResourceProvider().get_object_stores()[0])
     return resolve_capability("object_store", "minio")
 
 

--- a/packages/phlo-api/src/phlo_api/main.py
+++ b/packages/phlo-api/src/phlo_api/main.py
@@ -311,7 +311,7 @@ def _list_api_backends() -> list[dict[str, Any]]:
 
         discover_capabilities()
         registry = get_capability_registry()
-        specs = registry.list_api_backends()
+        specs = registry.list("api_backend")
     except Exception:
         return []
 
@@ -449,8 +449,8 @@ def _list_contracts() -> list[dict[str, Any]]:
 
         discover_capabilities()
         registry = get_capability_registry()
-        assets = registry.list_assets()
-        checks = registry.list_checks()
+        assets = registry.list("asset")
+        checks = registry.list("check")
     except Exception:
         assets = []
         checks = []

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -274,11 +274,11 @@ def _import_project_workflows(project_root: Path) -> None:
 def _load_capability_registry_uncached() -> Any | None:
     """Load the core capability registry if available."""
     try:
-        from phlo.capabilities import clear_capabilities
+        from phlo.capabilities import clear_all_capabilities
         from phlo.capabilities import get_capability_registry
         from phlo.capabilities.discovery import discover_capabilities
 
-        clear_capabilities()
+        clear_all_capabilities()
         _import_project_workflows(_project_root())
         discover_capabilities()
         return get_capability_registry()
@@ -706,11 +706,11 @@ def _load_assets() -> list[V2Asset]:
         return []
 
     checks_by_asset: dict[str, list[str]] = {}
-    for check in registry.list_checks():
+    for check in registry.list("check"):
         checks_by_asset.setdefault(check.asset_key, []).append(check.name)
 
     assets: list[V2Asset] = []
-    for asset in registry.list_assets():
+    for asset in registry.list("asset"):
         assets.append(
             V2Asset(
                 id=asset.key,
@@ -745,7 +745,7 @@ def _load_tables(*, enrich_catalog: bool = True) -> list[V2Table]:
 
     catalog_tables = _catalog_tables() if enrich_catalog else None
     tables: list[V2Table] = []
-    for asset in registry.list_assets():
+    for asset in registry.list("asset"):
         table_name = _table_name_from_asset(asset)
         if not table_name:
             continue
@@ -833,7 +833,7 @@ def _load_quality() -> list[V2QualityCheck]:
         return []
 
     checks: list[V2QualityCheck] = []
-    for check in registry.list_checks():
+    for check in registry.list("check"):
         check_id = f"{check.asset_key}:{check.name}"
         checks.append(
             V2QualityCheck(
@@ -876,7 +876,7 @@ def _load_operations() -> list[V2Operation]:
     if registry is None:
         return sort_operations(operations)
 
-    for spec in registry.list_maintenance_read_models():
+    for spec in registry.list("maintenance_read_model"):
         provider = getattr(spec, "provider", None)
         loader = getattr(provider, "load_maintenance_status", None)
         if not callable(loader):
@@ -1039,7 +1039,7 @@ def _quality_actions(check: V2QualityCheck) -> list[V2Action]:
         try:
             executable = any(
                 f"{item.asset_key}:{item.name}" == check.id and callable(getattr(item, "fn", None))
-                for item in registry.list_checks()
+                for item in registry.list("check")
             )
         except Exception:
             executable = False
@@ -1334,7 +1334,7 @@ def _catalog_branch_provider() -> Any | None:
     if registry is None:
         return None
     try:
-        catalog_specs = registry.list_catalogs()
+        catalog_specs = registry.list("catalog")
     except Exception:
         return None
     for spec in catalog_specs:
@@ -1364,11 +1364,11 @@ def _provider_branch_metadata(branch: Any) -> dict[str, Any]:
             for key in ("hash", "commit_hash", "created_at", "metadata")
             if hasattr(branch, key)
         }
-    metadata = raw.get("metadata") if isinstance(raw.get("metadata"), Mapping) else {}
+    metadata = dict(raw.get("metadata") or {}) if isinstance(raw.get("metadata"), Mapping) else {}
     return _safe_metadata(
         {
             "source": "catalog-provider",
-            **dict(metadata),
+            **metadata,
             "hash": raw.get("hash") or raw.get("commit_hash"),
             "created_at": raw.get("created_at"),
         }

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_actions.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_actions.py
@@ -181,7 +181,7 @@ def _operation(
 def _check_for_action(action_id: str, registry: Any) -> Any | None:
     check_action_id = action_id.removeprefix("quality:")
     try:
-        checks = registry.list_checks()
+        checks = registry.list("check")
     except Exception:
         return None
     for check in checks:

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_capabilities.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_capabilities.py
@@ -16,25 +16,25 @@ from phlo_api.observatory_api.v2_models import (
 )
 from phlo_api.observatory_api.v2_metadata import safe_metadata
 
-CAPABILITY_LISTERS: dict[str, str] = {
-    "query_engine": "list_query_engines",
-    "table_store": "list_table_stores",
-    "catalog": "list_catalogs",
-    "catalog_scanner": "list_catalog_scanners",
-    "object_store": "list_object_stores",
-    "quality_backend": "list_quality_backends",
-    "maintenance_read_model": "list_maintenance_read_models",
-    "metadata_catalog": "list_metadata_catalogs",
-    "lineage_sink": "list_lineage_sinks",
-    "governance_backend": "list_governance_backends",
-    "authorization_policy_backend": "list_authorization_policy_backends",
-    "authentication_provider": "list_authentication_providers",
-    "publish_target": "list_publish_targets",
-    "alert_sink": "list_alert_sinks",
-    "api_backend": "list_api_backends",
-    "observability_backend": "list_observability_backends",
-    "regulated_surface": "list_regulated_surfaces",
-}
+CAPABILITY_FAMILIES = (
+    "query_engine",
+    "table_store",
+    "catalog",
+    "catalog_scanner",
+    "object_store",
+    "quality_backend",
+    "maintenance_read_model",
+    "metadata_catalog",
+    "lineage_sink",
+    "governance_backend",
+    "authorization_policy_backend",
+    "authentication_provider",
+    "publish_target",
+    "alert_sink",
+    "api_backend",
+    "observability_backend",
+    "regulated_surface",
+)
 
 ROUTE_REQUIREMENTS = [
     V2RouteRequirement(
@@ -192,8 +192,8 @@ def build_capability_inventory(registry: Any | None) -> V2CapabilityInventory:
     providers: dict[str, list[V2CapabilityProvider]] = {}
     ui_contributions: list[V2UiContribution] = []
     if registry is not None:
-        for capability_type, method_name in CAPABILITY_LISTERS.items():
-            providers[capability_type] = _providers_for_type(registry, capability_type, method_name)
+        for capability_type in CAPABILITY_FAMILIES:
+            providers[capability_type] = _providers_for_type(registry, capability_type)
         ui_contributions = _ui_contributions(registry)
     return V2CapabilityInventory(
         providers=providers,
@@ -205,13 +205,12 @@ def build_capability_inventory(registry: Any | None) -> V2CapabilityInventory:
 def _providers_for_type(
     registry: Any,
     capability_type: str,
-    method_name: str,
 ) -> list[V2CapabilityProvider]:
-    method = getattr(registry, method_name, None)
+    method = getattr(registry, "list", None)
     if not callable(method):
         return []
     try:
-        specs = method()
+        specs = method(capability_type)
     except Exception:
         return []
     return [_provider_from_spec(capability_type, spec) for spec in specs]
@@ -252,11 +251,11 @@ def _native_links(metadata: Any) -> list[V2ExternalLink]:
 
 
 def _ui_contributions(registry: Any) -> list[V2UiContribution]:
-    method = getattr(registry, "list_ui_contributions", None)
+    method = getattr(registry, "list", None)
     if not callable(method):
         return []
     try:
-        specs = method()
+        specs = method("ui_contribution")
     except Exception:
         return []
     if isinstance(specs, str):

--- a/packages/phlo-api/src/phlo_api/regulated_surface_adapter.py
+++ b/packages/phlo-api/src/phlo_api/regulated_surface_adapter.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from phlo.capabilities import (
     RegulatedSurfaceSpec,
-    register_regulated_surface,
+    register_capability,
 )
 from phlo.rbac.models import CanonicalAction
 from phlo.security.adapters import SurfaceOperation
@@ -159,7 +159,7 @@ class PhloAPIRegulatedSurfaceAdapter:
             provider=self,
             metadata={"framework_runtime": "fastapi"},
         )
-        register_regulated_surface(spec)
+        register_capability("regulated_surface", spec)
 
 
 _adapter: PhloAPIRegulatedSurfaceAdapter | None = None

--- a/packages/phlo-api/tests/test_api_backend_endpoints.py
+++ b/packages/phlo-api/tests/test_api_backend_endpoints.py
@@ -68,7 +68,8 @@ def test_list_api_backends_marks_failing_provider_unhealthy(monkeypatch) -> None
             self.metadata = {"backend_kind": "test"}
 
     class FakeRegistry:
-        def list_api_backends(self) -> list[FakeSpec]:
+        def list(self, family: str) -> list[FakeSpec]:
+            assert family == "api_backend"
             return [
                 FakeSpec("healthy", HealthyProvider()),
                 FakeSpec("failing", FailingProvider()),

--- a/packages/phlo-api/tests/test_authentication_api.py
+++ b/packages/phlo-api/tests/test_authentication_api.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 import pytest
 from pathlib import Path
 
-from phlo.capabilities import AuthenticationProviderSpec, clear_capabilities
-from phlo.capabilities.registry import register_authentication_provider
+from phlo.capabilities import AuthenticationProviderSpec, clear_all_capabilities
+from phlo.capabilities.registry import register_capability
 from phlo.infrastructure.config import clear_config_cache
 from phlo_api.api.authentication import get_authentication_provider
 
 
 def teardown_function() -> None:
-    clear_capabilities()
+    clear_all_capabilities()
     clear_config_cache()
 
 
@@ -26,7 +26,9 @@ class _DummyAuthenticationProvider:
 
 def test_get_authentication_provider_uses_phlo_yaml(monkeypatch, tmp_path: Path) -> None:
     provider = _DummyAuthenticationProvider()
-    register_authentication_provider(AuthenticationProviderSpec(name="proxy", provider=provider))
+    register_capability(
+        "authentication_provider", AuthenticationProviderSpec(name="proxy", provider=provider)
+    )
 
     _write_phlo_config(
         tmp_path,
@@ -45,11 +47,12 @@ authentication:
 def test_env_authentication_provider_overrides_phlo_yaml(monkeypatch, tmp_path: Path) -> None:
     proxy_provider = _DummyAuthenticationProvider()
     static_provider = _DummyAuthenticationProvider()
-    register_authentication_provider(
-        AuthenticationProviderSpec(name="proxy", provider=proxy_provider)
+    register_capability(
+        "authentication_provider", AuthenticationProviderSpec(name="proxy", provider=proxy_provider)
     )
-    register_authentication_provider(
-        AuthenticationProviderSpec(name="static", provider=static_provider)
+    register_capability(
+        "authentication_provider",
+        AuthenticationProviderSpec(name="static", provider=static_provider),
     )
 
     _write_phlo_config(
@@ -70,7 +73,9 @@ def test_empty_env_authentication_provider_falls_back_to_phlo_yaml(
     monkeypatch, tmp_path: Path
 ) -> None:
     provider = _DummyAuthenticationProvider()
-    register_authentication_provider(AuthenticationProviderSpec(name="proxy", provider=provider))
+    register_capability(
+        "authentication_provider", AuthenticationProviderSpec(name="proxy", provider=provider)
+    )
 
     _write_phlo_config(
         tmp_path,

--- a/packages/phlo-api/tests/test_authorization_api.py
+++ b/packages/phlo-api/tests/test_authorization_api.py
@@ -7,11 +7,11 @@ from types import SimpleNamespace
 
 from fastapi import HTTPException, Request
 
-from phlo.capabilities import AuthorizationPolicyBackendSpec, clear_capabilities
+from phlo.capabilities import AuthorizationPolicyBackendSpec, clear_all_capabilities
 from phlo.capabilities.interfaces import AuthPrincipal, ResourceRef
 from phlo.capabilities.authorization import DefaultAuthorizationPolicyBackend
 from phlo.capabilities.interfaces import Principal
-from phlo.capabilities.registry import register_authorization_policy_backend
+from phlo.capabilities.registry import register_capability
 from phlo.infrastructure.config import clear_config_cache
 from phlo_api.api.authorization import (
     check_admin_read,
@@ -24,7 +24,7 @@ from phlo.security.adapters import EnforcementResult
 
 
 def teardown_function() -> None:
-    clear_capabilities()
+    clear_all_capabilities()
     clear_config_cache()
 
 
@@ -63,7 +63,8 @@ def test_resolve_request_principal_ignores_forwarded_identity_headers() -> None:
 def test_get_authorization_backend_requires_explicit_selection_for_multiple_backends(
     monkeypatch,
 ) -> None:
-    register_authorization_policy_backend(
+    register_capability(
+        "authorization_policy_backend",
         AuthorizationPolicyBackendSpec(
             name="default",
             provider=DefaultAuthorizationPolicyBackend(
@@ -76,9 +77,10 @@ def test_get_authorization_backend_requires_explicit_selection_for_multiple_back
                     }
                 ]
             ),
-        )
+        ),
     )
-    register_authorization_policy_backend(
+    register_capability(
+        "authorization_policy_backend",
         AuthorizationPolicyBackendSpec(
             name="opa",
             provider=DefaultAuthorizationPolicyBackend(
@@ -91,7 +93,7 @@ def test_get_authorization_backend_requires_explicit_selection_for_multiple_back
                     }
                 ]
             ),
-        )
+        ),
     )
 
     monkeypatch.delenv("PHLO_AUTHORIZATION_BACKEND", raising=False)
@@ -115,11 +117,14 @@ def test_get_authorization_backend_resolves_named_backend(monkeypatch) -> None:
             }
         ]
     )
-    register_authorization_policy_backend(
-        AuthorizationPolicyBackendSpec(name="default", provider=DefaultAuthorizationPolicyBackend())
+    register_capability(
+        "authorization_policy_backend",
+        AuthorizationPolicyBackendSpec(
+            name="default", provider=DefaultAuthorizationPolicyBackend()
+        ),
     )
-    register_authorization_policy_backend(
-        AuthorizationPolicyBackendSpec(name="opa", provider=backend)
+    register_capability(
+        "authorization_policy_backend", AuthorizationPolicyBackendSpec(name="opa", provider=backend)
     )
 
     monkeypatch.setenv("PHLO_AUTHORIZATION_BACKEND", "opa")
@@ -365,11 +370,14 @@ def test_get_authorization_backend_uses_service_specific_phlo_yaml(
     monkeypatch, tmp_path: Path
 ) -> None:
     backend = DefaultAuthorizationPolicyBackend()
-    register_authorization_policy_backend(
-        AuthorizationPolicyBackendSpec(name="default", provider=DefaultAuthorizationPolicyBackend())
+    register_capability(
+        "authorization_policy_backend",
+        AuthorizationPolicyBackendSpec(
+            name="default", provider=DefaultAuthorizationPolicyBackend()
+        ),
     )
-    register_authorization_policy_backend(
-        AuthorizationPolicyBackendSpec(name="opa", provider=backend)
+    register_capability(
+        "authorization_policy_backend", AuthorizationPolicyBackendSpec(name="opa", provider=backend)
     )
     _write_phlo_config(
         tmp_path,

--- a/packages/phlo-api/tests/test_maintenance_api.py
+++ b/packages/phlo-api/tests/test_maintenance_api.py
@@ -8,8 +8,8 @@ import pytest
 
 from phlo.capabilities import (
     MaintenanceReadModelSpec,
-    clear_capabilities,
-    register_maintenance_read_model,
+    clear_all_capabilities,
+    register_capability,
 )
 from phlo_api.api import maintenance
 
@@ -67,27 +67,35 @@ def test_get_maintenance_metrics_uses_capability(monkeypatch) -> None:
 
 def test_resolve_maintenance_read_model_uses_env_selection(monkeypatch) -> None:
     """Environment selection should pick one provider among many."""
-    clear_capabilities()
+    clear_all_capabilities()
     monkeypatch.setattr(maintenance, "discover_capabilities", lambda: None)
     monkeypatch.setenv("PHLO_MAINTENANCE_READ_MODEL", "custom")
-    register_maintenance_read_model(MaintenanceReadModelSpec(name="default", provider=object()))
-    register_maintenance_read_model(MaintenanceReadModelSpec(name="custom", provider=_ReadModel()))
+    register_capability(
+        "maintenance_read_model", MaintenanceReadModelSpec(name="default", provider=object())
+    )
+    register_capability(
+        "maintenance_read_model", MaintenanceReadModelSpec(name="custom", provider=_ReadModel())
+    )
 
     resolved = maintenance._resolve_maintenance_read_model()
 
     assert isinstance(resolved, _ReadModel)
-    clear_capabilities()
+    clear_all_capabilities()
 
 
 def test_resolve_maintenance_read_model_requires_selection_when_ambiguous(monkeypatch) -> None:
     """Ambiguous maintenance providers should fail with deterministic guidance."""
-    clear_capabilities()
+    clear_all_capabilities()
     monkeypatch.setattr(maintenance, "discover_capabilities", lambda: None)
     monkeypatch.delenv("PHLO_MAINTENANCE_READ_MODEL", raising=False)
-    register_maintenance_read_model(MaintenanceReadModelSpec(name="default", provider=object()))
-    register_maintenance_read_model(MaintenanceReadModelSpec(name="custom", provider=object()))
+    register_capability(
+        "maintenance_read_model", MaintenanceReadModelSpec(name="default", provider=object())
+    )
+    register_capability(
+        "maintenance_read_model", MaintenanceReadModelSpec(name="custom", provider=object())
+    )
 
     with pytest.raises(RuntimeError, match="Multiple maintenance_read_model providers"):
         maintenance._resolve_maintenance_read_model()
 
-    clear_capabilities()
+    clear_all_capabilities()

--- a/packages/phlo-api/tests/test_observability_api.py
+++ b/packages/phlo-api/tests/test_observability_api.py
@@ -9,8 +9,8 @@ import pytest
 from phlo.capabilities import (
     ObservabilityBackendSpec,
     TraceSpan,
-    clear_capabilities,
-    register_observability_backend,
+    clear_all_capabilities,
+    register_capability,
 )
 from phlo_api.api import observability
 
@@ -84,9 +84,9 @@ class _MockObservabilityBackend:
 @pytest.fixture(autouse=True)
 def clear_registry():
     """Clear capability registry before and after each test."""
-    clear_capabilities()
+    clear_all_capabilities()
     yield
-    clear_capabilities()
+    clear_all_capabilities()
 
 
 def test_get_health_summary_uses_capability(monkeypatch) -> None:
@@ -193,8 +193,12 @@ def test_resolve_observability_backend_uses_explicit_backend_name(monkeypatch) -
     """Explicit backend parameter should resolve one provider among many."""
     backend = _MockObservabilityBackend()
     monkeypatch.setattr(observability, "discover_capabilities", lambda: None)
-    register_observability_backend(ObservabilityBackendSpec(name="default", provider=object()))
-    register_observability_backend(ObservabilityBackendSpec(name="custom", provider=backend))
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="default", provider=object())
+    )
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="custom", provider=backend)
+    )
 
     resolved = observability._resolve_observability_backend("custom")
 
@@ -206,8 +210,12 @@ def test_resolve_observability_backend_uses_env_default(monkeypatch) -> None:
     backend = _MockObservabilityBackend()
     monkeypatch.setattr(observability, "discover_capabilities", lambda: None)
     monkeypatch.setenv("PHLO_OBSERVABILITY_BACKEND", "custom")
-    register_observability_backend(ObservabilityBackendSpec(name="default", provider=object()))
-    register_observability_backend(ObservabilityBackendSpec(name="custom", provider=backend))
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="default", provider=object())
+    )
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="custom", provider=backend)
+    )
 
     resolved = observability._resolve_observability_backend()
 
@@ -218,8 +226,12 @@ def test_resolve_observability_backend_requires_selection_when_ambiguous(monkeyp
     """Multiple backends without selection should return a deterministic error."""
     monkeypatch.setattr(observability, "discover_capabilities", lambda: None)
     monkeypatch.delenv("PHLO_OBSERVABILITY_BACKEND", raising=False)
-    register_observability_backend(ObservabilityBackendSpec(name="default", provider=object()))
-    register_observability_backend(ObservabilityBackendSpec(name="custom", provider=object()))
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="default", provider=object())
+    )
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="custom", provider=object())
+    )
 
     with pytest.raises(RuntimeError, match="Multiple observability backends are installed"):
         observability._resolve_observability_backend()

--- a/packages/phlo-api/tests/test_observatory_v2_actions.py
+++ b/packages/phlo-api/tests/test_observatory_v2_actions.py
@@ -50,7 +50,7 @@ def test_execute_v2_action_runs_registered_quality_check() -> None:
             metadata={"rows_checked": 3},
         )
 
-    registry.register_check(AssetCheckSpec(name="not_null", asset_key="orders", fn=check_fn))
+    registry.register("check", AssetCheckSpec(name="not_null", asset_key="orders", fn=check_fn))
 
     result = execute_v2_action(
         V2ActionRequest(action_id="quality:orders:not_null:rerun"),
@@ -78,7 +78,7 @@ def test_execute_v2_action_runs_registered_alert_sink() -> None:
 
     sink = Sink()
     registry = CapabilityRegistry()
-    registry.register_alert_sink(AlertSinkSpec(name="alerts", provider=sink))
+    registry.register("alert_sink", AlertSinkSpec(name="alerts", provider=sink))
 
     result = execute_v2_action(V2ActionRequest(action_id="alert:incident"), registry=registry)
 

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -1322,7 +1322,7 @@ def test_v2_branch_actions_use_registered_catalog_provider(
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     provider = CatalogProvider()
     registry = CapabilityRegistry()
-    registry.register_catalog(CatalogSpec(name="catalog", provider=provider))
+    registry.register("catalog", CatalogSpec(name="catalog", provider=provider))
     monkeypatch.setattr(v2, "_load_capability_registry", lambda: registry)
     v2._clear_read_model_cache()
 

--- a/packages/phlo-api/tests/test_observatory_v2_capabilities.py
+++ b/packages/phlo-api/tests/test_observatory_v2_capabilities.py
@@ -14,6 +14,11 @@ from phlo_api.observatory_api.v2_models import (
 
 
 class FakeRegistry:
+    def list(self, family: str):
+        if family == "query_engine":
+            return self.list_query_engines()
+        return []
+
     def list_query_engines(self):
         return [
             SimpleNamespace(
@@ -147,9 +152,10 @@ def test_build_capability_inventory_serializes_registry_without_private_urls() -
 
 
 def test_inventory_includes_ui_contributions() -> None:
-    registry = SimpleNamespace(
-        list_query_engines=lambda: [],
-        list_ui_contributions=lambda: [
+    def list_capabilities(family: str):
+        if family != "ui_contribution":
+            return []
+        return [
             SimpleNamespace(
                 name="trino-data",
                 capability_type="query_engine",
@@ -160,8 +166,9 @@ def test_inventory_includes_ui_contributions() -> None:
                 native_links=[],
                 metadata={"safe": "yes", "url": "http://internal"},
             )
-        ],
-    )
+        ]
+
+    registry = SimpleNamespace(list=list_capabilities)
 
     inventory = build_capability_inventory(registry)
 

--- a/packages/phlo-dagster/src/phlo_dagster/adapter.py
+++ b/packages/phlo-dagster/src/phlo_dagster/adapter.py
@@ -35,9 +35,9 @@ Example:
         # Build Dagster definitions
         adapter = DagsterOrchestratorAdapter()
         defs = adapter.build_definitions(
-            assets=registry.list_assets(),
-            checks=registry.list_checks(),
-            resources=registry.list_resources(),
+            assets=registry.list("asset"),
+            checks=registry.list("check"),
+            resources=registry.list("resource"),
         )
 
 """

--- a/packages/phlo-dagster/src/phlo_dagster/authorization.py
+++ b/packages/phlo-dagster/src/phlo_dagster/authorization.py
@@ -27,7 +27,7 @@ from typing import Any
 
 from phlo.capabilities import (
     RegulatedSurfaceSpec,
-    register_regulated_surface,
+    register_capability,
 )
 from phlo.rbac.models import CanonicalAction
 from phlo.security.adapters import SurfaceOperation
@@ -187,7 +187,7 @@ class DagsterRegulatedSurfaceAdapter:
                 "entrypoint": "graphql",
             },
         )
-        register_regulated_surface(spec)
+        register_capability("regulated_surface", spec)
 
 
 _adapter: DagsterRegulatedSurfaceAdapter | None = None

--- a/packages/phlo-dagster/src/phlo_dagster/framework/discovery.py
+++ b/packages/phlo-dagster/src/phlo_dagster/framework/discovery.py
@@ -57,7 +57,7 @@ from pathlib import Path
 from typing import Any
 
 from phlo.capabilities.discovery import discover_capabilities
-from phlo.capabilities.registry import clear_capabilities, get_capability_registry
+from phlo.capabilities.registry import clear_all_capabilities, get_capability_registry
 from phlo.exceptions import PhloConfigError
 from phlo.logging import get_logger
 from phlo.orchestrators import get_active_orchestrator
@@ -118,9 +118,9 @@ def discover_user_workflows(
     discover_capabilities()
 
     registry = get_capability_registry()
-    assets = registry.list_assets()
-    checks = registry.list_checks()
-    resources = registry.list_resources()
+    assets = registry.list("asset")
+    checks = registry.list("check")
+    resources = registry.list("resource")
     module_defs = _collect_module_dagster_definitions(imported_modules)
     try:
         adapter = get_active_orchestrator()
@@ -341,7 +341,7 @@ def _ensure_core_resources(definitions: Any) -> Any:
 def _default_trino_resource() -> Any | None:
     # Only auto-wire a trino resource if a provider has already registered one.
     registry = get_capability_registry()
-    for resource in registry.list_resources():
+    for resource in registry.list("resource"):
         if resource.name == "trino":
             return resource.resource
     return None
@@ -362,7 +362,7 @@ def _clear_capability_registries() -> None:
     """
     from phlo.plugins.discovery import discover_plugins, get_global_registry
 
-    clear_capabilities()
+    clear_all_capabilities()
     discover_plugins(plugin_type="asset_providers", auto_register=True)
     registry = get_global_registry()
 

--- a/packages/phlo-dagster/tests/test_authorization.py
+++ b/packages/phlo-dagster/tests/test_authorization.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from phlo.capabilities import list_regulated_surfaces
+from phlo.capabilities import get_capability_registry
 from phlo_dagster.authorization import (
     DagsterRegulatedSurfaceAdapter,
     get_adapter,
@@ -60,7 +60,7 @@ class TestDagsterRegulatedSurfaceAdapter:
 
         adapter.install(runtime)
 
-        registered = list_regulated_surfaces()
+        registered = get_capability_registry().list("regulated_surface")
         dagster_spec = next((s for s in registered if s.name == SURFACE_NAME), None)
         assert dagster_spec is not None
         assert dagster_spec.provider is adapter

--- a/packages/phlo-mcp/tests/smoke_stack.py
+++ b/packages/phlo-mcp/tests/smoke_stack.py
@@ -34,14 +34,14 @@ _SMOKE_ASSET_KEY = "mcp_smoke_asset"
 _SMOKE_ASSET_FILENAME = "mcp_smoke_asset.py"
 _SMOKE_ASSET_SOURCE = '''"""Generated asset used by packages/phlo-mcp/tests/smoke_stack.py."""
 
-from phlo.capabilities import AssetSpec, MaterializeResult, RunSpec, register_asset
+from phlo.capabilities import AssetSpec, MaterializeResult, RunSpec, register_capability
 
 
 def _run(runtime):
     return [MaterializeResult(metadata={"rows": 1})]
 
 
-register_asset(
+register_capability("asset",
     AssetSpec(
         key="mcp_smoke_asset",
         group="smoke",

--- a/packages/phlo-openmetadata/tests/test_openmetadata_resource_provider.py
+++ b/packages/phlo-openmetadata/tests/test_openmetadata_resource_provider.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock, patch
 
-from phlo.capabilities import clear_capabilities, resolve_capability
+from phlo.capabilities import clear_all_capabilities, resolve_capability
 from phlo.capabilities.discovery import discover_capabilities
 from phlo.hooks import QualityResultEvent
 from phlo_openmetadata.resource_provider import OpenMetadataResourceProvider
@@ -54,7 +54,7 @@ def test_metadata_catalog_provider_publishes_quality_result():
 
 def test_openmetadata_metadata_catalog_capability_resolves():
     """Capability discovery exposes OpenMetadata as a metadata catalog provider."""
-    clear_capabilities()
+    clear_all_capabilities()
     discover_capabilities()
     resolution = resolve_capability("metadata_catalog", "openmetadata")
 

--- a/packages/phlo-pandera/src/phlo_pandera/decorator.py
+++ b/packages/phlo-pandera/src/phlo_pandera/decorator.py
@@ -10,7 +10,12 @@ from __future__ import annotations
 import json
 from typing import Any, Callable, List, Optional
 
-from phlo.capabilities import AssetCheckSpec, CheckResult, get_capability_registry, register_check
+from phlo.capabilities import (
+    AssetCheckSpec,
+    CheckResult,
+    get_capability_registry,
+    register_capability,
+)
 from phlo.capabilities.runtime import RuntimeContext
 from phlo.contracts import Consumer, SLA, normalize_consumers, serialize_sla
 
@@ -302,7 +307,7 @@ def phlo_pandera(
                 description=f"Pandera schema contract for {table}",
                 tags=dict(contract_tags),
             )
-            register_check(pandera_spec)
+            register_capability("check", pandera_spec)
 
         if non_schema_checks:
 
@@ -548,7 +553,7 @@ def phlo_pandera(
                 description=description,
                 tags=dict(contract_tags),
             )
-            register_check(quality_spec)
+            register_capability("check", quality_spec)
 
         if schema_checks or non_schema_checks:
             return func
@@ -566,7 +571,7 @@ def get_quality_checks() -> list[AssetCheckSpec]:
 
     """
     registry = get_capability_registry()
-    return registry.list_checks()
+    return registry.list("check")
 
 
 def clear_quality_checks() -> None:
@@ -577,4 +582,4 @@ def clear_quality_checks() -> None:
 
     """
     registry = get_capability_registry()
-    registry.clear_checks()
+    registry.clear("check")

--- a/src/phlo/capabilities/__init__.py
+++ b/src/phlo/capabilities/__init__.py
@@ -34,7 +34,7 @@ Main Components:
     - :class:`CapabilityRegistry`: Thread-safe capability storage
     - :func:`get_capability_registry`: Access the global registry
     - :func:`resolve_capability`: Resolve a capability to a provider
-    - :func:`register_*`: Functions to register capability implementations
+    - :func:`register_capability`: Register capability implementations
     - :class:`CapabilitySupport`: Declare operational guarantees
     - :class:`RuntimeContext`: Context for capability resolution
 
@@ -43,16 +43,17 @@ Example:
     from phlo.capabilities import (
         get_capability_registry,
         resolve_capability,
-        register_query_engine,
+        register_capability,
         QueryEngineSpec,
     )
     from phlo.capabilities.interfaces import QueryEngine
 
     # Register a query engine
     registry = get_capability_registry()
-    register_query_engine(
-        "trino",
+    register_capability(
+        "query_engine",
         QueryEngineSpec(
+            name="trino",
             provider=MyTrinoEngine(),
             metadata={"default_catalog": "iceberg"}
         )
@@ -117,31 +118,10 @@ from phlo.capabilities.observability import (
 )
 from phlo.capabilities.registry import (
     CapabilityRegistry,
+    clear_all_capabilities,
     clear_capabilities,
     get_capability_registry,
-    list_regulated_surfaces,
-    register_alert_sink,
-    register_api_backend,
-    register_asset,
-    register_authentication_provider,
-    register_authorization_policy_backend,
-    register_catalog,
-    register_catalog_scanner,
-    register_check,
-    register_data_migration_source,
-    register_governance_backend,
-    register_lineage_sink,
-    register_maintenance_read_model,
-    register_metadata_catalog,
-    register_object_store,
-    register_observability_backend,
-    register_publish_target,
-    register_quality_backend,
-    register_query_engine,
-    register_regulated_surface,
-    register_resource,
-    register_schema_migrator,
-    register_table_store,
+    register_capability,
 )
 from phlo.capabilities.runtime import (
     RuntimeContext,
@@ -273,36 +253,15 @@ __all__ = [
     "TableStoreSpec",
     "TableStore",
     "coerce_capability_support",
+    "clear_all_capabilities",
     "clear_capabilities",
     "configured_capability_name",
     "detect_file_conflicts",
     "get_capability_registry",
     "list_capabilities",
-    "list_regulated_surfaces",
     "missing_required_capabilities",
-    "register_alert_sink",
-    "register_api_backend",
-    "register_asset",
-    "register_authorization_policy_backend",
-    "register_authentication_provider",
-    "register_catalog",
-    "register_catalog_scanner",
-    "register_check",
-    "register_data_migration_source",
-    "register_governance_backend",
-    "register_lineage_sink",
-    "register_maintenance_read_model",
-    "register_metadata_catalog",
-    "register_object_store",
-    "register_observability_backend",
-    "register_publish_target",
-    "register_quality_backend",
-    "register_query_engine",
-    "register_regulated_surface",
-    "register_resource",
-    "register_schema_migrator",
+    "register_capability",
     "register_default_capability_providers",
-    "register_table_store",
     "ResolutionResult",
     "render_maintenance_prometheus",
     "resolve_runtime_ref",

--- a/src/phlo/capabilities/authentication.py
+++ b/src/phlo/capabilities/authentication.py
@@ -22,7 +22,7 @@ from phlo.capabilities.interfaces import (
     LogoutResult,
     RequestContext,
 )
-from phlo.capabilities.registry import register_authentication_provider
+from phlo.capabilities.registry import register_capability
 from phlo.capabilities.specs import AuthenticationProviderSpec
 from phlo.capabilities.support import CapabilitySupport
 from phlo.infrastructure.config import (
@@ -921,7 +921,8 @@ def register_default_capability_providers() -> None:
         selected_provider=selected_provider,
         configured_payload=static_users or dev_mode,
     ):
-        register_authentication_provider(
+        register_capability(
+            "authentication_provider",
             AuthenticationProviderSpec(
                 name="static",
                 provider=StaticAuthenticationProvider(
@@ -939,7 +940,7 @@ def register_default_capability_providers() -> None:
                     supports_permissions=False,
                     supports_attributes=True,
                 ),
-            )
+            ),
         )
 
     proxy_block = _authentication_subconfig("proxy")
@@ -951,7 +952,8 @@ def register_default_capability_providers() -> None:
         selected_provider=selected_provider,
         configured_payload=proxy_config,
     ):
-        register_authentication_provider(
+        register_capability(
+            "authentication_provider",
             AuthenticationProviderSpec(
                 name="proxy",
                 provider=ProxyAuthenticationProvider(**proxy_config),
@@ -965,7 +967,7 @@ def register_default_capability_providers() -> None:
                     supports_permissions=False,
                     supports_attributes=True,
                 ),
-            )
+            ),
         )
 
     service_token_block = _authentication_subconfig("service_token")
@@ -977,7 +979,8 @@ def register_default_capability_providers() -> None:
         selected_provider=selected_provider,
         configured_payload=service_tokens,
     ):
-        register_authentication_provider(
+        register_capability(
+            "authentication_provider",
             AuthenticationProviderSpec(
                 name="service_token",
                 provider=ServiceTokenAuthenticationProvider(
@@ -993,7 +996,7 @@ def register_default_capability_providers() -> None:
                     supports_permissions=False,
                     supports_attributes=True,
                 ),
-            )
+            ),
         )
 
     jwt_block = _authentication_subconfig("jwt")
@@ -1008,7 +1011,8 @@ def register_default_capability_providers() -> None:
         if not jwt_config.get("secret"):
             logger.error("jwt_provider_requires_secret")
         else:
-            register_authentication_provider(
+            register_capability(
+                "authentication_provider",
                 AuthenticationProviderSpec(
                     name="jwt",
                     provider=JWTAuthenticationProvider(
@@ -1028,5 +1032,5 @@ def register_default_capability_providers() -> None:
                         supports_permissions=False,
                         supports_attributes=True,
                     ),
-                )
+                ),
             )

--- a/src/phlo/capabilities/authorization.py
+++ b/src/phlo/capabilities/authorization.py
@@ -13,7 +13,7 @@ from phlo.capabilities.interfaces import (
     Principal,
     ResourceRef,
 )
-from phlo.capabilities.registry import register_authorization_policy_backend
+from phlo.capabilities.registry import register_capability
 from phlo.capabilities.specs import AuthorizationPolicyBackendSpec
 from phlo.capabilities.support import CapabilitySupport
 from phlo.logging import get_logger
@@ -213,7 +213,8 @@ class DefaultAuthorizationPolicyBackend:
 
 def register_default_capability_providers() -> None:
     """Register the default authorization policy backend provider."""
-    register_authorization_policy_backend(
+    register_capability(
+        "authorization_policy_backend",
         AuthorizationPolicyBackendSpec(
             name="default",
             provider=DefaultAuthorizationPolicyBackend(),
@@ -225,5 +226,5 @@ def register_default_capability_providers() -> None:
                 supports_permissions=True,
                 supports_attributes=False,
             ),
-        )
+        ),
     )

--- a/src/phlo/capabilities/catalog.py
+++ b/src/phlo/capabilities/catalog.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import builtins
 from collections.abc import Callable, Hashable
 from dataclasses import dataclass, field
-from typing import Generic, Protocol, TypeVar
+from typing import Any, Generic, Protocol, TypeVar
 
 SpecT = TypeVar("SpecT")
 KeyT = TypeVar("KeyT", bound=Hashable)
@@ -37,3 +37,24 @@ class CapabilityFamily(Generic[SpecT, KeyT]):
 
 def named_family() -> CapabilityFamily[NamedSpecT, str]:
     return CapabilityFamily(key=lambda spec: spec.name)
+
+
+@dataclass(frozen=True, slots=True)
+class CapabilityFamilyDefinition(Generic[SpecT, KeyT]):
+    """Metadata describing one named capability family."""
+
+    name: str
+    spec_type: type[SpecT]
+    key: Callable[[SpecT], KeyT]
+    provider_method: str | None = None
+
+    def family(self) -> CapabilityFamily[SpecT, KeyT]:
+        """Create empty storage for this capability family."""
+        return CapabilityFamily(key=self.key)
+
+    def provider_specs(self, provider: Any) -> list[SpecT]:
+        """Return specs exposed by a provider for this family."""
+        if self.provider_method is None:
+            return []
+        method = getattr(provider, self.provider_method)
+        return list(method())

--- a/src/phlo/capabilities/discovery.py
+++ b/src/phlo/capabilities/discovery.py
@@ -4,28 +4,8 @@ from __future__ import annotations
 
 from phlo.capabilities.observability import register_default_capability_providers
 from phlo.capabilities.registry import (
-    register_alert_sink,
-    register_api_backend,
-    register_asset,
-    register_authentication_provider,
-    register_authorization_policy_backend,
-    register_catalog,
-    register_catalog_scanner,
-    register_check,
-    register_data_migration_source,
-    register_governance_backend,
-    register_lineage_sink,
-    register_maintenance_read_model,
-    register_metadata_catalog,
-    register_object_store,
-    register_observability_backend,
-    register_publish_target,
-    register_quality_backend,
-    register_query_engine,
-    register_resource,
-    register_schema_migrator,
-    register_secret_backend,
-    register_table_store,
+    iter_provider_capabilities,
+    register_capability,
 )
 from phlo.logging import get_logger
 from phlo.plugins.discovery import discover_plugins, get_global_registry
@@ -49,10 +29,9 @@ def discover_capabilities() -> None:
             continue
         asset_provider_count += 1
         try:
-            for asset in plugin.get_assets():
-                register_asset(asset)
-            for check in plugin.get_checks():
-                register_check(check)
+            for family, specs in iter_provider_capabilities(plugin):
+                for spec in specs:
+                    register_capability(family, spec)
         except Exception as exc:
             logger.warning(
                 "capability_asset_provider_registration_failed",
@@ -68,46 +47,9 @@ def discover_capabilities() -> None:
             continue
         resource_provider_count += 1
         try:
-            for resource in plugin.get_resources():
-                register_resource(resource)
-            for table_store in plugin.get_table_stores():
-                register_table_store(table_store)
-            for catalog in plugin.get_catalogs():
-                register_catalog(catalog)
-            for catalog_scanner in plugin.get_catalog_scanners():
-                register_catalog_scanner(catalog_scanner)
-            for query_engine in plugin.get_query_engines():
-                register_query_engine(query_engine)
-            for object_store in plugin.get_object_stores():
-                register_object_store(object_store)
-            for quality_backend in plugin.get_quality_backends():
-                register_quality_backend(quality_backend)
-            for maintenance_read_model in plugin.get_maintenance_read_models():
-                register_maintenance_read_model(maintenance_read_model)
-            for metadata_catalog in plugin.get_metadata_catalogs():
-                register_metadata_catalog(metadata_catalog)
-            for lineage_sink in plugin.get_lineage_sinks():
-                register_lineage_sink(lineage_sink)
-            for governance_backend in plugin.get_governance_backends():
-                register_governance_backend(governance_backend)
-            for authorization_policy_backend in plugin.get_authorization_policy_backends():
-                register_authorization_policy_backend(authorization_policy_backend)
-            for authentication_provider in plugin.get_authentication_providers():
-                register_authentication_provider(authentication_provider)
-            for publish_target in plugin.get_publish_targets():
-                register_publish_target(publish_target)
-            for alert_sink in plugin.get_alert_sinks():
-                register_alert_sink(alert_sink)
-            for api_backend in plugin.get_api_backends():
-                register_api_backend(api_backend)
-            for secret_backend in plugin.get_secret_backends():
-                register_secret_backend(secret_backend)
-            for schema_migrator in plugin.get_schema_migrators():
-                register_schema_migrator(schema_migrator)
-            for source_adapter in plugin.get_data_migration_sources():
-                register_data_migration_source(source_adapter)
-            for observability_backend in plugin.get_observability_backends():
-                register_observability_backend(observability_backend)
+            for family, specs in iter_provider_capabilities(plugin):
+                for spec in specs:
+                    register_capability(family, spec)
         except Exception as exc:
             missing_optional_config = "must be provided" in str(exc)
             logger.warning(

--- a/src/phlo/capabilities/observability.py
+++ b/src/phlo/capabilities/observability.py
@@ -19,8 +19,7 @@ from phlo.capabilities.interfaces import (
 )
 from phlo.capabilities.maintenance import DefaultMaintenanceReadModel
 from phlo.capabilities.registry import (
-    register_maintenance_read_model,
-    register_observability_backend,
+    register_capability,
 )
 from phlo.capabilities.specs import MaintenanceReadModelSpec, ObservabilityBackendSpec
 from phlo.capabilities.support import CapabilitySupport
@@ -228,13 +227,15 @@ class DefaultObservabilityBackend:
 
 def register_default_capability_providers() -> None:
     """Register core-owned default maintenance and observability providers."""
-    register_maintenance_read_model(
+    register_capability(
+        "maintenance_read_model",
         MaintenanceReadModelSpec(
             name="default",
             provider=DefaultMaintenanceReadModel(),
-        )
+        ),
     )
-    register_observability_backend(
+    register_capability(
+        "observability_backend",
         ObservabilityBackendSpec(
             name="default",
             provider=DefaultObservabilityBackend(),
@@ -248,7 +249,7 @@ def register_default_capability_providers() -> None:
                 supports_dashboards=True,
                 supports_alerts=True,
             ),
-        )
+        ),
     )
 
 

--- a/src/phlo/capabilities/registry.py
+++ b/src/phlo/capabilities/registry.py
@@ -1,11 +1,13 @@
-"""Capability registry for assets, checks, and resources."""
+"""Capability registry for named capability families."""
 
 from __future__ import annotations
 
+import builtins
 import threading
 from dataclasses import dataclass, field
+from typing import Any
 
-from phlo.capabilities.catalog import CapabilityFamily, named_family
+from phlo.capabilities.catalog import CapabilityFamily, CapabilityFamilyDefinition
 from phlo.capabilities.specs import (
     AlertSinkSpec,
     ApiBackendSpec,
@@ -33,669 +35,232 @@ from phlo.capabilities.specs import (
     UiContributionSpec,
 )
 
+CAPABILITY_FAMILIES: dict[str, CapabilityFamilyDefinition[Any, Any]] = {
+    "asset": CapabilityFamilyDefinition(
+        name="asset",
+        spec_type=AssetSpec,
+        key=lambda spec: spec.key,
+        provider_method="get_assets",
+    ),
+    "check": CapabilityFamilyDefinition(
+        name="check",
+        spec_type=AssetCheckSpec,
+        key=lambda spec: (spec.asset_key, spec.name),
+        provider_method="get_checks",
+    ),
+    "resource": CapabilityFamilyDefinition(
+        name="resource",
+        spec_type=ResourceSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_resources",
+    ),
+    "table_store": CapabilityFamilyDefinition(
+        name="table_store",
+        spec_type=TableStoreSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_table_stores",
+    ),
+    "catalog": CapabilityFamilyDefinition(
+        name="catalog",
+        spec_type=CatalogSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_catalogs",
+    ),
+    "catalog_scanner": CapabilityFamilyDefinition(
+        name="catalog_scanner",
+        spec_type=CatalogScannerSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_catalog_scanners",
+    ),
+    "query_engine": CapabilityFamilyDefinition(
+        name="query_engine",
+        spec_type=QueryEngineSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_query_engines",
+    ),
+    "object_store": CapabilityFamilyDefinition(
+        name="object_store",
+        spec_type=ObjectStoreSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_object_stores",
+    ),
+    "quality_backend": CapabilityFamilyDefinition(
+        name="quality_backend",
+        spec_type=QualityBackendSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_quality_backends",
+    ),
+    "maintenance_read_model": CapabilityFamilyDefinition(
+        name="maintenance_read_model",
+        spec_type=MaintenanceReadModelSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_maintenance_read_models",
+    ),
+    "metadata_catalog": CapabilityFamilyDefinition(
+        name="metadata_catalog",
+        spec_type=MetadataCatalogSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_metadata_catalogs",
+    ),
+    "lineage_sink": CapabilityFamilyDefinition(
+        name="lineage_sink",
+        spec_type=LineageSinkSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_lineage_sinks",
+    ),
+    "governance_backend": CapabilityFamilyDefinition(
+        name="governance_backend",
+        spec_type=GovernanceBackendSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_governance_backends",
+    ),
+    "authorization_policy_backend": CapabilityFamilyDefinition(
+        name="authorization_policy_backend",
+        spec_type=AuthorizationPolicyBackendSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_authorization_policy_backends",
+    ),
+    "authentication_provider": CapabilityFamilyDefinition(
+        name="authentication_provider",
+        spec_type=AuthenticationProviderSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_authentication_providers",
+    ),
+    "publish_target": CapabilityFamilyDefinition(
+        name="publish_target",
+        spec_type=PublishTargetSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_publish_targets",
+    ),
+    "alert_sink": CapabilityFamilyDefinition(
+        name="alert_sink",
+        spec_type=AlertSinkSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_alert_sinks",
+    ),
+    "api_backend": CapabilityFamilyDefinition(
+        name="api_backend",
+        spec_type=ApiBackendSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_api_backends",
+    ),
+    "secret_backend": CapabilityFamilyDefinition(
+        name="secret_backend",
+        spec_type=SecretBackendSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_secret_backends",
+    ),
+    "schema_migrator": CapabilityFamilyDefinition(
+        name="schema_migrator",
+        spec_type=SchemaMigrationSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_schema_migrators",
+    ),
+    "data_migration_source": CapabilityFamilyDefinition(
+        name="data_migration_source",
+        spec_type=DataMigrationSourceSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_data_migration_sources",
+    ),
+    "observability_backend": CapabilityFamilyDefinition(
+        name="observability_backend",
+        spec_type=ObservabilityBackendSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_observability_backends",
+    ),
+    "regulated_surface": CapabilityFamilyDefinition(
+        name="regulated_surface",
+        spec_type=RegulatedSurfaceSpec,
+        key=lambda spec: spec.name,
+    ),
+    "ui_contribution": CapabilityFamilyDefinition(
+        name="ui_contribution",
+        spec_type=UiContributionSpec,
+        key=lambda spec: spec.name,
+    ),
+}
+
+
+def capability_family(name: str) -> CapabilityFamilyDefinition[Any, Any]:
+    """Return metadata for a canonical capability family."""
+    try:
+        return CAPABILITY_FAMILIES[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown capability family: {name}") from exc
+
+
+def iter_provider_capabilities(provider: Any) -> list[tuple[str, list[Any]]]:
+    """Return all capability specs exposed by a resource provider."""
+    discovered: list[tuple[str, list[Any]]] = []
+    for family_name, definition in CAPABILITY_FAMILIES.items():
+        if definition.provider_method is None or not hasattr(provider, definition.provider_method):
+            continue
+        specs = definition.provider_specs(provider)
+        if specs:
+            discovered.append((family_name, specs))
+    return discovered
+
 
 @dataclass
 class CapabilityRegistry:
     """Thread-safe in-memory registry for capability specifications."""
 
-    assets: dict[str, AssetSpec] = field(default_factory=dict)
-    checks: dict[tuple[str, str], AssetCheckSpec] = field(default_factory=dict)
-    resources: dict[str, ResourceSpec] = field(default_factory=dict)
-    table_stores: dict[str, TableStoreSpec] = field(default_factory=dict)
-    catalogs: dict[str, CatalogSpec] = field(default_factory=dict)
-    catalog_scanners: dict[str, CatalogScannerSpec] = field(default_factory=dict)
-    query_engines: dict[str, QueryEngineSpec] = field(default_factory=dict)
-    object_stores: dict[str, ObjectStoreSpec] = field(default_factory=dict)
-    quality_backends: dict[str, QualityBackendSpec] = field(default_factory=dict)
-    maintenance_read_models: dict[str, MaintenanceReadModelSpec] = field(default_factory=dict)
-    metadata_catalogs: dict[str, MetadataCatalogSpec] = field(default_factory=dict)
-    lineage_sinks: dict[str, LineageSinkSpec] = field(default_factory=dict)
-    governance_backends: dict[str, GovernanceBackendSpec] = field(default_factory=dict)
-    authorization_policy_backends: dict[str, AuthorizationPolicyBackendSpec] = field(
-        default_factory=dict
-    )
-    authentication_providers: dict[str, AuthenticationProviderSpec] = field(default_factory=dict)
-    publish_targets: dict[str, PublishTargetSpec] = field(default_factory=dict)
-    alert_sinks: dict[str, AlertSinkSpec] = field(default_factory=dict)
-    api_backends: dict[str, ApiBackendSpec] = field(default_factory=dict)
-    secret_backends: dict[str, SecretBackendSpec] = field(default_factory=dict)
-    schema_migrators: dict[str, SchemaMigrationSpec] = field(default_factory=dict)
-    data_migration_sources: dict[str, DataMigrationSourceSpec] = field(default_factory=dict)
-    observability_backends: dict[str, ObservabilityBackendSpec] = field(default_factory=dict)
-    regulated_surfaces: dict[str, RegulatedSurfaceSpec] = field(default_factory=dict)
-    ui_contributions: dict[str, UiContributionSpec] = field(default_factory=dict)
-    _asset_family: CapabilityFamily[AssetSpec, str] = field(
-        default_factory=lambda: CapabilityFamily(key=lambda spec: spec.key),
-        init=False,
-        repr=False,
-    )
-    _check_family: CapabilityFamily[AssetCheckSpec, tuple[str, str]] = field(
-        default_factory=lambda: CapabilityFamily(key=lambda spec: (spec.asset_key, spec.name)),
-        init=False,
-        repr=False,
-    )
-    _resource_family: CapabilityFamily[ResourceSpec, str] = field(
-        default_factory=lambda: CapabilityFamily(key=lambda spec: spec.name),
-        init=False,
-        repr=False,
-    )
-    _table_store_family: CapabilityFamily[TableStoreSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _catalog_family: CapabilityFamily[CatalogSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _catalog_scanner_family: CapabilityFamily[CatalogScannerSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _query_engine_family: CapabilityFamily[QueryEngineSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _object_store_family: CapabilityFamily[ObjectStoreSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _quality_backend_family: CapabilityFamily[QualityBackendSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _maintenance_read_model_family: CapabilityFamily[MaintenanceReadModelSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _metadata_catalog_family: CapabilityFamily[MetadataCatalogSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _lineage_sink_family: CapabilityFamily[LineageSinkSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _governance_backend_family: CapabilityFamily[GovernanceBackendSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _authorization_policy_backend_family: CapabilityFamily[AuthorizationPolicyBackendSpec, str] = (
-        field(
-            default_factory=named_family,
-            init=False,
-            repr=False,
-        )
-    )
-    _authentication_provider_family: CapabilityFamily[AuthenticationProviderSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _publish_target_family: CapabilityFamily[PublishTargetSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _alert_sink_family: CapabilityFamily[AlertSinkSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _api_backend_family: CapabilityFamily[ApiBackendSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _secret_backend_family: CapabilityFamily[SecretBackendSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _schema_migrator_family: CapabilityFamily[SchemaMigrationSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _data_migration_source_family: CapabilityFamily[DataMigrationSourceSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _observability_backend_family: CapabilityFamily[ObservabilityBackendSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _regulated_surface_family: CapabilityFamily[RegulatedSurfaceSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
-    _ui_contribution_family: CapabilityFamily[UiContributionSpec, str] = field(
-        default_factory=named_family,
-        init=False,
-        repr=False,
-    )
+    _families: dict[str, CapabilityFamily[Any, Any]] = field(init=False, repr=False)
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
-    def register_asset(self, spec: AssetSpec) -> None:
-        """Register or replace an asset spec by key.
+    def __post_init__(self) -> None:
+        self._families = {
+            name: definition.family() for name, definition in CAPABILITY_FAMILIES.items()
+        }
 
-        Args:
-            spec: Asset capability specification to store.
-        """
-
-        with self._lock:
-            self._asset_family.register(spec)
-            self.assets = dict(self._asset_family._items)
-
-    def register_check(self, spec: AssetCheckSpec) -> None:
-        """Register or replace an asset check spec by asset/name tuple.
-
-        Args:
-            spec: Asset check capability specification to store.
-        """
-
-        with self._lock:
-            self._check_family.register(spec)
-            self.checks = dict(self._check_family._items)
-
-    def register_resource(self, spec: ResourceSpec) -> None:
-        """Register or replace a resource spec by name.
-
-        Args:
-            spec: Resource capability specification to store.
-        """
-
-        with self._lock:
-            self._resource_family.register(spec)
-            self.resources = dict(self._resource_family._items)
-
-    def list_assets(self) -> list[AssetSpec]:
-        """Return a snapshot list of all registered assets.
-
-        Returns:
-            List of currently registered asset specs.
-        """
-
-        with self._lock:
-            return self._asset_family.list()
-
-    def list_checks(self) -> list[AssetCheckSpec]:
-        """Return a snapshot list of all registered checks.
-
-        Returns:
-            List of currently registered asset check specs.
-        """
-
-        with self._lock:
-            return self._check_family.list()
-
-    def list_resources(self) -> list[ResourceSpec]:
-        """Return a snapshot list of all registered resources.
-
-        Returns:
-            List of currently registered resource specs.
-        """
-
-        with self._lock:
-            return self._resource_family.list()
-
-    def register_table_store(self, spec: TableStoreSpec) -> None:
-        """Register or replace a table store spec by name."""
-        with self._lock:
-            self._table_store_family.register(spec)
-            self.table_stores = dict(self._table_store_family._items)
-
-    def list_table_stores(self) -> list[TableStoreSpec]:
-        """Return a snapshot list of registered table store specs."""
-        with self._lock:
-            return self._table_store_family.list()
-
-    def register_catalog(self, spec: CatalogSpec) -> None:
-        """Register or replace a catalog spec by name."""
-        with self._lock:
-            self._catalog_family.register(spec)
-            self.catalogs = dict(self._catalog_family._items)
-
-    def list_catalogs(self) -> list[CatalogSpec]:
-        """Return a snapshot list of registered catalog specs."""
-        with self._lock:
-            return self._catalog_family.list()
-
-    def register_catalog_scanner(self, spec: CatalogScannerSpec) -> None:
-        """Register or replace a catalog scanner spec by name."""
-        with self._lock:
-            self._catalog_scanner_family.register(spec)
-            self.catalog_scanners = dict(self._catalog_scanner_family._items)
-
-    def list_catalog_scanners(self) -> list[CatalogScannerSpec]:
-        """Return a snapshot list of registered catalog scanner specs."""
-        with self._lock:
-            return self._catalog_scanner_family.list()
-
-    def register_query_engine(self, spec: QueryEngineSpec) -> None:
-        """Register or replace a query engine spec by name."""
-        with self._lock:
-            self._query_engine_family.register(spec)
-            self.query_engines = dict(self._query_engine_family._items)
-
-    def list_query_engines(self) -> list[QueryEngineSpec]:
-        """Return a snapshot list of registered query engine specs."""
-        with self._lock:
-            return self._query_engine_family.list()
-
-    def register_object_store(self, spec: ObjectStoreSpec) -> None:
-        """Register or replace an object store spec by name."""
-        with self._lock:
-            self._object_store_family.register(spec)
-            self.object_stores = dict(self._object_store_family._items)
-
-    def list_object_stores(self) -> list[ObjectStoreSpec]:
-        """Return a snapshot list of registered object store specs."""
-        with self._lock:
-            return self._object_store_family.list()
-
-    def register_quality_backend(self, spec: QualityBackendSpec) -> None:
-        """Register or replace a quality backend spec by name."""
-        with self._lock:
-            self._quality_backend_family.register(spec)
-            self.quality_backends = dict(self._quality_backend_family._items)
-
-    def list_quality_backends(self) -> list[QualityBackendSpec]:
-        """Return a snapshot list of registered quality backend specs."""
-        with self._lock:
-            return self._quality_backend_family.list()
-
-    def register_maintenance_read_model(self, spec: MaintenanceReadModelSpec) -> None:
-        """Register or replace a maintenance read-model spec by name."""
-        with self._lock:
-            self._maintenance_read_model_family.register(spec)
-            self.maintenance_read_models = dict(self._maintenance_read_model_family._items)
-
-    def list_maintenance_read_models(self) -> list[MaintenanceReadModelSpec]:
-        """Return a snapshot list of maintenance read-model specs."""
-        with self._lock:
-            return self._maintenance_read_model_family.list()
-
-    def register_metadata_catalog(self, spec: MetadataCatalogSpec) -> None:
-        """Register or replace a metadata catalog spec by name."""
-        with self._lock:
-            self._metadata_catalog_family.register(spec)
-            self.metadata_catalogs = dict(self._metadata_catalog_family._items)
-
-    def list_metadata_catalogs(self) -> list[MetadataCatalogSpec]:
-        """Return a snapshot list of registered metadata catalog specs."""
-        with self._lock:
-            return self._metadata_catalog_family.list()
-
-    def register_lineage_sink(self, spec: LineageSinkSpec) -> None:
-        """Register or replace a lineage sink spec by name."""
-        with self._lock:
-            self._lineage_sink_family.register(spec)
-            self.lineage_sinks = dict(self._lineage_sink_family._items)
-
-    def list_lineage_sinks(self) -> list[LineageSinkSpec]:
-        """Return a snapshot list of registered lineage sink specs."""
-        with self._lock:
-            return self._lineage_sink_family.list()
-
-    def register_governance_backend(self, spec: GovernanceBackendSpec) -> None:
-        """Register or replace a governance backend spec by name."""
-        with self._lock:
-            self._governance_backend_family.register(spec)
-            self.governance_backends = dict(self._governance_backend_family._items)
-
-    def list_governance_backends(self) -> list[GovernanceBackendSpec]:
-        """Return a snapshot list of registered governance backend specs."""
-        with self._lock:
-            return self._governance_backend_family.list()
-
-    def register_authorization_policy_backend(self, spec: AuthorizationPolicyBackendSpec) -> None:
-        """Register or replace an authorization policy backend spec by name."""
-        with self._lock:
-            self._authorization_policy_backend_family.register(spec)
-            self.authorization_policy_backends = dict(
-                self._authorization_policy_backend_family._items
+    def register(self, family: str, spec: Any) -> None:
+        """Register or replace a capability spec in a canonical family."""
+        definition = capability_family(family)
+        if not isinstance(spec, definition.spec_type):
+            raise TypeError(
+                f"Capability family '{family}' expects {definition.spec_type.__name__}, "
+                f"got {type(spec).__name__}."
             )
-
-    def list_authorization_policy_backends(self) -> list[AuthorizationPolicyBackendSpec]:
-        """Return a snapshot list of registered authorization policy backend specs."""
         with self._lock:
-            return self._authorization_policy_backend_family.list()
+            self._families[family].register(spec)
 
-    def register_authentication_provider(self, spec: AuthenticationProviderSpec) -> None:
-        """Register or replace an authentication provider spec by name."""
+    def list(self, family: str) -> builtins.list[Any]:
+        """Return a snapshot list of registered specs for one family."""
+        capability_family(family)
         with self._lock:
-            self._authentication_provider_family.register(spec)
-            self.authentication_providers = dict(self._authentication_provider_family._items)
+            return self._families[family].list()
 
-    def list_authentication_providers(self) -> list[AuthenticationProviderSpec]:
-        """Return a snapshot list of registered authentication provider specs."""
+    def clear(self, family: str) -> None:
+        """Remove all registered specs for one capability family."""
+        capability_family(family)
         with self._lock:
-            return self._authentication_provider_family.list()
+            self._families[family].clear()
 
-    def register_publish_target(self, spec: PublishTargetSpec) -> None:
-        """Register or replace a publish target spec by name."""
+    def clear_all(self) -> None:
+        """Remove all specs from every capability family."""
         with self._lock:
-            self._publish_target_family.register(spec)
-            self.publish_targets = dict(self._publish_target_family._items)
-
-    def list_publish_targets(self) -> list[PublishTargetSpec]:
-        """Return a snapshot list of registered publish target specs."""
-        with self._lock:
-            return self._publish_target_family.list()
-
-    def register_alert_sink(self, spec: AlertSinkSpec) -> None:
-        """Register or replace an alert sink spec by name."""
-        with self._lock:
-            self._alert_sink_family.register(spec)
-            self.alert_sinks = dict(self._alert_sink_family._items)
-
-    def list_alert_sinks(self) -> list[AlertSinkSpec]:
-        """Return a snapshot list of registered alert sink specs."""
-        with self._lock:
-            return self._alert_sink_family.list()
-
-    def register_api_backend(self, spec: ApiBackendSpec) -> None:
-        """Register or replace an API backend spec by name."""
-        with self._lock:
-            self._api_backend_family.register(spec)
-            self.api_backends = dict(self._api_backend_family._items)
-
-    def list_api_backends(self) -> list[ApiBackendSpec]:
-        """Return a snapshot list of registered API backend specs."""
-        with self._lock:
-            return self._api_backend_family.list()
-
-    def register_secret_backend(self, spec: SecretBackendSpec) -> None:
-        """Register or replace a secret backend spec by name."""
-        with self._lock:
-            self._secret_backend_family.register(spec)
-            self.secret_backends = dict(self._secret_backend_family._items)
-
-    def list_secret_backends(self) -> list[SecretBackendSpec]:
-        """Return a snapshot list of registered secret backend specs."""
-        with self._lock:
-            return self._secret_backend_family.list()
-
-    def register_schema_migrator(self, spec: SchemaMigrationSpec) -> None:
-        """Register or replace a schema migrator spec by name."""
-        with self._lock:
-            self._schema_migrator_family.register(spec)
-            self.schema_migrators = dict(self._schema_migrator_family._items)
-
-    def list_schema_migrators(self) -> list[SchemaMigrationSpec]:
-        """Return a snapshot list of registered schema migrator specs."""
-        with self._lock:
-            return self._schema_migrator_family.list()
-
-    def register_data_migration_source(self, spec: DataMigrationSourceSpec) -> None:
-        """Register or replace a data migration source adapter spec by name."""
-        with self._lock:
-            self._data_migration_source_family.register(spec)
-            self.data_migration_sources = dict(self._data_migration_source_family._items)
-
-    def list_data_migration_sources(self) -> list[DataMigrationSourceSpec]:
-        """Return a snapshot list of registered migration source adapter specs."""
-        with self._lock:
-            return self._data_migration_source_family.list()
-
-    def register_observability_backend(self, spec: ObservabilityBackendSpec) -> None:
-        """Register or replace an observability backend spec by name."""
-        with self._lock:
-            self._observability_backend_family.register(spec)
-            self.observability_backends = dict(self._observability_backend_family._items)
-
-    def list_observability_backends(self) -> list[ObservabilityBackendSpec]:
-        """Return a snapshot list of registered observability backend specs."""
-        with self._lock:
-            return self._observability_backend_family.list()
-
-    def register_regulated_surface(self, spec: RegulatedSurfaceSpec) -> None:
-        """Register or replace a regulated surface spec by name."""
-        with self._lock:
-            self._regulated_surface_family.register(spec)
-            self.regulated_surfaces = dict(self._regulated_surface_family._items)
-
-    def list_regulated_surfaces(self) -> list[RegulatedSurfaceSpec]:
-        """Return a snapshot list of registered regulated surface specs."""
-        with self._lock:
-            return self._regulated_surface_family.list()
-
-    def register_ui_contribution(self, spec: UiContributionSpec) -> None:
-        """Register or replace a UI contribution spec by name."""
-        with self._lock:
-            self._ui_contribution_family.register(spec)
-            self.ui_contributions = dict(self._ui_contribution_family._items)
-
-    def list_ui_contributions(self) -> list[UiContributionSpec]:
-        """Return a snapshot list of registered UI contribution specs."""
-        with self._lock:
-            return self._ui_contribution_family.list()
-
-    def clear(self) -> None:
-        """Remove all assets, checks, and resources from the registry."""
-
-        with self._lock:
-            self._asset_family.clear()
-            self.assets = dict(self._asset_family._items)
-            self._check_family.clear()
-            self.checks = dict(self._check_family._items)
-            self._resource_family.clear()
-            self.resources = dict(self._resource_family._items)
-            self._table_store_family.clear()
-            self.table_stores = dict(self._table_store_family._items)
-            self._catalog_family.clear()
-            self.catalogs = dict(self._catalog_family._items)
-            self._catalog_scanner_family.clear()
-            self.catalog_scanners = dict(self._catalog_scanner_family._items)
-            self._query_engine_family.clear()
-            self.query_engines = dict(self._query_engine_family._items)
-            self._object_store_family.clear()
-            self.object_stores = dict(self._object_store_family._items)
-            self._quality_backend_family.clear()
-            self.quality_backends = dict(self._quality_backend_family._items)
-            self._maintenance_read_model_family.clear()
-            self.maintenance_read_models = dict(self._maintenance_read_model_family._items)
-            self._metadata_catalog_family.clear()
-            self.metadata_catalogs = dict(self._metadata_catalog_family._items)
-            self._lineage_sink_family.clear()
-            self.lineage_sinks = dict(self._lineage_sink_family._items)
-            self._governance_backend_family.clear()
-            self.governance_backends = dict(self._governance_backend_family._items)
-            self._authorization_policy_backend_family.clear()
-            self.authorization_policy_backends = dict(
-                self._authorization_policy_backend_family._items
-            )
-            self._authentication_provider_family.clear()
-            self.authentication_providers = dict(self._authentication_provider_family._items)
-            self._publish_target_family.clear()
-            self.publish_targets = dict(self._publish_target_family._items)
-            self._alert_sink_family.clear()
-            self.alert_sinks = dict(self._alert_sink_family._items)
-            self._api_backend_family.clear()
-            self.api_backends = dict(self._api_backend_family._items)
-            self._secret_backend_family.clear()
-            self.secret_backends = dict(self._secret_backend_family._items)
-            self._schema_migrator_family.clear()
-            self.schema_migrators = dict(self._schema_migrator_family._items)
-            self._data_migration_source_family.clear()
-            self.data_migration_sources = dict(self._data_migration_source_family._items)
-            self._observability_backend_family.clear()
-            self.observability_backends = dict(self._observability_backend_family._items)
-            self._regulated_surface_family.clear()
-            self.regulated_surfaces = dict(self._regulated_surface_family._items)
-            self._ui_contribution_family.clear()
-            self.ui_contributions = dict(self._ui_contribution_family._items)
-
-    def clear_checks(self) -> None:
-        """Remove all registered checks while preserving assets/resources."""
-
-        with self._lock:
-            self._check_family.clear()
-            self.checks = dict(self._check_family._items)
+            for family_name in CAPABILITY_FAMILIES:
+                self._families[family_name].clear()
 
 
 _GLOBAL_REGISTRY = CapabilityRegistry()
 
 
 def get_capability_registry() -> CapabilityRegistry:
-    """Return the process-global capability registry instance.
-
-    Returns:
-        Shared in-memory capability registry.
-    """
-
+    """Return the process-global capability registry instance."""
     return _GLOBAL_REGISTRY
 
 
-def register_asset(spec: AssetSpec) -> None:
-    """Register an asset in the process-global registry.
-
-    Args:
-        spec: Asset capability specification to store.
-    """
-
-    _GLOBAL_REGISTRY.register_asset(spec)
+def register_capability(family: str, spec: Any) -> None:
+    """Register a capability spec in the process-global registry."""
+    _GLOBAL_REGISTRY.register(family, spec)
 
 
-def register_check(spec: AssetCheckSpec) -> None:
-    """Register an asset check in the process-global registry.
-
-    Args:
-        spec: Asset check capability specification to store.
-    """
-
-    _GLOBAL_REGISTRY.register_check(spec)
+def clear_capabilities(family: str) -> None:
+    """Clear one capability family from the process-global registry."""
+    _GLOBAL_REGISTRY.clear(family)
 
 
-def register_resource(spec: ResourceSpec) -> None:
-    """Register a resource in the process-global registry.
-
-    Args:
-        spec: Resource capability specification to store.
-    """
-
-    _GLOBAL_REGISTRY.register_resource(spec)
-
-
-def register_table_store(spec: TableStoreSpec) -> None:
-    """Register a table store in the process-global registry."""
-    _GLOBAL_REGISTRY.register_table_store(spec)
-
-
-def register_catalog(spec: CatalogSpec) -> None:
-    """Register a catalog in the process-global registry."""
-    _GLOBAL_REGISTRY.register_catalog(spec)
-
-
-def register_catalog_scanner(spec: CatalogScannerSpec) -> None:
-    """Register a catalog scanner in the process-global registry."""
-    _GLOBAL_REGISTRY.register_catalog_scanner(spec)
-
-
-def register_query_engine(spec: QueryEngineSpec) -> None:
-    """Register a query engine in the process-global registry."""
-    _GLOBAL_REGISTRY.register_query_engine(spec)
-
-
-def register_object_store(spec: ObjectStoreSpec) -> None:
-    """Register an object store in the process-global registry."""
-    _GLOBAL_REGISTRY.register_object_store(spec)
-
-
-def register_quality_backend(spec: QualityBackendSpec) -> None:
-    """Register a quality backend in the process-global registry."""
-    _GLOBAL_REGISTRY.register_quality_backend(spec)
-
-
-def register_maintenance_read_model(spec: MaintenanceReadModelSpec) -> None:
-    """Register a maintenance read model in the process-global registry."""
-    _GLOBAL_REGISTRY.register_maintenance_read_model(spec)
-
-
-def register_metadata_catalog(spec: MetadataCatalogSpec) -> None:
-    """Register a metadata catalog in the process-global registry."""
-    _GLOBAL_REGISTRY.register_metadata_catalog(spec)
-
-
-def register_lineage_sink(spec: LineageSinkSpec) -> None:
-    """Register a lineage sink in the process-global registry."""
-    _GLOBAL_REGISTRY.register_lineage_sink(spec)
-
-
-def register_governance_backend(spec: GovernanceBackendSpec) -> None:
-    """Register a governance backend in the process-global registry."""
-    _GLOBAL_REGISTRY.register_governance_backend(spec)
-
-
-def register_authorization_policy_backend(spec: AuthorizationPolicyBackendSpec) -> None:
-    """Register an authorization policy backend in the process-global registry."""
-    _GLOBAL_REGISTRY.register_authorization_policy_backend(spec)
-
-
-def register_authentication_provider(spec: AuthenticationProviderSpec) -> None:
-    """Register an authentication provider in the process-global registry."""
-    _GLOBAL_REGISTRY.register_authentication_provider(spec)
-
-
-def register_publish_target(spec: PublishTargetSpec) -> None:
-    """Register a publish target in the process-global registry."""
-    _GLOBAL_REGISTRY.register_publish_target(spec)
-
-
-def register_alert_sink(spec: AlertSinkSpec) -> None:
-    """Register an alert sink in the process-global registry."""
-    _GLOBAL_REGISTRY.register_alert_sink(spec)
-
-
-def register_api_backend(spec: ApiBackendSpec) -> None:
-    """Register an API backend in the process-global registry."""
-    _GLOBAL_REGISTRY.register_api_backend(spec)
-
-
-def register_secret_backend(spec: SecretBackendSpec) -> None:
-    """Register a secret backend in the process-global registry."""
-    _GLOBAL_REGISTRY.register_secret_backend(spec)
-
-
-def register_schema_migrator(spec: SchemaMigrationSpec) -> None:
-    """Register a schema migrator in the process-global registry."""
-    _GLOBAL_REGISTRY.register_schema_migrator(spec)
-
-
-def register_data_migration_source(spec: DataMigrationSourceSpec) -> None:
-    """Register a data migration source adapter in the global registry."""
-    _GLOBAL_REGISTRY.register_data_migration_source(spec)
-
-
-def register_observability_backend(spec: ObservabilityBackendSpec) -> None:
-    """Register an observability backend in the global registry."""
-    _GLOBAL_REGISTRY.register_observability_backend(spec)
-
-
-def register_regulated_surface(spec: RegulatedSurfaceSpec) -> None:
-    """Register a regulated surface in the global registry."""
-    _GLOBAL_REGISTRY.register_regulated_surface(spec)
-
-
-def list_regulated_surfaces() -> list[RegulatedSurfaceSpec]:
-    """Return a snapshot list of registered regulated surface specs."""
-    return _GLOBAL_REGISTRY.list_regulated_surfaces()
-
-
-def clear_capabilities() -> None:
-    """Clear all capability types from the global registry."""
-
-    _GLOBAL_REGISTRY.clear()
+def clear_all_capabilities() -> None:
+    """Clear every capability family from the process-global registry."""
+    _GLOBAL_REGISTRY.clear_all()

--- a/src/phlo/capabilities/resolver.py
+++ b/src/phlo/capabilities/resolver.py
@@ -17,27 +17,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_CAPABILITY_LISTERS = {
-    "table_store": "list_table_stores",
-    "catalog": "list_catalogs",
-    "catalog_scanner": "list_catalog_scanners",
-    "query_engine": "list_query_engines",
-    "object_store": "list_object_stores",
-    "quality_backend": "list_quality_backends",
-    "maintenance_read_model": "list_maintenance_read_models",
-    "metadata_catalog": "list_metadata_catalogs",
-    "lineage_sink": "list_lineage_sinks",
-    "governance_backend": "list_governance_backends",
-    "authorization_policy_backend": "list_authorization_policy_backends",
-    "authentication_provider": "list_authentication_providers",
-    "publish_target": "list_publish_targets",
-    "alert_sink": "list_alert_sinks",
-    "api_backend": "list_api_backends",
-    "secret_backend": "list_secret_backends",
-    "schema_migrator": "list_schema_migrators",
-    "observability_backend": "list_observability_backends",
-}
-
 
 @dataclass(frozen=True)
 class ResolutionResult:
@@ -57,11 +36,7 @@ def list_capabilities(
 ) -> list[str]:
     """List registered capability names for a given capability type."""
     registry = registry or get_capability_registry()
-    list_method = _CAPABILITY_LISTERS.get(capability_type)
-    if not list_method:
-        logger.debug("capability_list_unknown_type", capability_type=capability_type)
-        return []
-    specs = getattr(registry, list_method)()
+    specs = registry.list(capability_type)
     logger.debug(
         "capability_listed",
         capability_type=capability_type,
@@ -83,17 +58,9 @@ def resolve_capability(
     Otherwise return ``None`` so callers can surface deterministic guidance.
     """
     registry = registry or get_capability_registry()
-    list_method = _CAPABILITY_LISTERS.get(capability_type)
-    if not list_method:
-        logger.debug(
-            "capability_resolution_unknown_type",
-            capability_type=capability_type,
-            requested_name=name,
-        )
-        return None
 
     requested_name = name or configured_capability_name(capability_type, runtime=runtime)
-    specs = getattr(registry, list_method)()
+    specs = registry.list(capability_type)
     if requested_name is not None:
         for spec in specs:
             if spec.name == requested_name:

--- a/src/phlo/cli/commands/schema_migrate.py
+++ b/src/phlo/cli/commands/schema_migrate.py
@@ -43,7 +43,7 @@ def _resolve_migrator() -> Any:
     discover_capabilities()
 
     registry = get_capability_registry()
-    migrators = registry.list_schema_migrators()
+    migrators = registry.list("schema_migrator")
     if not migrators:
         console.print("[red]No schema migrator registered.[/red]")
         console.print(
@@ -207,7 +207,7 @@ def _collect_quality_checks(table_name: str) -> list[dict[str, Any]]:
     short_name = table_name.split(".")[-1]
     target_key = f"dlt_{short_name}"
     checks: list[dict[str, Any]] = []
-    for check in get_capability_registry().list_checks():
+    for check in get_capability_registry().list("check"):
         if check.asset_key != target_key:
             continue
         tags = dict(check.tags)
@@ -245,7 +245,7 @@ def _collect_contract_metadata(table_name: str) -> dict[str, Any]:
     consumers: list[dict[str, Any]] = []
     sla: dict[str, Any] | None = None
 
-    for asset in get_capability_registry().list_assets():
+    for asset in get_capability_registry().list("asset"):
         if asset.key != target_key:
             continue
         if asset.metadata.get("table_name") not in {short_name, table_name}:
@@ -272,7 +272,7 @@ def _collect_transform_refs(table_name: str) -> list[str]:
     short_name = table_name.split(".")[-1]
     target_key = f"dlt_{short_name}"
     refs: list[str] = []
-    for asset in get_capability_registry().list_assets():
+    for asset in get_capability_registry().list("asset"):
         kinds = asset.kinds or set()
         deps = asset.deps or []
         if "dbt" not in kinds:
@@ -347,7 +347,7 @@ def refresh_contracts_for_selection(
     if selection_value.startswith("dlt_"):
         candidate_tables.add(selection_value.removeprefix("dlt_"))
 
-    for asset in registry.list_assets():
+    for asset in registry.list("asset"):
         kinds = asset.kinds or set()
         if "dlt" not in kinds:
             continue

--- a/src/phlo/migrations/adapters.py
+++ b/src/phlo/migrations/adapters.py
@@ -98,7 +98,7 @@ def resolve_source_adapter(source_type: str) -> SourceAdapter | None:
     if adapter is not None:
         return adapter
 
-    for spec in get_capability_registry().list_data_migration_sources():
+    for spec in get_capability_registry().list("data_migration_source"):
         if spec.name != source_type:
             continue
         provider = spec.provider
@@ -110,7 +110,7 @@ def resolve_source_adapter(source_type: str) -> SourceAdapter | None:
 def list_source_adapter_types() -> list[str]:
     """List all known source adapter types."""
     adapter_types = set(_BUILTIN_ADAPTERS.keys())
-    for spec in get_capability_registry().list_data_migration_sources():
+    for spec in get_capability_registry().list("data_migration_source"):
         adapter_types.add(spec.name)
     return sorted(adapter_types)
 

--- a/src/phlo/rbac/sync.py
+++ b/src/phlo/rbac/sync.py
@@ -305,7 +305,7 @@ class SyncController:
         from phlo.rbac.compiler import get_compiler
 
         registry = get_capability_registry()
-        registered_backends = registry.list_governance_backends()
+        registered_backends = registry.list("governance_backend")
 
         backend_instance = None
         for spec in registered_backends:

--- a/src/phlo/security/validation.py
+++ b/src/phlo/security/validation.py
@@ -239,9 +239,9 @@ def _check_phlo_api_adapter(runtime: Any) -> ValidationResult:
     Per plan: phlo-api is the only required regulated surface in v1.
     Startup must fail if the adapter is missing, not installed, or inactive.
     """
-    from phlo.capabilities import list_regulated_surfaces
+    from phlo.capabilities import get_capability_registry
 
-    registered = list_regulated_surfaces()
+    registered = get_capability_registry().list("regulated_surface")
     phlo_api_spec = next((s for s in registered if s.name == "phlo-api"), None)
 
     if phlo_api_spec is None:
@@ -277,12 +277,12 @@ def _collect_adapter_taxonomy(runtime: Any) -> tuple[set[str], set[str]]:
     Returns:
         Tuple of (surface_actions, surface_resource_types) from registered adapters.
     """
-    from phlo.capabilities import list_regulated_surfaces
+    from phlo.capabilities import get_capability_registry
 
     surface_actions: set[str] = set()
     surface_resource_types: set[str] = set()
 
-    for spec in list_regulated_surfaces():
+    for spec in get_capability_registry().list("regulated_surface"):
         adapter = spec.provider
         with suppress(Exception):
             ops = adapter.list_operations()
@@ -302,9 +302,9 @@ def _check_registered_surfaces(runtime: Any) -> ValidationResult:
     For surfaces that support the runtime-aware is_active(runtime) protocol,
     passes the runtime so activation can be checked against the real framework.
     """
-    from phlo.capabilities import list_regulated_surfaces
+    from phlo.capabilities import get_capability_registry
 
-    registered = list_regulated_surfaces()
+    registered = get_capability_registry().list("regulated_surface")
     registered_names = {spec.name for spec in registered}
 
     not_yet_integrated: list[str] = []

--- a/tests/cli/test_cli_schema_migrate.py
+++ b/tests/cli/test_cli_schema_migrate.py
@@ -57,13 +57,15 @@ def test_resolve_migrator_prefers_matching_table_store_default(monkeypatch) -> N
 
     iceberg_migrator = object()
     delta_migrator = object()
+    migrators = [
+        SchemaMigrationSpec(name="delta", provider=delta_migrator),
+        SchemaMigrationSpec(name="iceberg", provider=iceberg_migrator),
+    ]
 
     class FakeRegistry:
-        def list_schema_migrators(self) -> list[SchemaMigrationSpec]:
-            return [
-                SchemaMigrationSpec(name="delta", provider=delta_migrator),
-                SchemaMigrationSpec(name="iceberg", provider=iceberg_migrator),
-            ]
+        def list(self, family: str) -> list[SchemaMigrationSpec]:
+            assert family == "schema_migrator"
+            return migrators
 
     monkeypatch.setattr(schema_migrate_commands, "get_capability_registry", lambda: FakeRegistry())
     monkeypatch.setattr(
@@ -83,13 +85,15 @@ def test_resolve_migrator_prefers_explicit_schema_migrator_default(monkeypatch) 
 
     iceberg_migrator = object()
     delta_migrator = object()
+    migrators = [
+        SchemaMigrationSpec(name="delta", provider=delta_migrator),
+        SchemaMigrationSpec(name="iceberg", provider=iceberg_migrator),
+    ]
 
     class FakeRegistry:
-        def list_schema_migrators(self) -> list[SchemaMigrationSpec]:
-            return [
-                SchemaMigrationSpec(name="delta", provider=delta_migrator),
-                SchemaMigrationSpec(name="iceberg", provider=iceberg_migrator),
-            ]
+        def list(self, family: str) -> list[SchemaMigrationSpec]:
+            assert family == "schema_migrator"
+            return migrators
 
     monkeypatch.setattr(schema_migrate_commands, "get_capability_registry", lambda: FakeRegistry())
     monkeypatch.setattr(
@@ -108,7 +112,8 @@ def test_resolve_migrator_fails_when_configured_schema_migrator_missing(monkeypa
     """Missing explicit schema_migrator config errors deterministically."""
 
     class FakeRegistry:
-        def list_schema_migrators(self) -> list[SchemaMigrationSpec]:
+        def list(self, family: str) -> list[SchemaMigrationSpec]:
+            assert family == "schema_migrator"
             return [SchemaMigrationSpec(name="iceberg", provider=object())]
 
     monkeypatch.setattr(schema_migrate_commands, "get_capability_registry", lambda: FakeRegistry())
@@ -134,7 +139,8 @@ def test_resolve_migrator_fails_when_multiple_installed_without_selection(monkey
     """Ambiguous schema migrators require config instead of first-provider fallback."""
 
     class FakeRegistry:
-        def list_schema_migrators(self) -> list[SchemaMigrationSpec]:
+        def list(self, family: str) -> list[SchemaMigrationSpec]:
+            assert family == "schema_migrator"
             return [
                 SchemaMigrationSpec(name="delta", provider=object()),
                 SchemaMigrationSpec(name="iceberg", provider=object()),
@@ -165,7 +171,8 @@ def test_resolve_migrator_reports_table_store_mismatch_when_ambiguous(monkeypatc
     """Ambiguous error explains when configured table_store did not match any migrator."""
 
     class FakeRegistry:
-        def list_schema_migrators(self) -> list[SchemaMigrationSpec]:
+        def list(self, family: str) -> list[SchemaMigrationSpec]:
+            assert family == "schema_migrator"
             return [
                 SchemaMigrationSpec(name="delta", provider=object()),
                 SchemaMigrationSpec(name="iceberg", provider=object()),
@@ -501,7 +508,9 @@ def test_collect_quality_checks_parses_contract_tags(monkeypatch) -> None:
     """Quality check payload includes parsed owner/consumers/sla from tags."""
 
     class FakeRegistry:
-        def list_checks(self):
+        def list(self, family: str):
+            assert family == "check"
+
             class Check:
                 asset_key = "dlt_contract_demo"
                 name = "quality_contract_demo"
@@ -528,7 +537,9 @@ def test_collect_contract_metadata_filters_matching_asset(monkeypatch) -> None:
     """Contract metadata should be sourced from the matching asset only."""
 
     class FakeRegistry:
-        def list_assets(self):
+        def list(self, family: str):
+            assert family == "asset"
+
             class OtherAsset:
                 key = "dlt_other"
                 metadata = {
@@ -565,7 +576,9 @@ def test_collect_transform_refs_filters_and_deduplicates(monkeypatch) -> None:
     """Only dbt assets that depend on the target table should be returned."""
 
     class FakeRegistry:
-        def list_assets(self):
+        def list(self, family: str):
+            assert family == "asset"
+
             class MatchingByKey:
                 key = "transform_a"
                 kinds = {"dbt"}
@@ -645,7 +658,8 @@ def test_refresh_contracts_skips_missing_tables_without_warning(monkeypatch) -> 
         metadata = {"table_name": "raw.orders"}
 
     class FakeRegistry:
-        def list_assets(self) -> list[FakeAsset]:
+        def list(self, family: str) -> list[FakeAsset]:
+            assert family == "asset"
             return [FakeAsset()]
 
     logger = FakeLogger()

--- a/tests/data/test_migration_adapters.py
+++ b/tests/data/test_migration_adapters.py
@@ -78,7 +78,8 @@ class TestCsvSourceAdapter:
 
 
 class _FakeRegistry:
-    def list_data_migration_sources(self) -> list:
+    def list(self, family: str):
+        assert family == "data_migration_source"
         return []
 
 

--- a/tests/data/test_schema_migration.py
+++ b/tests/data/test_schema_migration.py
@@ -12,9 +12,9 @@ from phlo.capabilities import (
     SchemaMigrationPlan,
     SchemaMigrationSpec,
     SchemaMigrator,
-    clear_capabilities,
+    clear_all_capabilities,
     get_capability_registry,
-    register_schema_migrator,
+    register_capability,
 )
 from phlo.capabilities.schema import (
     default_classify_change,
@@ -172,16 +172,16 @@ class TestWorstClassification:
 class TestSchemaMigrationRegistry:
     def test_register_and_list(self) -> None:
         spec = SchemaMigrationSpec(name="iceberg", provider=object())
-        register_schema_migrator(spec)
+        register_capability("schema_migrator", spec)
 
         registry = get_capability_registry()
-        migrators = registry.list_schema_migrators()
+        migrators = registry.list("schema_migrator")
         assert any(m.name == "iceberg" for m in migrators)
 
     def test_clear(self) -> None:
-        register_schema_migrator(SchemaMigrationSpec(name="delta", provider=object()))
-        clear_capabilities()
-        assert get_capability_registry().list_schema_migrators() == []
+        register_capability("schema_migrator", SchemaMigrationSpec(name="delta", provider=object()))
+        clear_all_capabilities()
+        assert get_capability_registry().list("schema_migrator") == []
 
 
 # -- Protocol structural checks --

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,13 +9,13 @@ from phlo.plugins.discovery import ServiceDefinition
 
 def reset_capability_test_state() -> None:
     """Clear global capability and config caches between stateful tests."""
-    from phlo.capabilities import clear_capabilities
+    from phlo.capabilities import clear_all_capabilities
     from phlo.config import _get_config
     from phlo.infrastructure import clear_config_cache
 
     _get_config.cache_clear()
     clear_config_cache()
-    clear_capabilities()
+    clear_all_capabilities()
 
 
 def _service(

--- a/tests/integration/regulated_surface/test_discovery_and_enforcement.py
+++ b/tests/integration/regulated_surface/test_discovery_and_enforcement.py
@@ -19,7 +19,8 @@ import yaml
 
 from phlo.capabilities import (
     RegulatedSurfaceSpec,
-    register_regulated_surface,
+    get_capability_registry,
+    register_capability,
 )
 from phlo.capabilities.interfaces import (
     AuthPrincipal,
@@ -75,11 +76,9 @@ class TestRegulatedSurfaceDiscovery:
             provider=MockRegulatedSurfaceAdapter(),
             metadata={},
         )
-        register_regulated_surface(spec)
+        register_capability("regulated_surface", spec)
 
-        from phlo.capabilities import list_regulated_surfaces
-
-        surfaces = list_regulated_surfaces()
+        surfaces = get_capability_registry().list("regulated_surface")
         assert len(surfaces) >= 1
         assert any(s.name == "test-surface" for s in surfaces)
 
@@ -90,11 +89,9 @@ class TestRegulatedSurfaceDiscovery:
             provider=MockRegulatedSurfaceAdapter(),
             metadata={"test": True},
         )
-        register_regulated_surface(spec)
+        register_capability("regulated_surface", spec)
 
-        from phlo.capabilities import list_regulated_surfaces
-
-        surfaces = list_regulated_surfaces()
+        surfaces = get_capability_registry().list("regulated_surface")
         test_surface = next((s for s in surfaces if s.name == "integration-test-surface"), None)
         assert test_surface is not None
         assert test_surface.metadata.get("test") is True

--- a/tests/plugins/test_capabilities_runtime.py
+++ b/tests/plugins/test_capabilities_runtime.py
@@ -17,14 +17,7 @@ from phlo.capabilities import (
     get_capability_registry,
     list_capabilities,
     missing_required_capabilities,
-    register_catalog,
-    register_lineage_sink,
-    register_metadata_catalog,
-    register_observability_backend,
-    register_publish_target,
-    register_query_engine,
-    register_schema_migrator,
-    register_table_store,
+    register_capability,
     resolve_capability,
     resolve_runtime_ref,
     routing_from_context,
@@ -44,22 +37,22 @@ def teardown_function() -> None:
 
 
 def test_registry_tracks_new_platform_capability_types() -> None:
-    register_table_store(TableStoreSpec(name="iceberg", provider=object()))
-    register_catalog(CatalogSpec(name="nessie", provider=object()))
-    register_query_engine(QueryEngineSpec(name="trino", provider=object()))
-    register_schema_migrator(SchemaMigrationSpec(name="iceberg", provider=object()))
-    register_publish_target(PublishTargetSpec(name="postgres", provider=object()))
+    register_capability("table_store", TableStoreSpec(name="iceberg", provider=object()))
+    register_capability("catalog", CatalogSpec(name="nessie", provider=object()))
+    register_capability("query_engine", QueryEngineSpec(name="trino", provider=object()))
+    register_capability("schema_migrator", SchemaMigrationSpec(name="iceberg", provider=object()))
+    register_capability("publish_target", PublishTargetSpec(name="postgres", provider=object()))
 
     registry = get_capability_registry()
 
     def names(specs):
         return {spec.name for spec in specs}
 
-    assert "iceberg" in names(registry.list_table_stores())
-    assert "nessie" in names(registry.list_catalogs())
-    assert "trino" in names(registry.list_query_engines())
-    assert "iceberg" in names(registry.list_schema_migrators())
-    assert "postgres" in names(registry.list_publish_targets())
+    assert "iceberg" in names(registry.list("table_store"))
+    assert "nessie" in names(registry.list("catalog"))
+    assert "trino" in names(registry.list("query_engine"))
+    assert "iceberg" in names(registry.list("schema_migrator"))
+    assert "postgres" in names(registry.list("publish_target"))
 
 
 def test_registry_tracks_ui_contributions() -> None:
@@ -70,19 +63,22 @@ def test_registry_tracks_ui_contributions() -> None:
         capability_name="trino",
         surfaces=["data", "observability"],
     )
-    registry.register_ui_contribution(spec)
-    assert registry.list_ui_contributions() == [spec]
+    registry.register("ui_contribution", spec)
+    assert registry.list("ui_contribution") == [spec]
 
 
 def test_resolve_capability_prefers_explicit_name() -> None:
-    register_query_engine(
+    register_capability(
+        "query_engine",
         QueryEngineSpec(
             name="trino",
             provider={"engine": "trino"},
             support=CapabilitySupport(supports_refs=True),
-        )
+        ),
     )
-    register_query_engine(QueryEngineSpec(name="duckdb", provider={"engine": "duckdb"}))
+    register_capability(
+        "query_engine", QueryEngineSpec(name="duckdb", provider={"engine": "duckdb"})
+    )
 
     resolved = resolve_capability("query_engine", "duckdb")
     assert resolved is not None
@@ -92,7 +88,8 @@ def test_resolve_capability_prefers_explicit_name() -> None:
 
 
 def test_resolve_capability_returns_support_metadata() -> None:
-    register_table_store(
+    register_capability(
+        "table_store",
         TableStoreSpec(
             name="iceberg",
             provider=object(),
@@ -101,7 +98,7 @@ def test_resolve_capability_returns_support_metadata() -> None:
                 supports_schema_evolution=True,
                 supports_time_travel=True,
             ),
-        )
+        ),
     )
 
     resolved = resolve_capability("table_store", "iceberg")
@@ -112,7 +109,7 @@ def test_resolve_capability_returns_support_metadata() -> None:
 
 
 def test_missing_required_capabilities_reports_unsatisfied_requirements() -> None:
-    register_catalog(CatalogSpec(name="nessie", provider=object()))
+    register_capability("catalog", CatalogSpec(name="nessie", provider=object()))
 
     plugin = PluginMetadata(
         name="test_plugin",
@@ -124,36 +121,38 @@ def test_missing_required_capabilities_reports_unsatisfied_requirements() -> Non
 
 
 def test_list_capabilities_returns_registered_names() -> None:
-    register_table_store(TableStoreSpec(name="iceberg", provider=object()))
-    register_table_store(TableStoreSpec(name="delta", provider=object()))
+    register_capability("table_store", TableStoreSpec(name="iceberg", provider=object()))
+    register_capability("table_store", TableStoreSpec(name="delta", provider=object()))
 
     assert sorted(list_capabilities("table_store")) == ["delta", "iceberg"]
 
 
 def test_list_capabilities_returns_schema_migrators() -> None:
-    register_schema_migrator(SchemaMigrationSpec(name="iceberg", provider=object()))
+    register_capability("schema_migrator", SchemaMigrationSpec(name="iceberg", provider=object()))
 
     assert list_capabilities("schema_migrator") == ["iceberg"]
 
 
 def test_list_capabilities_returns_publish_targets() -> None:
-    register_publish_target(PublishTargetSpec(name="postgres", provider=object()))
+    register_capability("publish_target", PublishTargetSpec(name="postgres", provider=object()))
 
     assert list_capabilities("publish_target") == ["postgres"]
 
 
 def test_registry_tracks_api_backends() -> None:
-    from phlo.capabilities import register_api_backend
-
-    register_api_backend(ApiBackendSpec(name="hasura", provider=object()))
+    register_capability("api_backend", ApiBackendSpec(name="hasura", provider=object()))
 
     registry = get_capability_registry()
-    assert [spec.name for spec in registry.list_api_backends()] == ["hasura"]
+    assert [spec.name for spec in registry.list("api_backend")] == ["hasura"]
 
 
 def test_resolve_metadata_and_lineage_capabilities() -> None:
-    register_metadata_catalog(MetadataCatalogSpec(name="openmetadata", provider={"catalog": True}))
-    register_lineage_sink(LineageSinkSpec(name="phlo-lineage", provider={"lineage": True}))
+    register_capability(
+        "metadata_catalog", MetadataCatalogSpec(name="openmetadata", provider={"catalog": True})
+    )
+    register_capability(
+        "lineage_sink", LineageSinkSpec(name="phlo-lineage", provider={"lineage": True})
+    )
 
     metadata = resolve_capability("metadata_catalog", "openmetadata")
     lineage = resolve_capability("lineage_sink", "phlo-lineage")
@@ -206,8 +205,10 @@ def test_routing_from_context_reads_canonical_tags() -> None:
 def test_resolve_capability_uses_global_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("PHLO_DEFAULT_CAPABILITIES", '{"table_store":"delta"}')
     _get_config.cache_clear()
-    register_table_store(TableStoreSpec(name="iceberg", provider={"engine": "iceberg"}))
-    register_table_store(TableStoreSpec(name="delta", provider={"engine": "delta"}))
+    register_capability(
+        "table_store", TableStoreSpec(name="iceberg", provider={"engine": "iceberg"})
+    )
+    register_capability("table_store", TableStoreSpec(name="delta", provider={"engine": "delta"}))
 
     resolved = resolve_capability("table_store")
 
@@ -224,8 +225,10 @@ def test_resolve_capability_uses_phlo_yaml_default(
         "capabilities:\n  defaults:\n    table_store: iceberg\n",
         encoding="utf-8",
     )
-    register_table_store(TableStoreSpec(name="iceberg", provider={"engine": "iceberg"}))
-    register_table_store(TableStoreSpec(name="delta", provider={"engine": "delta"}))
+    register_capability(
+        "table_store", TableStoreSpec(name="iceberg", provider={"engine": "iceberg"})
+    )
+    register_capability("table_store", TableStoreSpec(name="delta", provider={"engine": "delta"}))
 
     resolved = resolve_capability("table_store")
 
@@ -241,8 +244,10 @@ def test_env_default_overrides_phlo_yaml_default(tmp_path, monkeypatch: pytest.M
     )
     monkeypatch.setenv("PHLO_DEFAULT_CAPABILITIES", '{"table_store":"delta"}')
     _get_config.cache_clear()
-    register_table_store(TableStoreSpec(name="iceberg", provider={"engine": "iceberg"}))
-    register_table_store(TableStoreSpec(name="delta", provider={"engine": "delta"}))
+    register_capability(
+        "table_store", TableStoreSpec(name="iceberg", provider={"engine": "iceberg"})
+    )
+    register_capability("table_store", TableStoreSpec(name="delta", provider={"engine": "delta"}))
 
     resolved = resolve_capability("table_store")
 
@@ -251,8 +256,10 @@ def test_env_default_overrides_phlo_yaml_default(tmp_path, monkeypatch: pytest.M
 
 
 def test_resolve_capability_uses_runtime_override_over_global_default() -> None:
-    register_table_store(TableStoreSpec(name="iceberg", provider={"engine": "iceberg"}))
-    register_table_store(TableStoreSpec(name="delta", provider={"engine": "delta"}))
+    register_capability(
+        "table_store", TableStoreSpec(name="iceberg", provider={"engine": "iceberg"})
+    )
+    register_capability("table_store", TableStoreSpec(name="delta", provider={"engine": "delta"}))
 
     runtime = type(
         "StubRuntime",
@@ -352,10 +359,12 @@ def test_resolve_runtime_ref_ignores_ref_for_non_versioned_capability() -> None:
 def test_registry_tracks_observability_backend_capability() -> None:
     """Observability backend capability should be registrable and listable."""
     mock_backend = object()
-    register_observability_backend(ObservabilityBackendSpec(name="default", provider=mock_backend))
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="default", provider=mock_backend)
+    )
 
     registry = get_capability_registry()
-    specs = registry.list_observability_backends()
+    specs = registry.list("observability_backend")
 
     assert len(specs) == 1
     assert specs[0].name == "default"
@@ -365,7 +374,9 @@ def test_registry_tracks_observability_backend_capability() -> None:
 def test_resolve_observability_backend_capability() -> None:
     """Should be able to resolve observability backend capability by name."""
     mock_backend = object()
-    register_observability_backend(ObservabilityBackendSpec(name="default", provider=mock_backend))
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="default", provider=mock_backend)
+    )
 
     resolved = resolve_capability("observability_backend", "default")
 
@@ -377,8 +388,12 @@ def test_resolve_observability_backend_capability() -> None:
 def test_list_observability_backend_capabilities() -> None:
     """list_capabilities should return observability backend names."""
     mock_backend = object()
-    register_observability_backend(ObservabilityBackendSpec(name="default", provider=mock_backend))
-    register_observability_backend(ObservabilityBackendSpec(name="custom", provider=object()))
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="default", provider=mock_backend)
+    )
+    register_capability(
+        "observability_backend", ObservabilityBackendSpec(name="custom", provider=object())
+    )
 
     names = list_capabilities("observability_backend")
 
@@ -388,7 +403,8 @@ def test_list_observability_backend_capabilities() -> None:
 
 def test_observability_support_flags_round_trip() -> None:
     """Observability support flags should survive resolution."""
-    register_observability_backend(
+    register_capability(
+        "observability_backend",
         ObservabilityBackendSpec(
             name="default",
             provider=object(),
@@ -398,7 +414,7 @@ def test_observability_support_flags_round_trip() -> None:
                 supports_dashboards=True,
                 supports_alerts=True,
             ),
-        )
+        ),
     )
 
     resolved = resolve_capability("observability_backend", "default")

--- a/tests/plugins/test_capability_catalog.py
+++ b/tests/plugins/test_capability_catalog.py
@@ -50,13 +50,13 @@ def test_registry_core_families_keep_existing_interface() -> None:
     check = AssetCheckSpec(asset_key="raw.events", name="freshness", fn=lambda _ctx: None)
     resource = ResourceSpec(name="trino", resource=object())
 
-    registry.register_asset(asset)
-    registry.register_check(check)
-    registry.register_resource(resource)
+    registry.register("asset", asset)
+    registry.register("check", check)
+    registry.register("resource", resource)
 
-    assert registry.list_assets() == [asset]
-    assert registry.list_checks() == [check]
-    assert registry.list_resources() == [resource]
+    assert registry.list("asset") == [asset]
+    assert registry.list("check") == [check]
+    assert registry.list("resource") == [resource]
 
 
 def test_named_family_uses_spec_name() -> None:
@@ -72,8 +72,8 @@ def test_registry_named_provider_families_keep_existing_interface() -> None:
     table_store = TableStoreSpec(name="iceberg", provider=object())
     query_engine = QueryEngineSpec(name="trino", provider=object())
 
-    registry.register_table_store(table_store)
-    registry.register_query_engine(query_engine)
+    registry.register("table_store", table_store)
+    registry.register("query_engine", query_engine)
 
-    assert registry.list_table_stores() == [table_store]
-    assert registry.list_query_engines() == [query_engine]
+    assert registry.list("table_store") == [table_store]
+    assert registry.list("query_engine") == [query_engine]

--- a/tests/plugins/test_default_capabilities.py
+++ b/tests/plugins/test_default_capabilities.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from phlo.capabilities import (
     DefaultMaintenanceReadModel,
     DefaultObservabilityBackend,
-    clear_capabilities,
+    clear_all_capabilities,
     get_capability_registry,
 )
 from phlo.capabilities.authorization import DefaultAuthorizationPolicyBackend
@@ -31,12 +31,12 @@ class _Snapshot:
 
 
 def test_discover_capabilities_registers_core_default_providers() -> None:
-    clear_capabilities()
+    clear_all_capabilities()
     discover_capabilities()
     registry = get_capability_registry()
-    authorization_specs = registry.list_authorization_policy_backends()
-    maintenance_specs = registry.list_maintenance_read_models()
-    observability_specs = registry.list_observability_backends()
+    authorization_specs = registry.list("authorization_policy_backend")
+    maintenance_specs = registry.list("maintenance_read_model")
+    observability_specs = registry.list("observability_backend")
     assert authorization_specs == []
     assert [spec.name for spec in maintenance_specs] == ["default"]
     assert isinstance(maintenance_specs[0].provider, DefaultMaintenanceReadModel)

--- a/tests/security/test_authentication_provider.py
+++ b/tests/security/test_authentication_provider.py
@@ -11,7 +11,7 @@ import pytest
 
 from phlo.capabilities import (
     RequestContext,
-    clear_capabilities,
+    clear_all_capabilities,
 )
 from phlo.capabilities.authentication import (
     JWTAuthenticationProvider,
@@ -27,10 +27,10 @@ from phlo.infrastructure.config import clear_config_cache
 @pytest.fixture(autouse=True)
 def clear_auth_providers():
     """Clear auth providers before and after each test."""
-    clear_capabilities()
+    clear_all_capabilities()
     clear_config_cache()
     yield
-    clear_capabilities()
+    clear_all_capabilities()
     clear_config_cache()
 
 
@@ -721,10 +721,10 @@ class TestAuthenticationProviderRegistration:
     def test_register_default_providers_explicit_env(self):
         """Test providers are registered when explicitly enabled via env."""
         with patch.dict(os.environ, {"PHLO_AUTH_STATIC_ENABLED": "true"}):
-            clear_capabilities()
+            clear_all_capabilities()
             register_default_capability_providers()
             registry = get_capability_registry()
-            providers = registry.list_authentication_providers()
+            providers = registry.list("authentication_provider")
             assert len(providers) == 1
             assert providers[0].name == "static"
 
@@ -737,10 +737,10 @@ class TestAuthenticationProviderRegistration:
             "PHLO_AUTH_DEV_MODE",
         ]
         with patch.dict(os.environ, dict.fromkeys(env_to_clear, ""), clear=True):
-            clear_capabilities()
+            clear_all_capabilities()
             register_default_capability_providers()
             registry = get_capability_registry()
-            providers = registry.list_authentication_providers()
+            providers = registry.list("authentication_provider")
             assert len(providers) == 0
 
     def test_register_proxy_provider_loads_shared_secret_from_environment(self):
@@ -756,10 +756,10 @@ class TestAuthenticationProviderRegistration:
             },
             clear=True,
         ):
-            clear_capabilities()
+            clear_all_capabilities()
             register_default_capability_providers()
             registry = get_capability_registry()
-            providers = registry.list_authentication_providers()
+            providers = registry.list("authentication_provider")
 
             assert len(providers) == 1
             assert providers[0].name == "proxy"
@@ -792,7 +792,7 @@ authentication:
 
         register_default_capability_providers()
         registry = get_capability_registry()
-        providers = registry.list_authentication_providers()
+        providers = registry.list("authentication_provider")
 
         assert len(providers) == 1
         assert providers[0].name == "proxy"
@@ -819,7 +819,7 @@ authentication:
 
         register_default_capability_providers()
         registry = get_capability_registry()
-        providers = registry.list_authentication_providers()
+        providers = registry.list("authentication_provider")
 
         assert len(providers) == 1
         provider = providers[0].provider
@@ -839,10 +839,10 @@ class TestProviderSelection:
                 "PHLO_AUTH_PROXY_ENABLED": "true",
             },
         ):
-            clear_capabilities()
+            clear_all_capabilities()
             register_default_capability_providers()
             registry = get_capability_registry()
-            providers = registry.list_authentication_providers()
+            providers = registry.list("authentication_provider")
             assert len(providers) == 2
             names = {p.name for p in providers}
             assert "static" in names

--- a/tests/security/test_authorization_policy_backend.py
+++ b/tests/security/test_authorization_policy_backend.py
@@ -10,7 +10,7 @@ from phlo.capabilities import (
     ResourceRef,
     get_capability_registry,
     list_capabilities,
-    register_authorization_policy_backend,
+    register_capability,
     resolve_capability,
 )
 from phlo.capabilities.authorization import DefaultAuthorizationPolicyBackend
@@ -26,15 +26,16 @@ def teardown_function() -> None:
 
 def test_registry_tracks_authorization_policy_backends() -> None:
     backend = DefaultAuthorizationPolicyBackend()
-    register_authorization_policy_backend(
+    register_capability(
+        "authorization_policy_backend",
         AuthorizationPolicyBackendSpec(
             name="default",
             provider=backend,
-        )
+        ),
     )
 
     registry = get_capability_registry()
-    backends = registry.list_authorization_policy_backends()
+    backends = registry.list("authorization_policy_backend")
 
     assert len(backends) == 1
     assert backends[0].name == "default"
@@ -42,11 +43,12 @@ def test_registry_tracks_authorization_policy_backends() -> None:
 
 
 def test_list_authorization_policy_backends() -> None:
-    register_authorization_policy_backend(
+    register_capability(
+        "authorization_policy_backend",
         AuthorizationPolicyBackendSpec(
             name="rbac",
             provider=DefaultAuthorizationPolicyBackend(),
-        )
+        ),
     )
 
     names = list_capabilities("authorization_policy_backend")
@@ -55,11 +57,12 @@ def test_list_authorization_policy_backends() -> None:
 
 def test_resolve_authorization_policy_backend() -> None:
     backend = DefaultAuthorizationPolicyBackend()
-    register_authorization_policy_backend(
+    register_capability(
+        "authorization_policy_backend",
         AuthorizationPolicyBackendSpec(
             name="rbac",
             provider=backend,
-        )
+        ),
     )
 
     resolved = resolve_capability("authorization_policy_backend", "rbac")


### PR DESCRIPTION
## Summary
- Replace family-specific capability registry APIs with generic register/list/clear operations keyed by canonical singular family names.
- Move family metadata into first-class definitions and use it for provider discovery and Observatory/API consumers.
- Remove legacy capability exports and update downstream packages/tests to use the generic registry surface.

## Verification
- uv run ruff check src/phlo/capabilities packages/phlo-api/src/phlo_api/main.py packages/phlo-api/src/phlo_api/observatory_api/v2.py packages/phlo-api/src/phlo_api/observatory_api/v2_capabilities.py packages/phlo-api/src/phlo_api/observatory_api/v2_actions.py packages/phlo-api/src/phlo_api/regulated_surface_adapter.py packages/phlo-dagster/src/phlo_dagster/adapter.py packages/phlo-dagster/src/phlo_dagster/framework/discovery.py packages/phlo-dagster/src/phlo_dagster/authorization.py packages/phlo-pandera/src/phlo_pandera/decorator.py --fix
- uv run ty check src/phlo/capabilities packages/phlo-api/src/phlo_api/main.py packages/phlo-api/src/phlo_api/observatory_api/v2.py packages/phlo-api/src/phlo_api/observatory_api/v2_capabilities.py packages/phlo-api/src/phlo_api/observatory_api/v2_actions.py packages/phlo-api/src/phlo_api/regulated_surface_adapter.py packages/phlo-dagster/src/phlo_dagster/adapter.py packages/phlo-dagster/src/phlo_dagster/framework/discovery.py packages/phlo-dagster/src/phlo_dagster/authorization.py packages/phlo-pandera/src/phlo_pandera/decorator.py
- uv run pytest tests/plugins/test_capability_catalog.py tests/plugins/test_capabilities_runtime.py tests/plugins/test_default_capabilities.py tests/data/test_schema_migration.py tests/security/test_authorization_policy_backend.py tests/security/test_authentication_provider.py tests/integration/regulated_surface/test_discovery_and_enforcement.py packages/phlo-api/tests/test_maintenance_api.py packages/phlo-api/tests/test_observability_api.py packages/phlo-api/tests/test_authentication_api.py packages/phlo-api/tests/test_authorization_api.py packages/phlo-api/tests/test_observatory_v2_actions.py packages/phlo-api/tests/test_observatory_v2_api.py packages/phlo-api/tests/test_observatory_v2_capabilities.py packages/phlo-api/tests/test_api_backend_endpoints.py packages/phlo-openmetadata/tests/test_openmetadata_resource_provider.py -q
- git diff --check