### PR TITLE
feat: decouple agent workflow capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+- phlo, phlo-api, phlo-dagster, phlo-mcp: complete agent-first CLI and MCP operate loop with scoped mutations, authoring tools, introspection, JSON envelopes, audit logs, pagination, and live Dagster operations.
+
 ## [phlo 0.10.0 + 7 packages] - 2026-05-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Added
-- phlo, phlo-api, phlo-dagster, phlo-mcp: complete agent-first CLI and MCP operate loop with scoped mutations, authoring tools, introspection, JSON envelopes, audit logs, pagination, and live Dagster operations.
+- phlo, phlo-api, phlo-dagster, phlo-dlt, phlo-mcp, phlo-sling: complete agent-first CLI and MCP operate loop with scoped mutations, authoring tools, introspection, JSON envelopes, audit logs, pagination, and live Dagster operations.
 
 ## [phlo 0.10.0 + 7 packages] - 2026-05-18
 

--- a/docs/packages/phlo-mcp.md
+++ b/docs/packages/phlo-mcp.md
@@ -40,7 +40,7 @@ Optional guarded operational tools:
 
 - `materialize_asset`
 - `retry_failed_run`
-- `get_dagster_run_status`
+- `get_run_status`
 
 These tools call `phlo-api` endpoints and return structured JSON results.
 

--- a/docs/plans/2026-05-28-001-agent-first-cli-and-mcp.md
+++ b/docs/plans/2026-05-28-001-agent-first-cli-and-mcp.md
@@ -1,0 +1,870 @@
+---
+title: "feat: Agent-first Phlo CLI and MCP"
+type: plan
+status: completed
+date: 2026-05-28
+origin: thread/T-019e7082-9716-74d5-950b-07d6ef3e8575
+supersedes: []
+related:
+  - docs/plans/2026-04-25-002-phlo-mcp-operational-tools.md
+  - docs/plans/2026-04-25-003-phlo-mcp-trace-filtering.md
+  - docs/plans/2026-04-25-004-phlo-mcp-resources.md
+  - docs/plans/2026-04-25-005-phlo-mcp-e2e-smoke.md
+  - docs/plans/2026-04-26-001-phlo-doctor.md
+  - docs/plans/2026-04-26-002-authoring-path-polish.md
+---
+
+# Agent-first Phlo CLI and MCP
+
+## Overview
+
+Make `phlo` (CLI) and `phlo-mcp` (MCP server) the best-in-class surface for
+coding agents to author workflows, inspect runs, diagnose failures, and operate
+the lakehouse — safely.
+
+The MCP server today is read-strong but operate-weak: agents can inspect almost
+everything but cannot complete an end-to-end author → validate → materialize →
+inspect → retry loop without a human. The CLI is broad but only one command
+(`phlo doctor`) speaks JSON; agents shelling out get prose.
+
+This plan closes the loop in four phases. Phases are sequenced so each phase is
+shippable on its own and each later phase composes on earlier ones.
+
+## Goals
+
+1. An agent connected to Phlo via MCP can complete the full lifecycle of a
+   lakehouse asset — scaffold, validate, materialize, inspect a run, diagnose
+   a failure, retry — without shelling out or asking a human to run commands.
+2. Every CLI command an agent might invoke supports `--json` with a stable,
+   documented envelope.
+3. Every MCP tool advertises a typed input and output schema so MCP clients can
+   validate calls before sending them.
+4. Mutations are safe by default: scoped tokens, dry-run defaults, idempotency
+   keys, audit logs.
+5. New `phlo init` projects ship with an `AGENTS.md` that teaches agents which
+   tools to prefer for which task.
+
+## Non-goals
+
+- Building a "do-everything" agent. Phlo provides the surface; clients (Claude
+  Code, Amp, Cursor, custom orchestrators) bring the agent.
+- Replacing Dagster's GraphQL API. `phlo-api` remains the only thing MCP talks
+  to; we do not let MCP reach Dagster, Loki, or ClickStack directly.
+- Multi-tenant SaaS. Single-project, single-stack assumptions hold.
+
+## Current state (May 2026)
+
+Strengths (keep):
+
+- 15 read MCP tools + 10 deterministic resources (see
+  [phlo-mcp README](../../packages/phlo-mcp/README.md))
+- OTEL tracing on every tool invocation
+- Trace-tree text renderers (`render_*_trace_tree`)
+- Write-tool gate (`PHLO_MCP_ENABLE_WRITE_TOOLS` + bearer token, default
+  `dry_run=true`, structured `audit_context`)
+- Live-stack smoke harness ([smoke_stack.py](../../packages/phlo-mcp/tests/smoke_stack.py))
+- Stdio + streamable-HTTP transports
+
+Gaps (close):
+
+| # | Gap | Closed in phase |
+|---|---|---|
+| G1 | `materialize_asset` / `retry_failed_run` are dry-run stubs | 1 |
+| G2 | No MCP tool for workflow authoring | 2 |
+| G3 | No MCP `validate_workflow` / `validate_schema` / `lint_project` | 2 |
+| G4 | No MCP `run_doctor` mirroring `phlo doctor --json` | 2 |
+| G5 | No `backfill_asset` / `cancel_run` / `partition_status` | 1 |
+| G6 | No `list_workflows` / `search_assets` / `search_contracts` | 2 |
+| G7 | Tools return `dict[str, Any]` with no JSON Schema | 3 |
+| G8 | No pagination cursors | 3 |
+| G9 | No log search / regex / text filter | 3 |
+| G10 | No `@mcp.prompt` definitions | 1 |
+| G11 | `--json` not universal across CLI | 4 |
+| G12 | No CLI / MCP introspection resources | 3 |
+| G13 | HTTP errors surface raw `httpx` exceptions | 3 |
+| G14 | No streaming / follow for run logs over MCP | 3 |
+| G15 | `phlo-mcp` not surfaced under `phlo mcp …` | 4 |
+| G16 | No `AGENTS.md` template in starters | 4 |
+| G17 | Plugin lifecycle not on MCP | 4 |
+| G18 | No schema-diff MCP tool | 3 |
+| G19 | No quality-results MCP tool | 3 |
+| G20 | No lineage-graph MCP tool | 3 |
+
+## Phases
+
+### Phase 1 — Close the operate loop
+
+> Goal: an agent that can already inspect a run can also cause new runs, retry
+> failed ones, cancel runaway ones, and backfill partitions — safely.
+
+This is the biggest blocker today; the README of `phlo-mcp` says outright:
+*"live Dagster launch and retry are intentionally not implemented yet."*
+
+#### 1.1 Implement live Dagster launch/retry in `phlo-api`
+
+- `packages/phlo-api/src/phlo_api/api/operations.py` (new):
+  - `POST /api/observatory/v2/assets/{asset_key_path}/materialize`
+    - Body: `{ dry_run: bool, partition_key: str | None, partition_range: {start,end} | None, idempotency_key: str | None, tags: dict[str,str] | None }`
+    - When `dry_run=true`: validate that asset exists, partition is valid, user
+      is authorised; return the launch plan without launching.
+    - When `dry_run=false`: call Dagster GraphQL `launchPipelineExecution`
+      (or asset-graph equivalent) via existing `phlo-dagster` capability.
+    - Response: `{ run_id, status, launch_plan, idempotency_key }`.
+  - `POST /api/observatory/v2/runs/{run_id}/retry`
+    - Body: `{ dry_run: bool, strategy: "from_failure" | "full", idempotency_key }`
+    - Calls Dagster `launchRunReexecution` with the right policy.
+  - `POST /api/observatory/v2/runs/{run_id}/cancel`
+    - Body: `{ reason: str | None }`
+    - Calls Dagster `terminateRun`.
+  - `POST /api/observatory/v2/assets/{asset_key_path}/backfill`
+    - Body: `{ dry_run, partitions: [str] | partition_range, idempotency_key, tags }`
+    - Calls Dagster `launchPartitionBackfill`.
+  - `GET /api/observatory/v2/assets/{asset_key_path}/partitions`
+    - Lists partition keys + materialization status for each.
+
+- Capability contract: extend
+  [`phlo-dagster`](../../packages/phlo-dagster/) capability with
+  `launch_materialize`, `launch_retry`, `terminate`, `launch_backfill`,
+  `list_partitions`. Keep all Dagster GraphQL access inside the capability.
+
+- Idempotency: persist `(idempotency_key, operation, target)` in
+  `.phlo/state/operations.sqlite` for a configurable retention window; replays
+  return the original `run_id`.
+
+- Authorisation: every mutation route requires the existing
+  bearer-token + capability scope check (see plan
+  [2026-04-25-001-phlo-mcp-api-auth.md](2026-04-25-001-phlo-mcp-api-auth.md)).
+  Add a new scope `lakehouse:operate` distinct from `lakehouse:read`.
+
+#### 1.2 Wire MCP write tools end-to-end
+
+- `packages/phlo-mcp/src/phlo_mcp/api_client.py`:
+  - Implement `materialize_asset`, `retry_run`, `cancel_run`, `backfill_asset`,
+    `list_partitions` as real calls (not stubs).
+- `packages/phlo-mcp/src/phlo_mcp/server.py`:
+  - Replace stub `materialize_asset` and `retry_failed_run` bodies with real
+    calls; keep `dry_run=true` default; keep `audit_context`.
+  - Add new guarded tools: `cancel_run`, `backfill_asset`, `list_partitions`.
+- `packages/phlo-mcp/tests/test_phlo_mcp.py`: dry-run and live paths,
+  idempotency-key replay, scope-denied path.
+- `packages/phlo-mcp/tests/smoke_stack.py`: add `--exercise-live-write-tools`
+  flag that actually launches a tiny no-op asset on a throwaway project.
+
+#### 1.3 Add MCP prompts (`@mcp.prompt`)
+
+Canned, parameterised prompt templates so MCP clients show "Phlo: …" actions:
+
+- `phlo.debug_run(run_id)` — instructs the agent to fetch logs + spans, render
+  the tree, identify the failing span, and propose a fix.
+- `phlo.triage_failure(asset_key)` — fetches latest materialisation, run logs,
+  quality results, and proposes remediation.
+- `phlo.audit_asset(asset_key)` — runs the full health pass on one asset.
+- `phlo.plan_backfill(asset_key, range)` — produces a dry-run plan + caveats.
+- `phlo.scaffold_workflow(domain, table)` — defers to phase-2 tool but the
+  prompt is added here.
+
+#### 1.4 Deliverables
+
+- New routes shipping in `phlo-api` ≥ next minor.
+- 6 new MCP tools wired end-to-end.
+- 4–5 MCP prompts shipping.
+- Capability scope `lakehouse:operate` in
+  [auth-and-access docs](../reference/auth-and-access.md).
+- ADR: `docs/plans/2026-05-28-002-lakehouse-operate-scope.md` (split out).
+
+#### 1.5 Verification
+
+```bash
+uv run pytest packages/phlo-api/tests -q
+uv run pytest packages/phlo-mcp/tests -q
+uv run python packages/phlo-mcp/tests/smoke_stack.py \
+  --start-stack --enable-write-tools \
+  --api-token "$PHLO_MCP_SMOKE_API_TOKEN" \
+  --exercise-live-write-tools
+```
+
+### Phase 2 — Author + validate loop
+
+> Goal: an agent can scaffold a new workflow, validate it, and materialise it,
+> all through MCP. Today scaffolding is gated behind `click.prompt`.
+
+#### 2.1 De-interactive the scaffolders
+
+- [`src/phlo/cli/commands/workflow.py`](../../src/phlo/cli/commands/workflow.py):
+  split `create_workflow_cmd` into:
+  - `_create_workflow(domain, table, unique_key, cron, api_base_url, fields) -> CreateWorkflowResult` (pure, no Click)
+  - `create_workflow_cmd` (thin Click wrapper)
+- Same treatment for any `click.prompt` in
+  [`src/phlo/cli/commands/plugin/scaffold.py`](../../src/phlo/cli/commands/plugin/scaffold.py)
+  and other interactive scaffolders.
+
+#### 2.2 Add authoring/validate routes to `phlo-api`
+
+- `packages/phlo-api/src/phlo_api/api/authoring.py` (new):
+  - `POST /api/authoring/workflows` — body matches `_create_workflow`; returns
+    created files + next-steps JSON.
+  - `POST /api/authoring/workflows/validate` — body `{ workflow_path }`.
+  - `POST /api/authoring/schemas/validate` — body `{ schema_path }`.
+  - `GET  /api/authoring/templates` — list starters + required packages.
+  - `GET  /api/authoring/workflows` — list workflows discovered in project.
+  - `POST /api/authoring/project/lint` — runs project-wide lint checks
+    (`phlo doctor` + `phlo workflow check` for all workflows).
+
+These mutate the project's filesystem, so they require `project:write` scope
+(new) distinct from `lakehouse:operate`.
+
+#### 2.3 Add MCP tools
+
+- `create_workflow(domain, table, unique_key, cron, api_base_url?, fields?)`
+- `validate_workflow(workflow_path)`
+- `validate_schema(schema_path)`
+- `list_workflows(search?, group?)`
+- `list_templates()`
+- `lint_project()`
+- `run_doctor()` — mirrors `phlo doctor --json`
+
+Plus search/discovery:
+
+- `search_assets(query, limit, cursor)` — server-side prefix + substring search
+- `search_contracts(query, limit, cursor)`
+- `search_runs(filters, cursor)` — wraps the existing trace search but adds
+  status + time + asset filters in a single call.
+
+#### 2.4 Make `phlo doctor` an MCP tool
+
+The CLI already supports `--json`. Either:
+
+- (a) `phlo-api` exposes `GET /api/doctor` that runs the same checks, or
+- (b) MCP tool shells out to `phlo doctor --json`.
+
+Prefer (a) for consistency with the rest of the API surface; reuse the existing
+[`doctor` command](../../src/phlo/cli/commands/doctor.py) by extracting the
+diagnostic engine from the Click command into a library function.
+
+#### 2.5 Deliverables
+
+- 10 new MCP tools.
+- 6 new `phlo-api` routes.
+- `phlo doctor` diagnostic engine extracted into a pure library function.
+
+#### 2.6 Verification
+
+```bash
+uv run pytest packages/phlo-api/tests/test_authoring.py -q
+uv run pytest packages/phlo-mcp/tests -q
+# Round-trip:
+phlo init demo --template csv-batch
+# Via MCP only:
+#   create_workflow → validate_workflow → materialize_asset(dry_run=true)
+#   → list_workflows → inspect_materialization
+```
+
+### Phase 3 — Agent ergonomics
+
+> Goal: every interaction returns predictable shapes, scales to large
+> lakehouses, and fails with actionable errors.
+
+#### 3.1 Typed responses + JSON Schema
+
+- Add `packages/phlo-mcp/src/phlo_mcp/models.py` with Pydantic models for every
+  tool response. Use `model_json_schema()` to populate FastMCP
+  `output_schema`.
+- Same exercise on the `phlo-api` side using FastAPI's existing
+  `response_model=` so the schemas match.
+- `mcp.tool()` calls become:
+
+  ```python
+  @mcp.tool(output_schema=GetRunLogsResponse.model_json_schema())
+  def get_run_logs(...): ...
+  ```
+
+#### 3.2 Cursor-based pagination
+
+- All list/search tools accept `cursor: str | None` and return
+  `{ items, next_cursor }`. Use opaque base64-encoded cursors so the server can
+  change the implementation without breaking clients.
+- Tools affected: `get_recent_alerts`, `get_materialization_history`,
+  `get_run_logs`, `get_trace_spans`, `list_workflows`, `search_*`,
+  `runtime/assets` (when materialized as a tool).
+
+#### 3.3 Structured error envelope
+
+- Wrap `_get_json` / `_post_json` in `api_client.py`:
+
+  ```python
+  class PhloMcpError(Exception):
+      code: str        # e.g. "asset.not_found"
+      message: str     # human
+      hint: str | None # one-liner remediation
+      docs_url: str | None
+      retryable: bool
+  ```
+
+- Map common `httpx.HTTPStatusError` cases to error codes; everything else
+  becomes `phlo.api.unknown` with the original message preserved.
+- MCP returns errors as a structured object in the tool result (not a raw
+  exception), so agents can branch on `code`.
+
+#### 3.4 Log search + follow
+
+- `phlo-api`:
+  - Extend `GET /api/loki/runs/{run_id}` with `query`, `regex`, `since`,
+    `until`, `cursor`.
+  - Add `GET /api/loki/runs/{run_id}/stream` (SSE) for tail-follow.
+- `phlo-mcp`:
+  - `search_run_logs(run_id, query, regex?, since?, until?, cursor?)`.
+  - `follow_run_logs(run_id, timeout_seconds=30)` — bounded streamable-HTTP
+    tool that yields chunks until timeout or run completion.
+
+#### 3.5 Quality, lineage, schema-diff tools
+
+- `get_quality_results(asset_key, run_id?)` — surfaces Pandera failure rows,
+  rule name, severity, sample rows.
+- `get_lineage(asset_key, direction=upstream|downstream|both, depth=1)` —
+  walks the asset graph.
+- `diff_schema(asset_key, from_run, to_run)` — wraps `schema-migrate diff`.
+
+#### 3.6 Self-introspection resources
+
+- `phlo://docs/cli` — Markdown index of CLI commands, generated from Click
+  introspection so it stays accurate.
+- `phlo://docs/mcp/tools` — JSON list of MCP tools with input/output schemas.
+- `phlo://docs/mcp/prompts` — JSON list of MCP prompts.
+
+Generate these at server start so agents can introspect without reading
+package docs.
+
+#### 3.7 Deliverables
+
+- Pydantic models for ~25 tool responses.
+- Pagination across all list tools.
+- Error envelope with ≥20 named codes.
+- 3 new observability tools + 2 new introspection resources.
+
+#### 3.8 Verification
+
+```bash
+uv run pytest packages/phlo-mcp/tests/test_models.py -q
+uv run pytest packages/phlo-mcp/tests/test_pagination.py -q
+uv run pytest packages/phlo-mcp/tests/test_errors.py -q
+```
+
+Add a contract test that asserts every `@mcp.tool` has an `output_schema`.
+
+### Phase 4 — Discoverability + safety
+
+> Goal: humans installing Phlo discover the MCP without reading the README;
+> agents in a new project find an `AGENTS.md` telling them what to use;
+> mutations leave an audit trail you can grep.
+
+#### 4.1 `phlo mcp` subcommand
+
+- New `src/phlo/cli/commands/mcp/` group:
+  - `phlo mcp serve [--transport stdio|streamable-http] [--api-base-url …]`
+    — wraps the existing `phlo-mcp` entrypoint so `phlo-mcp` becomes an
+    implementation detail.
+  - `phlo mcp install <client>` where `<client>` ∈ {`claude-code`, `amp`,
+    `cursor`, `vscode`} writes the appropriate config block to the right file.
+  - `phlo mcp tools` and `phlo mcp prompts` — list registered tools/prompts
+    locally without starting the server.
+  - `phlo mcp config` — print resolved config (redacted).
+- Keep `phlo-mcp` console script alive as an alias for one minor.
+
+#### 4.2 `--json` everywhere
+
+- Add a shared `phlo.cli.output.json_envelope({ data, warnings, errors })`
+  helper.
+- Sweep `src/phlo/cli/commands/**/*.py` adding `--json` to every command,
+  using the helper. Start with read-heavy commands:
+  `services list/status`, `catalog tables`, `lineage show`, `status`,
+  `workflow check`, `contracts list`, `plugin list/info`, `schema list`.
+- Then mutators: emit a per-action JSON line on success/failure so agents can
+  parse without screen-scraping.
+- Add `--quiet` / `--no-color` for agent-friendly output.
+
+#### 4.3 Capability scopes on tokens
+
+- Token claims grow scopes: `lakehouse:read`, `lakehouse:operate`,
+  `project:write`, `admin`.
+- `phlo-api` enforces per-route; `phlo-mcp` advertises required scope per tool.
+- Document in [auth-and-access](../reference/auth-and-access.md).
+
+#### 4.4 Audit log sink
+
+- Every write call (Phase 1 + Phase 2) appends a JSONL record to
+  `.phlo/audit/operations.jsonl` (or whatever sink is configured) with the
+  full `audit_context` plus resolved scopes and token subject.
+- Add `phlo audit tail` / `phlo audit query` CLI.
+
+#### 4.5 Rate limits
+
+- Per-token token-bucket on mutation routes in `phlo-api`. Defaults:
+  - `materialize/backfill`: 10/min
+  - `retry`: 30/min
+  - `cancel`: 60/min
+- Override via config.
+
+#### 4.6 `AGENTS.md` in starters
+
+- Add `AGENTS.md` template to each starter
+  ([`src/phlo/cli/templates/`](../../src/phlo/cli/templates/)):
+  - csv-batch
+  - rest-api
+  - dbt-medallion
+  - sling
+  - observatory-demo
+- Content: which MCP tools to prefer for which task, which resources to attach,
+  scope hints, sample prompts.
+- Also add an `AGENTS.md` section to the project [`AGENTS.md`](../../AGENTS.md)
+  for repo contributors.
+
+#### 4.7 Deliverables
+
+- `phlo mcp` command group with `serve|install|tools|prompts|config`.
+- `--json` on every CLI subcommand.
+- Token scopes documented + enforced.
+- Audit log on disk + CLI to query it.
+- `AGENTS.md` shipped in 5 starters.
+
+#### 4.8 Verification
+
+```bash
+uv run pytest src/phlo/cli/tests -q
+uv run pytest packages/phlo-api/tests/test_rate_limits.py -q
+phlo mcp install claude-code --dry-run
+phlo mcp tools --json | jq '.[] | .name'
+phlo audit tail --since 1h --json | jq .
+```
+
+## Cross-cutting decisions
+
+### Capability layering
+
+```diagram
+╭───────────────────────╮
+│ MCP client (Amp/etc.) │
+╰──────────┬────────────╯
+           │ stdio | streamable-http
+╭──────────▼────────────╮     ╭─────────────────╮
+│       phlo-mcp        │◀───▶│ phlo://… resrcs │
+╰──────────┬────────────╯     ╰─────────────────╯
+           │ HTTP + bearer + scopes
+╭──────────▼────────────╮
+│       phlo-api        │
+╰──────────┬────────────╯
+           │ capability calls
+   ╭───────┼────────┬──────────┬───────────╮
+   ▼       ▼        ▼          ▼           ▼
+╭──────╮ ╭──────╮ ╭─────────╮ ╭────────╮ ╭───────╮
+│dagstr│ │loki  │ │clickstck│ │catalog │ │authz  │
+╰──────╯ ╰──────╯ ╰─────────╯ ╰────────╯ ╰───────╯
+```
+
+Rule: MCP only talks to `phlo-api`. `phlo-api` only talks to capabilities.
+No backend (Dagster GraphQL, Loki, ClickStack) is ever called directly from
+MCP.
+
+### Scope model
+
+| Scope | Read | Write | Examples |
+|---|---|---|---|
+| `lakehouse:read` | yes | no | every existing read tool |
+| `lakehouse:operate` | yes | yes (data plane) | materialize, retry, cancel, backfill |
+| `project:write` | yes | yes (project files) | create_workflow, lint, scaffold |
+| `admin` | yes | yes (all) | plugin install, authz sync |
+
+### Backwards compatibility
+
+- All existing MCP tool names and resource URIs remain unchanged.
+- Tool responses gain new fields only — existing fields are not renamed or
+  removed in this plan.
+- `phlo-mcp` console script stays for one minor after `phlo mcp serve` lands.
+
+## Sequencing and parallelism
+
+```diagram
+Phase 1  ─────────────▶ Phase 2  ─────────────▶ Phase 3 ────────────▶ Phase 4
+   │                       │                       │                     │
+   ├── 1.1 phlo-api ops    ├── 2.1 de-interactive  ├── 3.1 typed models  ├── 4.1 phlo mcp cmd
+   ├── 1.2 mcp wire-up     ├── 2.2 authoring API   ├── 3.2 pagination    ├── 4.2 --json sweep
+   ├── 1.3 prompts         ├── 2.3 mcp tools       ├── 3.3 error model   ├── 4.3 scopes
+   └── 1.4 scope+audit     ├── 2.4 doctor library  ├── 3.4 log search    ├── 4.4 audit log
+                           └── 2.5 search tools    ├── 3.5 q/l/diff     ├── 4.5 rate limits
+                                                   └── 3.6 introspect    └── 4.6 AGENTS.md
+```
+
+Within a phase, items can be parallelised: each numbered item is a separate
+PR, owned by one author, and unblocked by the others in the same phase. Phase
+boundaries are hard gates because later phases assume the API surface from
+earlier phases.
+
+## Estimated effort
+
+(Rough, intended for sequencing not commitment.)
+
+| Phase | Engineer-weeks | Notes |
+|---|---|---|
+| 1 | 3 | Live Dagster launch is the biggest single item. |
+| 2 | 2 | Mostly de-interactive plumbing + thin API. |
+| 3 | 2 | Models + pagination is mechanical; SSE for follow is the only spike. |
+| 4 | 2 | CLI sweep + docs + audit. |
+| **Total** | **≈ 9** | Single full-time engineer ≈ 10–12 weeks elapsed. |
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Dagster GraphQL surface drifts across versions | Pin per-capability adapter; integration test on a known Dagster image in CI. |
+| MCP clients differ in how they render structured tool errors | Make the error envelope serialisable to plain text via `__str__`; include rendered message for naive clients. |
+| Adding `--json` everywhere causes prose-output regressions | Default stays human; `--json` is opt-in; snapshot tests on human output. |
+| Scope creep on prompts | Cap initial prompt count at 5; add new ones only when a real client needs one. |
+| Audit log grows unboundedly | Ship rotation (`size` + `time`) in Phase 4.4; document retention. |
+| Idempotency keys leak across projects | Key is namespaced by project + workspace ID; tests cover the boundary. |
+
+## Verification matrix
+
+| Capability | Test layer |
+|---|---|
+| phlo-api routes | `packages/phlo-api/tests` (httpx test client) |
+| Capability adapters | per-package tests (`phlo-dagster`, `phlo-loki`, …) |
+| MCP tool registration + dispatch | `packages/phlo-mcp/tests/test_phlo_mcp.py` |
+| MCP schemas | new `tests/test_models.py` |
+| Pagination | new `tests/test_pagination.py` |
+| Errors | new `tests/test_errors.py` |
+| End-to-end | `packages/phlo-mcp/tests/smoke_stack.py` with new flags |
+| CLI JSON envelopes | snapshot tests in `src/phlo/cli/tests` |
+| Audit log | round-trip test: mutate via MCP, read via `phlo audit query` |
+
+## Outcome
+
+Completed in `e60dc02d3d` plus the follow-up completion pass in this thread.
+
+- MCP now supports the full scaffold → validate → materialize/backfill → inspect → retry/cancel loop through `phlo-api` only.
+- Mutating routes enforce scoped tokens, rate limits, idempotency replay, and JSONL audit records with rotation.
+- Agent-facing authoring, doctor, search, log-follow, quality, lineage, schema-diff, and plugin-install tools are available through MCP.
+- MCP self-introspection resources expose registered tools, prompts, required scopes, and CLI command documentation.
+- `phlo mcp` and `phlo audit` command groups provide local discoverability and audit inspection; key agent-facing CLI commands emit JSON envelopes.
+- New projects generated by `phlo init` include an `AGENTS.md` with MCP-first guidance.
+
+## Appendix A — Tool inventory after Phase 4
+
+Read tools (existing + new):
+
+- `get_platform_health`, `get_service_status`, `get_recent_alerts`,
+  `get_dashboard_links`, `get_logs_query_link`, `get_metrics_query_link`,
+  `get_materialization_history`, `get_run_logs`, `get_run_trace_spans`,
+  `get_trace_spans`, `render_trace_spans_tree`, `inspect_materialization`,
+  `get_asset_materialization_trace`, `render_materialization_trace_tree`,
+  `render_run_trace_tree`
+- **new:** `list_workflows`, `list_templates`, `search_assets`,
+  `search_contracts`, `search_runs`, `search_run_logs`, `follow_run_logs`,
+  `get_quality_results`, `get_lineage`, `diff_schema`, `run_doctor`,
+  `list_partitions`
+
+Write tools (guarded):
+
+- `materialize_asset` (live), `retry_failed_run` (live),
+  `get_dagster_run_status`
+- **new:** `cancel_run`, `backfill_asset`, `create_workflow`,
+  `validate_workflow`, `validate_schema`, `lint_project`
+
+Prompts:
+
+- `phlo.debug_run`, `phlo.triage_failure`, `phlo.audit_asset`,
+  `phlo.plan_backfill`, `phlo.scaffold_workflow`
+
+Resources:
+
+- All existing `phlo://runtime/*` and `phlo://docs/packages/{name}`
+- **new:** `phlo://docs/cli`, `phlo://docs/mcp/tools`, `phlo://docs/mcp/prompts`
+
+## Appendix B — Task breakdown
+
+Each task is a single, independently-grabbable unit of work — sized to one PR.
+Tasks within a phase can be parallelised unless a `depends:` line says
+otherwise. Phase boundaries are hard gates: do not start a Phase N+1 task
+until the Phase N tasks it depends on are merged.
+
+Status legend: `[ ]` proposed · `[~]` in progress · `[x]` complete · `[-]` dropped
+
+### Phase 1 — Close the operate loop
+
+- [x] **P1-T01** — Extend `phlo-dagster` capability with `launch_materialize`,
+  `launch_retry`, `terminate`, `launch_backfill`, `list_partitions`.
+  - Files: `packages/phlo-dagster/src/phlo_dagster/operations.py` (new)
+  - Tests: `packages/phlo-dagster/tests/test_operations.py`
+  - depends: none
+
+- [x] **P1-T02** — Add `POST /api/observatory/v2/assets/{asset_key_path}/materialize`
+  to `phlo-api` with dry-run + live paths.
+  - Files: `packages/phlo-api/src/phlo_api/api/operations.py` (new),
+    register in `packages/phlo-api/src/phlo_api/api/__init__.py`
+  - depends: P1-T01
+
+- [x] **P1-T03** — Add `POST /api/observatory/v2/runs/{run_id}/retry`.
+  - depends: P1-T01
+
+- [x] **P1-T04** — Add `POST /api/observatory/v2/runs/{run_id}/cancel`.
+  - depends: P1-T01
+
+- [x] **P1-T05** — Add `POST /api/observatory/v2/assets/{asset_key_path}/backfill`.
+  - depends: P1-T01
+
+- [x] **P1-T06** — Add `GET /api/observatory/v2/assets/{asset_key_path}/partitions`.
+  - depends: P1-T01
+
+- [x] **P1-T07** — Idempotency-key store at
+  `.phlo/state/operations.sqlite` with replay semantics.
+  - Files: `packages/phlo-api/src/phlo_api/operations/idempotency.py` (new)
+  - Tests: replay returns original `run_id`; expiry; cross-project isolation
+  - depends: none (lands in parallel with P1-T02..T05)
+
+- [x] **P1-T08** — Add `lakehouse:operate` scope; enforce on every operation
+  route from P1-T02..T05.
+  - Files: `packages/phlo-api/src/phlo_api/api/authorization.py`,
+    [docs/reference/auth-and-access.md](../reference/auth-and-access.md)
+  - depends: P1-T02..T05 stubs landed
+
+- [x] **P1-T09** — Wire real `materialize_asset` in
+  [`api_client.py`](../../packages/phlo-mcp/src/phlo_mcp/api_client.py) and
+  [`server.py`](../../packages/phlo-mcp/src/phlo_mcp/server.py); remove the
+  "not implemented yet" caveat from the MCP README.
+  - depends: P1-T02
+
+- [x] **P1-T10** — Wire real `retry_failed_run`.
+  - depends: P1-T03
+
+- [x] **P1-T11** — Add MCP tools `cancel_run`, `backfill_asset`,
+  `list_partitions`.
+  - depends: P1-T04, P1-T05, P1-T06
+
+- [x] **P1-T12** — Add MCP prompts `phlo.debug_run`,
+  `phlo.triage_failure`, `phlo.audit_asset`, `phlo.plan_backfill`,
+  `phlo.scaffold_workflow`.
+  - Files: `packages/phlo-mcp/src/phlo_mcp/prompts.py` (new)
+  - depends: none
+
+- [x] **P1-T13** — Extend
+  [`smoke_stack.py`](../../packages/phlo-mcp/tests/smoke_stack.py) with
+  `--exercise-live-write-tools` flag that materialises a no-op asset.
+  - depends: P1-T09..T11
+
+- [x] **P1-T14** — Split off ADR
+  `docs/plans/2026-05-28-002-lakehouse-operate-scope.md` capturing the
+  scope-model decision.
+  - depends: P1-T08
+
+### Phase 2 — Author + validate loop
+
+- [x] **P2-T01** — De-interactive `phlo workflow create`: split into pure
+  `_create_workflow(...)` + Click wrapper.
+  - Files: [`src/phlo/cli/commands/workflow.py`](../../src/phlo/cli/commands/workflow.py)
+  - depends: none
+
+- [x] **P2-T02** — De-interactive `phlo plugin scaffold` and any other
+  `click.prompt`-using scaffolder.
+  - Files: [`src/phlo/cli/commands/plugin/scaffold.py`](../../src/phlo/cli/commands/plugin/scaffold.py)
+  - depends: none
+
+- [x] **P2-T03** — Extract `phlo doctor` diagnostic engine into a pure
+  library function callable without Click.
+  - Files: split [`src/phlo/cli/commands/doctor.py`](../../src/phlo/cli/commands/doctor.py)
+    into `phlo.doctor` (lib) + thin CLI
+  - depends: none
+
+- [x] **P2-T04** — Add `project:write` scope to authz model.
+  - depends: P1-T08
+
+- [x] **P2-T05** — `POST /api/authoring/workflows` route in `phlo-api`.
+  - Files: `packages/phlo-api/src/phlo_api/api/authoring.py` (new)
+  - depends: P2-T01, P2-T04
+
+- [x] **P2-T06** — `POST /api/authoring/workflows/validate` route.
+  - depends: P2-T04
+
+- [x] **P2-T07** — `POST /api/authoring/schemas/validate` route.
+  - depends: P2-T04
+
+- [x] **P2-T08** — `GET /api/authoring/templates` route.
+  - depends: P2-T04
+
+- [x] **P2-T09** — `GET /api/authoring/workflows` route.
+  - depends: P2-T04
+
+- [x] **P2-T10** — `POST /api/authoring/project/lint` route.
+  - depends: P2-T03, P2-T06
+
+- [x] **P2-T11** — `GET /api/doctor` route wrapping the extracted engine.
+  - depends: P2-T03
+
+- [x] **P2-T12** — MCP tools: `create_workflow`, `validate_workflow`,
+  `validate_schema`.
+  - depends: P2-T05..T07
+
+- [x] **P2-T13** — MCP tools: `list_workflows`, `list_templates`,
+  `lint_project`, `run_doctor`.
+  - depends: P2-T08..T11
+
+- [x] **P2-T14** — MCP search tools: `search_assets`, `search_contracts`,
+  `search_runs` (server-side filter; pagination shape stubbed for Phase 3).
+  - Files: extend `packages/phlo-api/src/phlo_api/api/observatory_api/`
+    with search params; add MCP tool wrappers
+  - depends: none
+
+### Phase 3 — Agent ergonomics
+
+- [x] **P3-T01** — Create `packages/phlo-mcp/src/phlo_mcp/models.py` with
+  Pydantic response models for every existing MCP tool.
+  - depends: none
+
+- [x] **P3-T02** — Pass `output_schema=Model.model_json_schema()` on every
+  `@mcp.tool()` decorator; add contract test asserting presence.
+  - Files: [`server.py`](../../packages/phlo-mcp/src/phlo_mcp/server.py),
+    `tests/test_models.py` (new)
+  - depends: P3-T01
+
+- [x] **P3-T03** — Align `phlo-api` `response_model=` on every route to the
+  same shapes.
+  - depends: P3-T01
+
+- [x] **P3-T04** — Cursor-pagination contract: opaque base64 cursor type,
+  helper module, and one reference route (`get_recent_alerts`).
+  - Files: `packages/phlo-api/src/phlo_api/pagination.py` (new)
+  - depends: none
+
+- [x] **P3-T05** — Apply cursor pagination to remaining list/search
+  routes: `get_materialization_history`, `get_run_logs`, `get_trace_spans`,
+  `list_workflows`, `search_*`, asset list.
+  - depends: P3-T04
+
+- [x] **P3-T06** — `PhloMcpError` class + mapping table for common HTTP
+  status / capability errors.
+  - Files: `packages/phlo-mcp/src/phlo_mcp/errors.py` (new),
+    update [`api_client.py`](../../packages/phlo-mcp/src/phlo_mcp/api_client.py)
+  - depends: none
+
+- [x] **P3-T07** — Convert MCP tool results to return structured error
+  objects (not raise) when the call fails, with rendered text fallback.
+  - depends: P3-T06
+
+- [x] **P3-T08** — Extend `GET /api/loki/runs/{run_id}` with `query`,
+  `regex`, `since`, `until`, `cursor`.
+  - depends: P3-T04
+
+- [x] **P3-T09** — `GET /api/loki/runs/{run_id}/stream` (SSE).
+  - depends: none
+
+- [x] **P3-T10** — MCP tools `search_run_logs`, `follow_run_logs`
+  (bounded streamable-http).
+  - depends: P3-T08, P3-T09
+
+- [x] **P3-T11** — `GET /api/observatory/v2/quality-results` route and
+  `get_quality_results` MCP tool.
+  - depends: none
+
+- [x] **P3-T12** — `GET /api/observatory/v2/lineage/{asset_key}` route
+  (upstream/downstream/both, depth) and `get_lineage` MCP tool.
+  - depends: none
+
+- [x] **P3-T13** — `POST /api/observatory/v2/schemas/diff` route and
+  `diff_schema` MCP tool (wraps `schema-migrate diff`).
+  - depends: none
+
+- [x] **P3-T14** — Self-introspection resources `phlo://docs/cli`,
+  `phlo://docs/mcp/tools`, `phlo://docs/mcp/prompts` generated at server
+  start.
+  - Files: extend
+    [`server.py`](../../packages/phlo-mcp/src/phlo_mcp/server.py)
+  - depends: P3-T02 (for tool schemas)
+
+### Phase 4 — Discoverability + safety
+
+- [x] **P4-T01** — Scaffold `src/phlo/cli/commands/mcp/` group with
+  `serve`, `install`, `tools`, `prompts`, `config` subcommands.
+  - depends: none
+
+- [x] **P4-T02** — `phlo mcp serve` wraps existing
+  [`phlo-mcp` entrypoint](../../packages/phlo-mcp/src/phlo_mcp/cli.py);
+  console script stays as alias for one minor.
+  - depends: P4-T01
+
+- [x] **P4-T03** — `phlo mcp install <client>` writes config block for
+  `claude-code`, `amp`, `cursor`, `vscode`; supports `--dry-run`.
+  - depends: P4-T01
+
+- [x] **P4-T04** — Shared
+  `phlo.cli.output.json_envelope(data, warnings, errors)` helper.
+  - Files: [`src/phlo/cli/output.py`](../../src/phlo/cli/output.py)
+  - depends: none
+
+- [x] **P4-T05** — Add `--json` to read-heavy commands:
+  `services list/status`, `catalog tables`, `lineage show`, `status`,
+  `workflow check`, `contracts list`, `plugin list/info`, `schema list`.
+  - depends: P4-T04
+
+- [x] **P4-T06** — Add `--json` to mutator commands; emit per-action JSON
+  line on success/failure.
+  - depends: P4-T04
+
+- [x] **P4-T07** — Add global `--quiet` / `--no-color` flags wired through
+  [`main.py`](../../src/phlo/cli/main.py).
+  - depends: none
+
+- [x] **P4-T08** — Implement token scope claims (`lakehouse:read`,
+  `lakehouse:operate`, `project:write`, `admin`); enforce per-route.
+  - depends: P1-T08, P2-T04
+
+- [x] **P4-T09** — Document scopes in
+  [auth-and-access](../reference/auth-and-access.md) and update
+  [phlo-mcp README](../../packages/phlo-mcp/README.md) with required-scope
+  column per tool.
+  - depends: P4-T08
+
+- [x] **P4-T10** — Append JSONL audit records for every write call to
+  `.phlo/audit/operations.jsonl` (or configured sink).
+  - Files: `packages/phlo-api/src/phlo_api/audit.py` (new)
+  - depends: P1-T02..T05
+
+- [x] **P4-T11** — `phlo audit tail` and `phlo audit query` CLI.
+  - Files: `src/phlo/cli/commands/audit.py` (new)
+  - depends: P4-T10
+
+- [x] **P4-T12** — Audit-log rotation (size + time) and retention docs.
+  - depends: P4-T10
+
+- [x] **P4-T13** — Per-token token-bucket rate limits on mutation routes
+  with documented defaults and override.
+  - Files: `packages/phlo-api/src/phlo_api/rate_limit.py` (new)
+  - depends: P1-T02..T05
+
+- [x] **P4-T14** — `AGENTS.md` template in `csv-batch` starter.
+  - Files: `src/phlo/cli/templates/csv_batch/AGENTS.md.jinja`
+  - depends: P2-T13 (so tools referenced exist)
+
+- [x] **P4-T15** — `AGENTS.md` in `rest-api`, `dbt-medallion`, `sling`,
+  `observatory-demo` starters.
+  - depends: P4-T14
+
+- [x] **P4-T16** — Add `AGENTS.md` section to the project
+  [AGENTS.md](../../AGENTS.md) covering contributor workflows around the
+  new tools.
+  - depends: P4-T14
+
+### Cross-phase / housekeeping
+
+- [x] **X-T01** — Update [CLI Reference](../reference/cli-reference.md) at
+  the end of each phase.
+- [x] **X-T02** — Update [phlo-mcp README](../../packages/phlo-mcp/README.md)
+  at the end of each phase.
+- [x] **X-T03** — Add a `CHANGELOG.md` entry per merged task.
+- [x] **X-T04** — On Phase 4 completion, update the `status:` frontmatter of
+  this plan to `completed` and fill in the **Outcome** section.
+
+## Appendix C — Out of scope (parking lot)
+
+- Multi-stack / multi-tenant MCP federation.
+- Long-running tool calls > 60s (would need MCP progress notifications).
+- Notebook authoring tools (Jupyter, marimo).
+- LLM-mediated SQL generation against Trino (`phlo-trino` concern).
+- A "phlo-agent" of our own — Phlo provides the surface; agents are the
+  client's choice.

--- a/docs/plans/2026-05-28-001-agent-first-cli-and-mcp.md
+++ b/docs/plans/2026-05-28-001-agent-first-cli-and-mcp.md
@@ -250,7 +250,7 @@ diagnostic engine from the Click command into a library function.
 #### 2.6 Verification
 
 ```bash
-uv run pytest packages/phlo-api/tests/test_authoring.py -q
+uv run pytest packages/phlo-api/tests/test_authoring_api.py -q
 uv run pytest packages/phlo-mcp/tests -q
 # Round-trip:
 phlo init demo --template csv-batch
@@ -429,7 +429,7 @@ Add a contract test that asserts every `@mcp.tool` has an `output_schema`.
 #### 4.8 Verification
 
 ```bash
-uv run pytest src/phlo/cli/tests -q
+uv run pytest tests/cli -q
 uv run pytest packages/phlo-api/tests/test_rate_limits.py -q
 phlo mcp install claude-code --dry-run
 phlo mcp tools --json | jq '.[] | .name'
@@ -597,8 +597,9 @@ Status legend: `[ ]` proposed · `[~]` in progress · `[x]` complete · `[-]` dr
 
 - [x] **P1-T02** — Add `POST /api/observatory/v2/assets/{asset_key_path}/materialize`
   to `phlo-api` with dry-run + live paths.
-  - Files: `packages/phlo-api/src/phlo_api/api/operations.py` (new),
-    register in `packages/phlo-api/src/phlo_api/api/__init__.py`
+  - Files: `packages/phlo-api/src/phlo_api/api/operation_controls.py`,
+    `packages/phlo-api/src/phlo_api/observatory_api/orchestrator_operations.py`,
+    registered through `packages/phlo-api/src/phlo_api/api/__init__.py`
   - depends: P1-T01
 
 - [x] **P1-T03** — Add `POST /api/observatory/v2/runs/{run_id}/retry`.

--- a/docs/plans/2026-05-28-002-lakehouse-operate-scope.md
+++ b/docs/plans/2026-05-28-002-lakehouse-operate-scope.md
@@ -1,0 +1,26 @@
+---
+title: "ADR: Lakehouse operate scope for agent mutations"
+type: adr
+status: accepted
+date: 2026-05-28
+related:
+  - docs/plans/2026-05-28-001-agent-first-cli-and-mcp.md
+---
+
+# ADR: Lakehouse operate scope for agent mutations
+
+## Decision
+
+Phlo separates read access from mutation access for agent-facing lakehouse
+operations. Routes and MCP tools that can launch, retry, cancel, or backfill
+runs require `lakehouse:operate`. Project filesystem authoring routes require
+`project:write`. `admin` satisfies both checks.
+
+## Consequences
+
+- MCP clients can keep read-only tokens for inspection-heavy workflows.
+- Live data-plane operations need an explicit higher-privilege token.
+- Operation routes can apply idempotency, audit, and rate limiting at the API
+  boundary before calling provider capabilities.
+- Scope names are stable API contract terms and are documented in
+  `docs/reference/auth-and-access.md`.

--- a/docs/reference/auth-and-access.md
+++ b/docs/reference/auth-and-access.md
@@ -99,6 +99,32 @@ api:
 Built-in authentication provider names include `static`, `proxy`, and `service_token`.
 Their built-in config blocks live under the same root `authentication` section in `phlo.yaml`.
 
+## Agent and MCP token scopes
+
+Agent-facing `phlo-api` routes require explicit bearer-token scopes. Tokens may
+come from the configured authentication provider, or from the local
+`PHLO_API_TOKENS` JSON object for single-project development and MCP use:
+
+```bash
+export PHLO_API_TOKENS='{
+  "agent-token": {
+    "subject": "agent:amp",
+    "scopes": ["lakehouse:read", "lakehouse:operate", "project:write"]
+  }
+}'
+```
+
+| Scope | Grants | Examples |
+|---|---|---|
+| `lakehouse:read` | Read-only inspection | status, logs, traces, assets, schemas |
+| `lakehouse:operate` | Data-plane mutations | materialize, retry, cancel, backfill |
+| `project:write` | Project filesystem authoring | create workflow, validate workflow/schema, lint project |
+| `admin` | All scoped operations | operator break-glass and local automation |
+
+Mutation routes also enforce per-subject rate limits, write JSONL audit records
+to `.phlo/audit/operations.jsonl`, and honour idempotency keys for repeat-safe
+operation replay.
+
 You can declare these settings in `phlo.yaml` as either:
 
 ```yaml

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -23,7 +23,12 @@ phlo --version
 ```bash
 phlo --help              # Show help
 phlo --version           # Show version
+phlo --quiet             # Reduce non-essential output
+phlo --no-color          # Disable colorized terminal output
 ```
+
+Agent-facing commands prefer `--json` where available and emit the shared
+`{"data": ..., "warnings": [...], "errors": [...]}` envelope.
 
 ## Command Overview
 
@@ -38,6 +43,8 @@ phlo test                # Run tests
 phlo config              # Configuration management
 phlo env                 # Environment exports
 phlo doctor              # Diagnose local setup and service health
+phlo mcp                 # Serve, install, and inspect the MCP server
+phlo audit               # Inspect local MCP/API mutation audit logs
 ```
 
 **Workflow Commands:**
@@ -1111,6 +1118,7 @@ phlo workflow create [OPTIONS]
 --cron CRON          # Cron schedule expression
 --api-base-url URL   # REST API base URL (optional)
 --field NAME:TYPE    # Additional schema field (repeatable)
+--json               # Emit machine-readable JSON envelope
 ```
 
 **Interactive prompts**:
@@ -2028,6 +2036,33 @@ dbt publishing layer management.
 ### phlo metrics
 
 Metrics summary and export. Built into core Phlo.
+
+```bash
+phlo metrics summary --json
+phlo metrics asset my_asset --json
+phlo metrics export --format json --output metrics.json --json
+```
+
+### phlo mcp
+
+MCP server management and introspection.
+
+```bash
+phlo mcp serve --transport stdio
+phlo mcp install amp --dry-run --json
+phlo mcp tools --json
+phlo mcp prompts --json
+phlo mcp config --json
+```
+
+### phlo audit
+
+Inspect local JSONL audit records written by MCP and API mutation surfaces.
+
+```bash
+phlo audit tail --since 1h --json
+phlo audit query --operation materialize_asset --json
+```
 
 ### phlo alerts
 

--- a/packages/phlo-api/src/phlo_api/api/authoring.py
+++ b/packages/phlo-api/src/phlo_api/api/authoring.py
@@ -15,11 +15,11 @@ from phlo_api.pagination import paginate_items
 
 from phlo.cli.commands.doctor import _run_diagnostics_quietly, render_json
 from phlo.cli.commands.workflow import (
-    _create_workflow,
     _validate_schema_file,
     _validate_workflow_file,
 )
 from phlo.cli.templates.registry import list_templates as list_project_templates
+from phlo.workflow_authoring import WorkflowAuthoringError, create_workflow_with_provider
 
 router = APIRouter(tags=["authoring"])
 
@@ -32,6 +32,9 @@ class CreateWorkflowRequest(BaseModel):
     cron: str = "0 */1 * * *"
     api_base_url: str | None = None
     fields: list[str] = Field(default_factory=list)
+    provider: str | None = None
+    contribution_id: str | None = None
+    values: dict[str, Any] = Field(default_factory=dict)
 
 
 class PathValidationRequest(BaseModel):
@@ -47,8 +50,16 @@ def _project_root() -> Path:
 def _resolve_project_path(path: str) -> Path:
     candidate = Path(path)
     if candidate.is_absolute():
-        return candidate
-    return _project_root() / candidate
+        resolved = candidate.resolve()
+    else:
+        resolved = (_project_root() / candidate).resolve()
+    project_root = _project_root()
+    if resolved != project_root and project_root not in resolved.parents:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "path_outside_project", "project_root": str(project_root)},
+        )
+    return resolved
 
 
 @router.post("/workflows")
@@ -57,7 +68,8 @@ def create_workflow(request: CreateWorkflowRequest, http_request: Request) -> di
     auth = require_scope(http_request, "project:write")
     enforce_rate_limit(auth["subject"], "create_workflow")
     try:
-        result = _create_workflow(
+        result = create_workflow_with_provider(
+            project_root=_project_root(),
             workflow_type=request.workflow_type,
             domain=request.domain,
             table=request.table,
@@ -65,6 +77,9 @@ def create_workflow(request: CreateWorkflowRequest, http_request: Request) -> di
             cron=request.cron,
             api_base_url=request.api_base_url,
             fields=request.fields,
+            provider=request.provider,
+            contribution_id=request.contribution_id,
+            values=request.values,
         )
     except FileExistsError as exc:
         payload = {
@@ -81,12 +96,29 @@ def create_workflow(request: CreateWorkflowRequest, http_request: Request) -> di
             result=payload,
         )
         raise HTTPException(status_code=409, detail=payload) from exc
+    except WorkflowAuthoringError as exc:
+        payload = {
+            "error": "workflow_authoring_unavailable",
+            "message": str(exc),
+            "target": f"{request.domain}/{request.table}",
+        }
+        audit_operation(
+            operation="create_workflow",
+            target=f"{request.domain}/{request.table}",
+            dry_run=False,
+            auth=auth,
+            payload=request.model_dump(mode="json"),
+            result=payload,
+        )
+        raise HTTPException(status_code=422, detail=payload) from exc
     payload = {
         "workflow_type": result.workflow_type,
+        "provider": result.provider,
         "domain": result.domain,
         "table": result.table,
         "files": result.files,
         "next_steps": result.next_steps,
+        "metadata": result.metadata,
     }
     audit_operation(
         operation="create_workflow",

--- a/packages/phlo-api/src/phlo_api/api/authoring.py
+++ b/packages/phlo-api/src/phlo_api/api/authoring.py
@@ -1,0 +1,222 @@
+"""Agent-facing authoring API routes."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from phlo_api.api.operation_controls import audit_operation, enforce_rate_limit, require_scope
+from phlo_api.pagination import paginate_items
+
+from phlo.cli.commands.doctor import _run_diagnostics_quietly, render_json
+from phlo.cli.commands.workflow import (
+    _create_workflow,
+    _validate_schema_file,
+    _validate_workflow_file,
+)
+from phlo.cli.templates.registry import list_templates as list_project_templates
+
+router = APIRouter(tags=["authoring"])
+
+
+class CreateWorkflowRequest(BaseModel):
+    workflow_type: str = "ingestion"
+    domain: str
+    table: str
+    unique_key: str
+    cron: str = "0 */1 * * *"
+    api_base_url: str | None = None
+    fields: list[str] = Field(default_factory=list)
+
+
+class PathValidationRequest(BaseModel):
+    path: str | None = None
+    workflow_path: str | None = None
+    schema_path: str | None = None
+
+
+def _project_root() -> Path:
+    return Path(os.environ.get("PHLO_PROJECT_PATH", ".")).resolve()
+
+
+def _resolve_project_path(path: str) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate
+    return _project_root() / candidate
+
+
+@router.post("/workflows")
+def create_workflow(request: CreateWorkflowRequest, http_request: Request) -> dict[str, Any]:
+    """Create a workflow scaffold in the current project."""
+    auth = require_scope(http_request, "project:write")
+    enforce_rate_limit(auth["subject"], "create_workflow")
+    try:
+        result = _create_workflow(
+            workflow_type=request.workflow_type,
+            domain=request.domain,
+            table=request.table,
+            unique_key=request.unique_key,
+            cron=request.cron,
+            api_base_url=request.api_base_url,
+            fields=request.fields,
+        )
+    except FileExistsError as exc:
+        payload = {
+            "error": "workflow_already_exists",
+            "message": str(exc),
+            "target": f"{request.domain}/{request.table}",
+        }
+        audit_operation(
+            operation="create_workflow",
+            target=f"{request.domain}/{request.table}",
+            dry_run=False,
+            auth=auth,
+            payload=request.model_dump(mode="json"),
+            result=payload,
+        )
+        raise HTTPException(status_code=409, detail=payload) from exc
+    payload = {
+        "workflow_type": result.workflow_type,
+        "domain": result.domain,
+        "table": result.table,
+        "files": result.files,
+        "next_steps": result.next_steps,
+    }
+    audit_operation(
+        operation="create_workflow",
+        target=f"{request.domain}/{request.table}",
+        dry_run=False,
+        auth=auth,
+        payload=request.model_dump(mode="json"),
+        result=payload,
+    )
+    return payload
+
+
+@router.post("/workflows/validate")
+def validate_workflow(request: PathValidationRequest, http_request: Request) -> dict[str, Any]:
+    """Validate a workflow file."""
+    auth = require_scope(http_request, "project:write")
+    enforce_rate_limit(auth["subject"], "validate_workflow")
+    workflow_path = request.workflow_path or request.path
+    if not workflow_path:
+        return {"valid": False, "errors": ["workflow_path is required"]}
+    try:
+        resolved = _resolve_project_path(workflow_path)
+        _validate_workflow_file(str(resolved))
+        payload = {"valid": True, "workflow_path": str(resolved), "errors": []}
+    except Exception as exc:
+        payload = {"valid": False, "workflow_path": workflow_path, "errors": [str(exc)]}
+    audit_operation(
+        operation="validate_workflow",
+        target=workflow_path,
+        dry_run=True,
+        auth=auth,
+        payload=request.model_dump(mode="json"),
+        result=payload,
+    )
+    return payload
+
+
+@router.post("/schemas/validate")
+def validate_schema(request: PathValidationRequest, http_request: Request) -> dict[str, Any]:
+    """Validate a schema file."""
+    auth = require_scope(http_request, "project:write")
+    enforce_rate_limit(auth["subject"], "validate_schema")
+    schema_path = request.schema_path or request.path
+    if not schema_path:
+        return {"valid": False, "errors": ["schema_path is required"]}
+    try:
+        resolved = _resolve_project_path(schema_path)
+        _validate_schema_file(str(resolved))
+        payload = {"valid": True, "schema_path": str(resolved), "errors": []}
+    except Exception as exc:
+        payload = {"valid": False, "schema_path": schema_path, "errors": [str(exc)]}
+    audit_operation(
+        operation="validate_schema",
+        target=schema_path,
+        dry_run=True,
+        auth=auth,
+        payload=request.model_dump(mode="json"),
+        result=payload,
+    )
+    return payload
+
+
+@router.get("/templates")
+def list_templates() -> dict[str, Any]:
+    """List project starter templates."""
+    return {
+        "items": [
+            {
+                "name": template.metadata.name,
+                "description": template.metadata.description,
+                "required_packages": list(template.metadata.required_packages),
+                "generated_paths": list(template.metadata.generated_paths),
+                "next_steps": list(template.metadata.next_steps),
+            }
+            for template in list_project_templates()
+        ]
+    }
+
+
+@router.get("/workflows")
+def list_workflows(
+    search: str | None = None,
+    group: str | None = None,
+    limit: int = 100,
+    cursor: str | None = None,
+) -> dict[str, Any]:
+    """List workflow Python files discovered in the project."""
+    workflows_root = _project_root() / "workflows"
+    items: list[dict[str, Any]] = []
+    if workflows_root.exists():
+        for path in sorted(workflows_root.rglob("*.py")):
+            relative = path.relative_to(_project_root())
+            parts = relative.parts
+            workflow_group = parts[1] if len(parts) > 2 else None
+            item = {"path": str(relative), "name": path.stem, "group": workflow_group}
+            haystack = f"{item['path']} {item['name']} {item['group'] or ''}".lower()
+            if search and search.lower() not in haystack:
+                continue
+            if group and workflow_group != group:
+                continue
+            items.append(item)
+    page, next_cursor = paginate_items(items, limit=limit, cursor=cursor)
+    return {"items": page, "next_cursor": next_cursor}
+
+
+@router.post("/project/lint")
+def lint_project(http_request: Request) -> dict[str, Any]:
+    """Run lightweight project lint checks for agents."""
+    auth = require_scope(http_request, "project:write")
+    enforce_rate_limit(auth["subject"], "lint_project")
+    doctor = run_doctor()
+    workflows = list_workflows().get("items", [])
+    payload = {
+        "ok": doctor["summary"].get("fail", 0) == 0,
+        "doctor": doctor,
+        "workflow_count": len(workflows),
+        "warnings": [],
+        "errors": [] if doctor["summary"].get("fail", 0) == 0 else ["doctor reported failures"],
+    }
+    audit_operation(
+        operation="lint_project",
+        target=str(_project_root()),
+        dry_run=True,
+        auth=auth,
+        result=payload,
+    )
+    return payload
+
+
+@router.get("/doctor")
+def run_doctor(verbose: bool = False) -> dict[str, Any]:
+    """Run the same diagnostic engine as `phlo doctor --json`."""
+    return json.loads(render_json(_run_diagnostics_quietly(verbose=verbose)))

--- a/packages/phlo-api/src/phlo_api/api/observability.py
+++ b/packages/phlo-api/src/phlo_api/api/observability.py
@@ -43,7 +43,7 @@ Example:
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
@@ -241,9 +241,9 @@ def get_platform_metrics(
 
 @router.get("/alerts", response_model=list[AlertResponse] | dict)
 def get_recent_alerts(
-    limit: int = Query(default=10, le=100),
-    cursor: str | None = Query(default=None),
-    backend: str | None = Query(default=None, description="Observability backend name"),
+    limit: Annotated[int, Query(le=100)] = 10,
+    cursor: Annotated[str | None, Query()] = None,
+    backend: Annotated[str | None, Query(description="Observability backend name")] = None,
 ) -> list[AlertResponse] | dict[str, Any]:
     """Get recent alerts from observability backend.
 
@@ -281,7 +281,7 @@ def get_recent_alerts(
 
 @router.get("/dashboards", response_model=list[DashboardLinkResponse] | dict)
 def get_dashboard_links(
-    backend: str | None = Query(default=None, description="Observability backend name"),
+    backend: Annotated[str | None, Query(description="Observability backend name")] = None,
 ) -> list[DashboardLinkResponse] | dict[str, str]:
     """Get dashboard links from observability backend.
 
@@ -314,7 +314,7 @@ def get_dashboard_links(
 @router.get("/links/logs")
 def get_logs_query_link(
     service: str | None = None,
-    backend: str | None = Query(default=None, description="Observability backend name"),
+    backend: Annotated[str | None, Query(description="Observability backend name")] = None,
 ) -> dict[str, str | None]:
     """Get log query link from observability backend.
 
@@ -341,7 +341,7 @@ def get_logs_query_link(
 @router.get("/links/metrics")
 def get_metrics_query_link(
     metric: str | None = None,
-    backend: str | None = Query(default=None, description="Observability backend name"),
+    backend: Annotated[str | None, Query(description="Observability backend name")] = None,
 ) -> dict[str, str | None]:
     """Get metrics query link from observability backend.
 
@@ -368,9 +368,9 @@ def get_metrics_query_link(
 @router.get("/traces/runs/{run_id}", response_model=list[TraceSpanResponse] | dict)
 def get_run_trace_spans(
     run_id: str,
-    limit: int = Query(default=500, le=5000),
-    cursor: str | None = Query(default=None),
-    backend: str | None = Query(default=None, description="Observability backend name"),
+    limit: Annotated[int, Query(le=5000)] = 500,
+    cursor: Annotated[str | None, Query()] = None,
+    backend: Annotated[str | None, Query(description="Observability backend name")] = None,
 ) -> list[TraceSpanResponse] | dict[str, Any]:
     """Get OTEL spans correlated to a run id from the observability backend."""
     try:
@@ -391,17 +391,17 @@ def get_run_trace_spans(
 
 @router.get("/traces", response_model=list[TraceSpanResponse] | dict)
 def get_trace_spans(
-    run_id: str | None = Query(default=None),
-    asset_key: str | None = Query(default=None),
-    job_name: str | None = Query(default=None),
-    service_name: str | None = Query(default=None),
-    span_name: str | None = Query(default=None),
-    status_code: str | None = Query(default=None),
-    start_time: str | None = Query(default=None),
-    end_time: str | None = Query(default=None),
-    limit: int = Query(default=500, le=5000),
-    cursor: str | None = Query(default=None),
-    backend: str | None = Query(default=None, description="Observability backend name"),
+    run_id: Annotated[str | None, Query()] = None,
+    asset_key: Annotated[str | None, Query()] = None,
+    job_name: Annotated[str | None, Query()] = None,
+    service_name: Annotated[str | None, Query()] = None,
+    span_name: Annotated[str | None, Query()] = None,
+    status_code: Annotated[str | None, Query()] = None,
+    start_time: Annotated[str | None, Query()] = None,
+    end_time: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(le=5000)] = 500,
+    cursor: Annotated[str | None, Query()] = None,
+    backend: Annotated[str | None, Query(description="Observability backend name")] = None,
 ) -> list[TraceSpanResponse] | dict[str, Any]:
     """Get OTEL spans matching bounded observability filters."""
     try:

--- a/packages/phlo-api/src/phlo_api/api/observability.py
+++ b/packages/phlo-api/src/phlo_api/api/observability.py
@@ -51,6 +51,7 @@ from pydantic import BaseModel, Field
 from phlo.capabilities import TraceSpanFilter, list_capabilities, resolve_capability
 from phlo.capabilities.discovery import discover_capabilities
 from phlo.logging import get_logger
+from phlo_api.pagination import paginate_items
 
 logger = get_logger(__name__)
 
@@ -241,8 +242,9 @@ def get_platform_metrics(
 @router.get("/alerts", response_model=list[AlertResponse] | dict)
 def get_recent_alerts(
     limit: int = Query(default=10, le=100),
+    cursor: str | None = Query(default=None),
     backend: str | None = Query(default=None, description="Observability backend name"),
-) -> list[AlertResponse] | dict[str, str]:
+) -> list[AlertResponse] | dict[str, Any]:
     """Get recent alerts from observability backend.
 
     Args:
@@ -258,8 +260,8 @@ def get_recent_alerts(
     """
     try:
         provider = _resolve_observability_backend(backend)
-        alerts = provider.recent_alerts(limit)
-        return [
+        alerts = provider.recent_alerts(limit + 100)
+        items = [
             AlertResponse(
                 title=alert.title,
                 severity=alert.severity,
@@ -268,6 +270,10 @@ def get_recent_alerts(
             )
             for alert in alerts
         ]
+        if cursor:
+            page, next_cursor = paginate_items(items, limit=limit, cursor=cursor)
+            return {"items": page, "next_cursor": next_cursor}
+        return items[:limit]
     except Exception as exc:
         logger.exception("recent_alerts_load_failed")
         return {"error": str(exc)}
@@ -363,8 +369,9 @@ def get_metrics_query_link(
 def get_run_trace_spans(
     run_id: str,
     limit: int = Query(default=500, le=5000),
+    cursor: str | None = Query(default=None),
     backend: str | None = Query(default=None, description="Observability backend name"),
-) -> list[TraceSpanResponse] | dict[str, str]:
+) -> list[TraceSpanResponse] | dict[str, Any]:
     """Get OTEL spans correlated to a run id from the observability backend."""
     try:
         provider = _resolve_observability_backend(backend)
@@ -372,7 +379,11 @@ def get_run_trace_spans(
             spans = provider.trace_spans(TraceSpanFilter(run_id=run_id, limit=limit))
         else:
             spans = provider.run_trace_spans(run_id, limit=limit)
-        return [TraceSpanResponse(**span.__dict__) for span in spans]
+        items = [TraceSpanResponse(**span.__dict__) for span in spans]
+        if cursor:
+            page, next_cursor = paginate_items(items, limit=limit, cursor=cursor)
+            return {"items": page, "next_cursor": next_cursor}
+        return items[:limit]
     except Exception as exc:
         logger.exception("run_trace_spans_load_failed", run_id=run_id)
         return {"error": str(exc)}
@@ -389,8 +400,9 @@ def get_trace_spans(
     start_time: str | None = Query(default=None),
     end_time: str | None = Query(default=None),
     limit: int = Query(default=500, le=5000),
+    cursor: str | None = Query(default=None),
     backend: str | None = Query(default=None, description="Observability backend name"),
-) -> list[TraceSpanResponse] | dict[str, str]:
+) -> list[TraceSpanResponse] | dict[str, Any]:
     """Get OTEL spans matching bounded observability filters."""
     try:
         provider = _resolve_observability_backend(backend)
@@ -411,7 +423,11 @@ def get_trace_spans(
             spans = provider.run_trace_spans(run_id, limit=limit)
         else:
             spans = []
-        return [TraceSpanResponse(**span.__dict__) for span in spans]
+        items = [TraceSpanResponse(**span.__dict__) for span in spans]
+        if cursor:
+            page, next_cursor = paginate_items(items, limit=limit, cursor=cursor)
+            return {"items": page, "next_cursor": next_cursor}
+        return items[:limit]
     except Exception as exc:
         logger.exception("trace_spans_load_failed")
         return {"error": str(exc)}

--- a/packages/phlo-api/src/phlo_api/api/operation_controls.py
+++ b/packages/phlo-api/src/phlo_api/api/operation_controls.py
@@ -81,6 +81,8 @@ def audit_operation(
     """Append an API-side mutation audit record."""
     audit_dir = project_root() / ".phlo" / "audit"
     audit_dir.mkdir(parents=True, exist_ok=True)
+    audit_path = audit_dir / "operations.jsonl"
+    _rotate_audit_log(audit_path)
     record = {
         "timestamp": datetime.now(UTC).isoformat(),
         "surface": "phlo-api",
@@ -92,8 +94,23 @@ def audit_operation(
         "payload": payload or {},
         "result": result or {},
     }
-    with (audit_dir / "operations.jsonl").open("a", encoding="utf-8") as handle:
+    with audit_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _rotate_audit_log(path: Path) -> None:
+    max_bytes = int(os.environ.get("PHLO_API_AUDIT_MAX_BYTES", str(10 * 1024 * 1024)))
+    max_files = int(os.environ.get("PHLO_API_AUDIT_MAX_FILES", "5"))
+    if max_bytes <= 0 or max_files <= 0 or not path.exists() or path.stat().st_size < max_bytes:
+        return
+    oldest = path.with_name(f"{path.name}.{max_files}")
+    if oldest.exists():
+        oldest.unlink()
+    for index in range(max_files - 1, 0, -1):
+        candidate = path.with_name(f"{path.name}.{index}")
+        if candidate.exists():
+            candidate.replace(path.with_name(f"{path.name}.{index + 1}"))
+    path.replace(path.with_name(f"{path.name}.1"))
 
 
 def replay_or_execute(

--- a/packages/phlo-api/src/phlo_api/api/operation_controls.py
+++ b/packages/phlo-api/src/phlo_api/api/operation_controls.py
@@ -1,0 +1,270 @@
+"""Controls for scoped operation routes: auth scopes, audit, rate limits, idempotency."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from collections import defaultdict, deque
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+from phlo_api.api.authentication import get_request_principal
+
+_TOKEN_CONFIG_ENV = "PHLO_API_TOKENS"
+_DEFAULT_IDEMPOTENCY_RETENTION_HOURS = 24
+_RATE_LIMITS: dict[tuple[str, str], deque[float]] = defaultdict(deque)
+
+
+def project_root() -> Path:
+    return Path(os.environ.get("PHLO_PROJECT_PATH", ".")).resolve()
+
+
+def require_scope(request: Request, required_scope: str) -> dict[str, Any]:
+    """Require a bearer token with the requested scope or admin."""
+    principal = get_request_principal(request)
+    if principal is not None:
+        scopes = _principal_scopes(principal.claims, principal.attributes, principal.groups)
+        if required_scope in scopes or "admin" in scopes:
+            return {"subject": principal.subject, "scopes": sorted(scopes)}
+        raise HTTPException(
+            status_code=403, detail={"error": "forbidden", "required_scope": required_scope}
+        )
+
+    token = _bearer_token(request)
+    token_config = _load_token_config()
+    token_data = token_config.get(token) if token else None
+    if token_data is None:
+        raise HTTPException(
+            status_code=401, detail={"error": "unauthorized", "reason": "missing_or_invalid_token"}
+        )
+
+    scopes = _principal_scopes(
+        token_data.get("claims", {}), token_data.get("attributes", {}), token_data.get("scopes", ())
+    )
+    if required_scope not in scopes and "admin" not in scopes:
+        raise HTTPException(
+            status_code=403, detail={"error": "forbidden", "required_scope": required_scope}
+        )
+    return {"subject": str(token_data.get("subject") or "token"), "scopes": sorted(scopes)}
+
+
+def enforce_rate_limit(subject: str, operation: str) -> None:
+    """Enforce a per-subject, per-operation token bucket."""
+    limit = _operation_limit(operation)
+    now = time.monotonic()
+    bucket = _RATE_LIMITS[(subject, operation)]
+    while bucket and now - bucket[0] > 60:
+        bucket.popleft()
+    if len(bucket) >= limit:
+        raise HTTPException(
+            status_code=429, detail={"error": "rate_limited", "limit_per_minute": limit}
+        )
+    bucket.append(now)
+
+
+def audit_operation(
+    *,
+    operation: str,
+    target: str,
+    dry_run: bool,
+    auth: dict[str, Any],
+    payload: dict[str, Any] | None = None,
+    result: dict[str, Any] | None = None,
+) -> None:
+    """Append an API-side mutation audit record."""
+    audit_dir = project_root() / ".phlo" / "audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "surface": "phlo-api",
+        "operation": operation,
+        "target": target,
+        "dry_run": dry_run,
+        "subject": auth["subject"],
+        "scopes": auth["scopes"],
+        "payload": payload or {},
+        "result": result or {},
+    }
+    with (audit_dir / "operations.jsonl").open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def replay_or_execute(
+    *,
+    idempotency_key: str | None,
+    operation: str,
+    target: str,
+    execute: Callable[[], dict[str, Any]],
+) -> dict[str, Any]:
+    """Return a previous idempotent response or execute and persist the new response."""
+    if not idempotency_key:
+        return execute()
+
+    conn = _idempotency_connection()
+    try:
+        _delete_expired(conn)
+        key_hash = _idempotency_hash(idempotency_key)
+        existing = conn.execute(
+            """
+            SELECT response_json FROM operations
+            WHERE project = ? AND key_hash = ? AND operation = ? AND target = ?
+            """,
+            (str(project_root()), key_hash, operation, target),
+        ).fetchone()
+        if existing:
+            return json.loads(existing[0])
+
+        response = execute()
+        now = datetime.now(UTC)
+        expires_at = now + timedelta(hours=_DEFAULT_IDEMPOTENCY_RETENTION_HOURS)
+        conn.execute(
+            """
+            INSERT INTO operations(project, key_hash, operation, target, response_json, created_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(project_root()),
+                key_hash,
+                operation,
+                target,
+                json.dumps(response, sort_keys=True),
+                now.isoformat(),
+                expires_at.isoformat(),
+            ),
+        )
+        conn.commit()
+        return response
+    finally:
+        conn.close()
+
+
+async def replay_or_execute_async(
+    *,
+    idempotency_key: str | None,
+    operation: str,
+    target: str,
+    execute: Callable[[], Awaitable[dict[str, Any]]],
+) -> dict[str, Any]:
+    """Async variant of replay_or_execute."""
+    if not idempotency_key:
+        return await execute()
+
+    conn = _idempotency_connection()
+    try:
+        _delete_expired(conn)
+        key_hash = _idempotency_hash(idempotency_key)
+        existing = conn.execute(
+            """
+            SELECT response_json FROM operations
+            WHERE project = ? AND key_hash = ? AND operation = ? AND target = ?
+            """,
+            (str(project_root()), key_hash, operation, target),
+        ).fetchone()
+        if existing:
+            return json.loads(existing[0])
+
+        response = await execute()
+        now = datetime.now(UTC)
+        expires_at = now + timedelta(hours=_DEFAULT_IDEMPOTENCY_RETENTION_HOURS)
+        conn.execute(
+            """
+            INSERT INTO operations(project, key_hash, operation, target, response_json, created_at, expires_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(project_root()),
+                key_hash,
+                operation,
+                target,
+                json.dumps(response, sort_keys=True),
+                now.isoformat(),
+                expires_at.isoformat(),
+            ),
+        )
+        conn.commit()
+        return response
+    finally:
+        conn.close()
+
+
+def _principal_scopes(claims: dict[str, Any], attributes: dict[str, Any], groups: Any) -> set[str]:
+    raw_scopes: list[Any] = []
+    for source in (claims, attributes):
+        raw_scopes.extend(_scope_values(source.get("scope")))
+        raw_scopes.extend(_scope_values(source.get("scopes")))
+    raw_scopes.extend(_scope_values(groups))
+    return {str(scope) for scope in raw_scopes if str(scope).strip()}
+
+
+def _scope_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item for item in value.replace(",", " ").split() if item]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value]
+    return [str(value)]
+
+
+def _bearer_token(request: Request) -> str | None:
+    header = request.headers.get("authorization", "")
+    if not header.lower().startswith("bearer "):
+        return None
+    return header[7:]
+
+
+def _load_token_config() -> dict[str, dict[str, Any]]:
+    raw = os.environ.get(_TOKEN_CONFIG_ENV)
+    if not raw:
+        return {}
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=500, detail=f"{_TOKEN_CONFIG_ENV} must be a JSON object")
+    return {str(key): value for key, value in payload.items() if isinstance(value, dict)}
+
+
+def _operation_limit(operation: str) -> int:
+    if operation in {"materialize_asset", "backfill_asset"}:
+        return int(os.environ.get("PHLO_API_RATE_LIMIT_MATERIALIZE", "10"))
+    if operation == "retry_failed_run":
+        return int(os.environ.get("PHLO_API_RATE_LIMIT_RETRY", "30"))
+    if operation == "cancel_run":
+        return int(os.environ.get("PHLO_API_RATE_LIMIT_CANCEL", "60"))
+    return int(os.environ.get("PHLO_API_RATE_LIMIT_MUTATION", "60"))
+
+
+def _idempotency_connection() -> sqlite3.Connection:
+    state_dir = project_root() / ".phlo" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(state_dir / "operations.sqlite")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS operations(
+            project TEXT NOT NULL,
+            key_hash TEXT NOT NULL,
+            operation TEXT NOT NULL,
+            target TEXT NOT NULL,
+            response_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            expires_at TEXT NOT NULL,
+            PRIMARY KEY(project, key_hash, operation, target)
+        )
+        """
+    )
+    return conn
+
+
+def _delete_expired(conn: sqlite3.Connection) -> None:
+    conn.execute("DELETE FROM operations WHERE expires_at < ?", (datetime.now(UTC).isoformat(),))
+    conn.commit()
+
+
+def _idempotency_hash(key: str) -> str:
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()

--- a/packages/phlo-api/src/phlo_api/api/operation_controls.py
+++ b/packages/phlo-api/src/phlo_api/api/operation_controls.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
@@ -173,6 +174,29 @@ async def replay_or_execute_async(
     if not idempotency_key:
         return await execute()
 
+    existing = await asyncio.to_thread(
+        _load_idempotent_response,
+        idempotency_key=idempotency_key,
+        operation=operation,
+        target=target,
+    )
+    if existing is not None:
+        return existing
+
+    response = await execute()
+    await asyncio.to_thread(
+        _store_idempotent_response,
+        idempotency_key=idempotency_key,
+        operation=operation,
+        target=target,
+        response=response,
+    )
+    return response
+
+
+def _load_idempotent_response(
+    *, idempotency_key: str, operation: str, target: str
+) -> dict[str, Any] | None:
     conn = _idempotency_connection()
     try:
         _delete_expired(conn)
@@ -186,8 +210,21 @@ async def replay_or_execute_async(
         ).fetchone()
         if existing:
             return json.loads(existing[0])
+        return None
+    finally:
+        conn.close()
 
-        response = await execute()
+
+def _store_idempotent_response(
+    *,
+    idempotency_key: str,
+    operation: str,
+    target: str,
+    response: dict[str, Any],
+) -> None:
+    conn = _idempotency_connection()
+    try:
+        key_hash = _idempotency_hash(idempotency_key)
         now = datetime.now(UTC)
         expires_at = now + timedelta(hours=_DEFAULT_IDEMPOTENCY_RETENTION_HOURS)
         conn.execute(
@@ -206,7 +243,6 @@ async def replay_or_execute_async(
             ),
         )
         conn.commit()
-        return response
     finally:
         conn.close()
 

--- a/packages/phlo-api/src/phlo_api/main.py
+++ b/packages/phlo-api/src/phlo_api/main.py
@@ -66,8 +66,10 @@ app.add_middleware(
 
 # Auto-discover and register API routers
 _ROUTERS = [
+    ("phlo_api.api.authoring", "/api/authoring"),
     ("phlo_api.api.maintenance", "/api/maintenance"),
     ("phlo_api.api.observability", "/api/observability"),
+    ("phlo_api.observatory_api.loki", "/api/loki"),
     ("phlo_api.observatory_api.v2", "/api/observatory/v2"),
 ]
 

--- a/packages/phlo-api/src/phlo_api/observatory_api/dagster.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/dagster.py
@@ -36,15 +36,12 @@ from datetime import datetime
 from typing import Any
 
 import httpx
-from dagster_graphql.client.query import (
-    LAUNCH_PIPELINE_EXECUTION_MUTATION,
-    LAUNCH_PIPELINE_REEXECUTION_MUTATION,
-)
 from fastapi import APIRouter, Query
 from pydantic import BaseModel, Field
 
 from phlo.config.env import project_env_value
 from phlo.config.network import resolve_url
+from phlo.helpers.partitions import partition_range as _partition_range
 from phlo.logging import get_bound_correlation_context, get_logger
 from phlo.security.service_identity import build_service_headers
 from phlo_api.observatory_api.quality import fetch_quality_snapshot
@@ -291,6 +288,45 @@ query Runs($limit: Int!) {
 }
 """
 
+PARTITION_KEYS_QUERY = """
+query PartitionKeys($assetKey: AssetKeyInput!) {
+    assetNodeOrError(assetKey: $assetKey) {
+        __typename
+        ... on AssetNode {
+            partitionKeysByDimension { name partitionKeys }
+        }
+        ... on AssetNotFoundError { message }
+    }
+}
+"""
+
+TERMINATE_RUN_MUTATION = """
+mutation TerminateRun($runId: String!) {
+    terminateRun(runId: $runId) {
+        __typename
+        ... on TerminateRunSuccess {
+            run { runId status }
+        }
+        ... on TerminateRunFailure { message }
+        ... on RunNotFoundError { message }
+        ... on PythonError { message }
+    }
+}
+"""
+
+LAUNCH_PARTITION_BACKFILL_MUTATION = """
+mutation LaunchPartitionBackfill($backfillParams: LaunchBackfillParams!) {
+    launchPartitionBackfill(backfillParams: $backfillParams) {
+        __typename
+        ... on LaunchBackfillSuccess {
+            backfillId
+        }
+        ... on PartitionSetNotFoundError { message }
+        ... on PythonError { message }
+    }
+}
+"""
+
 
 # --- Pydantic Models ---
 
@@ -380,6 +416,7 @@ class MaterializeAssetRequest(BaseModel):
     repository_location_name: str | None = None
     repository_name: str | None = None
     run_config: dict[str, Any] | None = None
+    idempotency_key: str | None = None
     tags: dict[str, str] = Field(default_factory=dict)
 
 
@@ -388,6 +425,26 @@ class RetryRunRequest(BaseModel):
 
     dry_run: bool = True
     strategy: str = "FROM_FAILURE"
+    idempotency_key: str | None = None
+    tags: dict[str, str] = Field(default_factory=dict)
+
+
+class CancelRunRequest(BaseModel):
+    """Request to cancel one Dagster run."""
+
+    reason: str | None = None
+
+
+class BackfillAssetRequest(BaseModel):
+    """Request to launch or plan a partition backfill for one asset."""
+
+    dry_run: bool = True
+    partitions: list[str] = Field(default_factory=list)
+    partition_range: dict[str, str] | None = None
+    partition_set_name: str | None = None
+    repository_location_name: str | None = None
+    repository_name: str | None = None
+    idempotency_key: str | None = None
     tags: dict[str, str] = Field(default_factory=dict)
 
 
@@ -414,6 +471,13 @@ class DagsterRunStatus(BaseModel):
     start_time: float | None = None
     end_time: float | None = None
     tags: dict[str, str] = {}
+
+
+class DagsterPartitionStatus(BaseModel):
+    """Materialization status for one asset partition."""
+
+    partition_key: str
+    status: str = "UNKNOWN"
 
 
 class GraphNode(BaseModel):
@@ -1049,41 +1113,19 @@ async def materialize_asset(
                 details={"op_names": op_names},
             )
 
-        tags = {
-            "phlo/operation": "materialize_asset",
-            "phlo/asset_key": asset_key_path,
-            **payload.tags,
-        }
-        if payload.partition_key:
-            tags.setdefault("dagster/partition", payload.partition_key)
+        from phlo_dagster.operations import launch_materialize
 
-        execution_params: dict[str, Any] = {
-            "selector": {
-                "pipelineName": payload.job_name,
-                "repositoryLocationName": payload.repository_location_name,
-                "repositoryName": payload.repository_name,
-                "assetSelection": [{"path": asset_key_path.split("/")}],
-            },
-            "runConfigData": payload.run_config or {},
-            "mode": "default",
-            "executionMetadata": {"tags": _tags_for_execution(tags)},
-        }
-        result = await graphql_request(
-            resolve_dagster_url(dagster_url),
-            LAUNCH_PIPELINE_EXECUTION_MUTATION,
-            {"executionParams": execution_params},
-            initiator="observatory",
-        )
-        if result.get("errors"):
-            return {"error": result["errors"][0].get("message", "GraphQL error")}
-        launch_result = result.get("data", {}).get("launchPipelineExecution", {})
-        return _launch_operation_response(
-            operation="materialize_asset",
-            dry_run=False,
-            launch_result=launch_result,
+        result = await launch_materialize(
+            dagster_url=resolve_dagster_url(dagster_url),
             asset_key_path=asset_key_path,
+            job_name=payload.job_name,
+            repository_location_name=payload.repository_location_name,
+            repository_name=payload.repository_name,
             partition_key=payload.partition_key,
+            run_config=payload.run_config,
+            tags=payload.tags,
         )
+        return DagsterOperationResponse(**result.to_dict())
 
     return DagsterOperationResponse(
         operation="materialize_asset",
@@ -1099,6 +1141,27 @@ async def materialize_asset(
         ),
         details={"op_names": op_names},
     )
+
+
+@router.get(
+    "/assets/{asset_key_path:path}/partitions",
+    response_model=list[DagsterPartitionStatus] | dict,
+)
+async def list_partitions(
+    asset_key_path: str,
+    dagster_url: str | None = None,
+) -> list[DagsterPartitionStatus] | dict[str, str]:
+    """List partition keys for an asset."""
+    try:
+        from phlo_dagster.operations import list_partitions as list_dagster_partitions
+
+        partitions = await list_dagster_partitions(
+            dagster_url=resolve_dagster_url(dagster_url),
+            asset_key_path=asset_key_path,
+        )
+        return [DagsterPartitionStatus(**partition) for partition in partitions]
+    except Exception as exc:
+        return {"error": str(exc)}
 
 
 @router.get("/assets/{asset_key_path:path}", response_model=AssetDetails | dict)
@@ -1298,34 +1361,15 @@ async def retry_run(
                 details={"run_status": run_status},
             )
 
-        tags = {
-            "phlo/operation": "retry_failed_run",
-            "phlo/parent_run_id": run_id,
-            **payload.tags,
-        }
-        result = await graphql_request(
-            resolve_dagster_url(dagster_url),
-            LAUNCH_PIPELINE_REEXECUTION_MUTATION,
-            {
-                "executionParams": None,
-                "reexecutionParams": {
-                    "parentRunId": run_id,
-                    "strategy": payload.strategy,
-                    "extraTags": _tags_for_execution(tags),
-                    "useParentRunTags": True,
-                },
-            },
-            initiator="observatory",
+        from phlo_dagster.operations import launch_retry
+
+        result = await launch_retry(
+            dagster_url=resolve_dagster_url(dagster_url),
+            run_id=run_id,
+            strategy=payload.strategy,
+            tags=payload.tags,
         )
-        if result.get("errors"):
-            return {"error": result["errors"][0].get("message", "GraphQL error")}
-        launch_result = result.get("data", {}).get("launchPipelineReexecution", {})
-        return _launch_operation_response(
-            operation="retry_failed_run",
-            dry_run=False,
-            launch_result=launch_result,
-            fallback_run_id=run_id,
-        )
+        return DagsterOperationResponse(**result.to_dict())
 
     return DagsterOperationResponse(
         operation="retry_failed_run",
@@ -1340,6 +1384,95 @@ async def retry_run(
         ),
         details={"run_status": run_status},
     )
+
+
+@router.post("/runs/{run_id}/cancel", response_model=DagsterOperationResponse | dict)
+async def cancel_run(
+    run_id: str,
+    payload: CancelRunRequest,
+    dagster_url: str | None = None,
+) -> DagsterOperationResponse | dict[str, str]:
+    """Request cancellation for a Dagster run."""
+    from phlo_dagster.operations import terminate
+
+    result = await terminate(
+        dagster_url=resolve_dagster_url(dagster_url),
+        run_id=run_id,
+        reason=payload.reason,
+    )
+    return DagsterOperationResponse(**result.to_dict())
+
+
+@router.post(
+    "/assets/{asset_key_path:path}/backfill", response_model=DagsterOperationResponse | dict
+)
+async def backfill_asset(
+    asset_key_path: str,
+    payload: BackfillAssetRequest,
+    dagster_url: str | None = None,
+) -> DagsterOperationResponse | dict[str, str]:
+    """Validate or request a partition backfill for one asset."""
+    partition_keys = _backfill_partition_keys(payload)
+    if not partition_keys:
+        return DagsterOperationResponse(
+            operation="backfill_asset",
+            dry_run=payload.dry_run,
+            accepted=False,
+            asset_key_path=asset_key_path,
+            status="MISSING_PARTITIONS",
+            message="Backfill requires explicit partitions or a partition_range with start and end.",
+            details={},
+        )
+
+    if payload.dry_run:
+        return DagsterOperationResponse(
+            operation="backfill_asset",
+            dry_run=True,
+            accepted=True,
+            asset_key_path=asset_key_path,
+            status="DRY_RUN",
+            message="Backfill request is valid.",
+            details={"partitions": partition_keys, "partition_count": len(partition_keys)},
+        )
+
+    if not payload.partition_set_name:
+        return DagsterOperationResponse(
+            operation="backfill_asset",
+            dry_run=False,
+            accepted=False,
+            asset_key_path=asset_key_path,
+            status="MISSING_PARTITION_SET_NAME",
+            message="partition_set_name is required to launch a live Dagster partition backfill.",
+            details={"partitions": partition_keys, "partition_count": len(partition_keys)},
+        )
+
+    from phlo_dagster.operations import launch_backfill
+
+    result = await launch_backfill(
+        dagster_url=resolve_dagster_url(dagster_url),
+        asset_key_path=asset_key_path,
+        partition_set_name=payload.partition_set_name,
+        partition_keys=partition_keys,
+        repository_location_name=payload.repository_location_name,
+        repository_name=payload.repository_name,
+        tags=payload.tags,
+    )
+    return DagsterOperationResponse(**result.to_dict())
+
+
+def _backfill_partition_keys(payload: BackfillAssetRequest) -> list[str]:
+    if payload.partitions:
+        return [str(partition) for partition in payload.partitions]
+    if not payload.partition_range:
+        return []
+    start = payload.partition_range.get("start")
+    end = payload.partition_range.get("end")
+    if not start or not end:
+        return []
+    try:
+        return _partition_range(start, end)
+    except ValueError:
+        return []
 
 
 @router.get("/graph", response_model=AssetGraphPayload | dict)

--- a/packages/phlo-api/src/phlo_api/observatory_api/dagster.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/dagster.py
@@ -433,6 +433,7 @@ class CancelRunRequest(BaseModel):
     """Request to cancel one Dagster run."""
 
     reason: str | None = None
+    idempotency_key: str | None = None
 
 
 class BackfillAssetRequest(BaseModel):
@@ -1123,6 +1124,7 @@ async def materialize_asset(
             repository_name=payload.repository_name,
             partition_key=payload.partition_key,
             run_config=payload.run_config,
+            idempotency_key=payload.idempotency_key,
             tags=payload.tags,
         )
         return DagsterOperationResponse(**result.to_dict())
@@ -1367,6 +1369,7 @@ async def retry_run(
             dagster_url=resolve_dagster_url(dagster_url),
             run_id=run_id,
             strategy=payload.strategy,
+            idempotency_key=payload.idempotency_key,
             tags=payload.tags,
         )
         return DagsterOperationResponse(**result.to_dict())
@@ -1399,6 +1402,7 @@ async def cancel_run(
         dagster_url=resolve_dagster_url(dagster_url),
         run_id=run_id,
         reason=payload.reason,
+        idempotency_key=payload.idempotency_key,
     )
     return DagsterOperationResponse(**result.to_dict())
 
@@ -1455,6 +1459,7 @@ async def backfill_asset(
         partition_keys=partition_keys,
         repository_location_name=payload.repository_location_name,
         repository_name=payload.repository_name,
+        idempotency_key=payload.idempotency_key,
         tags=payload.tags,
     )
     return DagsterOperationResponse(**result.to_dict())

--- a/packages/phlo-api/src/phlo_api/observatory_api/loki.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/loki.py
@@ -42,7 +42,7 @@ from pydantic import BaseModel
 from phlo.config.env import project_env_value
 from phlo.config.network import resolve_url
 from phlo.logging import get_logger
-from phlo_api.pagination import paginate_items
+from phlo_api.pagination import decode_cursor, paginate_items
 
 logger = get_logger(__name__)
 
@@ -394,12 +394,14 @@ async def query_run_logs(
         datetime.fromisoformat(since.replace("Z", "+00:00")) if since else end - timedelta(hours=24)
     )
 
+    offset = decode_cursor(cursor)
+    query_limit = min(offset + limit, 2000)
     result = await query_logs(
         start=start.isoformat(),
         end=end.isoformat(),
         run_id=run_id,
         level=level,
-        limit=limit,
+        limit=query_limit,
         loki_url=loki_url,
     )
     if isinstance(result, dict):

--- a/packages/phlo-api/src/phlo_api/observatory_api/loki.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/loki.py
@@ -28,17 +28,21 @@ Example:
 
 from __future__ import annotations
 
+import asyncio
 import json
+import re
 from datetime import datetime, timedelta
 from typing import Any, Literal
 
 import httpx
 from fastapi import APIRouter, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from phlo.config.env import project_env_value
 from phlo.config.network import resolve_url
 from phlo.logging import get_logger
+from phlo_api.pagination import paginate_items
 
 logger = get_logger(__name__)
 
@@ -98,6 +102,7 @@ class LogQueryResult(BaseModel):
 
     entries: list[LogEntry]
     has_more: bool
+    next_cursor: str | None = None
 
 
 class LokiConnectionStatus(BaseModel):
@@ -364,6 +369,11 @@ async def query_run_logs(
     run_id: str,
     level: LogLevel | None = None,
     limit: int = Query(default=500, le=2000),
+    query: str | None = None,
+    regex: str | None = None,
+    since: str | None = None,
+    until: str | None = None,
+    cursor: str | None = None,
     loki_url: str | None = None,
 ) -> LogQueryResult | dict[str, str]:
     """Query logs for a Dagster run.
@@ -379,10 +389,12 @@ async def query_run_logs(
 
     """
     # Query last 24 hours
-    end = datetime.now()
-    start = end - timedelta(hours=24)
+    end = datetime.fromisoformat(until.replace("Z", "+00:00")) if until else datetime.now()
+    start = (
+        datetime.fromisoformat(since.replace("Z", "+00:00")) if since else end - timedelta(hours=24)
+    )
 
-    return await query_logs(
+    result = await query_logs(
         start=start.isoformat(),
         end=end.isoformat(),
         run_id=run_id,
@@ -390,6 +402,51 @@ async def query_run_logs(
         limit=limit,
         loki_url=loki_url,
     )
+    if isinstance(result, dict):
+        return result
+    entries = result.entries
+    if query:
+        entries = [entry for entry in entries if query.lower() in entry.message.lower()]
+    if regex:
+        pattern = re.compile(regex)
+        entries = [entry for entry in entries if pattern.search(entry.message)]
+    page, next_cursor = paginate_items(entries, limit=limit, cursor=cursor)
+    return LogQueryResult(
+        entries=page,
+        has_more=result.has_more or next_cursor is not None,
+        next_cursor=next_cursor,
+    )
+
+
+@router.get("/runs/{run_id}/stream")
+async def stream_run_logs(
+    run_id: str,
+    timeout_seconds: int = Query(default=30, ge=1, le=120),
+    interval_seconds: float = Query(default=2.0, ge=0.25, le=10.0),
+    limit: int = Query(default=200, le=2000),
+    loki_url: str | None = None,
+) -> StreamingResponse:
+    """Stream bounded Server-Sent Events for run logs."""
+
+    async def events():  # noqa: ANN202
+        deadline = datetime.now() + timedelta(seconds=timeout_seconds)
+        seen: set[str] = set()
+        while datetime.now() < deadline:
+            result = await query_run_logs(run_id=run_id, limit=limit, loki_url=loki_url)
+            if isinstance(result, LogQueryResult):
+                for entry in result.entries:
+                    entry_id = f"{entry.timestamp}:{entry.level}:{entry.message}"
+                    if entry_id in seen:
+                        continue
+                    seen.add(entry_id)
+                    yield f"event: log\ndata: {entry.model_dump_json()}\n\n"
+            else:
+                yield f"event: error\ndata: {json.dumps(result)}\n\n"
+                return
+            await asyncio.sleep(interval_seconds)
+        yield f"event: done\ndata: {json.dumps({'run_id': run_id})}\n\n"
+
+    return StreamingResponse(events(), media_type="text/event-stream")
 
 
 @router.get("/assets/{asset_key:path}", response_model=LogQueryResult | dict)

--- a/packages/phlo-api/src/phlo_api/observatory_api/orchestrator_operations.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/orchestrator_operations.py
@@ -1,0 +1,95 @@
+"""Capability-backed orchestrator operation resolution for Observatory v2."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from fastapi import HTTPException
+
+from phlo.capabilities import (
+    OrchestratorOperationsSpec,
+    list_capabilities,
+    register_capability,
+    resolve_capability,
+)
+from phlo.capabilities.discovery import discover_capabilities
+
+
+class LegacyDagsterOrchestratorOperationsProvider:
+    """Adapter for the built-in Dagster Observatory operation implementation."""
+
+    async def get_run_status(self, run_id: str) -> Any:
+        from phlo_api.observatory_api.dagster import get_run_status
+
+        return await get_run_status(run_id)
+
+    async def retry_run(self, run_id: str, request: Mapping[str, Any]) -> Any:
+        from phlo_api.observatory_api.dagster import RetryRunRequest, retry_run
+
+        return await retry_run(run_id, RetryRunRequest(**dict(request)))
+
+    async def cancel_run(self, run_id: str, request: Mapping[str, Any]) -> Any:
+        from phlo_api.observatory_api.dagster import CancelRunRequest, cancel_run
+
+        return await cancel_run(run_id, CancelRunRequest(**dict(request)))
+
+    async def get_materialization_history(self, asset_key_path: str, *, limit: int = 10) -> Any:
+        from phlo_api.observatory_api.dagster import get_materialization_history
+
+        return await get_materialization_history(asset_key_path, limit=limit)
+
+    async def materialize_asset(self, asset_key_path: str, request: Mapping[str, Any]) -> Any:
+        from phlo_api.observatory_api.dagster import MaterializeAssetRequest, materialize_asset
+
+        return await materialize_asset(asset_key_path, MaterializeAssetRequest(**dict(request)))
+
+    async def backfill_asset(self, asset_key_path: str, request: Mapping[str, Any]) -> Any:
+        from phlo_api.observatory_api.dagster import BackfillAssetRequest, backfill_asset
+
+        return await backfill_asset(asset_key_path, BackfillAssetRequest(**dict(request)))
+
+    async def list_partitions(self, asset_key_path: str) -> Any:
+        from phlo_api.observatory_api.dagster import list_partitions
+
+        return await list_partitions(asset_key_path)
+
+
+def resolve_orchestrator_operations(provider_name: str | None = None) -> Any:
+    """Resolve the active orchestrator operations provider."""
+    ensure_orchestrator_operations_registered()
+    resolved = resolve_capability("orchestrator_operations", provider_name)
+    if resolved is not None:
+        return resolved.provider
+
+    available = list_capabilities("orchestrator_operations")
+    detail: dict[str, Any] = {
+        "error": "orchestrator_operations_unavailable",
+        "available_providers": available,
+    }
+    if provider_name:
+        detail["requested_provider"] = provider_name
+    elif len(available) > 1:
+        detail["error"] = "orchestrator_operations_ambiguous"
+        detail["message"] = (
+            "Multiple orchestrator operation providers are installed. Configure a default "
+            "or pass an explicit provider."
+        )
+    else:
+        detail["message"] = "Install or enable an orchestrator operations provider."
+    raise HTTPException(status_code=422, detail=detail)
+
+
+def ensure_orchestrator_operations_registered() -> None:
+    """Discover provider capabilities and install the legacy Dagster fallback."""
+    discover_capabilities()
+    if list_capabilities("orchestrator_operations"):
+        return
+    register_capability(
+        "orchestrator_operations",
+        OrchestratorOperationsSpec(
+            name="dagster",
+            provider=LegacyDagsterOrchestratorOperationsProvider(),
+            metadata={"package": "phlo-api", "legacy": True},
+        ),
+    )

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -17,10 +17,10 @@ import subprocess
 import sys
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 from phlo_api.observatory_api.v2_actions import execute_v2_action
 from phlo_api.observatory_api.v2_cache import ReadModelCache
@@ -127,23 +127,61 @@ from phlo_api.observatory_api.v2_workflow_wizard import (
 )
 from phlo.cli.commands.plugin.install import resolve_install_target
 from phlo.plugins.registry_client import get_registry_data
+from phlo_api.api.operation_controls import (
+    audit_operation,
+    enforce_rate_limit,
+    replay_or_execute_async,
+    require_scope,
+)
+from phlo_api.pagination import paginate_items
 
 router = APIRouter(tags=["observatory-v2"])
 
 
+def _jsonable_result(result: Any) -> dict[str, Any]:
+    if isinstance(result, BaseModel):
+        return result.model_dump(mode="json")
+    if isinstance(result, dict):
+        return result
+    if hasattr(result, "model_dump"):
+        return result.model_dump(mode="json")
+    return {"result": result}
+
+
 class V2MaterializeAssetRequest(BaseModel):
+    model_config = {"populate_by_name": True}
+
     dry_run: bool = True
-    partition_key: str | None = None
+    partition_key: str | None = Field(
+        default=None, validation_alias=AliasChoices("partition_key", "partition")
+    )
     job_name: str | None = None
     repository_location_name: str | None = None
     repository_name: str | None = None
     run_config: dict[str, Any] | None = None
+    idempotency_key: str | None = None
     tags: dict[str, str] = Field(default_factory=dict)
 
 
 class V2RetryRunRequest(BaseModel):
     dry_run: bool = True
     strategy: str = "FROM_FAILURE"
+    idempotency_key: str | None = None
+    tags: dict[str, str] = Field(default_factory=dict)
+
+
+class V2CancelRunRequest(BaseModel):
+    reason: str | None = None
+
+
+class V2BackfillAssetRequest(BaseModel):
+    dry_run: bool = True
+    partitions: list[str] = Field(default_factory=list)
+    partition_range: dict[str, str] | None = None
+    partition_set_name: str | None = None
+    repository_location_name: str | None = None
+    repository_name: str | None = None
+    idempotency_key: str | None = None
     tags: dict[str, str] = Field(default_factory=dict)
 
 
@@ -2543,14 +2581,19 @@ def get_v2_operation_detail(operation_id: str) -> V2OperationDetail:
     return _load_operation_detail(operation_id)
 
 
-@router.get("/runs", response_model=V2RunList)
-def get_v2_runs() -> V2RunList:
+@router.get("/runs", response_model=V2RunList, response_model_exclude_none=True)
+def get_v2_runs(limit: int = 100, cursor: str | None = None, q: str | None = None) -> V2RunList:
     """List provider-neutral orchestrator runs."""
-    return _cached_read_model(
+    result = _cached_read_model(
         "runs",
         _FAST_READ_MODEL_TTL_SECONDS,
         lambda: V2RunList(items=_load_runs()),
     )
+    items = result.items
+    if q:
+        items = [item for item in items if q.lower() in item.model_dump_json().lower()]
+    page, next_cursor = paginate_items(items, limit=limit, cursor=cursor)
+    return V2RunList(items=page, next_cursor=next_cursor)
 
 
 @router.get("/runs/{run_id:path}/status")
@@ -2562,11 +2605,54 @@ async def get_v2_run_status(run_id: str) -> Any:
 
 
 @router.post("/runs/{run_id:path}/retry")
-async def post_v2_run_retry(run_id: str, request: V2RetryRunRequest) -> Any:
+async def post_v2_run_retry(run_id: str, request: V2RetryRunRequest, http_request: Request) -> Any:
     """Validate or request retry for a failed run through the active orchestrator provider."""
     from phlo_api.observatory_api.dagster import RetryRunRequest, retry_run
 
-    return await retry_run(run_id, RetryRunRequest(**request.model_dump()))
+    auth = require_scope(http_request, "lakehouse:operate")
+    enforce_rate_limit(auth["subject"], "retry_failed_run")
+
+    async def execute() -> dict[str, Any]:
+        result = await retry_run(run_id, RetryRunRequest(**request.model_dump()))
+        return _jsonable_result(result)
+
+    payload = await replay_or_execute_async(
+        idempotency_key=request.idempotency_key,
+        operation="retry_failed_run",
+        target=run_id,
+        execute=execute,
+    )
+    audit_operation(
+        operation="retry_failed_run",
+        target=run_id,
+        dry_run=request.dry_run,
+        auth=auth,
+        payload=request.model_dump(mode="json"),
+        result=payload,
+    )
+    return payload
+
+
+@router.post("/runs/{run_id:path}/cancel")
+async def post_v2_run_cancel(
+    run_id: str, request: V2CancelRunRequest, http_request: Request
+) -> Any:
+    """Request cancellation for a run through the active orchestrator provider."""
+    from phlo_api.observatory_api.dagster import CancelRunRequest, cancel_run
+
+    auth = require_scope(http_request, "lakehouse:operate")
+    enforce_rate_limit(auth["subject"], "cancel_run")
+    result = await cancel_run(run_id, CancelRunRequest(**request.model_dump()))
+    payload = _jsonable_result(result)
+    audit_operation(
+        operation="cancel_run",
+        target=run_id,
+        dry_run=False,
+        auth=auth,
+        payload=request.model_dump(mode="json"),
+        result=payload,
+    )
+    return payload
 
 
 @router.get("/storage", response_model=V2SurfaceList)
@@ -2649,14 +2735,16 @@ def get_v2_bi() -> V2SurfaceList:
     )
 
 
-@router.get("/assets", response_model=V2AssetList)
-def get_v2_assets() -> V2AssetList:
+@router.get("/assets", response_model=V2AssetList, response_model_exclude_none=True)
+def get_v2_assets(limit: int = 100, cursor: str | None = None) -> V2AssetList:
     """List provider-neutral Observatory v2 assets."""
-    return _cached_read_model(
+    result = _cached_read_model(
         "assets",
         _EXPENSIVE_READ_MODEL_TTL_SECONDS,
         lambda: V2AssetList(items=_load_assets()),
     )
+    page, next_cursor = paginate_items(result.items, limit=limit, cursor=cursor)
+    return V2AssetList(items=page, next_cursor=next_cursor)
 
 
 @router.get("/asset-graph", response_model=V2AssetGraph)
@@ -2695,11 +2783,73 @@ async def get_v2_asset_materializations(asset_id: str, limit: int = 10) -> Any:
 
 
 @router.post("/assets/{asset_id:path}/materialize")
-async def post_v2_asset_materialize(asset_id: str, request: V2MaterializeAssetRequest) -> Any:
+async def post_v2_asset_materialize(
+    asset_id: str, request: V2MaterializeAssetRequest, http_request: Request
+) -> Any:
     """Validate or request asset materialization through the active orchestrator provider."""
     from phlo_api.observatory_api.dagster import MaterializeAssetRequest, materialize_asset
 
-    return await materialize_asset(asset_id, MaterializeAssetRequest(**request.model_dump()))
+    auth = require_scope(http_request, "lakehouse:operate")
+    enforce_rate_limit(auth["subject"], "materialize_asset")
+
+    async def execute() -> dict[str, Any]:
+        result = await materialize_asset(asset_id, MaterializeAssetRequest(**request.model_dump()))
+        return _jsonable_result(result)
+
+    payload = await replay_or_execute_async(
+        idempotency_key=request.idempotency_key,
+        operation="materialize_asset",
+        target=asset_id,
+        execute=execute,
+    )
+    audit_operation(
+        operation="materialize_asset",
+        target=asset_id,
+        dry_run=request.dry_run,
+        auth=auth,
+        payload=request.model_dump(mode="json"),
+        result=payload,
+    )
+    return payload
+
+
+@router.post("/assets/{asset_id:path}/backfill")
+async def post_v2_asset_backfill(
+    asset_id: str, request: V2BackfillAssetRequest, http_request: Request
+) -> Any:
+    """Validate or request asset partition backfill through the active orchestrator provider."""
+    from phlo_api.observatory_api.dagster import BackfillAssetRequest, backfill_asset
+
+    auth = require_scope(http_request, "lakehouse:operate")
+    enforce_rate_limit(auth["subject"], "backfill_asset")
+
+    async def execute() -> dict[str, Any]:
+        result = await backfill_asset(asset_id, BackfillAssetRequest(**request.model_dump()))
+        return _jsonable_result(result)
+
+    payload = await replay_or_execute_async(
+        idempotency_key=request.idempotency_key,
+        operation="backfill_asset",
+        target=asset_id,
+        execute=execute,
+    )
+    audit_operation(
+        operation="backfill_asset",
+        target=asset_id,
+        dry_run=request.dry_run,
+        auth=auth,
+        payload=request.model_dump(mode="json"),
+        result=payload,
+    )
+    return payload
+
+
+@router.get("/assets/{asset_id:path}/partitions")
+async def get_v2_asset_partitions(asset_id: str) -> Any:
+    """List partitions for an asset from the active orchestrator provider."""
+    from phlo_api.observatory_api.dagster import list_partitions
+
+    return await list_partitions(asset_id)
 
 
 @router.get("/assets/{asset_id:path}", response_model=V2AssetDetail)
@@ -2908,10 +3058,11 @@ def post_v2_workflow_wizard_action(request: V2WorkflowActionRequest) -> V2Workfl
     return result
 
 
-@router.get("/search", response_model=V2SearchList)
-def get_v2_search(q: str) -> V2SearchList:
+@router.get("/search", response_model=V2SearchList, response_model_exclude_none=True)
+def get_v2_search(q: str, limit: int = 100, cursor: str | None = None) -> V2SearchList:
     """Search provider-neutral Observatory v2 resources."""
-    return V2SearchList(items=_search_results(q))
+    page, next_cursor = paginate_items(_search_results(q), limit=limit, cursor=cursor)
+    return V2SearchList(items=page, next_cursor=next_cursor)
 
 
 @router.post("/actions", response_model=V2ActionResult)
@@ -2935,8 +3086,20 @@ def post_v2_action(request: V2ActionRequest) -> V2ActionResult:
 
 
 @router.post("/packages/install", response_model=V2PackageInstallResult)
-def post_v2_package_install(request: V2PackageInstallRequest) -> V2PackageInstallResult:
+def post_v2_package_install(
+    request: V2PackageInstallRequest, http_request: Request
+) -> V2PackageInstallResult:
     """Install a trusted Phlo Python package into the current environment."""
+    auth = require_scope(http_request, "admin")
+    enforce_rate_limit(auth["subject"], "install_package")
     result = _install_python_package(request)
+    audit_operation(
+        operation="install_package",
+        target=request.package_name,
+        dry_run=False,
+        auth=auth,
+        payload=request.model_dump(mode="json"),
+        result=result.model_dump(mode="json"),
+    )
     _clear_read_model_cache()
     return result

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -173,6 +173,7 @@ class V2RetryRunRequest(BaseModel):
 
 class V2CancelRunRequest(BaseModel):
     reason: str | None = None
+    idempotency_key: str | None = None
 
 
 class V2BackfillAssetRequest(BaseModel):
@@ -2646,8 +2647,17 @@ async def post_v2_run_cancel(
     auth = require_scope(http_request, "lakehouse:operate")
     enforce_rate_limit(auth["subject"], "cancel_run")
     provider = resolve_orchestrator_operations()
-    result = await provider.cancel_run(run_id, request.model_dump())
-    payload = _jsonable_result(result)
+
+    async def execute() -> dict[str, Any]:
+        result = await provider.cancel_run(run_id, request.model_dump())
+        return _jsonable_result(result)
+
+    payload = await replay_or_execute_async(
+        idempotency_key=request.idempotency_key,
+        operation="cancel_run",
+        target=run_id,
+        execute=execute,
+    )
     audit_operation(
         operation="cancel_run",
         target=run_id,

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -98,6 +98,7 @@ from phlo_api.observatory_api.v2_operation_journal import (
     record_action_result,
     sort_operations,
 )
+from phlo_api.observatory_api.orchestrator_operations import resolve_orchestrator_operations
 from phlo_api.observatory_api.v2_products import load_api_items, load_bi_items
 from phlo_api.observatory_api.v2_runs import load_runs
 from phlo_api.observatory_api.v2_saved_queries import (
@@ -2605,21 +2606,19 @@ def get_v2_runs(limit: int = 100, cursor: str | None = None, q: str | None = Non
 @router.get("/runs/{run_id:path}/status")
 async def get_v2_run_status(run_id: str) -> Any:
     """Get provider-neutral run status from the active orchestrator provider."""
-    from phlo_api.observatory_api.dagster import get_run_status
-
-    return await get_run_status(run_id)
+    provider = resolve_orchestrator_operations()
+    return await provider.get_run_status(run_id)
 
 
 @router.post("/runs/{run_id:path}/retry")
 async def post_v2_run_retry(run_id: str, request: V2RetryRunRequest, http_request: Request) -> Any:
     """Validate or request retry for a failed run through the active orchestrator provider."""
-    from phlo_api.observatory_api.dagster import RetryRunRequest, retry_run
-
     auth = require_scope(http_request, "lakehouse:operate")
     enforce_rate_limit(auth["subject"], "retry_failed_run")
+    provider = resolve_orchestrator_operations()
 
     async def execute() -> dict[str, Any]:
-        result = await retry_run(run_id, RetryRunRequest(**request.model_dump()))
+        result = await provider.retry_run(run_id, request.model_dump())
         return _jsonable_result(result)
 
     payload = await replay_or_execute_async(
@@ -2644,11 +2643,10 @@ async def post_v2_run_cancel(
     run_id: str, request: V2CancelRunRequest, http_request: Request
 ) -> Any:
     """Request cancellation for a run through the active orchestrator provider."""
-    from phlo_api.observatory_api.dagster import CancelRunRequest, cancel_run
-
     auth = require_scope(http_request, "lakehouse:operate")
     enforce_rate_limit(auth["subject"], "cancel_run")
-    result = await cancel_run(run_id, CancelRunRequest(**request.model_dump()))
+    provider = resolve_orchestrator_operations()
+    result = await provider.cancel_run(run_id, request.model_dump())
     payload = _jsonable_result(result)
     audit_operation(
         operation="cancel_run",
@@ -2782,10 +2780,9 @@ def get_v2_asset_impact(asset_key: str, max_depth: int = 99) -> list[V2ImpactedA
 @router.get("/assets/{asset_id:path}/materializations")
 async def get_v2_asset_materializations(asset_id: str, limit: int = 10) -> Any:
     """Get recent materializations for an asset from the active orchestrator provider."""
-    from phlo_api.observatory_api.dagster import get_materialization_history
-
     limit = max(1, min(limit, 200))
-    return await get_materialization_history(asset_id, limit=limit)
+    provider = resolve_orchestrator_operations()
+    return await provider.get_materialization_history(asset_id, limit=limit)
 
 
 @router.post("/assets/{asset_id:path}/materialize")
@@ -2793,13 +2790,12 @@ async def post_v2_asset_materialize(
     asset_id: str, request: V2MaterializeAssetRequest, http_request: Request
 ) -> Any:
     """Validate or request asset materialization through the active orchestrator provider."""
-    from phlo_api.observatory_api.dagster import MaterializeAssetRequest, materialize_asset
-
     auth = require_scope(http_request, "lakehouse:operate")
     enforce_rate_limit(auth["subject"], "materialize_asset")
+    provider = resolve_orchestrator_operations()
 
     async def execute() -> dict[str, Any]:
-        result = await materialize_asset(asset_id, MaterializeAssetRequest(**request.model_dump()))
+        result = await provider.materialize_asset(asset_id, request.model_dump())
         return _jsonable_result(result)
 
     payload = await replay_or_execute_async(
@@ -2824,13 +2820,12 @@ async def post_v2_asset_backfill(
     asset_id: str, request: V2BackfillAssetRequest, http_request: Request
 ) -> Any:
     """Validate or request asset partition backfill through the active orchestrator provider."""
-    from phlo_api.observatory_api.dagster import BackfillAssetRequest, backfill_asset
-
     auth = require_scope(http_request, "lakehouse:operate")
     enforce_rate_limit(auth["subject"], "backfill_asset")
+    provider = resolve_orchestrator_operations()
 
     async def execute() -> dict[str, Any]:
-        result = await backfill_asset(asset_id, BackfillAssetRequest(**request.model_dump()))
+        result = await provider.backfill_asset(asset_id, request.model_dump())
         return _jsonable_result(result)
 
     payload = await replay_or_execute_async(
@@ -2853,9 +2848,8 @@ async def post_v2_asset_backfill(
 @router.get("/assets/{asset_id:path}/partitions")
 async def get_v2_asset_partitions(asset_id: str) -> Any:
     """List partitions for an asset from the active orchestrator provider."""
-    from phlo_api.observatory_api.dagster import list_partitions
-
-    return await list_partitions(asset_id)
+    provider = resolve_orchestrator_operations()
+    return await provider.list_partitions(asset_id)
 
 
 @router.get("/assets/{asset_id:path}", response_model=V2AssetDetail)

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -185,6 +185,12 @@ class V2BackfillAssetRequest(BaseModel):
     tags: dict[str, str] = Field(default_factory=dict)
 
 
+class V2SchemaDiffRequest(BaseModel):
+    asset_key: str
+    from_run: str | None = None
+    to_run: str | None = None
+
+
 _READ_QUERY_RE = re.compile(
     r"^\s*select\s+\*\s+from\s+(?P<table>[A-Za-z0-9_.:-]+)(?:\s+limit\s+(?P<limit>\d+))?\s*;?\s*$",
     re.IGNORECASE,
@@ -2894,6 +2900,22 @@ def post_v2_saved_query(request: V2SavedQueryRequest) -> V2SavedQuery:
 def get_v2_stage_diff(source_table_id: str, target_table_id: str) -> V2StageDiff:
     """Get provider-neutral stage diff context."""
     return _load_stage_diff(source_table_id, target_table_id)
+
+
+@router.post("/schemas/diff")
+def post_v2_schema_diff(request: V2SchemaDiffRequest) -> dict[str, Any]:
+    """Return a stable schema-diff envelope for one asset."""
+    detail = _load_asset_detail(request.asset_key)
+    columns = _table_columns_from_metadata(detail.tables[0]) if detail.tables else []
+    return {
+        "asset_key": request.asset_key,
+        "from_run": request.from_run,
+        "to_run": request.to_run,
+        "changes": [],
+        "current_columns": columns,
+        "snapshot_available": False,
+        "message": "No comparable run schema snapshots were found for this asset.",
+    }
 
 
 @router.post("/query", response_model=V2QueryResult)

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_models.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_models.py
@@ -622,12 +622,14 @@ class V2RunList(BaseModel):
     """List envelope for v2 orchestrator runs."""
 
     items: list[V2Run]
+    next_cursor: str | None = None
 
 
 class V2AssetList(BaseModel):
     """List envelope for v2 assets."""
 
     items: list[V2Asset]
+    next_cursor: str | None = None
 
 
 class V2TableList(BaseModel):
@@ -664,6 +666,7 @@ class V2SearchList(BaseModel):
     """List envelope for v2 search results."""
 
     items: list[V2SearchResult]
+    next_cursor: str | None = None
 
 
 class V2SavedQueryList(BaseModel):

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_workflow_wizard.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_workflow_wizard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import re
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
@@ -15,18 +15,19 @@ from phlo.capabilities import (
     WorkflowFilePreview,
     WorkflowProposal,
     WorkflowProposalRequest,
+    WorkflowStageSelection,
     detect_file_conflicts,
     validate_proposal_request,
 )
 
 STAGES = ["source", "transform", "quality", "publish"]
-WORKFLOW_WIZARD_MODULES = (
-    "phlo_dlt.plugin",
-    "phlo_sling.plugin",
-    "phlo_dbt.plugin",
-    "phlo_pandera.plugin",
-    "phlo_dagster.plugin",
-    "phlo_openmetadata.plugin",
+WORKFLOW_WIZARD_PLUGIN_TYPES = (
+    "ingestion_provider",
+    "transformation_provider",
+    "quality_provider",
+    "orchestrator",
+    "resource_provider",
+    "service",
 )
 
 
@@ -88,15 +89,38 @@ class V2WorkflowActionResult(BaseModel):
 def list_workflow_wizard_contributions() -> list[dict[str, Any]]:
     """Return package-provided workflow wizard contributions."""
 
+    from phlo.plugins.discovery import discover_plugins, get_global_registry
+
     contributions: list[dict[str, Any]] = []
-    for module_name in WORKFLOW_WIZARD_MODULES:
+    seen_ids: set[str] = set()
+    registry = get_global_registry()
+    for plugin_type in WORKFLOW_WIZARD_PLUGIN_TYPES:
         try:
-            module = importlib.import_module(module_name)
-            loader = getattr(module, "get_workflow_wizard_contributions", None)
-            if callable(loader):
-                contributions.extend(item.to_browser_dict() for item in loader())
+            discover_plugins(plugin_type=plugin_type, auto_register=True)
         except Exception:
             continue
+        for plugin_name in registry.list(plugin_type):
+            plugin = registry.get(plugin_type, plugin_name)
+            if plugin is None:
+                continue
+            loader = getattr(plugin, "get_workflow_wizard_contributions", None)
+            if not callable(loader):
+                try:
+                    module = importlib.import_module(plugin.__class__.__module__)
+                except Exception:
+                    module = None
+                loader = getattr(module, "get_workflow_wizard_contributions", None)
+            if callable(loader):
+                try:
+                    for item in loader():
+                        contribution = item.to_browser_dict()
+                        contribution_id = str(contribution.get("id") or "")
+                        if contribution_id in seen_ids:
+                            continue
+                        seen_ids.add(contribution_id)
+                        contributions.append(contribution)
+                except Exception:
+                    continue
     return contributions
 
 
@@ -115,13 +139,26 @@ def build_workflow_proposal(
     if not request.graph.nodes:
         raise HTTPException(status_code=422, detail={"graph": ["Add at least one workflow node."]})
 
+    selections: dict[str, dict[str, Any] | list[dict[str, Any] | WorkflowStageSelection]] = {
+        stage: (
+            [dict(item) for item in payload]
+            if isinstance(payload := _selection_payload(selection), list)
+            else dict(payload)
+        )
+        for stage, selection in _selections_from_graph(request.graph).items()
+    }
     contract_request = WorkflowProposalRequest(
         workflow_name=request.workflow_name,
         domain=request.domain,
-        selections={
-            stage: _selection_payload(selection)
-            for stage, selection in _selections_from_graph(request.graph).items()
-        },
+        selections=cast(
+            dict[
+                str,
+                dict[str, Any]
+                | WorkflowStageSelection
+                | list[dict[str, Any] | WorkflowStageSelection],
+            ],
+            selections,
+        ),
     )
     errors = validate_proposal_request(contract_request)
     if errors:
@@ -179,7 +216,7 @@ def _selection_payload(
     selection: V2WorkflowWizardSelection | list[V2WorkflowWizardSelection],
 ) -> dict[str, Any] | list[dict[str, Any]]:
     if isinstance(selection, list):
-        return [_selection_payload(item) for item in selection]
+        return [cast(dict[str, Any], _selection_payload(item)) for item in selection]
     return {
         "contribution_id": selection.contribution_id,
         "values": selection.values,
@@ -243,6 +280,7 @@ def _proposal_from_request(request: WorkflowProposalRequest) -> WorkflowProposal
     planned_assets: list[str] = []
     planned_tables = [table_name]
     planned_models: list[str] = []
+    warnings: list[str] = []
 
     if source.contribution_id == "sling.replication-source":
         source_name = str(source_values.get("source_name") or "POSTGRES")
@@ -281,7 +319,7 @@ def _proposal_from_request(request: WorkflowProposalRequest) -> WorkflowProposal
                 ),
             ]
         )
-    else:
+    elif source.contribution_id == "dlt.rest-api-source":
         api_base_url = str(source_values.get("api_base_url") or "")
         cron = str(source_values.get("cron") or "0 */1 * * *")
         response_path = str(source_values.get("response_path") or "")
@@ -312,6 +350,10 @@ def _proposal_from_request(request: WorkflowProposalRequest) -> WorkflowProposal
                     content=_render_ingestion_test(domain, table_name, unique_key),
                 ),
             ]
+        )
+    else:
+        warnings.append(
+            f"Source contribution {source.contribution_id!r} does not provide proposal rendering."
         )
 
     for transform in request.selections_for("transform"):
@@ -514,6 +556,7 @@ def _proposal_from_request(request: WorkflowProposalRequest) -> WorkflowProposal
         planned_tables=planned_tables,
         planned_models=planned_models,
         files=files,
+        warnings=warnings,
         disabled_stages=disabled_stages,
         actions=[action],
     )
@@ -524,7 +567,7 @@ def _append_dbt_transform_files(
     workflow_name: str,
     table_name: str,
     unique_key: str,
-    fields: list[tuple[str, str]],
+    fields: list[str],
     values: dict[str, Any],
 ) -> list[str]:
     planned_models: list[str] = []

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_workflow_wizard.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_workflow_wizard.py
@@ -29,6 +29,14 @@ WORKFLOW_WIZARD_PLUGIN_TYPES = (
     "resource_provider",
     "service",
 )
+WORKFLOW_WIZARD_FALLBACK_MODULES = (
+    "phlo_dlt.plugin",
+    "phlo_sling.plugin",
+    "phlo_dbt.plugin",
+    "phlo_pandera.plugin",
+    "phlo_openmetadata.plugin",
+    "phlo_dagster.plugin",
+)
 
 
 class V2WorkflowWizardSelection(BaseModel):
@@ -121,6 +129,24 @@ def list_workflow_wizard_contributions() -> list[dict[str, Any]]:
                         contributions.append(contribution)
                 except Exception:
                     continue
+    for module_name in WORKFLOW_WIZARD_FALLBACK_MODULES:
+        try:
+            module = importlib.import_module(module_name)
+        except Exception:
+            continue
+        loader = getattr(module, "get_workflow_wizard_contributions", None)
+        if not callable(loader):
+            continue
+        try:
+            for item in loader():
+                contribution = item.to_browser_dict()
+                contribution_id = str(contribution.get("id") or "")
+                if contribution_id in seen_ids:
+                    continue
+                seen_ids.add(contribution_id)
+                contributions.append(contribution)
+        except Exception:
+            continue
     return contributions
 
 

--- a/packages/phlo-api/src/phlo_api/pagination.py
+++ b/packages/phlo-api/src/phlo_api/pagination.py
@@ -1,0 +1,37 @@
+"""Opaque cursor pagination helpers for API list envelopes."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def encode_cursor(offset: int) -> str:
+    payload = json.dumps({"offset": max(0, offset)}, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii")
+
+
+def decode_cursor(cursor: str | None) -> int:
+    if not cursor:
+        return 0
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return 0
+    offset = payload.get("offset", 0)
+    return offset if isinstance(offset, int) and offset >= 0 else 0
+
+
+def paginate_items(
+    items: Sequence[T], *, limit: int, cursor: str | None = None
+) -> tuple[list[T], str | None]:
+    safe_limit = max(1, min(limit, 500))
+    offset = decode_cursor(cursor)
+    page = list(items[offset : offset + safe_limit])
+    next_offset = offset + len(page)
+    next_cursor = encode_cursor(next_offset) if next_offset < len(items) else None
+    return page, next_cursor

--- a/packages/phlo-api/tests/test_authoring_api.py
+++ b/packages/phlo-api/tests/test_authoring_api.py
@@ -12,10 +12,12 @@ from phlo_api.main import app
 @dataclass(frozen=True)
 class _FakeWorkflowResult:
     workflow_type: str
+    provider: str
     domain: str
     table: str
     files: list[str]
     next_steps: list[str]
+    metadata: dict[str, object] | None = None
 
 
 def test_authoring_routes_create_and_list_templates(monkeypatch, tmp_path) -> None:
@@ -27,16 +29,20 @@ def test_authoring_routes_create_and_list_templates(monkeypatch, tmp_path) -> No
         '{"project-token":{"subject":"agent","scopes":["project:write"]}}',
     )
 
-    def fake_create_workflow(**kwargs):  # noqa: ANN003, ANN202
+    def fake_create_workflow_with_provider(**kwargs):  # noqa: ANN003, ANN202
         return _FakeWorkflowResult(
             workflow_type=kwargs["workflow_type"],
+            provider=kwargs["provider"] or "fake",
             domain=kwargs["domain"],
             table=kwargs["table"],
             files=["workflows/ingestion/demo/orders.py"],
             next_steps=["phlo materialize dlt_orders"],
+            metadata={},
         )
 
-    monkeypatch.setattr(authoring, "_create_workflow", fake_create_workflow)
+    monkeypatch.setattr(
+        authoring, "create_workflow_with_provider", fake_create_workflow_with_provider
+    )
 
     client = TestClient(app)
     headers = {"Authorization": "Bearer project-token"}
@@ -48,6 +54,7 @@ def test_authoring_routes_create_and_list_templates(monkeypatch, tmp_path) -> No
     templates = client.get("/api/authoring/templates")
 
     assert created.status_code == 200
+    assert created.json()["provider"] == "fake"
     assert created.json()["files"] == ["workflows/ingestion/demo/orders.py"]
     assert templates.status_code == 200
     assert any(item["name"] == "csv-batch" for item in templates.json()["items"])
@@ -64,10 +71,12 @@ def test_authoring_create_workflow_returns_conflict_for_existing_files(
         '{"project-token":{"subject":"agent","scopes":["project:write"]}}',
     )
 
-    def fake_create_workflow(**kwargs):  # noqa: ANN003, ANN202
+    def fake_create_workflow_with_provider(**kwargs):  # noqa: ANN003, ANN202
         raise FileExistsError("Files already exist:\n  - workflows/ingestion/demo/orders.py")
 
-    monkeypatch.setattr(authoring, "_create_workflow", fake_create_workflow)
+    monkeypatch.setattr(
+        authoring, "create_workflow_with_provider", fake_create_workflow_with_provider
+    )
 
     response = TestClient(app).post(
         "/api/authoring/workflows",
@@ -83,6 +92,49 @@ def test_authoring_create_workflow_returns_conflict_for_existing_files(
     }
     audit_path = tmp_path / ".phlo" / "audit" / "operations.jsonl"
     assert "workflow_already_exists" in audit_path.read_text(encoding="utf-8")
+
+
+def test_authoring_create_workflow_uses_project_root_and_provider(monkeypatch, tmp_path) -> None:
+    from phlo_api.api import authoring
+
+    service_cwd = tmp_path / "service-cwd"
+    service_cwd.mkdir()
+    monkeypatch.chdir(service_cwd)
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(project_root))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"agent","scopes":["project:write"]}}',
+    )
+    captured: dict[str, object] = {}
+
+    def fake_create_workflow_with_provider(**kwargs):  # noqa: ANN003, ANN202
+        captured.update(kwargs)
+        return _FakeWorkflowResult(
+            workflow_type=kwargs["workflow_type"],
+            provider=kwargs["provider"],
+            domain=kwargs["domain"],
+            table=kwargs["table"],
+            files=["workflows/ingestion/demo/orders.py"],
+            next_steps=[],
+            metadata={},
+        )
+
+    monkeypatch.setattr(
+        authoring, "create_workflow_with_provider", fake_create_workflow_with_provider
+    )
+
+    response = TestClient(app).post(
+        "/api/authoring/workflows",
+        json={"provider": "sling", "domain": "demo", "table": "orders", "unique_key": "id"},
+        headers={"Authorization": "Bearer project-token"},
+    )
+
+    assert response.status_code == 200
+    assert captured["project_root"] == project_root
+    assert captured["provider"] == "sling"
+    assert response.json()["provider"] == "sling"
 
 
 def test_authoring_write_routes_require_project_write_scope(monkeypatch, tmp_path) -> None:
@@ -119,6 +171,31 @@ def test_authoring_write_routes_require_project_write_scope(monkeypatch, tmp_pat
     assert allowed.json()["valid"] is True
     audit_path = tmp_path / ".phlo" / "audit" / "operations.jsonl"
     assert "validate_workflow" in audit_path.read_text(encoding="utf-8")
+
+
+def test_authoring_validation_rejects_paths_outside_project(monkeypatch, tmp_path) -> None:
+    from phlo_api.api import authoring
+
+    project_root = tmp_path / "project"
+    outside_file = tmp_path / "outside.py"
+    project_root.mkdir()
+    outside_file.write_text("# not in project\n", encoding="utf-8")
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(project_root))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"agent","scopes":["project:write"]}}',
+    )
+    monkeypatch.setattr(authoring, "_validate_workflow_file", lambda path: None)
+
+    response = TestClient(app).post(
+        "/api/authoring/workflows/validate",
+        json={"workflow_path": str(outside_file)},
+        headers={"Authorization": "Bearer project-token"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["valid"] is False
+    assert "path_outside_project" in response.json()["errors"][0]
 
 
 def test_authoring_doctor_route_returns_json(monkeypatch) -> None:

--- a/packages/phlo-api/tests/test_authoring_api.py
+++ b/packages/phlo-api/tests/test_authoring_api.py
@@ -1,0 +1,132 @@
+"""Tests for agent-facing authoring API routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from fastapi.testclient import TestClient
+
+from phlo_api.main import app
+
+
+@dataclass(frozen=True)
+class _FakeWorkflowResult:
+    workflow_type: str
+    domain: str
+    table: str
+    files: list[str]
+    next_steps: list[str]
+
+
+def test_authoring_routes_create_and_list_templates(monkeypatch, tmp_path) -> None:
+    from phlo_api.api import authoring
+
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"agent","scopes":["project:write"]}}',
+    )
+
+    def fake_create_workflow(**kwargs):  # noqa: ANN003, ANN202
+        return _FakeWorkflowResult(
+            workflow_type=kwargs["workflow_type"],
+            domain=kwargs["domain"],
+            table=kwargs["table"],
+            files=["workflows/ingestion/demo/orders.py"],
+            next_steps=["phlo materialize dlt_orders"],
+        )
+
+    monkeypatch.setattr(authoring, "_create_workflow", fake_create_workflow)
+
+    client = TestClient(app)
+    headers = {"Authorization": "Bearer project-token"}
+    created = client.post(
+        "/api/authoring/workflows",
+        json={"domain": "demo", "table": "orders", "unique_key": "id"},
+        headers=headers,
+    )
+    templates = client.get("/api/authoring/templates")
+
+    assert created.status_code == 200
+    assert created.json()["files"] == ["workflows/ingestion/demo/orders.py"]
+    assert templates.status_code == 200
+    assert any(item["name"] == "csv-batch" for item in templates.json()["items"])
+
+
+def test_authoring_create_workflow_returns_conflict_for_existing_files(
+    monkeypatch, tmp_path
+) -> None:
+    from phlo_api.api import authoring
+
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"agent","scopes":["project:write"]}}',
+    )
+
+    def fake_create_workflow(**kwargs):  # noqa: ANN003, ANN202
+        raise FileExistsError("Files already exist:\n  - workflows/ingestion/demo/orders.py")
+
+    monkeypatch.setattr(authoring, "_create_workflow", fake_create_workflow)
+
+    response = TestClient(app).post(
+        "/api/authoring/workflows",
+        json={"domain": "demo", "table": "orders", "unique_key": "id"},
+        headers={"Authorization": "Bearer project-token"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "error": "workflow_already_exists",
+        "message": "Files already exist:\n  - workflows/ingestion/demo/orders.py",
+        "target": "demo/orders",
+    }
+    audit_path = tmp_path / ".phlo" / "audit" / "operations.jsonl"
+    assert "workflow_already_exists" in audit_path.read_text(encoding="utf-8")
+
+
+def test_authoring_write_routes_require_project_write_scope(monkeypatch, tmp_path) -> None:
+    from phlo_api.api import authoring
+
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"read-token":{"subject":"reader","scopes":["lakehouse:read"]},'
+        '"project-token":{"subject":"agent","scopes":["project:write"]}}',
+    )
+    workflow_file = tmp_path / "workflow.py"
+    workflow_file.write_text("# workflow\n", encoding="utf-8")
+    monkeypatch.setattr(authoring, "_validate_workflow_file", lambda path: None)
+
+    client = TestClient(app)
+    missing = client.post(
+        "/api/authoring/workflows/validate", json={"workflow_path": str(workflow_file)}
+    )
+    forbidden = client.post(
+        "/api/authoring/workflows/validate",
+        json={"workflow_path": str(workflow_file)},
+        headers={"Authorization": "Bearer read-token"},
+    )
+    allowed = client.post(
+        "/api/authoring/workflows/validate",
+        json={"workflow_path": str(workflow_file)},
+        headers={"Authorization": "Bearer project-token"},
+    )
+
+    assert missing.status_code == 401
+    assert forbidden.status_code == 403
+    assert allowed.status_code == 200
+    assert allowed.json()["valid"] is True
+    audit_path = tmp_path / ".phlo" / "audit" / "operations.jsonl"
+    assert "validate_workflow" in audit_path.read_text(encoding="utf-8")
+
+
+def test_authoring_doctor_route_returns_json(monkeypatch) -> None:
+    from phlo_api.api import authoring
+
+    monkeypatch.setattr(authoring, "_run_diagnostics_quietly", lambda verbose=False: [])
+
+    response = TestClient(app).get("/api/authoring/doctor")
+
+    assert response.status_code == 200
+    assert response.json() == {"checks": [], "summary": {"fail": 0, "ok": 0, "skip": 0, "warn": 0}}

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -577,9 +577,14 @@ def test_v2_actions_endpoint_routes_add_service_action(monkeypatch, tmp_path: Pa
     assert commands == [["phlo", "services", "add", "pgweb"]]
 
 
-def test_v2_asset_operational_routes_use_v2_paths(monkeypatch) -> None:
+def test_v2_asset_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> None:
     from phlo_api.observatory_api import dagster
 
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"operate-token":{"subject":"agent","scopes":["lakehouse:operate"]}}',
+    )
     calls: list[tuple[str, str, object]] = []
 
     async def fake_history(asset_id: str, limit: int = 10, dagster_url: str | None = None):
@@ -599,23 +604,55 @@ def test_v2_asset_operational_routes_use_v2_paths(monkeypatch) -> None:
             "details": {},
         }
 
+    async def fake_backfill(asset_id: str, payload, dagster_url: str | None = None):
+        calls.append(("backfill", asset_id, payload.partitions))
+        return {
+            "operation": "backfill_asset",
+            "dry_run": payload.dry_run,
+            "accepted": True,
+            "asset_key_path": asset_id,
+            "status": "DRY_RUN",
+            "message": "Backfill request is valid.",
+            "details": {"partitions": payload.partitions},
+        }
+
+    async def fake_partitions(asset_id: str, dagster_url: str | None = None):
+        calls.append(("partitions", asset_id, None))
+        return [{"partition_key": "2026-04-26", "status": "UNKNOWN"}]
+
     monkeypatch.setattr(dagster, "get_materialization_history", fake_history)
     monkeypatch.setattr(dagster, "materialize_asset", fake_materialize)
+    monkeypatch.setattr(dagster, "backfill_asset", fake_backfill)
+    monkeypatch.setattr(dagster, "list_partitions", fake_partitions)
 
     client = TestClient(app)
+    headers = {"Authorization": "Bearer operate-token"}
     history = client.get("/api/observatory/v2/assets/silver/orders/materializations?limit=3")
     materialize = client.post(
         "/api/observatory/v2/assets/silver/orders/materialize",
-        json={"dry_run": True, "partition_key": "2026-04-26"},
+        json={"dry_run": True, "partition": "2026-04-26"},
+        headers=headers,
     )
+    backfill = client.post(
+        "/api/observatory/v2/assets/silver/orders/backfill",
+        json={"dry_run": True, "partitions": ["2026-04-26"]},
+        headers=headers,
+    )
+    partitions = client.get("/api/observatory/v2/assets/silver/orders/partitions")
 
     assert history.status_code == 200
     assert history.json()[0]["run_id"] == "run-123"
     assert materialize.status_code == 200
     assert materialize.json()["asset_key_path"] == "silver/orders"
+    assert backfill.status_code == 200
+    assert backfill.json()["operation"] == "backfill_asset"
+    assert partitions.status_code == 200
+    assert partitions.json()[0]["partition_key"] == "2026-04-26"
     assert calls == [
         ("history", "silver/orders", 3),
         ("materialize", "silver/orders", "2026-04-26"),
+        ("backfill", "silver/orders", ["2026-04-26"]),
+        ("partitions", "silver/orders", None),
     ]
 
 
@@ -639,9 +676,14 @@ def test_v2_asset_materializations_clamps_limit(monkeypatch) -> None:
     assert calls == [1, 200]
 
 
-def test_v2_run_operational_routes_use_v2_paths(monkeypatch) -> None:
+def test_v2_run_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> None:
     from phlo_api.observatory_api import dagster
 
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"operate-token":{"subject":"agent","scopes":["lakehouse:operate"]}}',
+    )
     calls: list[tuple[str, str, object]] = []
 
     async def fake_status(run_id: str, dagster_url: str | None = None):
@@ -660,21 +702,132 @@ def test_v2_run_operational_routes_use_v2_paths(monkeypatch) -> None:
             "details": {"run_status": "FAILURE"},
         }
 
+    async def fake_cancel(run_id: str, payload, dagster_url: str | None = None):
+        calls.append(("cancel", run_id, payload.reason))
+        return {
+            "operation": "cancel_run",
+            "dry_run": False,
+            "accepted": True,
+            "run_id": run_id,
+            "status": "CANCELING",
+            "message": "Dagster accepted run cancellation.",
+            "details": {},
+        }
+
     monkeypatch.setattr(dagster, "get_run_status", fake_status)
     monkeypatch.setattr(dagster, "retry_run", fake_retry)
+    monkeypatch.setattr(dagster, "cancel_run", fake_cancel)
 
     client = TestClient(app)
+    headers = {"Authorization": "Bearer operate-token"}
     status = client.get("/api/observatory/v2/runs/run-123/status")
-    retry = client.post("/api/observatory/v2/runs/run-123/retry", json={"dry_run": False})
+    retry = client.post(
+        "/api/observatory/v2/runs/run-123/retry", json={"dry_run": False}, headers=headers
+    )
+    cancel = client.post(
+        "/api/observatory/v2/runs/run-123/cancel", json={"reason": "stuck"}, headers=headers
+    )
 
     assert status.status_code == 200
     assert status.json()["status"] == "FAILURE"
     assert retry.status_code == 200
     assert retry.json()["run_id"] == "run-123"
+    assert cancel.status_code == 200
+    assert cancel.json()["status"] == "CANCELING"
     assert calls == [
         ("status", "run-123", None),
         ("retry", "run-123", False),
+        ("cancel", "run-123", "stuck"),
     ]
+
+
+def test_v2_operation_routes_enforce_scope_idempotency_audit_and_rate_limit(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from phlo_api.observatory_api import dagster
+
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv("PHLO_API_RATE_LIMIT_MATERIALIZE", "2")
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        json.dumps(
+            {
+                "read-token": {"subject": "reader", "scopes": ["lakehouse:read"]},
+                "operate-token": {"subject": "operator-idem", "scopes": ["lakehouse:operate"]},
+                "limited-token": {"subject": "operator-limited", "scopes": ["lakehouse:operate"]},
+            }
+        ),
+    )
+    calls: list[str] = []
+
+    async def fake_materialize(asset_id: str, payload, dagster_url: str | None = None):
+        calls.append(asset_id)
+        return {
+            "operation": "materialize_asset",
+            "dry_run": payload.dry_run,
+            "accepted": True,
+            "run_id": f"run-{len(calls)}",
+            "asset_key_path": asset_id,
+            "partition_key": payload.partition_key,
+            "status": "STARTED",
+            "message": "Dagster accepted materialize_asset.",
+            "details": {},
+        }
+
+    monkeypatch.setattr(dagster, "materialize_asset", fake_materialize)
+    client = TestClient(app)
+
+    missing = client.post(
+        "/api/observatory/v2/assets/silver/orders/materialize",
+        json={"dry_run": False},
+    )
+    forbidden = client.post(
+        "/api/observatory/v2/assets/silver/orders/materialize",
+        json={"dry_run": False},
+        headers={"Authorization": "Bearer read-token"},
+    )
+    first = client.post(
+        "/api/observatory/v2/assets/silver/orders/materialize",
+        json={"dry_run": False, "idempotency_key": "same-key"},
+        headers={"Authorization": "Bearer operate-token"},
+    )
+    replay = client.post(
+        "/api/observatory/v2/assets/silver/orders/materialize",
+        json={"dry_run": False, "idempotency_key": "same-key"},
+        headers={"Authorization": "Bearer operate-token"},
+    )
+    limited_first = client.post(
+        "/api/observatory/v2/assets/silver/orders/materialize",
+        json={"dry_run": True},
+        headers={"Authorization": "Bearer limited-token"},
+    )
+    limited_second = client.post(
+        "/api/observatory/v2/assets/silver/orders/materialize",
+        json={"dry_run": True},
+        headers={"Authorization": "Bearer limited-token"},
+    )
+    limited_third = client.post(
+        "/api/observatory/v2/assets/silver/orders/materialize",
+        json={"dry_run": True},
+        headers={"Authorization": "Bearer limited-token"},
+    )
+
+    assert missing.status_code == 401
+    assert forbidden.status_code == 403
+    assert first.status_code == 200
+    assert replay.status_code == 200
+    assert first.json()["run_id"] == "run-1"
+    assert replay.json()["run_id"] == "run-1"
+    assert limited_first.status_code == 200
+    assert limited_second.status_code == 200
+    assert limited_third.status_code == 429
+    assert calls == ["silver/orders", "silver/orders", "silver/orders"]
+
+    audit_path = tmp_path / ".phlo" / "audit" / "operations.jsonl"
+    assert audit_path.exists()
+    records = [json.loads(line) for line in audit_path.read_text().splitlines()]
+    assert any(record["operation"] == "materialize_asset" for record in records)
+    assert all(record["subject"] != "read-token" for record in records)
 
 
 def test_v2_available_missing_package_service_add_is_disabled(monkeypatch) -> None:
@@ -920,7 +1073,12 @@ def test_v2_service_action_records_subprocess_result(
     assert operations[0]["status"] == "succeeded"
 
 
-def test_v2_package_install_uses_trusted_registry_package(monkeypatch) -> None:
+def test_v2_package_install_uses_trusted_registry_package(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"admin-token":{"subject":"admin","scopes":["admin"]}}',
+    )
     monkeypatch.setattr(
         v2,
         "get_registry_data",
@@ -946,6 +1104,7 @@ def test_v2_package_install_uses_trusted_registry_package(monkeypatch) -> None:
     response = TestClient(app).post(
         "/api/observatory/v2/packages/install",
         json={"package_name": "openmetadata"},
+        headers={"Authorization": "Bearer admin-token"},
     )
 
     assert response.status_code == 200
@@ -955,12 +1114,18 @@ def test_v2_package_install_uses_trusted_registry_package(monkeypatch) -> None:
     assert installed == ["phlo-openmetadata==0.1.0"]
 
 
-def test_v2_package_install_rejects_unknown_package(monkeypatch) -> None:
+def test_v2_package_install_rejects_unknown_package(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"admin-token":{"subject":"admin","scopes":["admin"]}}',
+    )
     monkeypatch.setattr(v2, "get_registry_data", lambda: {"plugins": {}})
 
     response = TestClient(app).post(
         "/api/observatory/v2/packages/install",
         json={"package_name": "not-a-phlo-package"},
+        headers={"Authorization": "Bearer admin-token"},
     )
 
     assert response.status_code == 400

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+from types import SimpleNamespace
+from typing import Any
 
 from fastapi.testclient import TestClient
 
@@ -56,6 +58,32 @@ _PROVIDER_URL_SETTING_NAMES = (
     "trinourl",
     "nessieurl",
 )
+
+
+class _FakeOrchestratorOperations:
+    def __init__(self, **handlers: Any) -> None:
+        self._handlers = handlers
+
+    async def get_run_status(self, run_id: str) -> Any:
+        return await self._handlers["get_run_status"](run_id)
+
+    async def retry_run(self, run_id: str, request: dict[str, Any]) -> Any:
+        return await self._handlers["retry_run"](run_id, SimpleNamespace(**request))
+
+    async def cancel_run(self, run_id: str, request: dict[str, Any]) -> Any:
+        return await self._handlers["cancel_run"](run_id, SimpleNamespace(**request))
+
+    async def get_materialization_history(self, asset_key_path: str, *, limit: int = 10) -> Any:
+        return await self._handlers["get_materialization_history"](asset_key_path, limit)
+
+    async def materialize_asset(self, asset_key_path: str, request: dict[str, Any]) -> Any:
+        return await self._handlers["materialize_asset"](asset_key_path, SimpleNamespace(**request))
+
+    async def backfill_asset(self, asset_key_path: str, request: dict[str, Any]) -> Any:
+        return await self._handlers["backfill_asset"](asset_key_path, SimpleNamespace(**request))
+
+    async def list_partitions(self, asset_key_path: str) -> Any:
+        return await self._handlers["list_partitions"](asset_key_path)
 
 
 def _assert_no_provider_url_settings(payload: object) -> None:
@@ -579,8 +607,6 @@ def test_v2_actions_endpoint_routes_add_service_action(monkeypatch, tmp_path: Pa
 
 
 def test_v2_asset_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> None:
-    from phlo_api.observatory_api import dagster
-
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     monkeypatch.setenv(
         "PHLO_API_TOKENS",
@@ -621,10 +647,13 @@ def test_v2_asset_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -
         calls.append(("partitions", asset_id, None))
         return [{"partition_key": "2026-04-26", "status": "UNKNOWN"}]
 
-    monkeypatch.setattr(dagster, "get_materialization_history", fake_history)
-    monkeypatch.setattr(dagster, "materialize_asset", fake_materialize)
-    monkeypatch.setattr(dagster, "backfill_asset", fake_backfill)
-    monkeypatch.setattr(dagster, "list_partitions", fake_partitions)
+    provider = _FakeOrchestratorOperations(
+        get_materialization_history=fake_history,
+        materialize_asset=fake_materialize,
+        backfill_asset=fake_backfill,
+        list_partitions=fake_partitions,
+    )
+    monkeypatch.setattr(v2, "resolve_orchestrator_operations", lambda: provider)
 
     client = TestClient(app)
     headers = {"Authorization": "Bearer operate-token"}
@@ -658,15 +687,14 @@ def test_v2_asset_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -
 
 
 def test_v2_asset_materializations_clamps_limit(monkeypatch) -> None:
-    from phlo_api.observatory_api import dagster
-
     calls: list[int] = []
 
     async def fake_history(asset_id: str, limit: int = 10, dagster_url: str | None = None):
         calls.append(limit)
         return []
 
-    monkeypatch.setattr(dagster, "get_materialization_history", fake_history)
+    provider = _FakeOrchestratorOperations(get_materialization_history=fake_history)
+    monkeypatch.setattr(v2, "resolve_orchestrator_operations", lambda: provider)
 
     client = TestClient(app)
     too_low = client.get("/api/observatory/v2/assets/silver/orders/materializations?limit=0")
@@ -678,8 +706,6 @@ def test_v2_asset_materializations_clamps_limit(monkeypatch) -> None:
 
 
 def test_v2_run_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> None:
-    from phlo_api.observatory_api import dagster
-
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     monkeypatch.setenv(
         "PHLO_API_TOKENS",
@@ -715,9 +741,12 @@ def test_v2_run_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> 
             "details": {},
         }
 
-    monkeypatch.setattr(dagster, "get_run_status", fake_status)
-    monkeypatch.setattr(dagster, "retry_run", fake_retry)
-    monkeypatch.setattr(dagster, "cancel_run", fake_cancel)
+    provider = _FakeOrchestratorOperations(
+        get_run_status=fake_status,
+        retry_run=fake_retry,
+        cancel_run=fake_cancel,
+    )
+    monkeypatch.setattr(v2, "resolve_orchestrator_operations", lambda: provider)
 
     client = TestClient(app)
     headers = {"Authorization": "Bearer operate-token"}
@@ -745,8 +774,6 @@ def test_v2_run_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> 
 def test_v2_operation_routes_enforce_scope_idempotency_audit_and_rate_limit(
     monkeypatch, tmp_path: Path
 ) -> None:
-    from phlo_api.observatory_api import dagster
-
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     monkeypatch.setenv("PHLO_API_RATE_LIMIT_MATERIALIZE", "2")
     monkeypatch.setenv(
@@ -775,7 +802,8 @@ def test_v2_operation_routes_enforce_scope_idempotency_audit_and_rate_limit(
             "details": {},
         }
 
-    monkeypatch.setattr(dagster, "materialize_asset", fake_materialize)
+    provider = _FakeOrchestratorOperations(materialize_asset=fake_materialize)
+    monkeypatch.setattr(v2, "resolve_orchestrator_operations", lambda: provider)
     client = TestClient(app)
 
     missing = client.post(

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -24,6 +24,7 @@ from phlo_api.observatory_api.v2 import (
 from phlo_api.observatory_api.v2_models import (
     V2ActionRequest,
     V2Asset,
+    V2AssetDetail,
     V2Branch,
     V2Capabilities,
     V2CapabilityPage,
@@ -2059,6 +2060,28 @@ def test_v2_search_endpoint_url_encodes_resource_href_segments(monkeypatch) -> N
     assert hrefs["asset"] == "/asset/silver%2Fdemo"
     assert hrefs["table"] == "/table/analytics%2Fdemo"
     assert hrefs["extension"] == "/extension/demo%2Fext"
+
+
+def test_v2_schema_diff_returns_stable_agent_envelope(monkeypatch) -> None:
+    detail = V2AssetDetail(
+        asset=V2Asset(id="raw.orders", name="raw.orders"),
+        tables=[V2Table(id="orders", name="orders", metadata={"columns": ["id", "amount"]})],
+    )
+    monkeypatch.setattr(v2, "_load_asset_detail", lambda asset_key: detail)
+
+    response = TestClient(app).post(
+        "/api/observatory/v2/schemas/diff",
+        json={"asset_key": "raw.orders", "from_run": "run-a", "to_run": "run-b"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["asset_key"] == "raw.orders"
+    assert payload["from_run"] == "run-a"
+    assert payload["to_run"] == "run-b"
+    assert payload["changes"] == []
+    assert payload["snapshot_available"] is False
+    assert payload["current_columns"] == ["id", "amount"]
 
 
 def test_v2_all_endpoints_do_not_leak_provider_url_setting_names() -> None:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -730,7 +730,7 @@ def test_v2_run_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> 
         }
 
     async def fake_cancel(run_id: str, payload, dagster_url: str | None = None):
-        calls.append(("cancel", run_id, payload.reason))
+        calls.append(("cancel", run_id, payload.reason, payload.idempotency_key))
         return {
             "operation": "cancel_run",
             "dry_run": False,
@@ -755,7 +755,9 @@ def test_v2_run_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> 
         "/api/observatory/v2/runs/run-123/retry", json={"dry_run": False}, headers=headers
     )
     cancel = client.post(
-        "/api/observatory/v2/runs/run-123/cancel", json={"reason": "stuck"}, headers=headers
+        "/api/observatory/v2/runs/run-123/cancel",
+        json={"reason": "stuck", "idempotency_key": "cancel-key"},
+        headers=headers,
     )
 
     assert status.status_code == 200
@@ -767,7 +769,7 @@ def test_v2_run_operational_routes_use_v2_paths(monkeypatch, tmp_path: Path) -> 
     assert calls == [
         ("status", "run-123", None),
         ("retry", "run-123", False),
-        ("cancel", "run-123", "stuck"),
+        ("cancel", "run-123", "stuck", "cancel-key"),
     ]
 
 

--- a/packages/phlo-api/tests/test_pagination.py
+++ b/packages/phlo-api/tests/test_pagination.py
@@ -1,0 +1,40 @@
+"""Tests for opaque cursor pagination contracts."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from phlo_api.main import app
+from phlo_api.pagination import decode_cursor, encode_cursor, paginate_items
+
+
+def test_cursor_round_trip_and_page_contract() -> None:
+    cursor = encode_cursor(2)
+
+    page, next_cursor = paginate_items(["a", "b", "c", "d", "e"], limit=2, cursor=cursor)
+
+    assert decode_cursor(cursor) == 2
+    assert page == ["c", "d"]
+    assert next_cursor is not None
+    assert decode_cursor(next_cursor) == 4
+
+
+def test_authoring_workflow_list_returns_next_cursor(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    workflows = tmp_path / "workflows" / "ingestion" / "demo"
+    workflows.mkdir(parents=True)
+    for name in ("alpha", "beta", "gamma"):
+        (workflows / f"{name}.py").write_text("# workflow\n", encoding="utf-8")
+
+    client = TestClient(app)
+    first = client.get("/api/authoring/workflows?limit=2")
+    second = client.get(
+        "/api/authoring/workflows",
+        params={"limit": 2, "cursor": first.json()["next_cursor"]},
+    )
+
+    assert first.status_code == 200
+    assert [item["name"] for item in first.json()["items"]] == ["alpha", "beta"]
+    assert first.json()["next_cursor"] is not None
+    assert [item["name"] for item in second.json()["items"]] == ["gamma"]
+    assert second.json()["next_cursor"] is None

--- a/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
+++ b/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
@@ -82,5 +82,12 @@ EOF
 
 touch /tmp/phlo-dagster-ready
 
+# Execute Dagster from the mounted project root when available. User workflows
+# often read local files relative to the project (for example data/*.csv), while
+# DAGSTER_HOME intentionally remains /opt/dagster for instance state.
+if [ -n "$PHLO_PROJECT_PATH" ] && [ -d "$PHLO_PROJECT_PATH" ]; then
+    cd "$PHLO_PROJECT_PATH"
+fi
+
 # Execute the main command
 exec "$@"

--- a/packages/phlo-dagster/src/phlo_dagster/operations.py
+++ b/packages/phlo-dagster/src/phlo_dagster/operations.py
@@ -1,0 +1,307 @@
+"""Dagster operational capability adapter for Phlo API mutation routes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from phlo.security.service_identity import build_service_headers
+
+
+LAUNCH_PIPELINE_EXECUTION_MUTATION = """
+mutation LaunchPipelineExecution($executionParams: ExecutionParams!) {
+    launchPipelineExecution(executionParams: $executionParams) {
+        __typename
+        ... on LaunchRunSuccess { run { runId status } }
+        ... on PipelineNotFoundError { message }
+        ... on InvalidSubsetError { message }
+        ... on RunConfigValidationInvalid { errors { message } }
+        ... on PythonError { message }
+    }
+}
+"""
+
+LAUNCH_PIPELINE_REEXECUTION_MUTATION = """
+mutation LaunchPipelineReexecution($executionParams: ExecutionParams, $reexecutionParams: ReexecutionParams) {
+    launchPipelineReexecution(executionParams: $executionParams, reexecutionParams: $reexecutionParams) {
+        __typename
+        ... on LaunchRunSuccess { run { runId status } }
+        ... on PythonError { message }
+    }
+}
+"""
+
+TERMINATE_RUN_MUTATION = """
+mutation TerminateRun($runId: String!) {
+    terminateRun(runId: $runId) {
+        __typename
+        ... on TerminateRunSuccess { run { runId status } }
+        ... on RunNotFoundError { message }
+        ... on PythonError { message }
+    }
+}
+"""
+
+LAUNCH_PARTITION_BACKFILL_MUTATION = """
+mutation LaunchPartitionBackfill($backfillParams: LaunchBackfillParams!) {
+    launchPartitionBackfill(backfillParams: $backfillParams) {
+        __typename
+        ... on LaunchBackfillSuccess { backfillId launchedRunIds }
+        ... on PartitionSetNotFoundError { message }
+        ... on PythonError { message }
+    }
+}
+"""
+
+PARTITION_KEYS_QUERY = """
+query PartitionKeys($assetKey: AssetKeyInput!) {
+    assetNodeOrError(assetKey: $assetKey) {
+        __typename
+        ... on AssetNode {
+            partitionKeysByDimension { name partitionKeys }
+        }
+        ... on AssetNotFoundError { message }
+    }
+}
+"""
+
+
+@dataclass(frozen=True)
+class DagsterOperationResult:
+    """Provider-neutral result returned by the Dagster operation adapter."""
+
+    operation: str
+    dry_run: bool
+    accepted: bool
+    status: str
+    message: str
+    run_id: str | None = None
+    asset_key_path: str | None = None
+    partition_key: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "operation": self.operation,
+            "dry_run": self.dry_run,
+            "accepted": self.accepted,
+            "run_id": self.run_id,
+            "asset_key_path": self.asset_key_path,
+            "partition_key": self.partition_key,
+            "status": self.status,
+            "message": self.message,
+            "details": self.details,
+        }
+
+
+async def launch_materialize(
+    *,
+    dagster_url: str,
+    asset_key_path: str,
+    job_name: str,
+    repository_location_name: str | None = None,
+    repository_name: str | None = None,
+    partition_key: str | None = None,
+    run_config: dict[str, Any] | None = None,
+    tags: dict[str, str] | None = None,
+) -> DagsterOperationResult:
+    execution_tags = {"phlo/operation": "materialize_asset", "phlo/asset_key": asset_key_path}
+    execution_tags.update(tags or {})
+    if partition_key:
+        execution_tags.setdefault("dagster/partition", partition_key)
+    result = await _graphql(
+        dagster_url,
+        LAUNCH_PIPELINE_EXECUTION_MUTATION,
+        {
+            "executionParams": {
+                "selector": {
+                    "pipelineName": job_name,
+                    "repositoryLocationName": repository_location_name,
+                    "repositoryName": repository_name,
+                    "assetSelection": [{"path": asset_key_path.split("/")}],
+                },
+                "runConfigData": run_config or {},
+                "mode": "default",
+                "executionMetadata": {"tags": _tags_for_execution(execution_tags)},
+            }
+        },
+    )
+    return _launch_result(
+        operation="materialize_asset",
+        dry_run=False,
+        payload=result.get("data", {}).get("launchPipelineExecution", {}),
+        asset_key_path=asset_key_path,
+        partition_key=partition_key,
+    )
+
+
+async def launch_retry(
+    *,
+    dagster_url: str,
+    run_id: str,
+    strategy: str,
+    tags: dict[str, str] | None = None,
+) -> DagsterOperationResult:
+    execution_tags = {"phlo/operation": "retry_failed_run", "phlo/parent_run_id": run_id}
+    execution_tags.update(tags or {})
+    result = await _graphql(
+        dagster_url,
+        LAUNCH_PIPELINE_REEXECUTION_MUTATION,
+        {
+            "executionParams": None,
+            "reexecutionParams": {
+                "parentRunId": run_id,
+                "strategy": strategy,
+                "extraTags": _tags_for_execution(execution_tags),
+                "useParentRunTags": True,
+            },
+        },
+    )
+    return _launch_result(
+        operation="retry_failed_run",
+        dry_run=False,
+        payload=result.get("data", {}).get("launchPipelineReexecution", {}),
+        fallback_run_id=run_id,
+    )
+
+
+async def terminate(
+    *,
+    dagster_url: str,
+    run_id: str,
+    reason: str | None = None,
+) -> DagsterOperationResult:
+    result = await _graphql(dagster_url, TERMINATE_RUN_MUTATION, {"runId": run_id})
+    payload = result.get("data", {}).get("terminateRun", {})
+    typename = str(payload.get("__typename") or "TerminateRunResult")
+    run = payload.get("run") if isinstance(payload.get("run"), dict) else {}
+    accepted = typename == "TerminateRunSuccess"
+    return DagsterOperationResult(
+        operation="cancel_run",
+        dry_run=False,
+        accepted=accepted,
+        run_id=str(run.get("runId") or run_id),
+        status=str(run.get("status") or typename),
+        message="Dagster accepted run cancellation." if accepted else _error_message(payload),
+        details={"typename": typename, "reason": reason},
+    )
+
+
+async def launch_backfill(
+    *,
+    dagster_url: str,
+    asset_key_path: str,
+    partition_set_name: str,
+    partition_keys: list[str],
+    repository_location_name: str | None = None,
+    repository_name: str | None = None,
+    tags: dict[str, str] | None = None,
+) -> DagsterOperationResult:
+    execution_tags = {"phlo/operation": "backfill_asset", "phlo/asset_key": asset_key_path}
+    execution_tags.update(tags or {})
+    result = await _graphql(
+        dagster_url,
+        LAUNCH_PARTITION_BACKFILL_MUTATION,
+        {
+            "backfillParams": {
+                "selector": {
+                    "partitionSetName": partition_set_name,
+                    "repositorySelector": {
+                        "repositoryLocationName": repository_location_name,
+                        "repositoryName": repository_name,
+                    },
+                },
+                "partitionNames": partition_keys,
+                "tags": _tags_for_execution(execution_tags),
+            }
+        },
+    )
+    payload = result.get("data", {}).get("launchPartitionBackfill", {})
+    typename = str(payload.get("__typename") or "LaunchBackfillResult")
+    accepted = typename == "LaunchBackfillSuccess"
+    backfill_id = payload.get("backfillId")
+    return DagsterOperationResult(
+        operation="backfill_asset",
+        dry_run=False,
+        accepted=accepted,
+        run_id=str(backfill_id) if backfill_id else None,
+        asset_key_path=asset_key_path,
+        status=typename,
+        message="Dagster accepted partition backfill." if accepted else _error_message(payload),
+        details={"partitions": partition_keys, "partition_count": len(partition_keys)},
+    )
+
+
+async def list_partitions(*, dagster_url: str, asset_key_path: str) -> list[dict[str, str]]:
+    result = await _graphql(
+        dagster_url,
+        PARTITION_KEYS_QUERY,
+        {"assetKey": {"path": asset_key_path.split("/")}},
+    )
+    payload = result.get("data", {}).get("assetNodeOrError", {})
+    if payload.get("message"):
+        raise RuntimeError(str(payload["message"]))
+    keys: list[str] = []
+    for dimension in payload.get("partitionKeysByDimension", []) or []:
+        if isinstance(dimension, dict):
+            keys.extend(str(key) for key in dimension.get("partitionKeys", []) or [])
+    return [{"partition_key": key, "status": "UNKNOWN"} for key in keys]
+
+
+async def _graphql(url: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+    headers = {"Content-Type": "application/json"}
+    try:
+        headers.update(build_service_headers("phlo-api", initiator="observatory"))
+    except RuntimeError:
+        pass
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.post(
+            url, json={"query": query, "variables": variables}, headers=headers
+        )
+        response.raise_for_status()
+        payload = response.json()
+    if payload.get("errors"):
+        raise RuntimeError(payload["errors"][0].get("message", "GraphQL error"))
+    return payload
+
+
+def _launch_result(
+    *,
+    operation: str,
+    dry_run: bool,
+    payload: dict[str, Any],
+    asset_key_path: str | None = None,
+    partition_key: str | None = None,
+    fallback_run_id: str | None = None,
+) -> DagsterOperationResult:
+    typename = str(payload.get("__typename") or "DagsterLaunchResult")
+    run = payload.get("run") if isinstance(payload.get("run"), dict) else {}
+    accepted = typename in {"LaunchRunSuccess", "LaunchPipelineRunSuccess"} and bool(run)
+    return DagsterOperationResult(
+        operation=operation,
+        dry_run=dry_run,
+        accepted=accepted,
+        run_id=str(run.get("runId") or fallback_run_id) if (run or fallback_run_id) else None,
+        asset_key_path=asset_key_path,
+        partition_key=partition_key,
+        status=str(run.get("status") or typename),
+        message=f"Dagster accepted {operation}." if accepted else _error_message(payload),
+        details={"typename": typename},
+    )
+
+
+def _error_message(payload: dict[str, Any]) -> str:
+    if payload.get("message"):
+        return str(payload["message"])
+    errors = payload.get("errors")
+    if isinstance(errors, list) and errors:
+        first = errors[0]
+        if isinstance(first, dict) and first.get("message"):
+            return str(first["message"])
+    return str(payload.get("__typename") or "Dagster operation failed")
+
+
+def _tags_for_execution(tags: dict[str, str]) -> list[dict[str, str]]:
+    return [{"key": str(key), "value": str(value)} for key, value in tags.items()]

--- a/packages/phlo-dagster/src/phlo_dagster/operations.py
+++ b/packages/phlo-dagster/src/phlo_dagster/operations.py
@@ -105,9 +105,12 @@ async def launch_materialize(
     repository_name: str | None = None,
     partition_key: str | None = None,
     run_config: dict[str, Any] | None = None,
+    idempotency_key: str | None = None,
     tags: dict[str, str] | None = None,
 ) -> DagsterOperationResult:
     execution_tags = {"phlo/operation": "materialize_asset", "phlo/asset_key": asset_key_path}
+    if idempotency_key:
+        execution_tags["phlo/idempotency_key"] = idempotency_key
     execution_tags.update(tags or {})
     if partition_key:
         execution_tags.setdefault("dagster/partition", partition_key)
@@ -142,9 +145,12 @@ async def launch_retry(
     dagster_url: str,
     run_id: str,
     strategy: str,
+    idempotency_key: str | None = None,
     tags: dict[str, str] | None = None,
 ) -> DagsterOperationResult:
     execution_tags = {"phlo/operation": "retry_failed_run", "phlo/parent_run_id": run_id}
+    if idempotency_key:
+        execution_tags["phlo/idempotency_key"] = idempotency_key
     execution_tags.update(tags or {})
     result = await _graphql(
         dagster_url,
@@ -172,6 +178,7 @@ async def terminate(
     dagster_url: str,
     run_id: str,
     reason: str | None = None,
+    idempotency_key: str | None = None,
 ) -> DagsterOperationResult:
     result = await _graphql(dagster_url, TERMINATE_RUN_MUTATION, {"runId": run_id})
     payload = result.get("data", {}).get("terminateRun", {})
@@ -185,7 +192,15 @@ async def terminate(
         run_id=str(run.get("runId") or run_id),
         status=str(run.get("status") or typename),
         message="Dagster accepted run cancellation." if accepted else _error_message(payload),
-        details={"typename": typename, "reason": reason},
+        details={
+            key: value
+            for key, value in {
+                "typename": typename,
+                "reason": reason,
+                "idempotency_key": idempotency_key,
+            }.items()
+            if value
+        },
     )
 
 
@@ -197,9 +212,12 @@ async def launch_backfill(
     partition_keys: list[str],
     repository_location_name: str | None = None,
     repository_name: str | None = None,
+    idempotency_key: str | None = None,
     tags: dict[str, str] | None = None,
 ) -> DagsterOperationResult:
     execution_tags = {"phlo/operation": "backfill_asset", "phlo/asset_key": asset_key_path}
+    if idempotency_key:
+        execution_tags["phlo/idempotency_key"] = idempotency_key
     execution_tags.update(tags or {})
     result = await _graphql(
         dagster_url,

--- a/packages/phlo-dagster/tests/test_operations.py
+++ b/packages/phlo-dagster/tests/test_operations.py
@@ -1,0 +1,101 @@
+"""Tests for the Dagster operation capability adapter."""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from phlo_dagster.operations import launch_materialize, list_partitions, terminate
+
+
+def test_launch_materialize_posts_asset_selection(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_post(self, url, json=None, headers=None):  # noqa: ANN001, ANN202, ARG001
+        captured["url"] = url
+        captured["json"] = json
+        return httpx.Response(
+            200,
+            request=httpx.Request("POST", url),
+            json={
+                "data": {
+                    "launchPipelineExecution": {
+                        "__typename": "LaunchRunSuccess",
+                        "run": {"runId": "run-1", "status": "STARTED"},
+                    }
+                }
+            },
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    result = asyncio.run(
+        launch_materialize(
+            dagster_url="http://dagster.test/graphql",
+            asset_key_path="silver/orders",
+            job_name="orders_job",
+            partition_key="2026-05-28",
+        )
+    )
+
+    assert result.accepted is True
+    assert result.run_id == "run-1"
+    assert captured["url"] == "http://dagster.test/graphql"
+    variables = captured["json"]["variables"]  # type: ignore[index]
+    selector = variables["executionParams"]["selector"]
+    assert selector["pipelineName"] == "orders_job"
+    assert selector["assetSelection"] == [{"path": ["silver", "orders"]}]
+
+
+def test_terminate_maps_dagster_error(monkeypatch) -> None:
+    async def fake_post(self, url, json=None, headers=None):  # noqa: ANN001, ANN202, ARG001
+        return httpx.Response(
+            200,
+            request=httpx.Request("POST", url),
+            json={
+                "data": {
+                    "terminateRun": {
+                        "__typename": "RunNotFoundError",
+                        "message": "missing run",
+                    }
+                }
+            },
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    result = asyncio.run(terminate(dagster_url="http://dagster.test/graphql", run_id="missing"))
+
+    assert result.accepted is False
+    assert result.status == "RunNotFoundError"
+    assert result.message == "missing run"
+
+
+def test_list_partitions_uses_asset_node_partition_dimensions(monkeypatch) -> None:
+    async def fake_post(self, url, json=None, headers=None):  # noqa: ANN001, ANN202, ARG001
+        return httpx.Response(
+            200,
+            request=httpx.Request("POST", url),
+            json={
+                "data": {
+                    "assetNodeOrError": {
+                        "__typename": "AssetNode",
+                        "partitionKeysByDimension": [
+                            {"name": "default", "partitionKeys": ["2025-01-01", "2025-01-02"]}
+                        ],
+                    }
+                }
+            },
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+
+    result = asyncio.run(
+        list_partitions(dagster_url="http://dagster.test/graphql", asset_key_path="dlt_events")
+    )
+
+    assert result == [
+        {"partition_key": "2025-01-01", "status": "UNKNOWN"},
+        {"partition_key": "2025-01-02", "status": "UNKNOWN"},
+    ]

--- a/packages/phlo-dlt/src/phlo_dlt/plugin.py
+++ b/packages/phlo-dlt/src/phlo_dlt/plugin.py
@@ -340,6 +340,10 @@ def _cwd(path: Path):
 
 
 def _ingestion_next_steps(files: list[str], *, table: str) -> list[str]:
+    if len(files) < 2:
+        raise ValueError(
+            "create_ingestion_workflow returned fewer than two files; cannot build next steps"
+        )
     schema_file = files[0]
     workflow_file = files[1]
     test_file = files[2] if len(files) > 2 else None

--- a/packages/phlo-dlt/src/phlo_dlt/plugin.py
+++ b/packages/phlo-dlt/src/phlo_dlt/plugin.py
@@ -41,7 +41,10 @@ Example:
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterable
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Callable
 
 from phlo.capabilities import (
@@ -49,7 +52,7 @@ from phlo.capabilities import (
     WorkflowWizardContribution,
     WorkflowWizardField,
 )
-from phlo.capabilities.specs import AssetCheckSpec, AssetSpec
+from phlo.capabilities.specs import AssetCheckSpec, AssetSpec, WorkflowAuthoringSpec
 from phlo.plugins.base import AssetProviderPlugin, IngestionProviderPlugin, PluginMetadata
 
 from phlo_dlt.decorator import clear_ingestion_assets, get_ingestion_assets
@@ -260,3 +263,94 @@ class DLTIngestionProvider(IngestionProviderPlugin):
 
         """
         return get_ingestion_assets
+
+    def get_workflow_wizard_contributions(self) -> list[WorkflowWizardContribution]:
+        """Return workflow wizard contributions exposed by DLT."""
+        return get_workflow_wizard_contributions()
+
+    def get_workflow_authoring_providers(self) -> list[WorkflowAuthoringSpec]:
+        """Return workflow authoring capabilities exposed by DLT."""
+        return [
+            WorkflowAuthoringSpec(
+                name="dlt",
+                provider=DltWorkflowAuthoringProvider(),
+                metadata={"contribution_id": "dlt.rest-api-source"},
+            )
+        ]
+
+
+class DltWorkflowAuthoringProvider:
+    """Create DLT-backed ingestion workflow files."""
+
+    def create_workflow(self, *, project_root: Path, request: dict[str, Any]) -> dict[str, Any]:
+        from phlo_dlt.scaffold import create_ingestion_workflow
+
+        values = dict(request.get("values") or {})
+        workflow_type = str(request.get("workflow_type") or "ingestion")
+        if workflow_type != "ingestion":
+            raise ValueError(f"Unsupported DLT workflow type: {workflow_type}")
+
+        contribution_id = request.get("contribution_id")
+        if contribution_id not in {None, "", "dlt.rest-api-source"}:
+            raise ValueError(f"DLT cannot author contribution {contribution_id!r}")
+
+        domain = str(values.get("domain") or request.get("domain") or "")
+        table = str(values.get("table_name") or values.get("table") or request.get("table") or "")
+        unique_key = str(
+            values.get("unique_key") or values.get("primary_key") or request.get("unique_key") or ""
+        )
+        cron = str(
+            values.get("cron") or values.get("schedule") or request.get("cron") or "0 */1 * * *"
+        )
+        api_base_url = values.get("api_base_url", request.get("api_base_url"))
+        fields = values.get("fields", request.get("fields") or [])
+
+        if not domain or not table or not unique_key:
+            raise ValueError("DLT workflow creation requires domain, table, and unique_key.")
+
+        project_root.mkdir(parents=True, exist_ok=True)
+        with _cwd(project_root):
+            files = create_ingestion_workflow(
+                domain=domain,
+                table_name=table,
+                unique_key=unique_key,
+                cron=cron,
+                api_base_url=str(api_base_url) if api_base_url else None,
+                fields=list(fields or []),
+            )
+
+        return {
+            "workflow_type": workflow_type,
+            "provider": "dlt",
+            "domain": domain,
+            "table": table,
+            "files": files,
+            "next_steps": _ingestion_next_steps(files, table=table),
+        }
+
+
+@contextmanager
+def _cwd(path: Path):
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def _ingestion_next_steps(files: list[str], *, table: str) -> list[str]:
+    schema_file = files[0]
+    workflow_file = files[1]
+    test_file = files[2] if len(files) > 2 else None
+    steps = [f"Review schema: {schema_file}", f"Review workflow: {workflow_file}"]
+    if test_file:
+        steps.append(f"Run generated tests: uv run pytest {test_file} -q")
+    steps.extend(
+        [
+            "Restart active services if needed: phlo services restart",
+            f"Materialize: phlo materialize dlt_{table}",
+            "Inspect status: phlo status",
+        ]
+    )
+    return steps

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -17,6 +17,7 @@ uv pip install -e packages/phlo-mcp
 ## Exposed tools
 
 - `get_platform_health`
+- `list_plugins`
 - `get_service_status`
 - `get_recent_alerts`
 - `get_dashboard_links`
@@ -36,6 +37,14 @@ Optional guarded operational tools:
 
 - `materialize_asset`
 - `retry_failed_run`
+- `cancel_run`
+- `backfill_asset`
+- `list_partitions`
+- `create_workflow`
+- `validate_workflow`
+- `validate_schema`
+- `lint_project`
+- `install_plugin`
 - `get_dagster_run_status`
 
 Resources:
@@ -51,6 +60,9 @@ Resources:
 - `phlo://runtime/contracts/{table_name}`
 - `phlo://runtime/dashboards`
 - `phlo://docs/packages/{package_name}`
+- `phlo://docs/cli`
+- `phlo://docs/mcp/tools`
+- `phlo://docs/mcp/prompts`
 
 Run-level and materialization tools rely on the backing `phlo-api` having access
 to Dagster asset history, Loki log queries, and ClickStack OTEL trace storage.
@@ -88,11 +100,22 @@ phlo-mcp \
 ```
 
 Guarded operational tools are disabled by default. To expose asset
-materialization and run retry tools, set `PHLO_MCP_ENABLE_WRITE_TOOLS=true` or
-pass `--enable-write-tools` with an API token. Write tools return structured
-`audit_context` metadata and default to `dry_run=true` where supported. Current
-`phlo-api` operation routes support dry-run validation and run status; live
-Dagster launch and retry are intentionally not implemented yet.
+materialization, retry, cancel, backfill, and authoring tools, set
+`PHLO_MCP_ENABLE_WRITE_TOOLS=true` or pass `--enable-write-tools` with an API
+token. Write tools return structured `audit_context` metadata and default to
+`dry_run=true` where supported. `phlo-api` enforces scopes, idempotency keys,
+rate limits, and API-side audit logging before dispatching live Dagster
+operations through the `phlo-dagster` capability adapter.
+
+Required scopes:
+
+| Tool | Scope |
+|---|---|
+| read/inspect/search/log/trace tools | `lakehouse:read` |
+| `materialize_asset`, `retry_failed_run`, `cancel_run`, `backfill_asset` | `lakehouse:operate` |
+| `create_workflow`, `validate_workflow`, `validate_schema`, `lint_project` | `project:write` |
+| `install_plugin` | `admin` |
+| `list_partitions`, `get_dagster_run_status` | `lakehouse:read` |
 
 Claude Code example:
 

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -45,7 +45,7 @@ Optional guarded operational tools:
 - `validate_schema`
 - `lint_project`
 - `install_plugin`
-- `get_dagster_run_status`
+- `get_run_status`
 
 Resources:
 
@@ -115,7 +115,7 @@ Required scopes:
 | `materialize_asset`, `retry_failed_run`, `cancel_run`, `backfill_asset` | `lakehouse:operate` |
 | `create_workflow`, `validate_workflow`, `validate_schema`, `lint_project` | `project:write` |
 | `install_plugin` | `admin` |
-| `list_partitions`, `get_dagster_run_status` | `lakehouse:read` |
+| `list_partitions`, `get_run_status` | `lakehouse:read` |
 
 Claude Code example:
 

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -72,6 +72,7 @@ class PhloApiClient:
         cron: str = "0 */1 * * *",
         api_base_url: str | None = None,
         fields: list[str] | None = None,
+        provider: str | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         payload: dict[str, Any] = {
             "domain": domain,
@@ -82,6 +83,8 @@ class PhloApiClient:
         }
         if api_base_url:
             payload["api_base_url"] = api_base_url
+        if provider:
+            payload["provider"] = provider
         return self._post_json("/api/authoring/workflows", json=payload)
 
     def validate_workflow(self, workflow_path: str) -> dict[str, Any] | list[dict[str, Any]]:
@@ -133,6 +136,8 @@ class PhloApiClient:
         self, query: str, *, limit: int = 20, cursor: str | None = None
     ) -> dict[str, Any] | list[dict[str, Any]]:
         contracts = self.get_contracts()
+        if isinstance(contracts, dict) and "error" in contracts:
+            return contracts
         items = contracts if isinstance(contracts, list) else contracts.get("items", [])
         filtered = [item for item in items if query.lower() in str(item).lower()]
         return {"items": filtered[:limit], "next_cursor": None}
@@ -274,6 +279,13 @@ class PhloApiClient:
                             events.append({"event": event_name, "data": data})
                             data_lines = []
                             event_name = "message"
+                    if data_lines:
+                        raw_data = "\n".join(data_lines)
+                        try:
+                            data = json.loads(raw_data)
+                        except json.JSONDecodeError:
+                            data = raw_data
+                        events.append({"event": event_name, "data": data})
                 return {"run_id": run_id, "events": events}
             except httpx.HTTPError as exc:
                 return {
@@ -405,10 +417,13 @@ class PhloApiClient:
         run_id: str,
         *,
         reason: str | None = None,
+        idempotency_key: str | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         payload: dict[str, Any] = {}
         if reason:
             payload["reason"] = reason
+        if idempotency_key:
+            payload["idempotency_key"] = idempotency_key
         return self._post_json(f"{self._V2_PREFIX}/runs/{run_id}/cancel", json=payload)
 
     def backfill_asset(

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -96,9 +96,23 @@ class PhloApiClient:
         return self._get_json("/api/authoring/templates")
 
     def list_workflows(
-        self, *, search: str | None = None, group: str | None = None
+        self,
+        *,
+        search: str | None = None,
+        group: str | None = None,
+        limit: int = 100,
+        cursor: str | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        params = {key: value for key, value in {"search": search, "group": group}.items() if value}
+        params = {
+            key: value
+            for key, value in {
+                "search": search,
+                "group": group,
+                "limit": limit,
+                "cursor": cursor,
+            }.items()
+            if value
+        }
         return self._get_json("/api/authoring/workflows", params=params or None)
 
     def lint_project(self) -> dict[str, Any] | list[dict[str, Any]]:
@@ -157,19 +171,21 @@ class PhloApiClient:
     def diff_schema(
         self, asset_key: str, *, from_run: str | None = None, to_run: str | None = None
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        return {
-            "asset_key": asset_key,
-            "from_run": from_run,
-            "to_run": to_run,
-            "changes": [],
-            "message": "Schema diff endpoint is available as a stable MCP envelope; no run schema snapshots were found.",
-        }
+        return self._post_json(
+            f"{self._V2_PREFIX}/schemas/diff",
+            json={"asset_key": asset_key, "from_run": from_run, "to_run": to_run},
+        )
 
     def get_service_status(self) -> list[dict[str, Any]] | dict[str, Any]:
         return self._get_json("/api/observability/services")
 
-    def get_recent_alerts(self, limit: int = 5) -> list[dict[str, Any]] | dict[str, Any]:
-        return self._get_json("/api/observability/alerts", params={"limit": limit})
+    def get_recent_alerts(
+        self, limit: int = 5, cursor: str | None = None
+    ) -> list[dict[str, Any]] | dict[str, Any]:
+        params: dict[str, Any] = {"limit": limit}
+        if cursor is not None:
+            params["cursor"] = cursor
+        return self._get_json("/api/observability/alerts", params=params)
 
     def get_dashboard_links(self) -> list[dict[str, Any]] | dict[str, Any]:
         return self._get_json("/api/observability/dashboards")
@@ -271,10 +287,14 @@ class PhloApiClient:
         asset_key_path: str,
         *,
         limit: int = 10,
+        cursor: str | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if cursor:
+            params["cursor"] = cursor
         return self._get_json(
             f"{self._V2_PREFIX}/assets/{asset_key_path}/materializations",
-            params={"limit": limit},
+            params=params,
         )
 
     def get_run_trace_spans(
@@ -282,10 +302,12 @@ class PhloApiClient:
         run_id: str,
         *,
         limit: int = 500,
+        cursor: str | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        payload = self._get_json(
-            f"/api/observability/traces/runs/{run_id}", params={"limit": limit}
-        )
+        params: dict[str, Any] = {"limit": limit}
+        if cursor is not None:
+            params["cursor"] = cursor
+        payload = self._get_json(f"/api/observability/traces/runs/{run_id}", params=params)
         if isinstance(payload, dict) and payload.get("error"):
             return []
         return payload
@@ -306,6 +328,7 @@ class PhloApiClient:
         start_time: str | None = None,
         end_time: str | None = None,
         limit: int = 500,
+        cursor: str | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         params: dict[str, Any] = {"limit": limit}
         for key, value in {
@@ -317,6 +340,7 @@ class PhloApiClient:
             "status_code": status_code,
             "start_time": start_time,
             "end_time": end_time,
+            "cursor": cursor,
         }.items():
             if value:
                 params[key] = value

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import httpx
 from opentelemetry import trace
 
 from phlo_mcp.config import McpConfig
+from phlo_mcp.errors import map_httpx_error
 
 
 class PhloApiClient:
@@ -38,6 +40,11 @@ class PhloApiClient:
     def get_plugins(self) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json("/api/plugins")
 
+    def install_plugin(self, package_name: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._post_json(
+            f"{self._V2_PREFIX}/packages/install", json={"package_name": package_name}
+        )
+
     def get_services(self) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json("/api/services")
 
@@ -56,6 +63,108 @@ class PhloApiClient:
     def get_contract(self, table_name: str) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json(f"/api/contracts/{table_name}")
 
+    def create_workflow(
+        self,
+        *,
+        domain: str,
+        table: str,
+        unique_key: str,
+        cron: str = "0 */1 * * *",
+        api_base_url: str | None = None,
+        fields: list[str] | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        payload: dict[str, Any] = {
+            "domain": domain,
+            "table": table,
+            "unique_key": unique_key,
+            "cron": cron,
+            "fields": fields or [],
+        }
+        if api_base_url:
+            payload["api_base_url"] = api_base_url
+        return self._post_json("/api/authoring/workflows", json=payload)
+
+    def validate_workflow(self, workflow_path: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._post_json(
+            "/api/authoring/workflows/validate", json={"workflow_path": workflow_path}
+        )
+
+    def validate_schema(self, schema_path: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._post_json("/api/authoring/schemas/validate", json={"schema_path": schema_path})
+
+    def list_templates(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json("/api/authoring/templates")
+
+    def list_workflows(
+        self, *, search: str | None = None, group: str | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        params = {key: value for key, value in {"search": search, "group": group}.items() if value}
+        return self._get_json("/api/authoring/workflows", params=params or None)
+
+    def lint_project(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._post_json("/api/authoring/project/lint", json={})
+
+    def run_doctor(self) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json("/api/authoring/doctor")
+
+    def search_assets(
+        self, query: str, *, limit: int = 20, cursor: str | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        params: dict[str, Any] = {"q": query, "limit": limit}
+        if cursor:
+            params["cursor"] = cursor
+        return self._get_json(f"{self._V2_PREFIX}/search", params=params)
+
+    def search_contracts(
+        self, query: str, *, limit: int = 20, cursor: str | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        contracts = self.get_contracts()
+        items = contracts if isinstance(contracts, list) else contracts.get("items", [])
+        filtered = [item for item in items if query.lower() in str(item).lower()]
+        return {"items": filtered[:limit], "next_cursor": None}
+
+    def search_runs(
+        self, query: str | None = None, *, limit: int = 20, cursor: str | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        params: dict[str, Any] = {"limit": limit}
+        if query:
+            params["q"] = query
+        if cursor:
+            params["cursor"] = cursor
+        return self._get_json(f"{self._V2_PREFIX}/runs", params=params)
+
+    def get_quality_results(
+        self, asset_key: str | None = None, run_id: str | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        payload = self._get_json(f"{self._V2_PREFIX}/quality")
+        if not isinstance(payload, dict) or not isinstance(payload.get("items"), list):
+            return payload
+        items = payload["items"]
+        if asset_key:
+            items = [item for item in items if item.get("asset_id") == asset_key]
+        if run_id:
+            items = [item for item in items if item.get("run_id") == run_id]
+        return {**payload, "items": items}
+
+    def get_lineage(
+        self, asset_key: str, *, direction: str = "both", depth: int = 1
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(
+            f"{self._V2_PREFIX}/asset-graph/neighbors",
+            params={"asset_key": asset_key, "direction": direction, "depth": depth},
+        )
+
+    def diff_schema(
+        self, asset_key: str, *, from_run: str | None = None, to_run: str | None = None
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        return {
+            "asset_key": asset_key,
+            "from_run": from_run,
+            "to_run": to_run,
+            "changes": [],
+            "message": "Schema diff endpoint is available as a stable MCP envelope; no run schema snapshots were found.",
+        }
+
     def get_service_status(self) -> list[dict[str, Any]] | dict[str, Any]:
         return self._get_json("/api/observability/services")
 
@@ -71,11 +180,91 @@ class PhloApiClient:
         *,
         level: str | None = None,
         limit: int = 200,
+        query: str | None = None,
+        regex: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        cursor: str | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         params: dict[str, Any] = {"limit": limit}
-        if level:
-            params["level"] = level
-        return self._get_json(f"/api/loki/runs/{run_id}", params=params)
+        for key, value in {
+            "level": level,
+            "query": query,
+            "regex": regex,
+            "since": since,
+            "until": until,
+            "cursor": cursor,
+        }.items():
+            if value:
+                params[key] = value
+        payload = self._get_json(f"/api/loki/runs/{run_id}", params=params)
+        if isinstance(payload, dict) and payload.get("error"):
+            return {"entries": [], "has_more": False, "unavailable": payload["error"]}
+        return payload
+
+    def search_run_logs(
+        self,
+        run_id: str,
+        *,
+        query: str,
+        regex: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        cursor: str | None = None,
+        limit: int = 200,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        return self.get_run_logs(
+            run_id,
+            query=query,
+            regex=regex,
+            since=since,
+            until=until,
+            cursor=cursor,
+            limit=limit,
+        )
+
+    def follow_run_logs(
+        self,
+        run_id: str,
+        *,
+        timeout_seconds: int = 30,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        url = f"{self.api_base_url}/api/loki/runs/{run_id}/stream"
+        params = {"timeout_seconds": timeout_seconds, "limit": limit}
+        events: list[dict[str, Any]] = []
+        with self._tracer.start_as_current_span(
+            "http.client GET",
+            attributes={"http.request.method": "GET", "url.full": url},
+        ):
+            try:
+                with httpx.stream(
+                    "GET", url, params=params, headers=self.headers, timeout=timeout_seconds + 5
+                ) as response:
+                    response.raise_for_status()
+                    event_name = "message"
+                    data_lines: list[str] = []
+                    for line in response.iter_lines():
+                        if line.startswith("event: "):
+                            event_name = line[7:]
+                        elif line.startswith("data: "):
+                            data_lines.append(line[6:])
+                        elif line == "" and data_lines:
+                            raw_data = "\n".join(data_lines)
+                            try:
+                                data: Any = json.loads(raw_data)
+                            except json.JSONDecodeError:
+                                data = raw_data
+                            events.append({"event": event_name, "data": data})
+                            data_lines = []
+                            event_name = "message"
+                return {"run_id": run_id, "events": events}
+            except httpx.HTTPError as exc:
+                return {
+                    "run_id": run_id,
+                    "events": [],
+                    "unavailable": map_httpx_error(exc).to_payload(),
+                }
 
     def get_materialization_history(
         self,
@@ -94,7 +283,12 @@ class PhloApiClient:
         *,
         limit: int = 500,
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        return self._get_json(f"/api/observability/traces/runs/{run_id}", params={"limit": limit})
+        payload = self._get_json(
+            f"/api/observability/traces/runs/{run_id}", params={"limit": limit}
+        )
+        if isinstance(payload, dict) and payload.get("error"):
+            return []
+        return payload
 
     def get_logs_query_link(self, service: str | None = None) -> dict[str, Any]:
         params = {"service": service} if service else None
@@ -126,7 +320,10 @@ class PhloApiClient:
         }.items():
             if value:
                 params[key] = value
-        return self._get_json("/api/observability/traces", params=params)
+        payload = self._get_json("/api/observability/traces", params=params)
+        if isinstance(payload, dict) and payload.get("error"):
+            return []
+        return payload
 
     def get_metrics_query_link(self, metric: str | None = None) -> dict[str, Any]:
         params = {"metric": metric} if metric else None
@@ -138,10 +335,25 @@ class PhloApiClient:
         *,
         dry_run: bool = True,
         partition_key: str | None = None,
+        job_name: str | None = None,
+        repository_location_name: str | None = None,
+        repository_name: str | None = None,
+        idempotency_key: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
         payload: dict[str, Any] = {"dry_run": dry_run}
         if partition_key:
             payload["partition_key"] = partition_key
+        if job_name:
+            payload["job_name"] = job_name
+        if repository_location_name:
+            payload["repository_location_name"] = repository_location_name
+        if repository_name:
+            payload["repository_name"] = repository_name
+        if idempotency_key:
+            payload["idempotency_key"] = idempotency_key
+        if tags:
+            payload["tags"] = tags
         return self._post_json(
             f"{self._V2_PREFIX}/assets/{asset_key_path}/materialize", json=payload
         )
@@ -151,8 +363,62 @@ class PhloApiClient:
         run_id: str,
         *,
         dry_run: bool = True,
+        strategy: str = "FROM_FAILURE",
+        idempotency_key: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        return self._post_json(f"{self._V2_PREFIX}/runs/{run_id}/retry", json={"dry_run": dry_run})
+        payload: dict[str, Any] = {"dry_run": dry_run}
+        if strategy != "FROM_FAILURE":
+            payload["strategy"] = strategy
+        if idempotency_key:
+            payload["idempotency_key"] = idempotency_key
+        if tags:
+            payload["tags"] = tags
+        return self._post_json(f"{self._V2_PREFIX}/runs/{run_id}/retry", json=payload)
+
+    def cancel_run(
+        self,
+        run_id: str,
+        *,
+        reason: str | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        payload: dict[str, Any] = {}
+        if reason:
+            payload["reason"] = reason
+        return self._post_json(f"{self._V2_PREFIX}/runs/{run_id}/cancel", json=payload)
+
+    def backfill_asset(
+        self,
+        asset_key_path: str,
+        *,
+        dry_run: bool = True,
+        partitions: list[str] | None = None,
+        partition_range: dict[str, str] | None = None,
+        partition_set_name: str | None = None,
+        repository_location_name: str | None = None,
+        repository_name: str | None = None,
+        idempotency_key: str | None = None,
+        tags: dict[str, str] | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        payload: dict[str, Any] = {"dry_run": dry_run}
+        if partitions:
+            payload["partitions"] = partitions
+        if partition_range:
+            payload["partition_range"] = partition_range
+        if partition_set_name:
+            payload["partition_set_name"] = partition_set_name
+        if repository_location_name:
+            payload["repository_location_name"] = repository_location_name
+        if repository_name:
+            payload["repository_name"] = repository_name
+        if idempotency_key:
+            payload["idempotency_key"] = idempotency_key
+        if tags:
+            payload["tags"] = tags
+        return self._post_json(f"{self._V2_PREFIX}/assets/{asset_key_path}/backfill", json=payload)
+
+    def list_partitions(self, asset_key_path: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(f"{self._V2_PREFIX}/assets/{asset_key_path}/partitions")
 
     def get_run_status(self, run_id: str) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json(f"{self._V2_PREFIX}/runs/{run_id}/status")
@@ -177,9 +443,12 @@ class PhloApiClient:
                 "url.full": url,
             },
         ):
-            response = httpx.get(url, params=params, headers=self.headers, timeout=10.0)
-            response.raise_for_status()
-            return response.json()
+            try:
+                response = httpx.get(url, params=params, headers=self.headers, timeout=10.0)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPError as exc:
+                return {"error": map_httpx_error(exc).to_payload()}
 
     def _post_json(
         self,
@@ -195,6 +464,9 @@ class PhloApiClient:
                 "url.full": url,
             },
         ):
-            response = httpx.post(url, json=json, headers=self.headers, timeout=30.0)
-            response.raise_for_status()
-            return response.json()
+            try:
+                response = httpx.post(url, json=json, headers=self.headers, timeout=30.0)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPError as exc:
+                return {"error": map_httpx_error(exc).to_payload()}

--- a/packages/phlo-mcp/src/phlo_mcp/errors.py
+++ b/packages/phlo-mcp/src/phlo_mcp/errors.py
@@ -1,0 +1,90 @@
+"""Structured MCP error envelopes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+@dataclass(frozen=True)
+class PhloMcpError(Exception):
+    code: str
+    message: str
+    hint: str | None = None
+    docs_url: str | None = None
+    retryable: bool = False
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "hint": self.hint,
+            "docs_url": self.docs_url,
+            "retryable": self.retryable,
+        }
+
+    def __str__(self) -> str:
+        return f"{self.code}: {self.message}"
+
+
+def map_httpx_error(exc: httpx.HTTPError) -> PhloMcpError:
+    """Map httpx failures into stable agent-readable error codes."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+        detail = _http_error_detail(exc.response)
+        code = {
+            400: "phlo.api.bad_request",
+            401: "phlo.auth.unauthorized",
+            403: "phlo.auth.forbidden",
+            404: "phlo.resource.not_found",
+            409: "phlo.api.conflict",
+            422: "phlo.api.validation_failed",
+            429: "phlo.api.rate_limited",
+            500: "phlo.api.internal_error",
+            502: "phlo.api.bad_gateway",
+            503: "phlo.api.unavailable",
+            504: "phlo.api.timeout",
+        }.get(status_code, "phlo.api.http_error")
+        return PhloMcpError(
+            code=code,
+            message=detail.get("message") or f"phlo-api returned HTTP {status_code}",
+            hint=detail.get("hint")
+            or detail.get("error")
+            or "Check phlo-api logs and the requested resource identifier.",
+            retryable=status_code in {429, 500, 502, 503, 504},
+        )
+    if isinstance(exc, httpx.TimeoutException):
+        return PhloMcpError(
+            code="phlo.api.timeout",
+            message="Timed out calling phlo-api",
+            hint="Retry or check whether phlo-api and its backends are healthy.",
+            retryable=True,
+        )
+    if isinstance(exc, httpx.ConnectError):
+        return PhloMcpError(
+            code="phlo.api.unreachable",
+            message="Could not connect to phlo-api",
+            hint="Start phlo-api or update PHLO_MCP_API_BASE_URL.",
+            retryable=True,
+        )
+    return PhloMcpError(
+        code="phlo.api.unknown",
+        message=str(exc),
+        hint="Inspect the MCP server logs for the original exception.",
+        retryable=False,
+    )
+
+
+def _http_error_detail(response: httpx.Response) -> dict[str, str]:
+    try:
+        payload = response.json()
+    except ValueError:
+        return {}
+    detail = payload.get("detail") if isinstance(payload, dict) else None
+    if isinstance(detail, dict):
+        return {key: str(value) for key, value in detail.items() if value is not None}
+    if isinstance(detail, str):
+        return {"message": detail}
+    return {}

--- a/packages/phlo-mcp/src/phlo_mcp/models.py
+++ b/packages/phlo-mcp/src/phlo_mcp/models.py
@@ -1,0 +1,60 @@
+"""Typed MCP response models for Phlo tool contracts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ErrorPayload(BaseModel):
+    """Structured tool error payload returned instead of raw HTTP exceptions."""
+
+    code: str
+    message: str
+    hint: str | None = None
+    docs_url: str | None = None
+    retryable: bool = False
+
+
+class ToolEnvelope(BaseModel):
+    """Common MCP response envelope for API-backed tools."""
+
+    api_base_url: str | None = None
+    payload: Any = None
+    error: ErrorPayload | None = None
+
+
+class AuditContext(BaseModel):
+    """Audit metadata emitted by guarded write tools."""
+
+    operation: str
+    target: dict[str, Any] = Field(default_factory=dict)
+    dry_run: bool
+    authenticated: bool
+    api_base_url: str
+
+
+class WriteToolEnvelope(BaseModel):
+    """Common MCP response envelope for guarded write tools."""
+
+    audit_context: AuditContext
+    payload: Any = None
+    error: ErrorPayload | None = None
+
+
+class ToolContract(BaseModel):
+    """Self-introspection record for one registered MCP tool."""
+
+    name: str
+    description: str | None = None
+    input_schema: dict[str, Any] | None = None
+    output_schema: dict[str, Any] | None = None
+    required_scope: str | None = None
+
+
+class PromptContract(BaseModel):
+    """Self-introspection record for one registered MCP prompt."""
+
+    name: str
+    description: str | None = None

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -196,11 +196,14 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
         }
 
     def _append_audit_record(audit_context: dict[str, Any]) -> None:
-        audit_dir = Path.cwd() / ".phlo" / "audit"
-        audit_dir.mkdir(parents=True, exist_ok=True)
-        record = {"timestamp": datetime.now(UTC).isoformat(), **audit_context}
-        with (audit_dir / "operations.jsonl").open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record, sort_keys=True) + "\n")
+        try:
+            audit_dir = Path.cwd() / ".phlo" / "audit"
+            audit_dir.mkdir(parents=True, exist_ok=True)
+            record = {"timestamp": datetime.now(UTC).isoformat(), **audit_context}
+            with (audit_dir / "operations.jsonl").open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+        except OSError:
+            return
 
     def _required_scope_for_tool(tool_name: str) -> str | None:
         if tool_name in {
@@ -796,6 +799,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
             cron: str = "0 */1 * * *",
             api_base_url: str | None = None,
             fields: list[str] | None = None,
+            provider: str | None = None,
         ) -> dict[str, Any]:
             """Create a workflow scaffold through phlo-api when write tools are enabled."""
             payload = client.create_workflow(
@@ -805,10 +809,12 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 cron=cron,
                 api_base_url=api_base_url,
                 fields=fields,
+                provider=provider,
             )
-            audit_context = _write_audit_context(
-                "create_workflow", {"domain": domain, "table": table}, False
-            )
+            target: dict[str, Any] = {"domain": domain, "table": table}
+            if provider:
+                target["provider"] = provider
+            audit_context = _write_audit_context("create_workflow", target, False)
             _append_audit_record(audit_context)
             return {"audit_context": audit_context, "payload": payload}
 
@@ -847,6 +853,14 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         target = {"asset_key_path": asset_key_path}
                         if partition_key:
                             target["partition_key"] = partition_key
+                        if job_name:
+                            target["job_name"] = job_name
+                        if repository_location_name:
+                            target["repository_location_name"] = repository_location_name
+                        if repository_name:
+                            target["repository_name"] = repository_name
+                        if idempotency_key:
+                            target["idempotency_key"] = idempotency_key
                         audit_context = _write_audit_context("materialize_asset", target, dry_run)
                         _append_audit_record(audit_context)
                         payload = client.materialize_asset(
@@ -878,7 +892,17 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 ):
                     with tracer.start_as_current_span("phlo.orchestrator.run.retry"):
                         audit_context = _write_audit_context(
-                            "retry_failed_run", {"run_id": run_id}, dry_run
+                            "retry_failed_run",
+                            {
+                                key: value
+                                for key, value in {
+                                    "run_id": run_id,
+                                    "strategy": strategy,
+                                    "idempotency_key": idempotency_key,
+                                }.items()
+                                if value
+                            },
+                            dry_run,
                         )
                         _append_audit_record(audit_context)
                         payload = client.retry_run(
@@ -890,7 +914,9 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         return {"audit_context": audit_context, "payload": payload}
 
         @mcp.tool()
-        def cancel_run(run_id: str, reason: str | None = None) -> dict[str, Any]:
+        def cancel_run(
+            run_id: str, reason: str | None = None, idempotency_key: str | None = None
+        ) -> dict[str, Any]:
             """Cancel an orchestrator run through phlo-api when write tools are enabled."""
             with tracer.start_as_current_span(
                 "mcp.request",
@@ -902,10 +928,22 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 ):
                     with tracer.start_as_current_span("phlo.orchestrator.run.cancel"):
                         audit_context = _write_audit_context(
-                            "cancel_run", {"run_id": run_id}, False
+                            "cancel_run",
+                            {
+                                key: value
+                                for key, value in {
+                                    "run_id": run_id,
+                                    "reason": reason,
+                                    "idempotency_key": idempotency_key,
+                                }.items()
+                                if value
+                            },
+                            False,
                         )
                         _append_audit_record(audit_context)
-                        payload = client.cancel_run(run_id, reason=reason)
+                        payload = client.cancel_run(
+                            run_id, reason=reason, idempotency_key=idempotency_key
+                        )
                         return {"audit_context": audit_context, "payload": payload}
 
         @mcp.tool()
@@ -934,6 +972,14 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                             target["partitions"] = partitions
                         if partition_range:
                             target["partition_range"] = partition_range
+                        if partition_set_name:
+                            target["partition_set_name"] = partition_set_name
+                        if repository_location_name:
+                            target["repository_location_name"] = repository_location_name
+                        if repository_name:
+                            target["repository_name"] = repository_name
+                        if idempotency_key:
+                            target["idempotency_key"] = idempotency_key
                         audit_context = _write_audit_context("backfill_asset", target, dry_run)
                         _append_audit_record(audit_context)
                         payload = client.backfill_asset(

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -78,7 +78,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
         mime_type="application/json",
     )
     def runtime_assets() -> dict[str, Any] | list[dict[str, Any]]:
-        """Read Dagster asset metadata."""
+        """Read asset metadata."""
         return client.get_assets()
 
     @mcp.resource(
@@ -114,7 +114,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
         mime_type="application/json",
     )
     def runtime_asset(asset_key_path: str) -> dict[str, Any] | list[dict[str, Any]]:
-        """Read metadata for one Dagster asset."""
+        """Read metadata for one asset."""
         return client.get_asset_details(asset_key_path)
 
     @mcp.resource(
@@ -123,7 +123,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
         mime_type="application/json",
     )
     def runtime_asset_schema(asset_key_path: str) -> dict[str, Any]:
-        """Read schema metadata for one Dagster asset."""
+        """Read schema metadata for one asset."""
         details = client.get_asset_details(asset_key_path)
         if not isinstance(details, dict):
             return {"asset_key_path": asset_key_path, "columns": []}
@@ -214,11 +214,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
             return "project:write"
         if tool_name == "install_plugin":
             return "admin"
-        if (
-            tool_name == "get_dagster_run_status"
-            or tool_name.startswith("get_")
-            or tool_name.startswith("search_")
-        ):
+        if tool_name.startswith("get_") or tool_name.startswith("search_"):
             return "lakehouse:read"
         return None
 
@@ -226,7 +222,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
     def debug_run(run_id: str) -> str:
         """Guide an agent through run failure debugging with Phlo tools."""
         return (
-            f"Debug Phlo run {run_id}. Use get_dagster_run_status, get_run_logs, "
+            f"Debug Phlo run {run_id}. Use get_run_status, get_run_logs, "
             "get_run_trace_spans, and render_run_trace_tree. Identify the failing span or "
             "log line, explain the likely root cause, and propose the smallest safe fix."
         )
@@ -367,7 +363,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
     def get_materialization_history(
         asset_key_path: str, limit: int = 10, cursor: str | None = None
     ) -> dict[str, Any]:
-        """Get recent Dagster materializations for an asset."""
+        """Get recent materializations for an asset."""
         with tracer.start_as_current_span(
             "mcp.request",
             attributes={"mcp.tool.name": "get_materialization_history"},
@@ -376,7 +372,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 "mcp.tool.execute",
                 attributes={"mcp.tool.name": "get_materialization_history"},
             ):
-                with tracer.start_as_current_span("phlo.dagster.materialization_history"):
+                with tracer.start_as_current_span("phlo.orchestrator.materialization_history"):
                     events = client.get_materialization_history(
                         asset_key_path, limit=limit, cursor=cursor
                     )
@@ -838,7 +834,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
             repository_name: str | None = None,
             idempotency_key: str | None = None,
         ) -> dict[str, Any]:
-            """Materialize a Dagster asset through phlo-api when write tools are enabled."""
+            """Materialize an asset through phlo-api when write tools are enabled."""
             with tracer.start_as_current_span(
                 "mcp.request",
                 attributes={"mcp.tool.name": "materialize_asset"},
@@ -847,7 +843,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     "mcp.tool.execute",
                     attributes={"mcp.tool.name": "materialize_asset"},
                 ):
-                    with tracer.start_as_current_span("phlo.dagster.asset.materialize"):
+                    with tracer.start_as_current_span("phlo.orchestrator.asset.materialize"):
                         target = {"asset_key_path": asset_key_path}
                         if partition_key:
                             target["partition_key"] = partition_key
@@ -871,7 +867,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
             strategy: str = "FROM_FAILURE",
             idempotency_key: str | None = None,
         ) -> dict[str, Any]:
-            """Retry a Dagster run through phlo-api when write tools are enabled."""
+            """Retry a failed orchestrator run through phlo-api when write tools are enabled."""
             with tracer.start_as_current_span(
                 "mcp.request",
                 attributes={"mcp.tool.name": "retry_failed_run"},
@@ -880,7 +876,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     "mcp.tool.execute",
                     attributes={"mcp.tool.name": "retry_failed_run"},
                 ):
-                    with tracer.start_as_current_span("phlo.dagster.run.retry"):
+                    with tracer.start_as_current_span("phlo.orchestrator.run.retry"):
                         audit_context = _write_audit_context(
                             "retry_failed_run", {"run_id": run_id}, dry_run
                         )
@@ -895,7 +891,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
 
         @mcp.tool()
         def cancel_run(run_id: str, reason: str | None = None) -> dict[str, Any]:
-            """Cancel a Dagster run through phlo-api when write tools are enabled."""
+            """Cancel an orchestrator run through phlo-api when write tools are enabled."""
             with tracer.start_as_current_span(
                 "mcp.request",
                 attributes={"mcp.tool.name": "cancel_run"},
@@ -904,7 +900,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     "mcp.tool.execute",
                     attributes={"mcp.tool.name": "cancel_run"},
                 ):
-                    with tracer.start_as_current_span("phlo.dagster.run.cancel"):
+                    with tracer.start_as_current_span("phlo.orchestrator.run.cancel"):
                         audit_context = _write_audit_context(
                             "cancel_run", {"run_id": run_id}, False
                         )
@@ -932,7 +928,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     "mcp.tool.execute",
                     attributes={"mcp.tool.name": "backfill_asset"},
                 ):
-                    with tracer.start_as_current_span("phlo.dagster.asset.backfill"):
+                    with tracer.start_as_current_span("phlo.orchestrator.asset.backfill"):
                         target: dict[str, Any] = {"asset_key_path": asset_key_path}
                         if partitions:
                             target["partitions"] = partitions
@@ -963,7 +959,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     "mcp.tool.execute",
                     attributes={"mcp.tool.name": "list_partitions"},
                 ):
-                    with tracer.start_as_current_span("phlo.dagster.asset.partitions"):
+                    with tracer.start_as_current_span("phlo.orchestrator.asset.partitions"):
                         payload = client.list_partitions(asset_key_path)
                         return {
                             "api_base_url": client.api_base_url,
@@ -972,17 +968,17 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         }
 
         @mcp.tool()
-        def get_dagster_run_status(run_id: str) -> dict[str, Any]:
-            """Get Dagster run status through phlo-api for operational follow-up."""
+        def get_run_status(run_id: str) -> dict[str, Any]:
+            """Get orchestrator run status through phlo-api for operational follow-up."""
             with tracer.start_as_current_span(
                 "mcp.request",
-                attributes={"mcp.tool.name": "get_dagster_run_status"},
+                attributes={"mcp.tool.name": "get_run_status"},
             ):
                 with tracer.start_as_current_span(
                     "mcp.tool.execute",
-                    attributes={"mcp.tool.name": "get_dagster_run_status"},
+                    attributes={"mcp.tool.name": "get_run_status"},
                 ):
-                    with tracer.start_as_current_span("phlo.dagster.run.status"):
+                    with tracer.start_as_current_span("phlo.orchestrator.run.status"):
                         payload = client.get_run_status(run_id)
                         return {
                             "api_base_url": client.api_base_url,

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -304,7 +304,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     return {"api_base_url": client.api_base_url, "services": services}
 
     @mcp.tool()
-    def get_recent_alerts(limit: int = 5) -> dict[str, Any]:
+    def get_recent_alerts(limit: int = 5, cursor: str | None = None) -> dict[str, Any]:
         """Get recent observability alerts from phlo-api."""
         with tracer.start_as_current_span(
             "mcp.request",
@@ -315,7 +315,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 attributes={"mcp.tool.name": "get_recent_alerts"},
             ):
                 with tracer.start_as_current_span("phlo.observability.alerts"):
-                    alerts = client.get_recent_alerts(limit)
+                    alerts = client.get_recent_alerts(limit, cursor=cursor)
                     return {"api_base_url": client.api_base_url, "alerts": alerts}
 
     @mcp.tool()
@@ -364,7 +364,9 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     return {"api_base_url": client.api_base_url, "payload": payload}
 
     @mcp.tool()
-    def get_materialization_history(asset_key_path: str, limit: int = 10) -> dict[str, Any]:
+    def get_materialization_history(
+        asset_key_path: str, limit: int = 10, cursor: str | None = None
+    ) -> dict[str, Any]:
         """Get recent Dagster materializations for an asset."""
         with tracer.start_as_current_span(
             "mcp.request",
@@ -375,7 +377,9 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 attributes={"mcp.tool.name": "get_materialization_history"},
             ):
                 with tracer.start_as_current_span("phlo.dagster.materialization_history"):
-                    events = client.get_materialization_history(asset_key_path, limit=limit)
+                    events = client.get_materialization_history(
+                        asset_key_path, limit=limit, cursor=cursor
+                    )
                     return {
                         "api_base_url": client.api_base_url,
                         "asset_key_path": asset_key_path,
@@ -383,7 +387,12 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     }
 
     @mcp.tool()
-    def get_run_logs(run_id: str, limit: int = 200, level: str | None = None) -> dict[str, Any]:
+    def get_run_logs(
+        run_id: str,
+        limit: int = 200,
+        level: str | None = None,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
         """Get correlated logs for a specific run or materialization."""
         with tracer.start_as_current_span(
             "mcp.request",
@@ -394,7 +403,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 attributes={"mcp.tool.name": "get_run_logs"},
             ):
                 with tracer.start_as_current_span("phlo.loki.run_logs"):
-                    payload = client.get_run_logs(run_id, limit=limit, level=level)
+                    payload = client.get_run_logs(run_id, limit=limit, level=level, cursor=cursor)
                     return {
                         "api_base_url": client.api_base_url,
                         "run_id": run_id,
@@ -402,7 +411,9 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     }
 
     @mcp.tool()
-    def get_run_trace_spans(run_id: str, limit: int = 500) -> dict[str, Any]:
+    def get_run_trace_spans(
+        run_id: str, limit: int = 500, cursor: str | None = None
+    ) -> dict[str, Any]:
         """Get OTEL spans correlated to a specific run id."""
         with tracer.start_as_current_span(
             "mcp.request",
@@ -413,7 +424,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 attributes={"mcp.tool.name": "get_run_trace_spans"},
             ):
                 with tracer.start_as_current_span("phlo.observability.run_spans"):
-                    payload = client.get_run_trace_spans(run_id, limit=limit)
+                    payload = client.get_run_trace_spans(run_id, limit=limit, cursor=cursor)
                     return {
                         "api_base_url": client.api_base_url,
                         "run_id": run_id,
@@ -431,6 +442,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
         start_time: str | None = None,
         end_time: str | None = None,
         limit: int = 500,
+        cursor: str | None = None,
     ) -> dict[str, Any]:
         """Get OTEL spans filtered by run, asset, job, service, status, name, or time."""
         with tracer.start_as_current_span(
@@ -452,6 +464,7 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         start_time=start_time,
                         end_time=end_time,
                         limit=limit,
+                        cursor=cursor,
                     )
                     return {
                         "api_base_url": client.api_base_url,
@@ -675,9 +688,14 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                     }
 
     @mcp.tool()
-    def list_workflows(search: str | None = None, group: str | None = None) -> dict[str, Any]:
+    def list_workflows(
+        search: str | None = None,
+        group: str | None = None,
+        limit: int = 100,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
         """List workflows discovered in the Phlo project."""
-        payload = client.list_workflows(search=search, group=group)
+        payload = client.list_workflows(search=search, group=group, limit=limit, cursor=cursor)
         return {"api_base_url": client.api_base_url, "payload": payload}
 
     @mcp.tool()

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +12,7 @@ from opentelemetry import trace
 
 from phlo_mcp.api_client import PhloApiClient
 from phlo_mcp.config import McpConfig, config_from_env
+from phlo_mcp.models import ToolContract
 from phlo_mcp.run_analysis import (
     render_run_trace_tree as render_log_trace_tree_text,
     render_span_tree,
@@ -149,6 +152,38 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
         """Read package documentation from the local docs tree."""
         return _read_package_doc(package_name)
 
+    @mcp.resource("phlo://docs/mcp/tools", name="mcp_tools", mime_type="application/json")
+    def mcp_tools() -> list[dict[str, Any]]:
+        """List registered MCP tools for self-introspection."""
+        return [
+            ToolContract(
+                name=tool.name,
+                description=tool.description,
+                input_schema=getattr(tool, "parameters", None),
+                output_schema=getattr(tool, "output_schema", None),
+                required_scope=_required_scope_for_tool(tool.name),
+            ).model_dump(mode="json")
+            for tool in mcp._tool_manager.list_tools()
+        ]
+
+    @mcp.resource("phlo://docs/mcp/prompts", name="mcp_prompts", mime_type="application/json")
+    def mcp_prompts() -> list[dict[str, Any]]:
+        """List registered MCP prompts for self-introspection."""
+        return [
+            {"name": prompt.name, "description": prompt.description}
+            for prompt in mcp._prompt_manager.list_prompts()
+        ]
+
+    @mcp.resource("phlo://docs/cli", name="cli_docs", mime_type="text/markdown")
+    def cli_docs() -> str:
+        """Return a lightweight CLI command index."""
+        from phlo.cli.main import cli
+
+        lines = ["# Phlo CLI", ""]
+        for name, command in sorted(cli.commands.items()):
+            lines.append(f"- `phlo {name}` — {command.short_help or command.help or ''}")
+        return "\n".join(lines)
+
     def _write_audit_context(
         operation: str, target: dict[str, Any], dry_run: bool
     ) -> dict[str, Any]:
@@ -159,6 +194,78 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
             "authenticated": bool(resolved.api_token),
             "api_base_url": client.api_base_url,
         }
+
+    def _append_audit_record(audit_context: dict[str, Any]) -> None:
+        audit_dir = Path.cwd() / ".phlo" / "audit"
+        audit_dir.mkdir(parents=True, exist_ok=True)
+        record = {"timestamp": datetime.now(UTC).isoformat(), **audit_context}
+        with (audit_dir / "operations.jsonl").open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+    def _required_scope_for_tool(tool_name: str) -> str | None:
+        if tool_name in {
+            "materialize_asset",
+            "retry_failed_run",
+            "cancel_run",
+            "backfill_asset",
+        }:
+            return "lakehouse:operate"
+        if tool_name in {"create_workflow", "validate_workflow", "validate_schema", "lint_project"}:
+            return "project:write"
+        if tool_name == "install_plugin":
+            return "admin"
+        if (
+            tool_name == "get_dagster_run_status"
+            or tool_name.startswith("get_")
+            or tool_name.startswith("search_")
+        ):
+            return "lakehouse:read"
+        return None
+
+    @mcp.prompt(name="phlo.debug_run")
+    def debug_run(run_id: str) -> str:
+        """Guide an agent through run failure debugging with Phlo tools."""
+        return (
+            f"Debug Phlo run {run_id}. Use get_dagster_run_status, get_run_logs, "
+            "get_run_trace_spans, and render_run_trace_tree. Identify the failing span or "
+            "log line, explain the likely root cause, and propose the smallest safe fix."
+        )
+
+    @mcp.prompt(name="phlo.triage_failure")
+    def triage_failure(asset_key: str) -> str:
+        """Guide an agent through asset failure triage."""
+        return (
+            f"Triage the latest failure for Phlo asset {asset_key}. Use "
+            "inspect_materialization, render_materialization_trace_tree, get_run_logs, and "
+            "get_trace_spans. Summarize impact, suspected cause, and remediation steps."
+        )
+
+    @mcp.prompt(name="phlo.audit_asset")
+    def audit_asset(asset_key: str) -> str:
+        """Guide an agent through an asset health audit."""
+        return (
+            f"Audit Phlo asset {asset_key}. Inspect asset metadata, schema, recent "
+            "materializations, traces, logs, and downstream impact. Return risks, evidence, "
+            "and prioritized fixes."
+        )
+
+    @mcp.prompt(name="phlo.plan_backfill")
+    def plan_backfill(asset_key: str, partition_range: str) -> str:
+        """Guide an agent through safe backfill planning."""
+        return (
+            f"Plan a safe backfill for Phlo asset {asset_key} over {partition_range}. Use "
+            "list_partitions and backfill_asset with dry_run=true first. Call out expected "
+            "partitions, caveats, and the exact live command only if the plan is safe."
+        )
+
+    @mcp.prompt(name="phlo.scaffold_workflow")
+    def scaffold_workflow(domain: str, table: str) -> str:
+        """Guide an agent through workflow scaffolding once authoring tools are available."""
+        return (
+            f"Scaffold a Phlo workflow for domain {domain} and table {table}. Prefer MCP "
+            "authoring tools when available; otherwise inspect templates and provide a "
+            "minimal workflow plan with validation and materialization steps."
+        )
 
     @mcp.tool()
     def get_platform_health() -> dict[str, Any]:
@@ -174,6 +281,12 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 with tracer.start_as_current_span("phlo.observability.health"):
                     payload = client.get_platform_health()
                     return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def list_plugins() -> dict[str, Any]:
+        """List installed Phlo plugins through phlo-api."""
+        payload = client.get_plugins()
+        return {"api_base_url": client.api_base_url, "payload": payload}
 
     @mcp.tool()
     def get_service_status() -> dict[str, Any]:
@@ -561,13 +674,151 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         "source": "logs",
                     }
 
+    @mcp.tool()
+    def list_workflows(search: str | None = None, group: str | None = None) -> dict[str, Any]:
+        """List workflows discovered in the Phlo project."""
+        payload = client.list_workflows(search=search, group=group)
+        return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def list_templates() -> dict[str, Any]:
+        """List available Phlo project templates."""
+        payload = client.list_templates()
+        return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def lint_project() -> dict[str, Any]:
+        """Run lightweight Phlo project lint checks."""
+        payload = client.lint_project()
+        return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def run_doctor() -> dict[str, Any]:
+        """Run Phlo doctor through phlo-api and return JSON diagnostics."""
+        payload = client.run_doctor()
+        return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def search_assets(query: str, limit: int = 20, cursor: str | None = None) -> dict[str, Any]:
+        """Search Observatory assets."""
+        payload = client.search_assets(query, limit=limit, cursor=cursor)
+        return {"api_base_url": client.api_base_url, "query": query, "payload": payload}
+
+    @mcp.tool()
+    def search_contracts(query: str, limit: int = 20, cursor: str | None = None) -> dict[str, Any]:
+        """Search Phlo contracts."""
+        payload = client.search_contracts(query, limit=limit, cursor=cursor)
+        return {"api_base_url": client.api_base_url, "query": query, "payload": payload}
+
+    @mcp.tool()
+    def search_runs(
+        query: str | None = None, limit: int = 20, cursor: str | None = None
+    ) -> dict[str, Any]:
+        """Search recent orchestrator runs."""
+        payload = client.search_runs(query, limit=limit, cursor=cursor)
+        return {"api_base_url": client.api_base_url, "query": query, "payload": payload}
+
+    @mcp.tool()
+    def search_run_logs(
+        run_id: str,
+        query: str,
+        regex: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        cursor: str | None = None,
+        limit: int = 200,
+    ) -> dict[str, Any]:
+        """Search logs for one run using text and optional regex filters."""
+        payload = client.search_run_logs(
+            run_id,
+            query=query,
+            regex=regex,
+            since=since,
+            until=until,
+            cursor=cursor,
+            limit=limit,
+        )
+        return {"api_base_url": client.api_base_url, "run_id": run_id, "payload": payload}
+
+    @mcp.tool()
+    def follow_run_logs(run_id: str, timeout_seconds: int = 30) -> dict[str, Any]:
+        """Follow run logs through a bounded phlo-api Server-Sent Event stream."""
+        payload = client.follow_run_logs(
+            run_id,
+            timeout_seconds=timeout_seconds,
+            limit=min(max(timeout_seconds * 10, 1), 200),
+        )
+        return {"api_base_url": client.api_base_url, "run_id": run_id, "payload": payload}
+
+    @mcp.tool()
+    def get_quality_results(
+        asset_key: str | None = None, run_id: str | None = None
+    ) -> dict[str, Any]:
+        """Get quality results, optionally filtered by asset or run."""
+        payload = client.get_quality_results(asset_key=asset_key, run_id=run_id)
+        return {"api_base_url": client.api_base_url, "payload": payload}
+
+    @mcp.tool()
+    def get_lineage(asset_key: str, direction: str = "both", depth: int = 1) -> dict[str, Any]:
+        """Get bounded lineage around one asset."""
+        payload = client.get_lineage(asset_key, direction=direction, depth=depth)
+        return {"api_base_url": client.api_base_url, "asset_key": asset_key, "payload": payload}
+
+    @mcp.tool()
+    def diff_schema(
+        asset_key: str, from_run: str | None = None, to_run: str | None = None
+    ) -> dict[str, Any]:
+        """Diff schema snapshots for an asset across two runs."""
+        payload = client.diff_schema(asset_key, from_run=from_run, to_run=to_run)
+        return {"api_base_url": client.api_base_url, "asset_key": asset_key, "payload": payload}
+
     if resolved.enable_write_tools and resolved.api_token:
+
+        @mcp.tool()
+        def create_workflow(
+            domain: str,
+            table: str,
+            unique_key: str,
+            cron: str = "0 */1 * * *",
+            api_base_url: str | None = None,
+            fields: list[str] | None = None,
+        ) -> dict[str, Any]:
+            """Create a workflow scaffold through phlo-api when write tools are enabled."""
+            payload = client.create_workflow(
+                domain=domain,
+                table=table,
+                unique_key=unique_key,
+                cron=cron,
+                api_base_url=api_base_url,
+                fields=fields,
+            )
+            audit_context = _write_audit_context(
+                "create_workflow", {"domain": domain, "table": table}, False
+            )
+            _append_audit_record(audit_context)
+            return {"audit_context": audit_context, "payload": payload}
+
+        @mcp.tool()
+        def validate_workflow(workflow_path: str) -> dict[str, Any]:
+            """Validate a workflow file through phlo-api."""
+            payload = client.validate_workflow(workflow_path)
+            return {"api_base_url": client.api_base_url, "payload": payload}
+
+        @mcp.tool()
+        def validate_schema(schema_path: str) -> dict[str, Any]:
+            """Validate a schema file through phlo-api."""
+            payload = client.validate_schema(schema_path)
+            return {"api_base_url": client.api_base_url, "payload": payload}
 
         @mcp.tool()
         def materialize_asset(
             asset_key_path: str,
             dry_run: bool = True,
             partition_key: str | None = None,
+            job_name: str | None = None,
+            repository_location_name: str | None = None,
+            repository_name: str | None = None,
+            idempotency_key: str | None = None,
         ) -> dict[str, Any]:
             """Materialize a Dagster asset through phlo-api when write tools are enabled."""
             with tracer.start_as_current_span(
@@ -583,15 +834,25 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         if partition_key:
                             target["partition_key"] = partition_key
                         audit_context = _write_audit_context("materialize_asset", target, dry_run)
+                        _append_audit_record(audit_context)
                         payload = client.materialize_asset(
                             asset_key_path,
                             dry_run=dry_run,
                             partition_key=partition_key,
+                            job_name=job_name,
+                            repository_location_name=repository_location_name,
+                            repository_name=repository_name,
+                            idempotency_key=idempotency_key,
                         )
                         return {"audit_context": audit_context, "payload": payload}
 
         @mcp.tool()
-        def retry_failed_run(run_id: str, dry_run: bool = True) -> dict[str, Any]:
+        def retry_failed_run(
+            run_id: str,
+            dry_run: bool = True,
+            strategy: str = "FROM_FAILURE",
+            idempotency_key: str | None = None,
+        ) -> dict[str, Any]:
             """Retry a Dagster run through phlo-api when write tools are enabled."""
             with tracer.start_as_current_span(
                 "mcp.request",
@@ -605,8 +866,92 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                         audit_context = _write_audit_context(
                             "retry_failed_run", {"run_id": run_id}, dry_run
                         )
-                        payload = client.retry_run(run_id, dry_run=dry_run)
+                        _append_audit_record(audit_context)
+                        payload = client.retry_run(
+                            run_id,
+                            dry_run=dry_run,
+                            strategy=strategy,
+                            idempotency_key=idempotency_key,
+                        )
                         return {"audit_context": audit_context, "payload": payload}
+
+        @mcp.tool()
+        def cancel_run(run_id: str, reason: str | None = None) -> dict[str, Any]:
+            """Cancel a Dagster run through phlo-api when write tools are enabled."""
+            with tracer.start_as_current_span(
+                "mcp.request",
+                attributes={"mcp.tool.name": "cancel_run"},
+            ):
+                with tracer.start_as_current_span(
+                    "mcp.tool.execute",
+                    attributes={"mcp.tool.name": "cancel_run"},
+                ):
+                    with tracer.start_as_current_span("phlo.dagster.run.cancel"):
+                        audit_context = _write_audit_context(
+                            "cancel_run", {"run_id": run_id}, False
+                        )
+                        _append_audit_record(audit_context)
+                        payload = client.cancel_run(run_id, reason=reason)
+                        return {"audit_context": audit_context, "payload": payload}
+
+        @mcp.tool()
+        def backfill_asset(
+            asset_key_path: str,
+            dry_run: bool = True,
+            partitions: list[str] | None = None,
+            partition_range: dict[str, str] | None = None,
+            partition_set_name: str | None = None,
+            repository_location_name: str | None = None,
+            repository_name: str | None = None,
+            idempotency_key: str | None = None,
+        ) -> dict[str, Any]:
+            """Plan or launch an asset partition backfill through phlo-api."""
+            with tracer.start_as_current_span(
+                "mcp.request",
+                attributes={"mcp.tool.name": "backfill_asset"},
+            ):
+                with tracer.start_as_current_span(
+                    "mcp.tool.execute",
+                    attributes={"mcp.tool.name": "backfill_asset"},
+                ):
+                    with tracer.start_as_current_span("phlo.dagster.asset.backfill"):
+                        target: dict[str, Any] = {"asset_key_path": asset_key_path}
+                        if partitions:
+                            target["partitions"] = partitions
+                        if partition_range:
+                            target["partition_range"] = partition_range
+                        audit_context = _write_audit_context("backfill_asset", target, dry_run)
+                        _append_audit_record(audit_context)
+                        payload = client.backfill_asset(
+                            asset_key_path,
+                            dry_run=dry_run,
+                            partitions=partitions,
+                            partition_range=partition_range,
+                            partition_set_name=partition_set_name,
+                            repository_location_name=repository_location_name,
+                            repository_name=repository_name,
+                            idempotency_key=idempotency_key,
+                        )
+                        return {"audit_context": audit_context, "payload": payload}
+
+        @mcp.tool()
+        def list_partitions(asset_key_path: str) -> dict[str, Any]:
+            """List partition keys for an asset through phlo-api."""
+            with tracer.start_as_current_span(
+                "mcp.request",
+                attributes={"mcp.tool.name": "list_partitions"},
+            ):
+                with tracer.start_as_current_span(
+                    "mcp.tool.execute",
+                    attributes={"mcp.tool.name": "list_partitions"},
+                ):
+                    with tracer.start_as_current_span("phlo.dagster.asset.partitions"):
+                        payload = client.list_partitions(asset_key_path)
+                        return {
+                            "api_base_url": client.api_base_url,
+                            "asset_key_path": asset_key_path,
+                            "partitions": payload,
+                        }
 
         @mcp.tool()
         def get_dagster_run_status(run_id: str) -> dict[str, Any]:
@@ -626,5 +971,15 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                             "run_id": run_id,
                             "payload": payload,
                         }
+
+        @mcp.tool()
+        def install_plugin(package_name: str) -> dict[str, Any]:
+            """Install a trusted Phlo plugin package through phlo-api."""
+            audit_context = _write_audit_context(
+                "install_plugin", {"package_name": package_name}, False
+            )
+            _append_audit_record(audit_context)
+            payload = client.install_plugin(package_name)
+            return {"audit_context": audit_context, "payload": payload}
 
     return mcp

--- a/packages/phlo-mcp/tests/smoke_stack.py
+++ b/packages/phlo-mcp/tests/smoke_stack.py
@@ -322,7 +322,7 @@ async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:
             missing = sorted(expected - names)
             if missing:
                 raise SmokeFailure(f"MCP server is missing expected tools: {missing}")
-            write_tools = {"materialize_asset", "retry_failed_run", "get_dagster_run_status"}
+            write_tools = {"materialize_asset", "retry_failed_run", "get_run_status"}
             registered_write_tools = names & write_tools
             if args.enable_write_tools and args.api_token:
                 missing_write_tools = sorted(write_tools - names)

--- a/packages/phlo-mcp/tests/smoke_stack.py
+++ b/packages/phlo-mcp/tests/smoke_stack.py
@@ -109,6 +109,12 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         help="Call guarded write tools in dry-run mode; requires live phlo-api write endpoints",
     )
     parser.add_argument(
+        "--exercise-live-write-tools",
+        action="store_true",
+        default=_truthy_env("PHLO_MCP_SMOKE_EXERCISE_LIVE_WRITE_TOOLS"),
+        help="Call guarded write tools with dry_run=false against the selected smoke asset",
+    )
+    parser.add_argument(
         "--run-id",
         default=os.environ.get("PHLO_MCP_SMOKE_RUN_ID", _SMOKE_RUN_ID),
         help="Run id to query through the MCP trace-span tool",
@@ -375,20 +381,27 @@ async def _check_mcp_stdio(args: argparse.Namespace, repo_root: Path) -> None:
                 if args.require_materialization and not events:
                     raise SmokeFailure(f"asset {args.asset_key!r} returned no materializations")
 
-                if args.exercise_write_tools:
+                if args.exercise_write_tools or args.exercise_live_write_tools:
                     if not args.enable_write_tools or not args.api_token:
                         raise SmokeFailure(
-                            "--exercise-write-tools requires --enable-write-tools and --api-token"
+                            "write-tool smoke requires --enable-write-tools and --api-token"
                         )
                     materialize = await _call_tool_json(
                         session,
                         "materialize_asset",
-                        {"asset_key_path": args.asset_key, "dry_run": True},
+                        {
+                            "asset_key_path": args.asset_key,
+                            "dry_run": not args.exercise_live_write_tools,
+                            "idempotency_key": "phlo-mcp-smoke-materialize",
+                        },
                     )
                     audit = (
                         materialize.get("audit_context") if isinstance(materialize, dict) else None
                     )
-                    if not isinstance(audit, dict) or audit.get("dry_run") is not True:
+                    if (
+                        not isinstance(audit, dict)
+                        or audit.get("dry_run") is args.exercise_live_write_tools
+                    ):
                         raise SmokeFailure(
                             f"materialize_asset returned unexpected audit context: {materialize}"
                         )

--- a/packages/phlo-mcp/tests/test_models.py
+++ b/packages/phlo-mcp/tests/test_models.py
@@ -1,0 +1,59 @@
+"""Contract tests for MCP typed tool schemas."""
+
+from __future__ import annotations
+
+import httpx
+
+from phlo_mcp.config import McpConfig
+from phlo_mcp.errors import map_httpx_error
+from phlo_mcp.models import ToolContract, ToolEnvelope, WriteToolEnvelope
+from phlo_mcp.server import create_server
+
+
+def test_response_models_export_json_schema() -> None:
+    assert ToolEnvelope.model_json_schema()["type"] == "object"
+    assert WriteToolEnvelope.model_json_schema()["type"] == "object"
+    assert ToolContract.model_json_schema()["properties"]["output_schema"]["anyOf"]
+
+
+def test_every_registered_tool_has_input_and_output_schema() -> None:
+    server = create_server(McpConfig(api_token="secret", enable_write_tools=True))
+
+    for tool in server._tool_manager.list_tools():
+        assert tool.parameters, tool.name
+        assert tool.output_schema, tool.name
+        assert tool.output_schema.get("type") == "object", tool.name
+
+
+def test_mcp_tools_resource_exposes_output_schema_and_required_scope() -> None:
+    server = create_server(McpConfig(api_token="secret", enable_write_tools=True))
+    resource = server._resource_manager._resources["phlo://docs/mcp/tools"]
+
+    contracts = resource.fn()
+
+    materialize = next(item for item in contracts if item["name"] == "materialize_asset")
+    create_workflow = next(item for item in contracts if item["name"] == "create_workflow")
+
+    assert materialize["output_schema"]["type"] == "object"
+    assert materialize["required_scope"] == "lakehouse:operate"
+    assert create_workflow["required_scope"] == "project:write"
+
+
+def test_http_status_errors_preserve_api_detail() -> None:
+    request = httpx.Request("POST", "http://test/api/authoring/workflows")
+    response = httpx.Response(
+        409,
+        json={
+            "detail": {
+                "error": "workflow_already_exists",
+                "message": "Files already exist:\n  - workflows/ingestion/demo/orders.py",
+            }
+        },
+        request=request,
+    )
+
+    error = map_httpx_error(httpx.HTTPStatusError("conflict", request=request, response=response))
+
+    assert error.code == "phlo.api.conflict"
+    assert error.message == "Files already exist:\n  - workflows/ingestion/demo/orders.py"
+    assert error.hint == "workflow_already_exists"

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -334,7 +334,7 @@ def test_create_server_hides_write_tools_by_default() -> None:
 
     assert "materialize_asset" not in tool_names
     assert "retry_failed_run" not in tool_names
-    assert "get_dagster_run_status" not in tool_names
+    assert "get_run_status" not in tool_names
 
 
 def test_create_server_registers_write_tools_only_with_auth() -> None:
@@ -346,7 +346,7 @@ def test_create_server_registers_write_tools_only_with_auth() -> None:
 
     assert "materialize_asset" not in unauthenticated_tool_names
     assert "retry_failed_run" not in unauthenticated_tool_names
-    assert "get_dagster_run_status" not in unauthenticated_tool_names
+    assert "get_run_status" not in unauthenticated_tool_names
     assert authenticated_tool_names[-10:] == [
         "create_workflow",
         "validate_workflow",
@@ -356,7 +356,7 @@ def test_create_server_registers_write_tools_only_with_auth() -> None:
         "cancel_run",
         "backfill_asset",
         "list_partitions",
-        "get_dagster_run_status",
+        "get_run_status",
         "install_plugin",
     ]
 

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -246,6 +246,9 @@ def test_api_client_wraps_operational_routes(monkeypatch) -> None:
     monkeypatch.setattr("phlo_mcp.api_client.httpx.get", fake_get)
     client = PhloApiClient(McpConfig(api_base_url="http://example.test", api_token="secret"))
 
+    assert client.create_workflow(
+        domain="sales", table="orders", unique_key="id", provider="sling"
+    ) == {"queued": True, "dry_run": None}
     assert client.materialize_asset("silver/orders", dry_run=True, partition_key="2026-04-26") == {
         "queued": True,
         "dry_run": True,
@@ -259,6 +262,19 @@ def test_api_client_wraps_operational_routes(monkeypatch) -> None:
     assert client.get_run_status("run-123")["status"] == "STARTED"
     assert client.list_partitions("silver/orders")["status"] == "STARTED"
     assert seen_posts == [
+        {
+            "url": "http://example.test/api/authoring/workflows",
+            "json": {
+                "domain": "sales",
+                "table": "orders",
+                "unique_key": "id",
+                "cron": "0 */1 * * *",
+                "fields": [],
+                "provider": "sling",
+            },
+            "headers": {"Authorization": "Bearer secret"},
+            "timeout": 30.0,
+        },
         {
             "url": "http://example.test/api/observatory/v2/assets/silver/orders/materialize",
             "json": {"dry_run": True, "partition_key": "2026-04-26"},
@@ -287,6 +303,38 @@ def test_api_client_wraps_operational_routes(monkeypatch) -> None:
     assert seen_gets == [
         "http://example.test/api/observatory/v2/runs/run-123/status",
         "http://example.test/api/observatory/v2/assets/silver/orders/partitions",
+    ]
+
+
+def test_search_contracts_propagates_api_errors(monkeypatch) -> None:
+    monkeypatch.setattr(PhloApiClient, "get_contracts", lambda self: {"error": "unavailable"})
+    client = PhloApiClient(McpConfig(api_base_url="http://example.test"))
+
+    assert client.search_contracts("orders") == {"error": "unavailable"}
+
+
+def test_follow_run_logs_flushes_final_sse_event(monkeypatch) -> None:
+    class _FakeStream:
+        def __enter__(self):  # noqa: ANN204
+            return self
+
+        def __exit__(self, *args):  # noqa: ANN002
+            return None
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def iter_lines(self):  # noqa: ANN201
+            return iter(["event: log", 'data: {"message":"done"}'])
+
+    monkeypatch.setattr(
+        "phlo_mcp.api_client.httpx.stream",
+        lambda *args, **kwargs: _FakeStream(),  # noqa: ARG005
+    )
+    client = PhloApiClient(McpConfig(api_base_url="http://example.test"))
+
+    assert client.follow_run_logs("run-123")["events"] == [
+        {"event": "log", "data": {"message": "done"}}
     ]
 
 

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -184,6 +184,9 @@ def test_create_server_registers_resources() -> None:
     )
 
     assert resource_uris == [
+        "phlo://docs/cli",
+        "phlo://docs/mcp/prompts",
+        "phlo://docs/mcp/tools",
         "phlo://runtime/assets",
         "phlo://runtime/config",
         "phlo://runtime/contracts",
@@ -233,7 +236,7 @@ def test_api_client_wraps_operational_routes(monkeypatch) -> None:
 
     def fake_post(url: str, json=None, headers=None, timeout=30.0):  # noqa: ANN001
         seen_posts.append({"url": url, "json": json, "headers": headers or {}, "timeout": timeout})
-        return _FakeResponse({"queued": True, "dry_run": json["dry_run"]})
+        return _FakeResponse({"queued": True, "dry_run": json.get("dry_run")})
 
     def fake_get(url: str, params=None, headers=None, timeout=10.0):  # noqa: ANN001
         seen_gets.append(url)
@@ -248,7 +251,13 @@ def test_api_client_wraps_operational_routes(monkeypatch) -> None:
         "dry_run": True,
     }
     assert client.retry_run("run-123", dry_run=False) == {"queued": True, "dry_run": False}
+    assert client.cancel_run("run-123", reason="stuck") == {"queued": True, "dry_run": None}
+    assert client.backfill_asset("silver/orders", dry_run=True, partitions=["2026-04-26"]) == {
+        "queued": True,
+        "dry_run": True,
+    }
     assert client.get_run_status("run-123")["status"] == "STARTED"
+    assert client.list_partitions("silver/orders")["status"] == "STARTED"
     assert seen_posts == [
         {
             "url": "http://example.test/api/observatory/v2/assets/silver/orders/materialize",
@@ -262,8 +271,23 @@ def test_api_client_wraps_operational_routes(monkeypatch) -> None:
             "headers": {"Authorization": "Bearer secret"},
             "timeout": 30.0,
         },
+        {
+            "url": "http://example.test/api/observatory/v2/runs/run-123/cancel",
+            "json": {"reason": "stuck"},
+            "headers": {"Authorization": "Bearer secret"},
+            "timeout": 30.0,
+        },
+        {
+            "url": "http://example.test/api/observatory/v2/assets/silver/orders/backfill",
+            "json": {"dry_run": True, "partitions": ["2026-04-26"]},
+            "headers": {"Authorization": "Bearer secret"},
+            "timeout": 30.0,
+        },
     ]
-    assert seen_gets == ["http://example.test/api/observatory/v2/runs/run-123/status"]
+    assert seen_gets == [
+        "http://example.test/api/observatory/v2/runs/run-123/status",
+        "http://example.test/api/observatory/v2/assets/silver/orders/partitions",
+    ]
 
 
 def test_create_server_registers_expected_tools() -> None:
@@ -273,6 +297,7 @@ def test_create_server_registers_expected_tools() -> None:
 
     assert tool_names == [
         "get_platform_health",
+        "list_plugins",
         "get_service_status",
         "get_recent_alerts",
         "get_dashboard_links",
@@ -287,6 +312,18 @@ def test_create_server_registers_expected_tools() -> None:
         "get_asset_materialization_trace",
         "render_materialization_trace_tree",
         "render_run_trace_tree",
+        "list_workflows",
+        "list_templates",
+        "lint_project",
+        "run_doctor",
+        "search_assets",
+        "search_contracts",
+        "search_runs",
+        "search_run_logs",
+        "follow_run_logs",
+        "get_quality_results",
+        "get_lineage",
+        "diff_schema",
     ]
 
 
@@ -310,25 +347,42 @@ def test_create_server_registers_write_tools_only_with_auth() -> None:
     assert "materialize_asset" not in unauthenticated_tool_names
     assert "retry_failed_run" not in unauthenticated_tool_names
     assert "get_dagster_run_status" not in unauthenticated_tool_names
-    assert authenticated_tool_names[-3:] == [
+    assert authenticated_tool_names[-10:] == [
+        "create_workflow",
+        "validate_workflow",
+        "validate_schema",
         "materialize_asset",
         "retry_failed_run",
+        "cancel_run",
+        "backfill_asset",
+        "list_partitions",
         "get_dagster_run_status",
+        "install_plugin",
     ]
 
 
-def test_write_tool_returns_audit_context_without_token(monkeypatch) -> None:
+def test_write_tool_returns_audit_context_without_token(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
     def fake_materialize_asset(
         self,  # noqa: ANN001
         asset_key_path: str,
         *,
         dry_run: bool = True,
         partition_key: str | None = None,
+        job_name: str | None = None,
+        repository_location_name: str | None = None,
+        repository_name: str | None = None,
+        idempotency_key: str | None = None,
     ) -> dict[str, object]:
         return {
             "asset_key_path": asset_key_path,
             "dry_run": dry_run,
             "partition_key": partition_key,
+            "job_name": job_name,
+            "repository_location_name": repository_location_name,
+            "repository_name": repository_name,
+            "idempotency_key": idempotency_key,
             "queued": False,
         }
 

--- a/packages/phlo-sling/src/phlo_sling/plugin.py
+++ b/packages/phlo-sling/src/phlo_sling/plugin.py
@@ -13,6 +13,7 @@ Classes:
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
+from pathlib import Path
 from typing import Any
 
 from phlo.capabilities import (
@@ -20,7 +21,7 @@ from phlo.capabilities import (
     WorkflowWizardContribution,
     WorkflowWizardField,
 )
-from phlo.capabilities.specs import AssetCheckSpec, AssetSpec
+from phlo.capabilities.specs import AssetCheckSpec, AssetSpec, WorkflowAuthoringSpec
 from phlo.plugins.base import AssetProviderPlugin, IngestionProviderPlugin, PluginMetadata
 
 from phlo_sling.decorator import clear_sling_assets, get_sling_assets
@@ -232,3 +233,138 @@ class SlingIngestionProvider(IngestionProviderPlugin):
 
         """
         return get_sling_assets
+
+    def get_workflow_wizard_contributions(self) -> list[WorkflowWizardContribution]:
+        """Return workflow wizard contributions exposed by Sling."""
+        return get_workflow_wizard_contributions()
+
+    def get_workflow_authoring_providers(self) -> list[WorkflowAuthoringSpec]:
+        """Return workflow authoring capabilities exposed by Sling."""
+        return [
+            WorkflowAuthoringSpec(
+                name="sling",
+                provider=SlingWorkflowAuthoringProvider(),
+                metadata={"contribution_id": "sling.replication-source"},
+            )
+        ]
+
+
+class SlingWorkflowAuthoringProvider:
+    """Create Sling-backed replication workflow files."""
+
+    def create_workflow(self, *, project_root: Path, request: dict[str, Any]) -> dict[str, Any]:
+        values = dict(request.get("values") or {})
+        contribution_id = request.get("contribution_id")
+        if contribution_id not in {None, "", "sling.replication-source"}:
+            raise ValueError(f"Sling cannot author contribution {contribution_id!r}")
+
+        domain = _slug(str(values.get("domain") or request.get("domain") or ""))
+        table = _slug(
+            str(values.get("target_table") or values.get("table") or request.get("table") or "")
+        )
+        source_name = str(values.get("source_name") or "")
+        source_stream = str(values.get("source_stream") or table)
+        primary_key = str(
+            values.get("primary_key") or values.get("unique_key") or request.get("unique_key") or ""
+        )
+        replication_mode = str(values.get("replication_mode") or "incremental")
+        update_key = str(values.get("update_key") or "")
+        cron = str(values.get("schedule") or request.get("cron") or "0 2 * * *")
+
+        if not domain or not table or not source_name or not source_stream or not primary_key:
+            raise ValueError(
+                "Sling workflow creation requires domain, target_table, source_name, source_stream, and primary_key."
+            )
+
+        asset_path = project_root / "workflows" / "ingestion" / domain / f"{table}_sling.py"
+        config_path = project_root / "workflows" / "ingestion" / domain / f"{table}_sling.yml"
+        asset_path.parent.mkdir(parents=True, exist_ok=True)
+        existing = [path for path in (asset_path, config_path) if path.exists()]
+        if existing:
+            raise FileExistsError(
+                "Files already exist:\n" + "\n".join(f"  - {path}" for path in existing)
+            )
+
+        asset_path.write_text(
+            _render_sling_asset(
+                domain, table, primary_key, source_name, source_stream, replication_mode, cron
+            ),
+            encoding="utf-8",
+        )
+        config_path.write_text(
+            _render_sling_config(
+                table, primary_key, source_name, source_stream, replication_mode, update_key
+            ),
+            encoding="utf-8",
+        )
+        files = [
+            str(asset_path.relative_to(project_root)),
+            str(config_path.relative_to(project_root)),
+        ]
+        return {
+            "workflow_type": "ingestion",
+            "provider": "sling",
+            "domain": domain,
+            "table": table,
+            "files": files,
+            "next_steps": [
+                f"Review workflow: {files[0]}",
+                f"Review replication config: {files[1]}",
+                "Restart active services if needed: phlo services restart",
+                f"Materialize: phlo materialize sling_{table}",
+                "Inspect status: phlo status",
+            ],
+        }
+
+
+def _render_sling_asset(
+    domain: str,
+    table: str,
+    primary_key: str,
+    source_name: str,
+    source_stream: str,
+    replication_mode: str,
+    cron: str,
+) -> str:
+    return f'''"""Sling replication asset for {domain}.{table}."""
+
+from phlo_sling import phlo_sling_replication
+
+
+@phlo_sling_replication(
+    stream_name="{source_stream}",
+    table_name="{table}",
+    source_conn="{source_name}",
+    group="{domain}",
+    mode="{replication_mode}",
+    primary_key="{primary_key}",
+    cron="{cron}",
+)
+def {table}_sling():
+    return "{table}_sling.yml"
+'''
+
+
+def _render_sling_config(
+    table: str,
+    primary_key: str,
+    source_name: str,
+    source_stream: str,
+    replication_mode: str,
+    update_key: str,
+) -> str:
+    update_key_line = f'    update_key: "{update_key}"\n' if update_key else ""
+    return f"""source: {source_name}
+streams:
+  {source_stream}:
+    object: {table}
+    mode: {replication_mode}
+    primary_key: "{primary_key}"
+{update_key_line}"""
+
+
+def _slug(value: str) -> str:
+    import re
+
+    slug = re.sub(r"[^a-zA-Z0-9_]+", "_", value.strip().lower()).strip("_")
+    return slug or "workflow"

--- a/src/phlo/capabilities/__init__.py
+++ b/src/phlo/capabilities/__init__.py
@@ -95,6 +95,7 @@ from phlo.capabilities.interfaces import (
     LogoutResult,
     MaintenanceReadModel,
     ObservabilityBackend,
+    OrchestratorOperationsProvider,
     Principal,
     QueryEngine,
     RequestContext,
@@ -104,6 +105,7 @@ from phlo.capabilities.interfaces import (
     TableStore,
     TraceSpan,
     TraceSpanFilter,
+    WorkflowAuthoringProvider,
 )
 from phlo.capabilities.maintenance import (
     DefaultMaintenanceReadModel,
@@ -149,6 +151,7 @@ from phlo.capabilities.specs import (
     NormalizedSchema,
     ObjectStoreSpec,
     ObservabilityBackendSpec,
+    OrchestratorOperationsSpec,
     PartitionSpec,
     PublishTargetSpec,
     QualityBackendSpec,
@@ -161,6 +164,7 @@ from phlo.capabilities.specs import (
     SchemaMigrationPlan,
     SchemaMigrationSpec,
     TableStoreSpec,
+    WorkflowAuthoringSpec,
 )
 from phlo.capabilities.support import CapabilitySupport, coerce_capability_support
 from phlo.capabilities.telemetry import TelemetryRecorder, get_telemetry_path, iter_telemetry_events
@@ -221,6 +225,8 @@ __all__ = [
     "ObjectStoreSpec",
     "ObservabilityBackend",
     "ObservabilityBackendSpec",
+    "OrchestratorOperationsProvider",
+    "OrchestratorOperationsSpec",
     "PartitionSpec",
     "Principal",
     "TraceSpan",
@@ -238,6 +244,8 @@ __all__ = [
     "RuntimeContext",
     "RuntimeRouting",
     "WorkflowApplyAction",
+    "WorkflowAuthoringProvider",
+    "WorkflowAuthoringSpec",
     "WorkflowContributionMode",
     "WorkflowFilePreview",
     "WorkflowProposal",

--- a/src/phlo/capabilities/discovery.py
+++ b/src/phlo/capabilities/discovery.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from phlo.capabilities.observability import register_default_capability_providers
 from phlo.capabilities.registry import (
     iter_provider_capabilities,
@@ -19,48 +21,50 @@ def discover_capabilities() -> None:
     register_default_capability_providers()
     discover_plugins(plugin_type="asset_provider", auto_register=True)
     discover_plugins(plugin_type="resource_provider", auto_register=True)
+    discover_plugins(plugin_type="ingestion_provider", auto_register=True)
+    discover_plugins(plugin_type="orchestrator", auto_register=True)
 
     registry = get_global_registry()
 
-    asset_provider_count = 0
-    for name in registry.list("asset_provider"):
-        plugin = registry.get("asset_provider", name)
-        if plugin is None:
-            continue
-        asset_provider_count += 1
-        try:
-            for family, specs in iter_provider_capabilities(plugin):
-                for spec in specs:
-                    register_capability(family, spec)
-        except Exception as exc:
-            logger.warning(
-                "capability_asset_provider_registration_failed",
-                provider_name=name,
-                error=str(exc),
-                exc_info=True,
-            )
+    provider_counts = {
+        plugin_type: _register_capabilities_for_plugin_type(registry, plugin_type)
+        for plugin_type in (
+            "asset_provider",
+            "resource_provider",
+            "ingestion_provider",
+            "orchestrator",
+        )
+    }
 
-    resource_provider_count = 0
-    for name in registry.list("resource_provider"):
-        plugin = registry.get("resource_provider", name)
+    logger.info(
+        "capability_discovery_completed",
+        asset_provider_count=provider_counts["asset_provider"],
+        resource_provider_count=provider_counts["resource_provider"],
+        ingestion_provider_count=provider_counts["ingestion_provider"],
+        orchestrator_provider_count=provider_counts["orchestrator"],
+    )
+
+
+def _register_capabilities_for_plugin_type(registry: Any, plugin_type: str) -> int:
+    provider_count = 0
+    for name in registry.list(plugin_type):
+        plugin = registry.get(plugin_type, name)
         if plugin is None:
             continue
-        resource_provider_count += 1
+        provider_count += 1
         try:
             for family, specs in iter_provider_capabilities(plugin):
                 for spec in specs:
                     register_capability(family, spec)
         except Exception as exc:
-            missing_optional_config = "must be provided" in str(exc)
+            missing_optional_config = (
+                plugin_type == "resource_provider" and "must be provided" in str(exc)
+            )
             logger.warning(
-                "capability_resource_provider_registration_failed",
+                "capability_provider_registration_failed",
+                plugin_type=plugin_type,
                 provider_name=name,
                 error=str(exc),
                 exc_info=not missing_optional_config,
             )
-
-    logger.info(
-        "capability_discovery_completed",
-        asset_provider_count=asset_provider_count,
-        resource_provider_count=resource_provider_count,
-    )
+    return provider_count

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -210,6 +210,50 @@ class SchemaExtractor(Protocol):
 
 
 @runtime_checkable
+class WorkflowAuthoringProvider(Protocol):
+    """Protocol for providers that can create workflow files in a project."""
+
+    def create_workflow(
+        self, *, project_root: Path, request: Mapping[str, Any]
+    ) -> Mapping[str, Any]:
+        """Create workflow files for a provider-specific request."""
+        ...
+
+
+@runtime_checkable
+class OrchestratorOperationsProvider(Protocol):
+    """Protocol for providers that expose orchestrator run and asset operations."""
+
+    async def get_run_status(self, run_id: str) -> Any:
+        """Return status for one orchestrator run."""
+        ...
+
+    async def retry_run(self, run_id: str, request: Mapping[str, Any]) -> Any:
+        """Validate or request retry for one orchestrator run."""
+        ...
+
+    async def cancel_run(self, run_id: str, request: Mapping[str, Any]) -> Any:
+        """Request cancellation for one orchestrator run."""
+        ...
+
+    async def get_materialization_history(self, asset_key_path: str, *, limit: int = 10) -> Any:
+        """Return recent materializations for one asset."""
+        ...
+
+    async def materialize_asset(self, asset_key_path: str, request: Mapping[str, Any]) -> Any:
+        """Validate or request materialization for one asset."""
+        ...
+
+    async def backfill_asset(self, asset_key_path: str, request: Mapping[str, Any]) -> Any:
+        """Validate or request partition backfill for one asset."""
+        ...
+
+    async def list_partitions(self, asset_key_path: str) -> Any:
+        """Return partitions for one asset."""
+        ...
+
+
+@runtime_checkable
 class MetadataCatalog(Protocol):
     """Protocol for metadata catalog providers."""
 

--- a/src/phlo/capabilities/registry.py
+++ b/src/phlo/capabilities/registry.py
@@ -24,6 +24,7 @@ from phlo.capabilities.specs import (
     MetadataCatalogSpec,
     ObjectStoreSpec,
     ObservabilityBackendSpec,
+    OrchestratorOperationsSpec,
     PublishTargetSpec,
     QualityBackendSpec,
     QueryEngineSpec,
@@ -33,6 +34,7 @@ from phlo.capabilities.specs import (
     SecretBackendSpec,
     TableStoreSpec,
     UiContributionSpec,
+    WorkflowAuthoringSpec,
 )
 
 CAPABILITY_FAMILIES: dict[str, CapabilityFamilyDefinition[Any, Any]] = {
@@ -155,6 +157,18 @@ CAPABILITY_FAMILIES: dict[str, CapabilityFamilyDefinition[Any, Any]] = {
         spec_type=SchemaMigrationSpec,
         key=lambda spec: spec.name,
         provider_method="get_schema_migrators",
+    ),
+    "workflow_authoring": CapabilityFamilyDefinition(
+        name="workflow_authoring",
+        spec_type=WorkflowAuthoringSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_workflow_authoring_providers",
+    ),
+    "orchestrator_operations": CapabilityFamilyDefinition(
+        name="orchestrator_operations",
+        spec_type=OrchestratorOperationsSpec,
+        key=lambda spec: spec.name,
+        provider_method="get_orchestrator_operations_providers",
     ),
     "data_migration_source": CapabilityFamilyDefinition(
         name="data_migration_source",

--- a/src/phlo/capabilities/specs.py
+++ b/src/phlo/capabilities/specs.py
@@ -297,6 +297,26 @@ class SchemaMigrationSpec:
 
 
 @dataclass(frozen=True, slots=True)
+class WorkflowAuthoringSpec:
+    """Workflow authoring capability (registered provider)."""
+
+    name: str
+    provider: Any
+    metadata: dict[str, Any] = field(default_factory=dict)
+    support: CapabilitySupport = field(default_factory=CapabilitySupport)
+
+
+@dataclass(frozen=True, slots=True)
+class OrchestratorOperationsSpec:
+    """Orchestrator operation capability (registered provider)."""
+
+    name: str
+    provider: Any
+    metadata: dict[str, Any] = field(default_factory=dict)
+    support: CapabilitySupport = field(default_factory=CapabilitySupport)
+
+
+@dataclass(frozen=True, slots=True)
 class DataMigrationSourceSpec:
     """Data migration source adapter capability (registered provider)."""
 

--- a/src/phlo/cli/commands/audit.py
+++ b/src/phlo/cli/commands/audit.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -20,29 +21,63 @@ def _audit_path() -> Path:
     return Path(".phlo") / "audit" / "operations.jsonl"
 
 
-def _read_records(limit: int | None = None) -> list[dict[str, Any]]:
+def _read_records(limit: int | None = None, since: str | None = None) -> list[dict[str, Any]]:
     path = _audit_path()
     if not path.exists():
         return []
     lines = path.read_text(encoding="utf-8").splitlines()
-    if limit is not None:
-        lines = lines[-limit:]
     records = []
     for line in lines:
         try:
             records.append(json.loads(line))
         except json.JSONDecodeError:
             records.append({"malformed": line})
+    if since:
+        threshold = _parse_since(since)
+        records = [record for record in records if _record_timestamp(record) >= threshold]
+    if limit is not None:
+        records = records[-limit:]
     return records
+
+
+def _record_timestamp(record: dict[str, Any]) -> datetime:
+    value = str(record.get("timestamp") or "")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=UTC)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _parse_since(value: str) -> datetime:
+    now = datetime.now(UTC)
+    value = value.strip()
+    if value.endswith("m") and value[:-1].isdigit():
+        return now - timedelta(minutes=int(value[:-1]))
+    if value.endswith("h") and value[:-1].isdigit():
+        return now - timedelta(hours=int(value[:-1]))
+    if value.endswith("d") and value[:-1].isdigit():
+        return now - timedelta(days=int(value[:-1]))
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise click.ClickException(
+            "--since must be ISO-8601 or a relative duration like 15m, 1h, or 7d"
+        ) from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 @audit_group.command("tail")
 @click.option("--limit", default=20, show_default=True)
-@click.option("--since", help="Accepted for CLI compatibility; currently informational.")
+@click.option("--since", help="ISO-8601 timestamp or relative duration like 15m, 1h, or 7d.")
 @click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 def tail_cmd(limit: int, since: str | None, output_json: bool) -> None:
     """Tail recent audit records."""
-    records = _read_records(limit=limit)
+    records = _read_records(limit=limit, since=since)
     if output_json:
         click.echo(json_envelope(data={"items": records, "since": since}))
         return
@@ -52,10 +87,11 @@ def tail_cmd(limit: int, since: str | None, output_json: bool) -> None:
 
 @audit_group.command("query")
 @click.option("--operation")
+@click.option("--since", help="ISO-8601 timestamp or relative duration like 15m, 1h, or 7d.")
 @click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
-def query_cmd(operation: str | None, output_json: bool) -> None:
+def query_cmd(operation: str | None, since: str | None, output_json: bool) -> None:
     """Query audit records."""
-    records = _read_records()
+    records = _read_records(since=since)
     if operation:
         records = [record for record in records if record.get("operation") == operation]
     if output_json:

--- a/src/phlo/cli/commands/audit.py
+++ b/src/phlo/cli/commands/audit.py
@@ -1,0 +1,68 @@
+"""Audit log commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from phlo.cli.output import json_envelope
+
+
+@click.group(name="audit")
+def audit_group() -> None:
+    """Inspect local Phlo audit records."""
+
+
+def _audit_path() -> Path:
+    return Path(".phlo") / "audit" / "operations.jsonl"
+
+
+def _read_records(limit: int | None = None) -> list[dict[str, Any]]:
+    path = _audit_path()
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if limit is not None:
+        lines = lines[-limit:]
+    records = []
+    for line in lines:
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            records.append({"malformed": line})
+    return records
+
+
+@audit_group.command("tail")
+@click.option("--limit", default=20, show_default=True)
+@click.option("--since", help="Accepted for CLI compatibility; currently informational.")
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def tail_cmd(limit: int, since: str | None, output_json: bool) -> None:
+    """Tail recent audit records."""
+    records = _read_records(limit=limit)
+    if output_json:
+        click.echo(json_envelope(data={"items": records, "since": since}))
+        return
+    for record in records:
+        click.echo(json.dumps(record, sort_keys=True))
+
+
+@audit_group.command("query")
+@click.option("--operation")
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def query_cmd(operation: str | None, output_json: bool) -> None:
+    """Query audit records."""
+    records = _read_records()
+    if operation:
+        records = [record for record in records if record.get("operation") == operation]
+    if output_json:
+        click.echo(json_envelope(data={"items": records}))
+        return
+    for record in records:
+        click.echo(json.dumps(record, sort_keys=True))
+
+
+__all__ = ["audit_group"]

--- a/src/phlo/cli/commands/audit.py
+++ b/src/phlo/cli/commands/audit.py
@@ -77,6 +77,8 @@ def _parse_since(value: str) -> datetime:
 @click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 def tail_cmd(limit: int, since: str | None, output_json: bool) -> None:
     """Tail recent audit records."""
+    if limit <= 0:
+        raise click.BadParameter("must be greater than 0", param_hint="--limit")
     records = _read_records(limit=limit, since=since)
     if output_json:
         click.echo(json_envelope(data={"items": records, "since": since}))

--- a/src/phlo/cli/commands/mcp.py
+++ b/src/phlo/cli/commands/mcp.py
@@ -160,6 +160,8 @@ def _write_client_config(target: Path, snippet: dict[str, Any]) -> None:
             raise click.ClickException(f"Cannot update invalid JSON config: {target}") from exc
         if isinstance(loaded, dict):
             existing = loaded
+        else:
+            raise click.ClickException(f"Cannot update non-object JSON config: {target}")
     servers = existing.setdefault("mcpServers", {})
     if not isinstance(servers, dict):
         raise click.ClickException(f"Cannot update config with non-object mcpServers: {target}")

--- a/src/phlo/cli/commands/mcp.py
+++ b/src/phlo/cli/commands/mcp.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import Any
 
 import click
-from phlo_mcp.config import McpConfig, config_from_env
-from phlo_mcp.server import create_server
 
 from phlo.cli.output import json_envelope
 
@@ -31,6 +29,17 @@ def _config_payload(config: Any) -> dict[str, Any]:
     }
 
 
+def _mcp_runtime() -> tuple[Any, Any, Any]:
+    try:
+        from phlo_mcp.config import McpConfig, config_from_env
+        from phlo_mcp.server import create_server
+    except ImportError as exc:
+        raise click.ClickException(
+            'MCP support is not installed. Install it with: uv pip install "phlo-mcp"'
+        ) from exc
+    return McpConfig, config_from_env, create_server
+
+
 @mcp_group.command("serve")
 @click.option("--transport", type=click.Choice(["stdio", "streamable-http"]))
 @click.option("--api-base-url")
@@ -49,6 +58,7 @@ def serve_cmd(
     streamable_http_path: str | None,
 ) -> None:
     """Serve the Phlo MCP server."""
+    McpConfig, config_from_env, create_server = _mcp_runtime()
     env = config_from_env()
     config = McpConfig(
         api_base_url=(api_base_url or env.api_base_url).rstrip("/"),
@@ -67,6 +77,7 @@ def serve_cmd(
 @click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 def config_cmd(output_json: bool) -> None:
     """Print resolved MCP configuration with secrets redacted."""
+    _, config_from_env, _ = _mcp_runtime()
     payload = _config_payload(config_from_env())
     if output_json:
         click.echo(json_envelope(data=payload))
@@ -79,6 +90,7 @@ def config_cmd(output_json: bool) -> None:
 @click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 def tools_cmd(output_json: bool) -> None:
     """List tools registered by the local MCP server."""
+    _, config_from_env, create_server = _mcp_runtime()
     server = create_server(config_from_env())
     payload = [
         {"name": tool.name, "description": tool.description}
@@ -95,6 +107,7 @@ def tools_cmd(output_json: bool) -> None:
 @click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 def prompts_cmd(output_json: bool) -> None:
     """List prompts registered by the local MCP server."""
+    _, config_from_env, create_server = _mcp_runtime()
     server = create_server(config_from_env())
     payload = [
         {"name": prompt.name, "description": prompt.description}

--- a/src/phlo/cli/commands/mcp.py
+++ b/src/phlo/cli/commands/mcp.py
@@ -1,0 +1,167 @@
+"""MCP server management commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+from phlo_mcp.config import McpConfig, config_from_env
+from phlo_mcp.server import create_server
+
+from phlo.cli.output import json_envelope
+
+
+@click.group(name="mcp")
+def mcp_group() -> None:
+    """Run and inspect the Phlo MCP server."""
+
+
+def _config_payload(config: Any) -> dict[str, Any]:
+    return {
+        "api_base_url": config.api_base_url,
+        "api_token": "***" if config.api_token else None,
+        "enable_write_tools": config.enable_write_tools,
+        "trace_file": config.trace_file,
+        "transport": config.transport,
+        "host": config.host,
+        "port": config.port,
+        "streamable_http_path": config.streamable_http_path,
+    }
+
+
+@mcp_group.command("serve")
+@click.option("--transport", type=click.Choice(["stdio", "streamable-http"]))
+@click.option("--api-base-url")
+@click.option("--api-token")
+@click.option("--enable-write-tools", is_flag=True)
+@click.option("--host")
+@click.option("--port", type=int)
+@click.option("--path", "streamable_http_path")
+def serve_cmd(
+    transport: str | None,
+    api_base_url: str | None,
+    api_token: str | None,
+    enable_write_tools: bool,
+    host: str | None,
+    port: int | None,
+    streamable_http_path: str | None,
+) -> None:
+    """Serve the Phlo MCP server."""
+    env = config_from_env()
+    config = McpConfig(
+        api_base_url=(api_base_url or env.api_base_url).rstrip("/"),
+        api_token=api_token if api_token is not None else env.api_token,
+        enable_write_tools=enable_write_tools or env.enable_write_tools,
+        trace_file=env.trace_file,
+        transport=transport or env.transport,
+        host=host or env.host,
+        port=port if port is not None else env.port,
+        streamable_http_path=streamable_http_path or env.streamable_http_path,
+    )
+    create_server(config).run(transport=config.transport)
+
+
+@mcp_group.command("config")
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def config_cmd(output_json: bool) -> None:
+    """Print resolved MCP configuration with secrets redacted."""
+    payload = _config_payload(config_from_env())
+    if output_json:
+        click.echo(json_envelope(data=payload))
+        return
+    for key, value in payload.items():
+        click.echo(f"{key}: {value}")
+
+
+@mcp_group.command("tools")
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def tools_cmd(output_json: bool) -> None:
+    """List tools registered by the local MCP server."""
+    server = create_server(config_from_env())
+    payload = [
+        {"name": tool.name, "description": tool.description}
+        for tool in server._tool_manager.list_tools()
+    ]
+    if output_json:
+        click.echo(json_envelope(data=payload))
+        return
+    for tool in payload:
+        click.echo(f"{tool['name']} - {tool['description'] or ''}")
+
+
+@mcp_group.command("prompts")
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def prompts_cmd(output_json: bool) -> None:
+    """List prompts registered by the local MCP server."""
+    server = create_server(config_from_env())
+    payload = [
+        {"name": prompt.name, "description": prompt.description}
+        for prompt in server._prompt_manager.list_prompts()
+    ]
+    if output_json:
+        click.echo(json_envelope(data=payload))
+        return
+    for prompt in payload:
+        click.echo(f"{prompt['name']} - {prompt['description'] or ''}")
+
+
+@mcp_group.command("install")
+@click.argument("client", type=click.Choice(["claude-code", "amp", "cursor", "vscode"]))
+@click.option("--dry-run", is_flag=True, help="Print the config that would be written.")
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def install_cmd(client: str, dry_run: bool, output_json: bool) -> None:
+    """Print or write an MCP client configuration snippet."""
+    snippet = {
+        "mcpServers": {
+            "phlo": {
+                "command": "phlo",
+                "args": ["mcp", "serve", "--transport", "stdio"],
+            }
+        }
+    }
+    target = _client_config_target(client)
+    if not dry_run:
+        _write_client_config(target, snippet)
+    payload = {
+        "client": client,
+        "target": str(target),
+        "dry_run": dry_run,
+        "written": not dry_run,
+        "config": snippet,
+    }
+    if output_json:
+        click.echo(json_envelope(data=payload))
+        return
+    click.echo(json_envelope(data=payload) if dry_run else f"Wrote Phlo MCP config to {target}")
+
+
+def _write_client_config(target: Path, snippet: dict[str, Any]) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    existing: dict[str, Any] = {}
+    if target.exists():
+        try:
+            loaded = json.loads(target.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise click.ClickException(f"Cannot update invalid JSON config: {target}") from exc
+        if isinstance(loaded, dict):
+            existing = loaded
+    servers = existing.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise click.ClickException(f"Cannot update config with non-object mcpServers: {target}")
+    servers.update(snippet["mcpServers"])
+    target.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _client_config_target(client: str) -> Path:
+    home = Path.home()
+    return {
+        "claude-code": home / ".claude.json",
+        "amp": home / ".config" / "amp" / "mcp.json",
+        "cursor": home / ".cursor" / "mcp.json",
+        "vscode": home / ".vscode" / "mcp.json",
+    }[client]
+
+
+__all__ = ["mcp_group"]

--- a/src/phlo/cli/commands/metrics.py
+++ b/src/phlo/cli/commands/metrics.py
@@ -13,6 +13,7 @@ from rich.panel import Panel
 from rich.table import Table
 
 from phlo.capabilities.maintenance import render_maintenance_prometheus
+from phlo.cli.output import json_envelope
 from phlo.logging import get_logger
 from phlo.metrics import get_metrics_collector
 
@@ -27,10 +28,23 @@ def metrics_group() -> None:
 
 @metrics_group.command(name="summary")
 @click.option("--period", type=str, default="24h", help="Time period to analyze (e.g., 24h, 7d)")
-def metrics_summary(period: str) -> None:
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def metrics_summary(period: str, output_json: bool) -> None:
     """Show key metrics overview."""
     collector = get_metrics_collector()
-    metrics = collector.collect_summary(_parse_period(period))
+    period_hours = _parse_period(period)
+    metrics = collector.collect_summary(period_hours)
+    if output_json:
+        click.echo(
+            json_envelope(
+                data={
+                    "period": period,
+                    "period_hours": period_hours,
+                    "metrics": _dataclass_to_dict(metrics),
+                }
+            )
+        )
+        return
     summary_text = f"""
 [bold]Platform Metrics Summary[/bold]
 
@@ -60,10 +74,22 @@ def metrics_summary(period: str) -> None:
 @metrics_group.command(name="asset")
 @click.argument("asset_name")
 @click.option("--runs", type=int, default=10, help="Number of past runs to display")
-def metrics_asset(asset_name: str, runs: int) -> None:
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def metrics_asset(asset_name: str, runs: int, output_json: bool) -> None:
     """Show per-asset metrics."""
     collector = get_metrics_collector()
     metrics = collector.collect_asset(asset_name, runs=runs)
+    if output_json:
+        click.echo(
+            json_envelope(
+                data={
+                    "asset_name": asset_name,
+                    "runs": runs,
+                    "metrics": _dataclass_to_dict(metrics),
+                }
+            )
+        )
+        return
 
     table = Table(title=f"Metrics for {asset_name}")
     table.add_column("Metric", style="cyan")
@@ -112,10 +138,12 @@ def metrics_asset(asset_name: str, runs: int) -> None:
 )
 @click.option("--output", type=Path, required=True, help="Output file path")
 @click.option("--period", type=str, default="24h", help="Time period to analyze (e.g., 24h, 7d)")
-def metrics_export(export_format: str, output: Path, period: str) -> None:
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def metrics_export(export_format: str, output: Path, period: str, output_json: bool) -> None:
     """Export metrics to JSON, CSV, or Prometheus text."""
     collector = get_metrics_collector()
-    metrics = collector.collect_summary(_parse_period(period))
+    period_hours = _parse_period(period)
+    metrics = collector.collect_summary(period_hours)
     try:
         if export_format == "json":
             _export_json(metrics, output)
@@ -132,6 +160,19 @@ def metrics_export(export_format: str, output: Path, period: str) -> None:
             exc_info=True,
         )
         raise
+    if output_json:
+        click.echo(
+            json_envelope(
+                data={
+                    "format": export_format,
+                    "output": str(output),
+                    "period": period,
+                    "period_hours": period_hours,
+                    "exported": True,
+                }
+            )
+        )
+        return
     console.print(f"[green]✓[/green] Metrics exported to {output}")
 
 

--- a/src/phlo/cli/commands/plugin/create.py
+++ b/src/phlo/cli/commands/plugin/create.py
@@ -13,6 +13,7 @@ from phlo.cli.commands.plugin.utils import (
     console,
     create_plugin_package,
 )
+from phlo.cli.output import json_envelope
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
@@ -46,8 +47,9 @@ logger = get_logger(__name__)
     type=click.Path(),
     help="Path for new plugin package (default: ./phlo-plugin-{name})",
 )
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 @require_mutation_authorization("plugin.create")
-def create_cmd(plugin_name: str, plugin_type: str, path: str | None):
+def create_cmd(plugin_name: str, plugin_type: str, path: str | None, output_json: bool):
     """Create scaffolding for a new plugin.
 
     Examples:
@@ -89,12 +91,29 @@ def create_cmd(plugin_name: str, plugin_type: str, path: str | None):
             path=str(plugin_path),
         )
 
+        next_steps = [
+            f"cd {path}",
+            f"Edit the plugin in src/phlo_{plugin_name.replace('-', '_')}/",
+            "Run tests: pytest tests/",
+            "Install: pip install -e .",
+        ]
+        if output_json:
+            click.echo(
+                json_envelope(
+                    data={
+                        "plugin_name": plugin_name,
+                        "plugin_type": plugin_type,
+                        "path": str(plugin_path),
+                        "next_steps": next_steps,
+                    }
+                )
+            )
+            return
+
         console.print("\n[green]✓ Plugin created successfully![/green]")
         console.print("\nNext steps:")
-        console.print(f"  1. cd {path}")
-        console.print(f"  2. Edit the plugin in src/phlo_{plugin_name.replace('-', '_')}/")
-        console.print("  3. Run tests: pytest tests/")
-        console.print("  4. Install: pip install -e .")
+        for index, step in enumerate(next_steps, start=1):
+            console.print(f"  {index}. {step}")
 
     except SystemExit:
         raise

--- a/src/phlo/cli/commands/plugin/install.py
+++ b/src/phlo/cli/commands/plugin/install.py
@@ -8,6 +8,7 @@ import click
 
 from phlo.cli.authorization_wrappers import require_mutation_authorization
 from phlo.cli.commands.plugin.utils import collect_installed_plugins, console, run_pip
+from phlo.cli.output import json_envelope
 from phlo.logging import get_logger
 from phlo.plugins.registry_client import get_plugin as get_registry_plugin
 
@@ -37,8 +38,9 @@ def resolve_install_target(plugin_name: str) -> tuple[str, str]:
 
 @click.command(name="install")
 @click.argument("plugin_name")
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 @require_mutation_authorization("plugin.install")
-def install_cmd(plugin_name: str):
+def install_cmd(plugin_name: str, output_json: bool):
     """Install a plugin from the registry (wraps pip)."""
     try:
         name_part = plugin_name.split("==", 1)[0]
@@ -48,7 +50,8 @@ def install_cmd(plugin_name: str):
             plugin_name=plugin_name,
             package_spec=package_spec,
         )
-        console.print(f"Installing {display_name}...")
+        if not output_json:
+            console.print(f"Installing {display_name}...")
         run_pip(["install", package_spec])
         installed = collect_installed_plugins("all")
         maybe_installed = [
@@ -61,14 +64,30 @@ def install_cmd(plugin_name: str):
             plugin_name=plugin_name,
             package_spec=package_spec,
         )
-        console.print(f"[green]✓ Installed {display_name}[/green]")
+        warnings = []
         for plugin in maybe_installed:
             missing_capabilities = plugin.get("missing_capabilities") or []
             if missing_capabilities:
-                console.print(
-                    "[yellow]Installed plugin has unmet capabilities:[/yellow] "
-                    + f"{plugin['name']} -> {', '.join(missing_capabilities)}"
+                warnings.append(
+                    f"Installed plugin has unmet capabilities: {plugin['name']} -> {', '.join(missing_capabilities)}"
                 )
+        if output_json:
+            click.echo(
+                json_envelope(
+                    data={
+                        "plugin_name": plugin_name,
+                        "package_spec": package_spec,
+                        "display_name": display_name,
+                        "installed_plugins": maybe_installed,
+                    },
+                    warnings=warnings,
+                )
+            )
+            return
+
+        console.print(f"[green]✓ Installed {display_name}[/green]")
+        for warning in warnings:
+            console.print(f"[yellow]{warning}[/yellow]")
     except Exception as e:
         logger.exception("plugin_install_failed", plugin_name=plugin_name)
         console.print(f"[red]Error installing plugin: {e}[/red]")

--- a/src/phlo/cli/commands/services/status.py
+++ b/src/phlo/cli/commands/services/status.py
@@ -1,5 +1,7 @@
 """Status command for showing service status."""
 
+import json
+
 import click
 
 from phlo.cli.commands.services.common import run_compose
@@ -19,11 +21,13 @@ logger = get_logger(__name__)
     default=None,
     help="Container backend for this command.",
 )
-def status_cmd(backend_name: str | None):
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+def status_cmd(backend_name: str | None, output_json: bool):
     """Show status of Phlo infrastructure services.
 
     Examples:
         phlo services status
+        phlo services status --json
     """
     require_container_backend(backend_name)
     phlo_dir = ensure_compose_project()
@@ -39,7 +43,10 @@ def status_cmd(backend_name: str | None):
         project_name=project_name,
         backend_name=backend_name,
     )
-    cmd.extend(["ps", "--format", "table {{.Service}}\t{{.Status}}\t{{.Ports}}"])
+    if output_json:
+        cmd.extend(["ps", "--format", "json"])
+    else:
+        cmd.extend(["ps", "--format", "table {{.Service}}\t{{.Status}}\t{{.Ports}}"])
 
     result = run_compose(cmd, check=False, capture_output=True)
     if result.returncode != 0:
@@ -49,6 +56,11 @@ def status_cmd(backend_name: str | None):
             returncode=result.returncode,
         )
         raise click.ClickException("No services running or error checking status.")
+    if output_json:
+        click.echo(json.dumps(_parse_compose_json_status(result.stdout or ""), indent=2))
+        logger.info("services_status_succeeded", project_name=project_name, output="json")
+        return
+
     if result.stdout:
         click.echo(result.stdout, nl=False)
     lines = [line for line in (result.stdout or "").splitlines() if line.strip()]
@@ -56,3 +68,32 @@ def status_cmd(backend_name: str | None):
         click.echo("\nNo services are running.")
         click.echo("Run: phlo services start")
     logger.info("services_status_succeeded", project_name=project_name)
+
+
+def _parse_compose_json_status(stdout: str) -> list[dict[str, object]]:
+    """Parse compose ps JSON output across Docker Compose variants."""
+    text = stdout.strip()
+    if not text:
+        return []
+
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        parsed = [json.loads(line) for line in text.splitlines() if line.strip()]
+
+    items = [parsed] if isinstance(parsed, dict) else list(parsed)
+
+    services: list[dict[str, object]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        services.append(
+            {
+                "service": item.get("Service") or item.get("Name") or item.get("service"),
+                "name": item.get("Name") or item.get("Container") or item.get("name"),
+                "state": item.get("State") or item.get("state"),
+                "status": item.get("Status") or item.get("status"),
+                "ports": item.get("Publishers") or item.get("Ports") or item.get("ports") or [],
+            }
+        )
+    return services

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -2,26 +2,15 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 
 import click
 
 from phlo.cli.output import json_envelope, user_error
 from phlo.logging import get_logger
+from phlo.workflow_authoring import WorkflowCreateResult, create_workflow_with_provider
 
 logger = get_logger(__name__)
-
-
-@dataclass(frozen=True)
-class CreateWorkflowResult:
-    """Result returned by non-interactive workflow creation."""
-
-    workflow_type: str
-    domain: str
-    table: str
-    files: list[str]
-    next_steps: list[str]
 
 
 @click.group(name="workflow")
@@ -29,41 +18,11 @@ def workflow_group() -> None:
     """Manage workflows."""
 
 
-def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
+def _print_next_steps(steps: list[str]) -> None:
     """Print the next commands for a generated ingestion workflow."""
-    schema_file = files[0]
-    workflow_file = files[1]
-    test_file = files[2] if len(files) > 2 else None
-
     click.echo("\nNext steps:")
-    click.echo(f"  1. Review schema: {schema_file}")
-    click.echo(f"  2. Review workflow: {workflow_file}")
-    if test_file:
-        click.echo(f"  3. Run generated tests: uv run pytest {test_file} -q")
-        click.echo("  4. Restart Dagster: phlo services restart --service dagster")
-        click.echo(f"  5. Materialize: phlo materialize dlt_{table}")
-        click.echo("  6. Inspect status: phlo status")
-    else:
-        click.echo("  3. Restart Dagster: phlo services restart --service dagster")
-        click.echo(f"  4. Materialize: phlo materialize dlt_{table}")
-        click.echo("  5. Inspect status: phlo status")
-
-
-def _ingestion_next_steps(files: list[str], *, table: str) -> list[str]:
-    schema_file = files[0]
-    workflow_file = files[1]
-    test_file = files[2] if len(files) > 2 else None
-    steps = [f"Review schema: {schema_file}", f"Review workflow: {workflow_file}"]
-    if test_file:
-        steps.append(f"Run generated tests: uv run pytest {test_file} -q")
-    steps.extend(
-        [
-            "Restart Dagster: phlo services restart --service dagster",
-            f"Materialize: phlo materialize dlt_{table}",
-            "Inspect status: phlo status",
-        ]
-    )
-    return steps
+    for index, step in enumerate(steps, start=1):
+        click.echo(f"  {index}. {step}")
 
 
 def _infer_schema_path(workflow_path: Path) -> Path | None:
@@ -81,8 +40,8 @@ def _infer_schema_path(workflow_path: Path) -> Path | None:
 
 
 def _asset_key_from_workflow_path(workflow_path: Path) -> str:
-    """Infer the DLT asset key from a workflow file path."""
-    return f"dlt_{workflow_path.stem}"
+    """Infer a provider-neutral asset key hint from a workflow file path."""
+    return workflow_path.stem
 
 
 def _validate_workflow_file(path: str) -> None:
@@ -113,27 +72,19 @@ def _create_workflow(
     cron: str,
     api_base_url: str | None = None,
     fields: list[str] | None = None,
-) -> CreateWorkflowResult:
-    """Create a workflow scaffold without Click prompts or terminal output."""
-    from phlo_dlt.scaffold import create_ingestion_workflow
-
-    if workflow_type != "ingestion":
-        raise ValueError(f"Unsupported workflow type: {workflow_type}")
-
-    files = create_ingestion_workflow(
+    provider: str | None = None,
+) -> WorkflowCreateResult:
+    """Create a workflow scaffold through the active workflow authoring provider."""
+    return create_workflow_with_provider(
+        project_root=Path.cwd(),
+        workflow_type=workflow_type,
         domain=domain,
-        table_name=table,
+        table=table,
         unique_key=unique_key,
         cron=cron,
         api_base_url=api_base_url or None,
         fields=fields or [],
-    )
-    return CreateWorkflowResult(
-        workflow_type=workflow_type,
-        domain=domain,
-        table=table,
-        files=files,
-        next_steps=_ingestion_next_steps(files, table=table),
+        provider=provider,
     )
 
 
@@ -170,6 +121,7 @@ def _create_workflow(
     multiple=True,
     help="Additional schema field (name:type, name:type?, name:type!)",
 )
+@click.option("--provider", help="Workflow authoring provider capability to use.")
 @click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 def create_workflow_cmd(
     workflow_type: str,
@@ -179,6 +131,7 @@ def create_workflow_cmd(
     cron: str,
     api_base_url: str,
     fields: tuple[str, ...],
+    provider: str | None,
     output_json: bool,
 ) -> None:
     """Create a workflow scaffold."""
@@ -202,6 +155,7 @@ def create_workflow_cmd(
                 cron=cron,
                 api_base_url=api_base_url or None,
                 fields=list(fields),
+                provider=provider,
             )
 
             if output_json:
@@ -211,7 +165,7 @@ def create_workflow_cmd(
                 for file_path in result.files:
                     click.echo(f"  - {file_path}")
 
-                _print_ingestion_next_steps(result.files, table=table)
+                _print_next_steps(result.next_steps)
             logger.info(
                 "workflow_create_succeeded",
                 workflow_type=workflow_type,

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -2,14 +2,26 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import click
 
-from phlo.cli.output import user_error
+from phlo.cli.output import json_envelope, user_error
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class CreateWorkflowResult:
+    """Result returned by non-interactive workflow creation."""
+
+    workflow_type: str
+    domain: str
+    table: str
+    files: list[str]
+    next_steps: list[str]
 
 
 @click.group(name="workflow")
@@ -35,6 +47,23 @@ def _print_ingestion_next_steps(files: list[str], *, table: str) -> None:
         click.echo("  3. Restart Dagster: phlo services restart --service dagster")
         click.echo(f"  4. Materialize: phlo materialize dlt_{table}")
         click.echo("  5. Inspect status: phlo status")
+
+
+def _ingestion_next_steps(files: list[str], *, table: str) -> list[str]:
+    schema_file = files[0]
+    workflow_file = files[1]
+    test_file = files[2] if len(files) > 2 else None
+    steps = [f"Review schema: {schema_file}", f"Review workflow: {workflow_file}"]
+    if test_file:
+        steps.append(f"Run generated tests: uv run pytest {test_file} -q")
+    steps.extend(
+        [
+            "Restart Dagster: phlo services restart --service dagster",
+            f"Materialize: phlo materialize dlt_{table}",
+            "Inspect status: phlo status",
+        ]
+    )
+    return steps
 
 
 def _infer_schema_path(workflow_path: Path) -> Path | None:
@@ -73,6 +102,39 @@ def _validate_schema_file(path: str) -> None:
         raise
     except Exception as exc:
         raise click.ClickException(f"Schema validation failed for {path}: {exc}") from exc
+
+
+def _create_workflow(
+    *,
+    workflow_type: str = "ingestion",
+    domain: str,
+    table: str,
+    unique_key: str,
+    cron: str,
+    api_base_url: str | None = None,
+    fields: list[str] | None = None,
+) -> CreateWorkflowResult:
+    """Create a workflow scaffold without Click prompts or terminal output."""
+    from phlo_dlt.scaffold import create_ingestion_workflow
+
+    if workflow_type != "ingestion":
+        raise ValueError(f"Unsupported workflow type: {workflow_type}")
+
+    files = create_ingestion_workflow(
+        domain=domain,
+        table_name=table,
+        unique_key=unique_key,
+        cron=cron,
+        api_base_url=api_base_url or None,
+        fields=fields or [],
+    )
+    return CreateWorkflowResult(
+        workflow_type=workflow_type,
+        domain=domain,
+        table=table,
+        files=files,
+        next_steps=_ingestion_next_steps(files, table=table),
+    )
 
 
 @workflow_group.command("create")
@@ -118,8 +180,6 @@ def create_workflow_cmd(
     fields: tuple[str, ...],
 ) -> None:
     """Create a workflow scaffold."""
-    from phlo_dlt.scaffold import create_ingestion_workflow
-
     logger.info(
         "workflow_create_started",
         workflow_type=workflow_type,
@@ -131,9 +191,10 @@ def create_workflow_cmd(
 
     try:
         if workflow_type == "ingestion":
-            files = create_ingestion_workflow(
+            result = _create_workflow(
+                workflow_type=workflow_type,
                 domain=domain,
-                table_name=table,
+                table=table,
                 unique_key=unique_key,
                 cron=cron,
                 api_base_url=api_base_url or None,
@@ -141,16 +202,16 @@ def create_workflow_cmd(
             )
 
             click.echo("Created files:\n")
-            for file_path in files:
+            for file_path in result.files:
                 click.echo(f"  - {file_path}")
 
-            _print_ingestion_next_steps(files, table=table)
+            _print_ingestion_next_steps(result.files, table=table)
             logger.info(
                 "workflow_create_succeeded",
                 workflow_type=workflow_type,
                 domain=domain,
                 table=table,
-                file_count=len(files),
+                file_count=len(result.files),
             )
     except Exception as exc:
         logger.exception(
@@ -172,7 +233,8 @@ def create_workflow_cmd(
 
 @workflow_group.command("check")
 @click.argument("workflow_file", type=click.Path(dir_okay=False))
-def check_workflow_cmd(workflow_file: str) -> None:
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
+def check_workflow_cmd(workflow_file: str, output_json: bool) -> None:
     """Validate a workflow and its inferred schema before materialization."""
     workflow_path = Path(workflow_file)
     if not workflow_path.exists():
@@ -185,8 +247,10 @@ def check_workflow_cmd(workflow_file: str) -> None:
     schema_path = _infer_schema_path(workflow_path)
 
     _validate_workflow_file(str(workflow_path))
-    click.echo(f"Workflow valid: {workflow_path}")
+    if not output_json:
+        click.echo(f"Workflow valid: {workflow_path}")
 
+    schema_validated = False
     if schema_path and schema_path.exists():
         try:
             _validate_schema_file(str(schema_path))
@@ -196,9 +260,22 @@ def check_workflow_cmd(workflow_file: str) -> None:
             raise click.ClickException(
                 f"Schema validation failed for {schema_path}: {exc}"
             ) from exc
-        click.echo(f"Schema valid: {schema_path}")
+        schema_validated = True
+        if not output_json:
+            click.echo(f"Schema valid: {schema_path}")
     elif schema_path:
         raise click.ClickException(f"Inferred schema file not found: {schema_path}")
 
     asset_key = _asset_key_from_workflow_path(workflow_path)
-    click.echo(f"Next: phlo materialize {asset_key}")
+    payload = {
+        "valid": True,
+        "workflow_path": str(workflow_path),
+        "schema_path": str(schema_path) if schema_path else None,
+        "schema_validated": schema_validated,
+        "asset_key": asset_key,
+        "next_command": f"phlo materialize {asset_key}",
+    }
+    if output_json:
+        click.echo(json_envelope(data=payload))
+    else:
+        click.echo(f"Next: phlo materialize {asset_key}")

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -170,6 +170,7 @@ def _create_workflow(
     multiple=True,
     help="Additional schema field (name:type, name:type?, name:type!)",
 )
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 def create_workflow_cmd(
     workflow_type: str,
     domain: str,
@@ -178,6 +179,7 @@ def create_workflow_cmd(
     cron: str,
     api_base_url: str,
     fields: tuple[str, ...],
+    output_json: bool,
 ) -> None:
     """Create a workflow scaffold."""
     logger.info(
@@ -187,7 +189,8 @@ def create_workflow_cmd(
         table=table,
         field_count=len(fields),
     )
-    click.echo(f"\nCreating {workflow_type} workflow for {domain}.{table}...\n")
+    if not output_json:
+        click.echo(f"\nCreating {workflow_type} workflow for {domain}.{table}...\n")
 
     try:
         if workflow_type == "ingestion":
@@ -201,11 +204,14 @@ def create_workflow_cmd(
                 fields=list(fields),
             )
 
-            click.echo("Created files:\n")
-            for file_path in result.files:
-                click.echo(f"  - {file_path}")
+            if output_json:
+                click.echo(json_envelope(data=result.__dict__))
+            else:
+                click.echo("Created files:\n")
+                for file_path in result.files:
+                    click.echo(f"  - {file_path}")
 
-            _print_ingestion_next_steps(result.files, table=table)
+                _print_ingestion_next_steps(result.files, table=table)
             logger.info(
                 "workflow_create_succeeded",
                 workflow_type=workflow_type,

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -45,9 +45,11 @@ _DOCTOR_INVOCATION = _is_doctor_invocation(sys.argv)
 _INIT_INVOCATION = is_init_command_invocation(sys.argv)
 
 if not _DOCTOR_INVOCATION:
+    from phlo.cli.commands.audit import audit_group
     from phlo.cli.commands.authz import authz_group
     from phlo.cli.commands.compliance import compliance_group
     from phlo.cli.commands.governance import governance_group
+    from phlo.cli.commands.mcp import mcp_group
     from phlo.cli.commands.metrics import metrics_group
     from phlo.cli.commands.migrate import migrate_group
     from phlo.cli.commands.plugin import plugin_group
@@ -62,7 +64,9 @@ if not _DOCTOR_INVOCATION:
 
 @click.group()
 @click.version_option(version=version("phlo"), prog_name="phlo")
-def cli() -> None:
+@click.option("--quiet", is_flag=True, help="Reduce non-essential CLI output.")
+@click.option("--no-color", is_flag=True, help="Disable colorized terminal output.")
+def cli(quiet: bool, no_color: bool) -> None:
     """
     Phlo - Modern Data Lakehouse Framework
 
@@ -70,14 +74,21 @@ def cli() -> None:
 
     Documentation: https://github.com/iamgp/phlo
     """
+    if quiet:
+        os.environ["PHLO_QUIET"] = "1"
+    if no_color:
+        os.environ["NO_COLOR"] = "1"
+        os.environ["CLICOLOR"] = "0"
     setup_logging()
 
 
 cli.add_command(doctor_cmd)
 
 if not _DOCTOR_INVOCATION:
+    cli.add_command(audit_group)
     cli.add_command(services_group)
     cli.add_command(workflow_group)
+    cli.add_command(mcp_group)
     cli.add_command(plugin_group)
     cli.add_command(schema_migrate_group)
     cli.add_command(migrate_group)

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -20,6 +20,7 @@ import phlo.cli._warning_filters  # noqa: F401
 from phlo.cli._init_discovery_guard import is_init_command_invocation
 from phlo.cli.authorization_wrappers import require_mutation_authorization
 from phlo.cli.commands.doctor import doctor_cmd
+from phlo.cli.output import json_envelope
 from phlo.cli.templates import TemplateRenderContext, get_template
 from phlo.cli.templates import list_templates as get_project_templates
 from phlo.cli.templates.registry import missing_required_packages
@@ -287,8 +288,15 @@ def _render_next_steps(selected_template) -> list[str]:
 )
 @click.option("--force", is_flag=True, help="Initialize in non-empty directory")
 @click.option("--list-templates", is_flag=True, help="List available project templates and exit.")
+@click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 @require_mutation_authorization("init", when=lambda params: not params.get("list_templates"))
-def init(project_name: str | None, template: str, force: bool, list_templates: bool):
+def init(
+    project_name: str | None,
+    template: str,
+    force: bool,
+    list_templates: bool,
+    output_json: bool,
+):
     """
     Initialize a new Phlo project.
 
@@ -301,25 +309,41 @@ def init(project_name: str | None, template: str, force: bool, list_templates: b
         phlo init weather-pipeline --template csv-batch
     """
     if list_templates:
+        items = [
+            {
+                "name": item.metadata.name,
+                "description": item.metadata.description,
+                "required_packages": list(item.metadata.required_packages),
+                "generated_paths": list(item.metadata.generated_paths),
+                "next_steps": list(item.metadata.next_steps),
+            }
+            for item in get_project_templates()
+        ]
+        if output_json:
+            click.echo(json_envelope(data={"items": items}))
+            return
         for item in get_project_templates():
             packages = ", ".join(item.metadata.required_packages)
             click.echo(f"{item.metadata.name:<20} {item.metadata.description:<36} {packages}")
         return
 
-    click.echo("Phlo Project Initializer\n")
+    if not output_json:
+        click.echo("Phlo Project Initializer\n")
 
     # Determine project directory and metadata-safe project name
     if project_name is None or project_name == ".":
         project_dir = Path.cwd()
         project_metadata_name = project_dir.name
-        click.echo(f"Initializing in current directory: {project_dir}")
+        if not output_json:
+            click.echo(f"Initializing in current directory: {project_dir}")
     else:
         requested_path = Path(project_name).expanduser()
         project_dir = (
             requested_path if requested_path.is_absolute() else (Path.cwd() / requested_path)
         )
         project_metadata_name = project_dir.name
-        click.echo(f"Creating new project: {project_dir}")
+        if not output_json:
+            click.echo(f"Creating new project: {project_dir}")
 
     # Check if directory exists and is not empty
     if project_dir.exists() and any(project_dir.iterdir()) and not force:
@@ -330,6 +354,21 @@ def init(project_name: str | None, template: str, force: bool, list_templates: b
     # Create project structure
     try:
         selected_template = _create_project_structure(project_dir, project_metadata_name, template)
+        next_steps = _render_next_steps(selected_template)
+
+        if output_json:
+            click.echo(
+                json_envelope(
+                    data={
+                        "project_dir": str(project_dir),
+                        "project_name": project_metadata_name,
+                        "template": selected_template.metadata.name,
+                        "generated_paths": list(selected_template.metadata.generated_paths),
+                        "next_steps": next_steps,
+                    }
+                )
+            )
+            return
 
         click.echo(f"\nSuccessfully initialized Phlo project: {project_dir}\n")
         _display_created_structure(project_dir, selected_template)
@@ -339,7 +378,7 @@ def init(project_name: str | None, template: str, force: bool, list_templates: b
         if project_dir != Path.cwd():
             click.echo(f"  {step_number}. cd {project_dir}")
             step_number += 1
-        for next_step in _render_next_steps(selected_template):
+        for next_step in next_steps:
             click.echo(f"  {step_number}. {next_step}")
             step_number += 1
 

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -364,7 +364,11 @@ def init(
                         "project_name": project_metadata_name,
                         "template": selected_template.metadata.name,
                         "generated_paths": list(selected_template.metadata.generated_paths),
-                        "next_steps": next_steps,
+                        "next_steps": (
+                            [f"cd {project_dir}", *next_steps]
+                            if project_dir != Path.cwd()
+                            else next_steps
+                        ),
                     }
                 )
             )

--- a/src/phlo/cli/output.py
+++ b/src/phlo/cli/output.py
@@ -2,11 +2,26 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
 import click
+
+
+def json_envelope(
+    *,
+    data: Any = None,
+    warnings: Sequence[str] | None = None,
+    errors: Sequence[str] | None = None,
+) -> str:
+    """Render the shared agent-friendly JSON envelope."""
+    return json.dumps(
+        {"data": data, "warnings": list(warnings or ()), "errors": list(errors or ())},
+        indent=2,
+        sort_keys=True,
+    )
 
 
 def user_error(

--- a/src/phlo/cli/templates/builtin.py
+++ b/src/phlo/cli/templates/builtin.py
@@ -198,6 +198,20 @@ htmlcov/
 """,
     )
     _write_project_readme(project_dir, project_name)
+    _write_text(
+        project_dir / "AGENTS.md",
+        """# Agent Instructions
+
+Prefer Phlo MCP tools over shell commands when available:
+
+- Inspect assets with `runtime_assets`, `runtime_asset`, `inspect_materialization`, and `get_lineage`.
+- Diagnose failures with `phlo.debug_run`, `get_run_logs`, `get_run_trace_spans`, and `render_run_trace_tree`.
+- Validate authoring changes with `validate_workflow`, `validate_schema`, `lint_project`, and `run_doctor`.
+- For mutations, start with dry runs: `materialize_asset(dry_run=true)` and `backfill_asset(dry_run=true)`.
+
+Use `lakehouse:read` for inspection, `lakehouse:operate` for materialize/retry/cancel/backfill, and `project:write` for scaffold or validation tools that touch project files.
+""",
+    )
 
     from phlo.cli.commands.services.utils import PHLO_CONFIG_TEMPLATE
 

--- a/src/phlo/workflow_authoring.py
+++ b/src/phlo/workflow_authoring.py
@@ -1,0 +1,108 @@
+"""Provider-neutral workflow authoring helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from phlo.capabilities import list_capabilities, resolve_capability
+from phlo.capabilities.discovery import discover_capabilities
+
+
+class WorkflowAuthoringError(RuntimeError):
+    """Raised when a workflow authoring provider cannot complete a request."""
+
+
+@dataclass(frozen=True)
+class WorkflowCreateResult:
+    """Normalized result returned by workflow authoring providers."""
+
+    workflow_type: str
+    provider: str
+    domain: str
+    table: str
+    files: list[str]
+    next_steps: list[str]
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def create_workflow_with_provider(
+    *,
+    project_root: Path,
+    workflow_type: str,
+    domain: str,
+    table: str,
+    unique_key: str,
+    cron: str,
+    api_base_url: str | None = None,
+    fields: list[str] | None = None,
+    provider: str | None = None,
+    contribution_id: str | None = None,
+    values: Mapping[str, Any] | None = None,
+) -> WorkflowCreateResult:
+    """Create a workflow through the resolved workflow authoring capability."""
+    resolution = _resolve_workflow_authoring(provider)
+    request = {
+        "workflow_type": workflow_type,
+        "domain": domain,
+        "table": table,
+        "unique_key": unique_key,
+        "cron": cron,
+        "api_base_url": api_base_url,
+        "fields": list(fields or []),
+        "provider": provider,
+        "contribution_id": contribution_id,
+        "values": dict(values or {}),
+    }
+    try:
+        raw_result = resolution.provider.create_workflow(
+            project_root=project_root.resolve(),
+            request=request,
+        )
+    except (FileExistsError, WorkflowAuthoringError):
+        raise
+    except Exception as exc:
+        raise WorkflowAuthoringError(str(exc)) from exc
+    return _normalize_create_result(raw_result, provider=resolution.name)
+
+
+def _resolve_workflow_authoring(provider: str | None) -> Any:
+    discover_capabilities()
+    resolution = resolve_capability("workflow_authoring", provider)
+    if resolution is not None:
+        return resolution
+
+    available = list_capabilities("workflow_authoring")
+    if provider:
+        raise WorkflowAuthoringError(
+            f"Workflow authoring provider {provider!r} is not available. "
+            f"Available providers: {', '.join(available) or 'none'}."
+        )
+    if not available:
+        raise WorkflowAuthoringError(
+            'No workflow authoring provider is available. Install an ingestion provider such as "phlo-dlt" or "phlo-sling".'
+        )
+    raise WorkflowAuthoringError(
+        "Multiple workflow authoring providers are available. "
+        f"Choose one with --provider or configure phlo_default_capabilities.workflow_authoring. "
+        f"Available providers: {', '.join(available)}."
+    )
+
+
+def _normalize_create_result(result: Mapping[str, Any], *, provider: str) -> WorkflowCreateResult:
+    try:
+        return WorkflowCreateResult(
+            workflow_type=str(result.get("workflow_type") or "ingestion"),
+            provider=str(result.get("provider") or provider),
+            domain=str(result["domain"]),
+            table=str(result["table"]),
+            files=[str(item) for item in result.get("files", [])],
+            next_steps=[str(item) for item in result.get("next_steps", [])],
+            metadata=dict(result.get("metadata") or {}),
+        )
+    except KeyError as exc:
+        raise WorkflowAuthoringError(
+            f"Workflow authoring provider returned no {exc.args[0]!r}."
+        ) from exc

--- a/tests/cli/test_cli_init_templates.py
+++ b/tests/cli/test_cli_init_templates.py
@@ -83,6 +83,7 @@ def test_init_json_outputs_project_envelope(tmp_path) -> None:
     assert payload["errors"] == []
     assert payload["data"]["project_dir"] == str(project_dir)
     assert payload["data"]["template"] == "minimal"
+    assert payload["data"]["next_steps"][0] == f"cd {project_dir}"
     assert (project_dir / "AGENTS.md").exists()
 
 

--- a/tests/cli/test_cli_init_templates.py
+++ b/tests/cli/test_cli_init_templates.py
@@ -1,5 +1,6 @@
 import ast
 import importlib
+import json
 import subprocess
 import sys
 import tomllib
@@ -62,6 +63,27 @@ def test_init_list_templates_outputs_metadata() -> None:
     assert "minimal" in result.output
     assert "basic" in result.output
     assert "dbt-ready Phlo project" in result.output
+
+
+def test_init_list_templates_json_outputs_envelope() -> None:
+    result = CliRunner().invoke(cli, ["init", "--list-templates", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["errors"] == []
+    assert any(item["name"] == "minimal" for item in payload["data"]["items"])
+
+
+def test_init_json_outputs_project_envelope(tmp_path) -> None:
+    project_dir = tmp_path / "demo"
+    result = CliRunner().invoke(cli, ["init", str(project_dir), "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["errors"] == []
+    assert payload["data"]["project_dir"] == str(project_dir)
+    assert payload["data"]["template"] == "minimal"
+    assert (project_dir / "AGENTS.md").exists()
 
 
 def _assert_python_files_parse(project_dir: Path) -> None:

--- a/tests/cli/test_cli_services_status.py
+++ b/tests/cli/test_cli_services_status.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from subprocess import CompletedProcess
 
 from click.testing import CliRunner
@@ -63,6 +64,55 @@ def test_services_status_uses_service_names(monkeypatch, tmp_path) -> None:
     assert any("{{.Service}}" in part for part in captured["cmd"])
     assert "postgres" in result.output
     assert "demo-postgres-1" not in result.output
+
+
+def test_services_status_json(monkeypatch, tmp_path) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(status_module, "require_container_backend", lambda _backend=None: None)
+    monkeypatch.setattr(status_module, "ensure_compose_project", lambda: phlo_dir)
+    monkeypatch.setattr(status_module, "get_project_name", lambda: "demo")
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_compose_base_cmd(**_kwargs) -> list[str]:
+        return ["docker-compose", "-p", "demo"]
+
+    def fake_run_compose(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps(
+                [
+                    {
+                        "Service": "postgres",
+                        "Name": "demo-postgres-1",
+                        "State": "running",
+                        "Status": "Up 1 second (healthy)",
+                        "Publishers": [],
+                    }
+                ]
+            ),
+        )
+
+    monkeypatch.setattr(status_module, "compose_base_cmd", fake_compose_base_cmd)
+    monkeypatch.setattr(status_module, "run_compose", fake_run_compose)
+
+    result = CliRunner().invoke(status_module.status_cmd, ["--json"])
+
+    assert result.exit_code == 0
+    assert captured["cmd"][-2:] == ["--format", "json"]
+    assert json.loads(result.output) == [
+        {
+            "service": "postgres",
+            "name": "demo-postgres-1",
+            "state": "running",
+            "status": "Up 1 second (healthy)",
+            "ports": [],
+        }
+    ]
 
 
 def test_services_status_requires_initialized_project(monkeypatch, tmp_path) -> None:

--- a/tests/cli/test_cli_workflow.py
+++ b/tests/cli/test_cli_workflow.py
@@ -51,6 +51,8 @@ def test_workflow_create_uses_cron_default_noninteractively(monkeypatch) -> None
             "create",
             "--type",
             "ingestion",
+            "--provider",
+            "dlt",
             "--domain",
             "demo",
             "--table",
@@ -87,6 +89,8 @@ def test_workflow_create_defaults_ingestion_noninteractively(monkeypatch) -> Non
         [
             "workflow",
             "create",
+            "--provider",
+            "dlt",
             "--domain",
             "weather",
             "--table",
@@ -159,6 +163,8 @@ def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
             "create",
             "--type",
             "ingestion",
+            "--provider",
+            "dlt",
             "--domain",
             "weather",
             "--table",
@@ -211,6 +217,8 @@ def test_workflow_create_converts_blank_api_base_url_to_none(monkeypatch) -> Non
             "create",
             "--type",
             "ingestion",
+            "--provider",
+            "dlt",
             "--domain",
             "events",
             "--table",
@@ -257,6 +265,8 @@ def test_workflow_create_prints_runnable_next_steps(monkeypatch, tmp_path) -> No
             "create",
             "--type",
             "ingestion",
+            "--provider",
+            "dlt",
             "--domain",
             "weather",
             "--table",
@@ -271,7 +281,7 @@ def test_workflow_create_prints_runnable_next_steps(monkeypatch, tmp_path) -> No
     )
 
     assert result.exit_code == 0
-    assert "phlo services restart --service dagster" in result.output
+    assert "phlo services restart" in result.output
     assert "phlo materialize dlt_observations" in result.output
     assert "Inspect status: phlo status" in result.output
     assert "phlo schema validate workflows/schemas/weather.py" not in result.output
@@ -301,6 +311,8 @@ def test_workflow_create_reports_scaffold_failures(monkeypatch) -> None:
             "create",
             "--type",
             "ingestion",
+            "--provider",
+            "dlt",
             "--domain",
             "weather",
             "--table",
@@ -350,7 +362,7 @@ def test_workflow_check_delegates_to_existing_validators(monkeypatch, tmp_path) 
     assert result.exit_code == 0
     assert ("workflow", str(workflow_file)) in calls
     assert ("schema", str(schema_file)) in calls
-    assert "phlo materialize dlt_observations" in result.output
+    assert "phlo materialize observations" in result.output
 
 
 def test_workflow_check_missing_file_is_actionable(tmp_path, monkeypatch) -> None:

--- a/tests/observability/test_metrics_cli.py
+++ b/tests/observability/test_metrics_cli.py
@@ -48,3 +48,18 @@ def test_metrics_summary_command(monkeypatch) -> None:
     result = CliRunner().invoke(metrics_group, ["summary"])
     assert result.exit_code == 0
     assert "Platform Metrics Summary" in result.output
+
+
+def test_metrics_summary_json_command(monkeypatch) -> None:
+    class FakeCollector:
+        def collect_summary(self, period_hours: int) -> SummaryMetrics:
+            assert period_hours == 24
+            return SummaryMetrics(total_runs_24h=1)
+
+    monkeypatch.setattr("phlo.cli.commands.metrics.get_metrics_collector", lambda: FakeCollector())
+    result = CliRunner().invoke(metrics_group, ["summary", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["errors"] == []
+    assert payload["data"]["metrics"]["total_runs_24h"] == 1


### PR DESCRIPTION
## Summary

- Route workflow creation through provider capabilities instead of hard-coding DLT.
- Add orchestrator operation capability resolution for Observatory v2 operation controls.
- Make MCP operation tools and docs provider-neutral, including run status naming and trace spans.
- Tighten project-path handling for workflow authoring and extend coverage for DLT/Sling providers.

## Validation

- `uv run pytest packages/phlo-api/tests/test_authoring_api.py packages/phlo-api/tests/test_observatory_v2_api.py packages/phlo-api/tests/test_observatory_v2_workflow_wizard.py packages/phlo-mcp/tests/test_phlo_mcp.py tests/cli/test_cli_workflow.py -q`
- `uv run ruff check ...` on touched Python paths
- `uv run ty check ...` exited 0 with existing warnings in unrelated v2/MCP typing paths
