### PR TITLE
ci: add dependency refresh release lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Check package test groups
         run: python3 scripts/check_ci_package_groups.py
 
-      - name: Check dependency refresh lanes
-        run: make dependency-refresh-check
-
       - name: Lint workflows with zizmor
         run: make zizmor
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Check package test groups
         run: python3 scripts/check_ci_package_groups.py
 
+      - name: Check dependency refresh lanes
+        run: make dependency-refresh-check
+
       - name: Lint workflows with zizmor
         run: make zizmor
 

--- a/.github/workflows/dependency-refresh.yml
+++ b/.github/workflows/dependency-refresh.yml
@@ -1,0 +1,36 @@
+name: Dependency Refresh
+
+on:
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: Dependency refresh lane to inspect
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - patch
+          - risk-managed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-refresh:
+    name: dependency refresh / plan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Print dependency refresh plan
+        run: make dependency-refresh LANE="${{ inputs.lane }}"
+
+      - name: Validate dependency refresh lanes
+        run: make dependency-refresh-check

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ PYMDX_DOCS_PORT ?= 3000
 	dagster-shell superset-shell postgres-shell minio-shell hub-shell trino-shell nessie-shell \
 	health-observability health-api health-catalog \
 	check lint lint-sql lint-python format-python typecheck-python \
+	dependency-refresh dependency-refresh-check \
 	lint-ts format-ts typecheck-ts test-core-regression test-quickstart-smoke fix-sql \
 	prek-install prek-run prek-validate zizmor actionlint docs-generate docs-dev docs-build docs-serve docs-clean
 
@@ -343,6 +344,12 @@ format-python:
 
 typecheck-python:
 	uv run ty check $(TY_CHECK_SCOPE)
+
+dependency-refresh:
+	python3 scripts/dependency_refresh_plan.py
+
+dependency-refresh-check:
+	python3 scripts/dependency_refresh_plan.py --check
 
 lint-ts:
 	$(NPM_OBSERVATORY) run lint

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ CHECK_CMD := scripts/run-parallel \
 CORE_REGRESSION_TEST_PATHS ?= tests
 CORE_REGRESSION_PYTEST_ARGS ?= --tb=short
 QUICKSTART_SMOKE_PYTEST_ARGS ?= --tb=short
+LANE ?= all
 
 # Docker Compose profiles
 PROFILE_CORE ?= postgres minio minio-setup dagster-webserver dagster-daemon hub
@@ -346,7 +347,7 @@ typecheck-python:
 	uv run ty check $(TY_CHECK_SCOPE)
 
 dependency-refresh:
-	python3 scripts/dependency_refresh_plan.py
+	python3 scripts/dependency_refresh_plan.py --lane $(LANE)
 
 dependency-refresh-check:
 	python3 scripts/dependency_refresh_plan.py --check

--- a/docs/operations/release-management.md
+++ b/docs/operations/release-management.md
@@ -35,6 +35,41 @@ relx validate
 relx status --channel
 ```
 
+### Dependency Refresh Lane
+
+Run the dependency refresh lane before opening or merging release PRs that should
+pick up third-party maintenance updates.
+
+```bash
+make dependency-refresh
+make dependency-refresh-check
+```
+
+The refresh lane is intentionally split:
+
+- Patch lane first: `ruff`, `pytest`, `dbt-core`, and `psycopg2-binary`.
+- Risk-managed lane after patch CI is green: `pyarrow`, OpenTelemetry packages,
+  `dagster`, `dagster-webserver`, `rich`, and `clickhouse-connect`.
+
+Prefer one PR for the patch lane and a separate PR for the risk-managed lane.
+For the patch lane, update only the selected low-risk packages and lockfile:
+
+```bash
+uv lock \
+  --upgrade-package ruff \
+  --upgrade-package pytest \
+  --upgrade-package dbt-core \
+  --upgrade-package psycopg2-binary
+make dependency-refresh-check
+make check
+```
+
+For the risk-managed lane, use `make dependency-refresh` to inspect which
+manifests reference each package, then group related runtime surfaces and run the
+targeted smoke/regression checks for the affected packages before the broad
+release checks. Renovate mirrors this split with `release-safe-python-patches`
+and `release-risk-managed-python-deps` groups.
+
 If local ignored runtime folders exist under `packages/`, use a clean worktree for
 ReleaseX checks. Generated local folders can confuse workspace discovery because
 the real workspace also uses `packages/*`.

--- a/docs/operations/release-management.md
+++ b/docs/operations/release-management.md
@@ -48,9 +48,10 @@ make dependency-refresh-check
 
 The refresh lane is intentionally split:
 
-- Patch lane first: `ruff`, `pytest`, `dbt-core`, and `psycopg2-binary`.
-- Risk-managed lane after patch CI is green: `pyarrow`, OpenTelemetry packages,
-  `dagster`, `dagster-webserver`, `rich`, and `clickhouse-connect`.
+- Patch lane first: `ruff`, `pytest`, and `psycopg2-binary`.
+- Risk-managed lane after patch CI is green: `dbt-core`, `pyarrow`,
+  OpenTelemetry packages, `dagster`, `dagster-webserver`, `rich`, and
+  `clickhouse-connect`.
 
 Prefer one PR for the patch lane and a separate PR for the risk-managed lane.
 For the patch lane, update only the selected low-risk packages and lockfile:
@@ -59,7 +60,6 @@ For the patch lane, update only the selected low-risk packages and lockfile:
 uv lock \
   --upgrade-package ruff \
   --upgrade-package pytest \
-  --upgrade-package dbt-core \
   --upgrade-package psycopg2-binary
 make dependency-refresh-check
 make check

--- a/docs/operations/release-management.md
+++ b/docs/operations/release-management.md
@@ -37,10 +37,11 @@ relx status --channel
 
 ### Dependency Refresh Lane
 
-Run the dependency refresh lane before opening or merging release PRs that should
-pick up third-party maintenance updates.
+Run dependency refreshes only as an explicit release-maintenance task. They are
+not part of normal pull-request CI.
 
 ```bash
+gh workflow run "Dependency Refresh" --ref main -f lane=all
 make dependency-refresh
 make dependency-refresh-check
 ```
@@ -64,11 +65,12 @@ make dependency-refresh-check
 make check
 ```
 
-For the risk-managed lane, use `make dependency-refresh` to inspect which
-manifests reference each package, then group related runtime surfaces and run the
-targeted smoke/regression checks for the affected packages before the broad
-release checks. Renovate mirrors this split with `release-safe-python-patches`
-and `release-risk-managed-python-deps` groups.
+For the risk-managed lane, use `make dependency-refresh LANE=risk-managed` to
+inspect which manifests reference each package, then group related runtime
+surfaces and run the targeted smoke/regression checks for the affected packages
+before the broad release checks. Renovate mirrors this split with
+`release-safe-python-patches` and `release-risk-managed-python-deps` groups, and
+both groups require Dependency Dashboard approval before Renovate opens PRs.
 
 If local ignored runtime folders exist under `packages/`, use a clean worktree for
 ReleaseX checks. Generated local folders can confuse workspace discovery because

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,7 @@
       "matchPackageNames": ["ruff", "pytest", "dbt-core", "psycopg2-binary"],
       "matchUpdateTypes": ["patch"],
       "groupName": "release-safe-python-patches",
+      "dependencyDashboardApproval": true,
       "labels": ["dependencies", "release-refresh", "safe-patch"]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -12,9 +12,48 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Group Python dependency updates.",
+      "description": "Group Python dependency updates outside release refresh lanes.",
       "matchManagers": ["pep621", "poetry", "pip_requirements", "pip_setup"],
+      "excludePackageNames": [
+        "ruff",
+        "pytest",
+        "dbt-core",
+        "psycopg2-binary",
+        "pyarrow",
+        "opentelemetry-api",
+        "opentelemetry-sdk",
+        "opentelemetry-exporter-otlp-proto-grpc",
+        "dagster",
+        "dagster-webserver",
+        "rich",
+        "clickhouse-connect"
+      ],
       "groupName": "python-deps"
+    },
+    {
+      "description": "Release refresh lane: patch-only low-risk Python dependency updates.",
+      "matchManagers": ["pep621", "poetry", "pip_requirements", "pip_setup"],
+      "matchPackageNames": ["ruff", "pytest", "dbt-core", "psycopg2-binary"],
+      "matchUpdateTypes": ["patch"],
+      "groupName": "release-safe-python-patches",
+      "labels": ["dependencies", "release-refresh", "safe-patch"]
+    },
+    {
+      "description": "Release refresh lane: larger runtime/tooling jumps that need explicit release validation.",
+      "matchManagers": ["pep621", "poetry", "pip_requirements", "pip_setup"],
+      "matchPackageNames": [
+        "pyarrow",
+        "opentelemetry-api",
+        "opentelemetry-sdk",
+        "opentelemetry-exporter-otlp-proto-grpc",
+        "dagster",
+        "dagster-webserver",
+        "rich",
+        "clickhouse-connect"
+      ],
+      "groupName": "release-risk-managed-python-deps",
+      "dependencyDashboardApproval": true,
+      "labels": ["dependencies", "release-refresh", "risk-managed"]
     },
     {
       "description": "Group Observatory (JS/TS) dependencies.",

--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,8 @@
       "excludePackageNames": [
         "ruff",
         "pytest",
-        "dbt-core",
         "psycopg2-binary",
+        "dbt-core",
         "pyarrow",
         "opentelemetry-api",
         "opentelemetry-sdk",
@@ -33,7 +33,7 @@
     {
       "description": "Release refresh lane: patch-only low-risk Python dependency updates.",
       "matchManagers": ["pep621", "poetry", "pip_requirements", "pip_setup"],
-      "matchPackageNames": ["ruff", "pytest", "dbt-core", "psycopg2-binary"],
+      "matchPackageNames": ["ruff", "pytest", "psycopg2-binary"],
       "matchUpdateTypes": ["patch"],
       "groupName": "release-safe-python-patches",
       "dependencyDashboardApproval": true,
@@ -44,6 +44,7 @@
       "matchManagers": ["pep621", "poetry", "pip_requirements", "pip_setup"],
       "matchPackageNames": [
         "pyarrow",
+        "dbt-core",
         "opentelemetry-api",
         "opentelemetry-sdk",
         "opentelemetry-exporter-otlp-proto-grpc",

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Importable repository maintenance scripts."""

--- a/scripts/dependency_refresh_plan.py
+++ b/scripts/dependency_refresh_plan.py
@@ -212,14 +212,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
-    plan = _select_lanes(collect_plan(args.repo_root), args.lane)
+    full_plan = collect_plan(args.repo_root)
+    plan = _select_lanes(full_plan, args.lane)
     if args.format == "json":
         _print_json(plan)
     else:
         _print_markdown(plan)
 
     if args.check:
-        errors = validate_plan(plan)
+        errors = validate_plan(full_plan)
         if errors:
             print("Dependency refresh plan validation failed:", file=sys.stderr)
             for error in errors:

--- a/scripts/dependency_refresh_plan.py
+++ b/scripts/dependency_refresh_plan.py
@@ -14,11 +14,12 @@ from typing import Literal
 
 Lane = Literal["patch", "risk-managed"]
 
-PATCH_REFRESH_PACKAGES = ("dbt-core", "psycopg2-binary", "pytest", "ruff")
+PATCH_REFRESH_PACKAGES = ("psycopg2-binary", "pytest", "ruff")
 RISK_MANAGED_PACKAGES = (
     "clickhouse-connect",
     "dagster",
     "dagster-webserver",
+    "dbt-core",
     "opentelemetry-api",
     "opentelemetry-exporter-otlp",
     "opentelemetry-exporter-otlp-proto-grpc",

--- a/scripts/dependency_refresh_plan.py
+++ b/scripts/dependency_refresh_plan.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Plan the release dependency refresh lanes without mutating dependency files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+Lane = Literal["patch", "risk-managed"]
+
+PATCH_REFRESH_PACKAGES = ("dbt-core", "psycopg2-binary", "pytest", "ruff")
+RISK_MANAGED_PACKAGES = (
+    "clickhouse-connect",
+    "dagster",
+    "dagster-webserver",
+    "opentelemetry-api",
+    "opentelemetry-exporter-otlp",
+    "opentelemetry-exporter-otlp-proto-grpc",
+    "opentelemetry-sdk",
+    "pyarrow",
+    "rich",
+)
+LANES: dict[Lane, tuple[str, ...]] = {
+    "patch": PATCH_REFRESH_PACKAGES,
+    "risk-managed": RISK_MANAGED_PACKAGES,
+}
+REQUIREMENT_NAME = re.compile(r"^\s*([A-Za-z0-9_.-]+)")
+
+
+@dataclass(frozen=True)
+class DependencyRefreshEntry:
+    name: str
+    lane: Lane
+    locked_version: str | None
+    manifest_files: list[str]
+
+
+def _dependency_name(requirement: str) -> str | None:
+    match = REQUIREMENT_NAME.match(requirement)
+    if match is None:
+        return None
+    return match.group(1).lower().replace("_", "-")
+
+
+def _iter_requirement_strings(pyproject: dict[str, object]) -> list[str]:
+    requirements: list[str] = []
+    project = pyproject.get("project")
+    if isinstance(project, dict):
+        dependencies = project.get("dependencies")
+        if isinstance(dependencies, list):
+            requirements.extend(item for item in dependencies if isinstance(item, str))
+        optional = project.get("optional-dependencies")
+        if isinstance(optional, dict):
+            for group_requirements in optional.values():
+                if isinstance(group_requirements, list):
+                    requirements.extend(
+                        item for item in group_requirements if isinstance(item, str)
+                    )
+
+    dependency_groups = pyproject.get("dependency-groups")
+    if isinstance(dependency_groups, dict):
+        for group_requirements in dependency_groups.values():
+            if isinstance(group_requirements, list):
+                requirements.extend(item for item in group_requirements if isinstance(item, str))
+
+    return requirements
+
+
+def _discover_manifests(repo_root: Path) -> dict[str, list[str]]:
+    manifests: dict[str, list[str]] = {}
+    for manifest in sorted(repo_root.glob("**/pyproject.toml")):
+        if any(part in {".venv", "dist", "docs-site"} for part in manifest.parts):
+            continue
+        try:
+            pyproject = tomllib.loads(manifest.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            raise ValueError(f"Invalid TOML in {manifest}: {exc}") from exc
+        relative_manifest = manifest.relative_to(repo_root).as_posix()
+        for requirement in _iter_requirement_strings(pyproject):
+            name = _dependency_name(requirement)
+            if name is None:
+                continue
+            manifest_files = manifests.setdefault(name, [])
+            if relative_manifest not in manifest_files:
+                manifest_files.append(relative_manifest)
+    return manifests
+
+
+def _locked_versions(repo_root: Path) -> dict[str, str]:
+    lockfile = repo_root / "uv.lock"
+    if not lockfile.exists():
+        return {}
+    lock = tomllib.loads(lockfile.read_text(encoding="utf-8"))
+    versions: dict[str, str] = {}
+    packages = lock.get("package", [])
+    if isinstance(packages, list):
+        for package in packages:
+            if not isinstance(package, dict):
+                continue
+            name = package.get("name")
+            version = package.get("version")
+            if isinstance(name, str) and isinstance(version, str):
+                versions[name.lower().replace("_", "-")] = version
+    return versions
+
+
+def collect_plan(repo_root: Path) -> dict[Lane, list[DependencyRefreshEntry]]:
+    repo_root = repo_root.resolve()
+    manifests = _discover_manifests(repo_root)
+    locked_versions = _locked_versions(repo_root)
+    plan: dict[Lane, list[DependencyRefreshEntry]] = {"patch": [], "risk-managed": []}
+    for lane, package_names in LANES.items():
+        for package_name in package_names:
+            manifest_files = sorted(manifests.get(package_name, []))
+            if not manifest_files:
+                continue
+            plan[lane].append(
+                DependencyRefreshEntry(
+                    name=package_name,
+                    lane=lane,
+                    locked_version=locked_versions.get(package_name),
+                    manifest_files=manifest_files,
+                )
+            )
+    return plan
+
+
+def validate_plan(plan: dict[Lane, list[DependencyRefreshEntry]]) -> list[str]:
+    errors: list[str] = []
+    if not plan["patch"]:
+        errors.append("Patch lane has no discovered dependencies.")
+    if not plan["risk-managed"]:
+        errors.append("Risk-managed lane has no discovered dependencies.")
+
+    missing_lock_versions = [
+        entry.name for entries in plan.values() for entry in entries if entry.locked_version is None
+    ]
+    if missing_lock_versions:
+        errors.append("Dependencies missing from uv.lock: " + ", ".join(missing_lock_versions))
+    return errors
+
+
+def _select_lanes(
+    plan: dict[Lane, list[DependencyRefreshEntry]], selected_lane: str
+) -> dict[Lane, list[DependencyRefreshEntry]]:
+    if selected_lane == "all":
+        return plan
+    return {selected_lane: plan[selected_lane]}  # type: ignore[index, return-value]
+
+
+def _print_json(plan: dict[Lane, list[DependencyRefreshEntry]]) -> None:
+    print(
+        json.dumps(
+            {lane: [asdict(entry) for entry in entries] for lane, entries in plan.items()},
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _print_markdown(plan: dict[Lane, list[DependencyRefreshEntry]]) -> None:
+    print("# Dependency Refresh Plan")
+    for lane, entries in plan.items():
+        print()
+        print(f"## {lane.title()} Lane")
+        if not entries:
+            print()
+            print("No matching dependencies discovered.")
+            continue
+        print()
+        print("| Dependency | Locked | Manifest files |")
+        print("|---|---:|---|")
+        for entry in entries:
+            locked = entry.locked_version or "not locked"
+            manifests = "<br>".join(entry.manifest_files)
+            print(f"| `{entry.name}` | `{locked}` | {manifests} |")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root to inspect.",
+    )
+    parser.add_argument(
+        "--lane",
+        choices=("patch", "risk-managed", "all"),
+        default="all",
+        help="Refresh lane to print.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the lane configuration no longer matches repo manifests and uv.lock.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    plan = _select_lanes(collect_plan(args.repo_root), args.lane)
+    if args.format == "json":
+        _print_json(plan)
+    else:
+        _print_markdown(plan)
+
+    if args.check:
+        errors = validate_plan(plan)
+        if errors:
+            print("Dependency refresh plan validation failed:", file=sys.stderr)
+            for error in errors:
+                print(f"- {error}", file=sys.stderr)
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tooling/test_dependency_refresh_plan.py
+++ b/tests/tooling/test_dependency_refresh_plan.py
@@ -83,6 +83,26 @@ dev = ["ruff>=0.14.1"]
     assert "risk-managed" not in payload
 
 
+def test_check_validates_full_plan_when_displaying_patch_lane(tmp_path: Path) -> None:
+    write_complete_plan_fixture(tmp_path)
+
+    exit_code = dependency_refresh_plan.main(
+        ["--repo-root", str(tmp_path), "--lane", "patch", "--check"]
+    )
+
+    assert exit_code == 0
+
+
+def test_check_validates_full_plan_when_displaying_risk_managed_lane(tmp_path: Path) -> None:
+    write_complete_plan_fixture(tmp_path)
+
+    exit_code = dependency_refresh_plan.main(
+        ["--repo-root", str(tmp_path), "--lane", "risk-managed", "--check"]
+    )
+
+    assert exit_code == 0
+
+
 def test_validate_fails_when_patch_lane_is_missing() -> None:
     errors = dependency_refresh_plan.validate_plan(
         {
@@ -92,3 +112,28 @@ def test_validate_fails_when_patch_lane_is_missing() -> None:
     )
 
     assert "Patch lane has no discovered dependencies." in errors
+
+
+def write_complete_plan_fixture(root: Path) -> None:
+    (root / "pyproject.toml").write_text(
+        """
+[project]
+dependencies = ["rich>=13.0"]
+
+[dependency-groups]
+dev = ["ruff>=0.14.1"]
+""",
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text(
+        """
+[[package]]
+name = "ruff"
+version = "0.14.1"
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+""",
+        encoding="utf-8",
+    )

--- a/tests/tooling/test_dependency_refresh_plan.py
+++ b/tests/tooling/test_dependency_refresh_plan.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "dependency_refresh_plan.py"
+SPEC = importlib.util.spec_from_file_location("dependency_refresh_plan", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+dependency_refresh_plan = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = dependency_refresh_plan
+SPEC.loader.exec_module(dependency_refresh_plan)
+
+
+def test_collect_plan_separates_patch_and_risk_lanes(tmp_path: Path) -> None:
+    root = tmp_path
+    package_dir = root / "packages" / "phlo-dbt"
+    package_dir.mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        """
+[project]
+dependencies = ["rich>=13.0"]
+
+[dependency-groups]
+dev = ["ruff>=0.14.1", "pytest>=8.4.2"]
+""",
+        encoding="utf-8",
+    )
+    (package_dir / "pyproject.toml").write_text(
+        """
+[project]
+dependencies = ["dbt-core>=1.10.8", "pyarrow>=21.0.0"]
+""",
+        encoding="utf-8",
+    )
+    (root / "uv.lock").write_text(
+        """
+[[package]]
+name = "ruff"
+version = "0.14.1"
+
+[[package]]
+name = "dbt-core"
+version = "1.10.8"
+
+[[package]]
+name = "pyarrow"
+version = "21.0.0"
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+""",
+        encoding="utf-8",
+    )
+
+    plan = dependency_refresh_plan.collect_plan(root)
+
+    assert [entry.name for entry in plan["patch"]] == ["dbt-core", "pytest", "ruff"]
+    assert [entry.name for entry in plan["risk-managed"]] == ["pyarrow", "rich"]
+    assert plan["patch"][0].locked_version == "1.10.8"
+    assert plan["patch"][0].manifest_files == ["packages/phlo-dbt/pyproject.toml"]
+
+
+def test_json_output_is_machine_readable(tmp_path: Path, capsys) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        """
+[dependency-groups]
+dev = ["ruff>=0.14.1"]
+""",
+        encoding="utf-8",
+    )
+    exit_code = dependency_refresh_plan.main(
+        ["--repo-root", str(tmp_path), "--lane", "patch", "--format", "json"]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert [entry["name"] for entry in payload["patch"]] == ["ruff"]
+    assert "risk-managed" not in payload
+
+
+def test_validate_fails_when_patch_lane_is_missing() -> None:
+    errors = dependency_refresh_plan.validate_plan(
+        {
+            "patch": [],
+            "risk-managed": [],
+        }
+    )
+
+    assert "Patch lane has no discovered dependencies." in errors

--- a/tests/tooling/test_dependency_refresh_plan.py
+++ b/tests/tooling/test_dependency_refresh_plan.py
@@ -59,10 +59,10 @@ version = "14.2.0"
 
     plan = dependency_refresh_plan.collect_plan(root)
 
-    assert [entry.name for entry in plan["patch"]] == ["dbt-core", "pytest", "ruff"]
-    assert [entry.name for entry in plan["risk-managed"]] == ["pyarrow", "rich"]
-    assert plan["patch"][0].locked_version == "1.10.8"
-    assert plan["patch"][0].manifest_files == ["packages/phlo-dbt/pyproject.toml"]
+    assert [entry.name for entry in plan["patch"]] == ["pytest", "ruff"]
+    assert [entry.name for entry in plan["risk-managed"]] == ["dbt-core", "pyarrow", "rich"]
+    assert plan["risk-managed"][0].locked_version == "1.10.8"
+    assert plan["risk-managed"][0].manifest_files == ["packages/phlo-dbt/pyproject.toml"]
 
 
 def test_json_output_is_machine_readable(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add a dependency refresh planning script with safe patch and risk-managed lanes
- expose make targets and CI validation for lane drift
- document the release-flow dependency refresh process and mirror the grouping in Renovate

## Validation
- uv run pytest tests/tooling/test_dependency_refresh_plan.py -q
- uv run ruff check scripts/dependency_refresh_plan.py tests/tooling/test_dependency_refresh_plan.py
- uv run ruff format --check scripts/dependency_refresh_plan.py tests/tooling/test_dependency_refresh_plan.py
- make dependency-refresh-check
- python3 scripts/check_ci_package_groups.py
- ruby -e 'Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }' -r yaml\n- python3 -m json.tool renovate.json >/tmp/phlo-renovate.json\n