### PR TITLE
feat: add agent observability operation context

### DIFF
--- a/docs/reference/observatory-v2-contracts.md
+++ b/docs/reference/observatory-v2-contracts.md
@@ -148,6 +148,17 @@ recorded timestamp, and affected file paths. It must not include secrets,
 provider credentials, private connection strings, raw provider URLs, or signed
 URLs.
 
+Journaled operations also include an agent-ready observability contract under
+`metadata.observability_contract`. The v1 schema name is
+`phlo.operation_observability.v1` and carries stable operation, trace, log,
+metric, and incident identifiers. Agents should use those identifiers rather
+than parsing names or provider-specific metadata.
+
+`GET /api/observatory/v2/operations/{operation_id}/agent-context` returns a
+compact incident and operation context for MCP clients. It includes the stable
+identifiers, operation health, related resources, correlated logs, available
+follow-up actions, and the retained history limit for the local journal.
+
 ## Native Links
 
 Native links may eventually point users to provider-native tools when Observatory

--- a/docs/reference/phlo-api.md
+++ b/docs/reference/phlo-api.md
@@ -89,6 +89,7 @@ Observatory v2 endpoints live under `/api/observatory/v2`. They are provider-neu
 | `GET /api/observatory/v2/services/{service_id}` | Service detail |
 | `GET /api/observatory/v2/operations` | Operator workflow and recovery operations |
 | `GET /api/observatory/v2/operations/{operation_id}` | Operation detail |
+| `GET /api/observatory/v2/operations/{operation_id}/agent-context` | Stable operation observability and incident context for agents |
 | `GET /api/observatory/v2/runs` | Runtime run list |
 | `GET /api/observatory/v2/storage` | Storage surface read model |
 | `GET /api/observatory/v2/observability` | Observability surface read model |

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 from typing import Any
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Query, Request
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import AliasChoices, BaseModel, Field
@@ -596,6 +596,32 @@ def _load_operations() -> list[V2Operation]:
         for status in getattr(snapshot, "operations", []):
             operations.append(_operation_from_maintenance_status(status))
     return sort_operations(operations)
+
+
+def _filter_operations(
+    operations: list[V2Operation],
+    *,
+    status: str | None = None,
+    kind: str | None = None,
+    q: str | None = None,
+    limit: int | None = None,
+) -> list[V2Operation]:
+    status_filter = status.strip().lower() if status else None
+    kind_filter = kind.strip().lower() if kind else None
+    query = q.strip().lower() if q else None
+
+    filtered: list[V2Operation] = []
+    for operation in operations:
+        if status_filter and operation.status.lower() != status_filter:
+            continue
+        if kind_filter and operation.kind.lower() != kind_filter:
+            continue
+        if query and query not in operation.model_dump_json().lower():
+            continue
+        filtered.append(operation)
+        if limit is not None and len(filtered) >= limit:
+            break
+    return filtered
 
 
 def _load_runs() -> list[V2Run]:
@@ -2575,12 +2601,26 @@ def get_v2_service_detail(service_id: str) -> V2ServiceDetail:
 
 
 @router.get("/operations", response_model=V2OperationList)
-def get_v2_operations() -> V2OperationList:
+def get_v2_operations(
+    status: str | None = None,
+    kind: str | None = None,
+    q: str | None = None,
+    limit: int | None = Query(default=None, ge=1, le=200),
+) -> V2OperationList:
     """List provider-neutral Observatory v2 operations."""
-    return _cached_read_model(
+    result = _cached_read_model(
         "operations",
         _FAST_READ_MODEL_TTL_SECONDS,
         lambda: V2OperationList(items=_load_operations()),
+    )
+    return V2OperationList(
+        items=_filter_operations(
+            result.items,
+            status=status,
+            kind=kind,
+            q=q,
+            limit=limit,
+        )
     )
 
 

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -93,6 +93,7 @@ from phlo_api.observatory_api.v2_metadata import safe_metadata as _safe_metadata
 from phlo_api.observatory_api.v2_observability import load_observability_items
 from phlo_api.observatory_api.v2_operation_journal import (
     append_operation,
+    build_operation_observability_context,
     load_operation_journal,
     operation_from_workflow_action,
     record_action_result,
@@ -2581,6 +2582,17 @@ def get_v2_operations() -> V2OperationList:
         _FAST_READ_MODEL_TTL_SECONDS,
         lambda: V2OperationList(items=_load_operations()),
     )
+
+
+@router.get("/operations/{operation_id:path}/agent-context")
+def get_v2_operation_agent_context(operation_id: str) -> dict[str, object]:
+    """Get stable observability context for agents investigating an operation."""
+    detail = _load_operation_detail(operation_id)
+    context = build_operation_observability_context(detail.operation)
+    context["related"] = [item.model_dump(mode="json") for item in detail.related]
+    context["logs"] = [item.model_dump(mode="json") for item in detail.logs]
+    context["actions"] = [item.model_dump(mode="json") for item in detail.actions]
+    return context
 
 
 @router.get("/operations/{operation_id:path}", response_model=V2OperationDetail)

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2_operation_journal.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2_operation_journal.py
@@ -20,6 +20,7 @@ from phlo_api.observatory_api.v2_models import (
 )
 
 MAX_OPERATION_RECORDS = 200
+OPERATION_OBSERVABILITY_SCHEMA_VERSION = "phlo.operation_observability.v1"
 
 
 def operation_journal_path(project_root: Path) -> Path:
@@ -69,6 +70,7 @@ def append_operation(
 ) -> V2Operation:
     timestamp = recorded_at or datetime.now(UTC).isoformat()
     original_id = operation.id
+    operation_id = record_id or f"op-{uuid4().hex[:12]}"
     metadata = safe_metadata(
         {
             **operation.metadata,
@@ -76,9 +78,14 @@ def append_operation(
             "recorded_at": timestamp,
         }
     )
+    metadata["observability_contract"] = _operation_observability_contract(
+        operation,
+        operation_id=operation_id,
+        original_operation_id=original_id,
+    )
     recorded = operation.model_copy(
         update={
-            "id": record_id or f"op-{uuid4().hex[:12]}",
+            "id": operation_id,
             "started_at": operation.started_at or timestamp,
             "completed_at": operation.completed_at or timestamp,
             "duration_seconds": operation.duration_seconds
@@ -107,6 +114,40 @@ def record_action_result(
         recorded_at=recorded_at,
     )
     return result.model_copy(update={"operation": recorded})
+
+
+def build_operation_observability_context(operation: V2Operation) -> dict[str, object]:
+    """Build the stable agent-readable observability context for an operation."""
+    identifiers = _contract_from_operation(operation)
+    status = (
+        "open" if operation.status in {"failed", "running", "queued", "unknown"} else "resolved"
+    )
+    return {
+        "schema_version": OPERATION_OBSERVABILITY_SCHEMA_VERSION,
+        "operation": {
+            "id": operation.id,
+            "name": operation.name,
+            "kind": operation.kind,
+            "status": operation.status,
+            "health": operation.health.model_dump(mode="json"),
+            "target": operation.target.model_dump(mode="json") if operation.target else None,
+            "started_at": operation.started_at,
+            "completed_at": operation.completed_at,
+            "duration_seconds": operation.duration_seconds,
+        },
+        "identifiers": identifiers,
+        "incident": {
+            "status": status,
+            "severity": operation.health.state,
+            "message": operation.health.message or operation.metadata.get("message"),
+            "incident_ids": identifiers["incident_ids"],
+        },
+        "retention": {
+            "history_limit": MAX_OPERATION_RECORDS,
+            "history_store": ".phlo/observatory-v2/operation_journal.json",
+        },
+        "metadata": safe_metadata(operation.metadata),
+    }
 
 
 def operation_from_action_result(
@@ -163,6 +204,65 @@ def operation_from_workflow_action(
             }
         ),
     )
+
+
+def _operation_observability_contract(
+    operation: V2Operation,
+    *,
+    operation_id: str,
+    original_operation_id: str | None = None,
+) -> dict[str, object]:
+    return {
+        "schema_version": OPERATION_OBSERVABILITY_SCHEMA_VERSION,
+        "operation_id": operation_id,
+        "original_operation_id": original_operation_id or operation.id,
+        "trace_ids": _identifier_values(operation.metadata, "trace"),
+        "log_ids": _identifier_values(operation.metadata, "log"),
+        "metric_ids": _identifier_values(operation.metadata, "metric"),
+        "incident_ids": _identifier_values(operation.metadata, "incident"),
+    }
+
+
+def _contract_from_operation(operation: V2Operation) -> dict[str, object]:
+    raw_contract = operation.metadata.get("observability_contract")
+    if isinstance(raw_contract, Mapping):
+        return {
+            "operation_id": _string_or_default(raw_contract.get("operation_id"), operation.id),
+            "trace_ids": _string_list(raw_contract.get("trace_ids")),
+            "log_ids": _string_list(raw_contract.get("log_ids")),
+            "metric_ids": _string_list(raw_contract.get("metric_ids")),
+            "incident_ids": _string_list(raw_contract.get("incident_ids")),
+        }
+    contract = _operation_observability_contract(operation, operation_id=operation.id)
+    return {
+        "operation_id": operation.id,
+        "trace_ids": contract["trace_ids"],
+        "log_ids": contract["log_ids"],
+        "metric_ids": contract["metric_ids"],
+        "incident_ids": contract["incident_ids"],
+    }
+
+
+def _identifier_values(metadata: Mapping[str, object], family: str) -> list[str]:
+    keys = (f"{family}_id", f"{family}_ids", f"{family}s", f"phlo.{family}_id")
+    values: list[str] = []
+    for key in keys:
+        values.extend(_string_list(metadata.get(key)))
+    return sorted(dict.fromkeys(values))
+
+
+def _string_list(value: object) -> list[str]:
+    if isinstance(value, str) and value:
+        return [value]
+    if isinstance(value, Iterable) and not isinstance(value, str | bytes | Mapping):
+        return [item for item in (_string_or_default(raw, "") for raw in value) if item]
+    return []
+
+
+def _string_or_default(value: object, default: str) -> str:
+    if isinstance(value, str) and value:
+        return value
+    return default
 
 
 def sort_operations(operations: Iterable[V2Operation]) -> list[V2Operation]:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -1377,6 +1377,47 @@ def test_v2_operations_endpoint_returns_provider_neutral_payload() -> None:
     _assert_no_provider_url_settings(payload)
 
 
+def test_v2_operations_endpoint_filters_before_returning_context_candidates(monkeypatch) -> None:
+    operations = [
+        V2Operation(
+            id="op-orders-failed",
+            name="Apply orders workflow",
+            kind="workflow.apply",
+            status="failed",
+            health=V2Health(state="error", message="Validation failed"),
+            target=V2ResourceRef(kind="workflow", id="orders", label="orders"),
+        ),
+        V2Operation(
+            id="op-customers-failed",
+            name="Apply customers workflow",
+            kind="workflow.apply",
+            status="failed",
+            health=V2Health(state="error", message="Validation failed"),
+            target=V2ResourceRef(kind="workflow", id="customers", label="customers"),
+        ),
+        V2Operation(
+            id="op-orders-restart",
+            name="Restart API",
+            kind="service.restart",
+            status="succeeded",
+            health=V2Health(state="ok"),
+            target=V2ResourceRef(kind="service", id="phlo-api", label="phlo-api"),
+        ),
+    ]
+    monkeypatch.setattr(v2, "_load_operations", lambda: operations)
+    v2._clear_read_model_cache()
+
+    response = TestClient(app).get(
+        "/api/observatory/v2/operations",
+        params={"status": "failed", "kind": "workflow.apply", "q": "orders", "limit": 1},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [item["id"] for item in payload["items"]] == ["op-orders-failed"]
+    _assert_no_provider_url_settings(payload)
+
+
 def test_v2_operation_detail_endpoint_returns_provider_neutral_payload(monkeypatch) -> None:
     client = TestClient(app)
     operation = V2Operation(

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -1399,6 +1399,39 @@ def test_v2_operation_detail_endpoint_returns_provider_neutral_payload(monkeypat
     _assert_no_provider_url_settings(payload)
 
 
+def test_v2_operation_agent_context_endpoint_returns_stable_contract(monkeypatch) -> None:
+    client = TestClient(app)
+    operation = V2Operation(
+        id="op-recorded",
+        name="Apply workflow proposal",
+        kind="workflow.apply",
+        status="failed",
+        health=V2Health(state="error", message="Validation failed"),
+        metadata={
+            "observability_contract": {
+                "operation_id": "op-recorded",
+                "trace_ids": ["trace-123"],
+                "log_ids": ["log-456"],
+                "metric_ids": ["metric-789"],
+                "incident_ids": ["incident-001"],
+            }
+        },
+    )
+    monkeypatch.setattr("phlo_api.observatory_api.v2._load_operations", lambda: [operation])
+    monkeypatch.setattr("phlo_api.observatory_api.v2._load_logs", lambda: [])
+
+    response = client.get("/api/observatory/v2/operations/op-recorded/agent-context")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == "phlo.operation_observability.v1"
+    assert payload["operation"]["id"] == "op-recorded"
+    assert payload["identifiers"]["trace_ids"] == ["trace-123"]
+    assert payload["incident"]["incident_ids"] == ["incident-001"]
+    assert payload["retention"]["history_limit"] == 200
+    _assert_no_provider_url_settings(payload)
+
+
 def test_v2_assets_endpoint_returns_provider_neutral_payload() -> None:
     response = TestClient(app).get("/api/observatory/v2/assets")
 

--- a/packages/phlo-api/tests/test_observatory_v2_operation_journal.py
+++ b/packages/phlo-api/tests/test_observatory_v2_operation_journal.py
@@ -11,6 +11,7 @@ from phlo_api.observatory_api.v2_models import (
 )
 from phlo_api.observatory_api.v2_operation_journal import (
     append_operation,
+    build_operation_observability_context,
     load_operation_journal,
     operation_from_action_result,
     record_action_result,
@@ -104,3 +105,72 @@ def test_record_action_result_returns_result_with_recorded_operation(tmp_path: P
     assert recorded_result.operation.id == "op-recorded"
     assert recorded_result.operation.status == "failed"
     assert load_operation_journal(tmp_path)[0].id == "op-recorded"
+
+
+def test_append_operation_adds_stable_observability_identifiers(tmp_path: Path) -> None:
+    operation = V2Operation(
+        id="workflow:apply:raw-orders",
+        name="Apply workflow proposal",
+        kind="workflow.apply",
+        status="succeeded",
+        health=V2Health(state="ok"),
+        target=V2ResourceRef(kind="workflow", id="raw-orders", label="raw-orders"),
+        metadata={
+            "trace_id": "trace-123",
+            "log_id": "log-456",
+            "metric_id": "metric-789",
+            "incident_id": "incident-001",
+        },
+    )
+
+    recorded = append_operation(
+        tmp_path,
+        operation,
+        record_id="op-recorded",
+        recorded_at="2026-05-16T12:00:00+00:00",
+    )
+
+    assert recorded.metadata["observability_contract"]["operation_id"] == "op-recorded"
+    assert recorded.metadata["observability_contract"]["original_operation_id"] == (
+        "workflow:apply:raw-orders"
+    )
+    assert recorded.metadata["observability_contract"]["trace_ids"] == ["trace-123"]
+    assert recorded.metadata["observability_contract"]["log_ids"] == ["log-456"]
+    assert recorded.metadata["observability_contract"]["metric_ids"] == ["metric-789"]
+    assert recorded.metadata["observability_contract"]["incident_ids"] == ["incident-001"]
+
+
+def test_build_operation_observability_context_is_agent_readable() -> None:
+    operation = V2Operation(
+        id="op-recorded",
+        name="Apply workflow proposal",
+        kind="workflow.apply",
+        status="failed",
+        health=V2Health(state="error", message="Validation failed"),
+        target=V2ResourceRef(kind="workflow", id="raw-orders", label="raw-orders"),
+        metadata={
+            "observability_contract": {
+                "operation_id": "op-recorded",
+                "trace_ids": ["trace-123"],
+                "log_ids": ["log-456"],
+                "metric_ids": ["metric-789"],
+                "incident_ids": ["incident-001"],
+            },
+            "message": "Validation failed",
+        },
+    )
+
+    context = build_operation_observability_context(operation)
+
+    assert context["schema_version"] == "phlo.operation_observability.v1"
+    assert context["operation"]["id"] == "op-recorded"
+    assert context["identifiers"] == {
+        "operation_id": "op-recorded",
+        "trace_ids": ["trace-123"],
+        "log_ids": ["log-456"],
+        "metric_ids": ["metric-789"],
+        "incident_ids": ["incident-001"],
+    }
+    assert context["incident"]["status"] == "open"
+    assert context["incident"]["severity"] == "error"
+    assert context["retention"]["history_limit"] == 200

--- a/packages/phlo-mcp/README.md
+++ b/packages/phlo-mcp/README.md
@@ -21,6 +21,7 @@ uv pip install -e packages/phlo-mcp
 - `get_service_status`
 - `get_recent_alerts`
 - `get_dashboard_links`
+- `get_operation_context`
 - `get_logs_query_link`
 - `get_metrics_query_link`
 - `get_materialization_history`
@@ -58,6 +59,7 @@ Resources:
 - `phlo://runtime/schemas/{asset_key_path}`
 - `phlo://runtime/contracts`
 - `phlo://runtime/contracts/{table_name}`
+- `phlo://runtime/operations/{operation_id}`
 - `phlo://runtime/dashboards`
 - `phlo://docs/packages/{package_name}`
 - `phlo://docs/cli`
@@ -70,6 +72,9 @@ Trace tools can be filtered by run id, asset key, job name, service name, span
 name, status code, and start/end time.
 Resource URIs are read-only and deterministic so MCP clients can attach Phlo
 runtime context without invoking parameterized tools.
+`phlo://runtime/operations/{operation_id}` returns the same v1 operation
+observability contract exposed by `phlo-api`, including stable operation, trace,
+log, metric, and incident identifiers.
 
 When real spans are available, rendered trees include:
 - span kind

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -57,6 +57,9 @@ class PhloApiClient:
     def get_asset_details(self, asset_key_path: str) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json(f"{self._V2_PREFIX}/assets/{asset_key_path}")
 
+    def get_operation_context(self, operation_id: str) -> dict[str, Any] | list[dict[str, Any]]:
+        return self._get_json(f"{self._V2_PREFIX}/operations/{operation_id}/agent-context")
+
     def get_contracts(self) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json("/api/contracts")
 

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -57,6 +57,26 @@ class PhloApiClient:
     def get_asset_details(self, asset_key_path: str) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json(f"{self._V2_PREFIX}/assets/{asset_key_path}")
 
+    def list_operations(
+        self,
+        *,
+        status: str | None = None,
+        kind: str | None = None,
+        query: str | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any] | list[dict[str, Any]]:
+        params = {
+            key: value
+            for key, value in {
+                "status": status,
+                "kind": kind,
+                "q": query,
+                "limit": limit,
+            }.items()
+            if value is not None
+        }
+        return self._get_json(f"{self._V2_PREFIX}/operations", params=params)
+
     def get_operation_context(self, operation_id: str) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json(f"{self._V2_PREFIX}/operations/{operation_id}/agent-context")
 

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -135,6 +135,15 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
         }
 
     @mcp.resource(
+        "phlo://runtime/operations/{operation_id}",
+        name="runtime_operation_context",
+        mime_type="application/json",
+    )
+    def runtime_operation_context(operation_id: str) -> dict[str, Any] | list[dict[str, Any]]:
+        """Read stable observability context for one Phlo operation."""
+        return client.get_operation_context(operation_id)
+
+    @mcp.resource(
         "phlo://runtime/contracts/{table_name}",
         name="runtime_contract",
         mime_type="application/json",
@@ -331,6 +340,25 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 with tracer.start_as_current_span("phlo.observability.dashboards"):
                     dashboards = client.get_dashboard_links()
                     return {"api_base_url": client.api_base_url, "dashboards": dashboards}
+
+    @mcp.tool()
+    def get_operation_context(operation_id: str) -> dict[str, Any]:
+        """Get stable operation, trace, log, metric, and incident context."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "get_operation_context"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "get_operation_context"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.operation_context"):
+                    payload = client.get_operation_context(operation_id)
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "operation_id": operation_id,
+                        "payload": payload,
+                    }
 
     @mcp.tool()
     def get_logs_query_link(service: str | None = None) -> dict[str, Any]:

--- a/packages/phlo-mcp/src/phlo_mcp/server.py
+++ b/packages/phlo-mcp/src/phlo_mcp/server.py
@@ -226,7 +226,11 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
             return "project:write"
         if tool_name == "install_plugin":
             return "admin"
-        if tool_name.startswith("get_") or tool_name.startswith("search_"):
+        if (
+            tool_name.startswith("get_")
+            or tool_name.startswith("search_")
+            or tool_name == "list_operations"
+        ):
             return "lakehouse:read"
         return None
 
@@ -340,6 +344,40 @@ def create_server(config: McpConfig | None = None) -> FastMCP:
                 with tracer.start_as_current_span("phlo.observability.dashboards"):
                     dashboards = client.get_dashboard_links()
                     return {"api_base_url": client.api_base_url, "dashboards": dashboards}
+
+    @mcp.tool()
+    def list_operations(
+        status: str | None = None,
+        kind: str | None = None,
+        query: str | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        """Find recent operations before fetching stable operation context."""
+        with tracer.start_as_current_span(
+            "mcp.request",
+            attributes={"mcp.tool.name": "list_operations"},
+        ):
+            with tracer.start_as_current_span(
+                "mcp.tool.execute",
+                attributes={"mcp.tool.name": "list_operations"},
+            ):
+                with tracer.start_as_current_span("phlo.observability.operations"):
+                    payload = client.list_operations(
+                        status=status,
+                        kind=kind,
+                        query=query,
+                        limit=limit,
+                    )
+                    return {
+                        "api_base_url": client.api_base_url,
+                        "filters": {
+                            "status": status,
+                            "kind": kind,
+                            "query": query,
+                            "limit": limit,
+                        },
+                        "payload": payload,
+                    }
 
     @mcp.tool()
     def get_operation_context(operation_id: str) -> dict[str, Any]:

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -30,10 +30,12 @@ class _FakeResponse:
 
 def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     seen_urls: list[str] = []
+    seen_params: list[dict[str, object] | None] = []
     seen_headers: list[dict[str, str]] = []
 
     def fake_get(url: str, params=None, headers=None, timeout=10.0):  # noqa: ANN001
         seen_urls.append(url)
+        seen_params.append(params)
         seen_headers.append(headers or {})
         if url.endswith("/api/config"):
             return _FakeResponse({"name": "demo"})
@@ -52,6 +54,16 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
                     "materializations": [{"id": "run-123", "metadata": {"run_id": "run-123"}}],
                     "column_lineage": {"id": []},
                 }
+            )
+        if url.endswith("/api/observatory/v2/operations"):
+            assert params == {
+                "status": "failed",
+                "kind": "workflow.apply",
+                "q": "orders",
+                "limit": 2,
+            }
+            return _FakeResponse(
+                {"items": [{"id": "op-123", "kind": "workflow.apply", "status": "failed"}]}
             )
         if url.endswith("/api/observatory/v2/operations/op-123/agent-context"):
             return _FakeResponse(
@@ -159,6 +171,12 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     assert client.get_service_info("dagster")["name"] == "dagster"
     assert client.get_assets()[0]["id"] == "silver/orders"
     assert client.get_asset_details("silver/orders")["asset"]["id"] == "silver/orders"
+    assert (
+        client.list_operations(status="failed", kind="workflow.apply", query="orders", limit=2)[
+            "items"
+        ][0]["id"]
+        == "op-123"
+    )
     assert client.get_operation_context("op-123")["identifiers"]["trace_ids"] == ["trace-123"]
     assert client.get_contracts()[0]["table"] == "silver.orders"
     assert client.get_contract("silver.orders")["table"] == "silver.orders"
@@ -181,6 +199,12 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     assert client.get_logs_query_link()["url"] == "http://logs.test"
     assert client.get_metrics_query_link()["url"] == "http://metrics.test"
     assert "http://example.test/api/observability/health" in seen_urls
+    assert seen_params[seen_urls.index("http://example.test/api/observatory/v2/operations")] == {
+        "status": "failed",
+        "kind": "workflow.apply",
+        "q": "orders",
+        "limit": 2,
+    }
     assert seen_headers[0] == {}
 
 
@@ -359,6 +383,7 @@ def test_create_server_registers_expected_tools() -> None:
         "get_service_status",
         "get_recent_alerts",
         "get_dashboard_links",
+        "list_operations",
         "get_operation_context",
         "get_logs_query_link",
         "get_metrics_query_link",

--- a/packages/phlo-mcp/tests/test_phlo_mcp.py
+++ b/packages/phlo-mcp/tests/test_phlo_mcp.py
@@ -53,6 +53,14 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
                     "column_lineage": {"id": []},
                 }
             )
+        if url.endswith("/api/observatory/v2/operations/op-123/agent-context"):
+            return _FakeResponse(
+                {
+                    "schema_version": "phlo.operation_observability.v1",
+                    "operation": {"id": "op-123", "status": "failed"},
+                    "identifiers": {"operation_id": "op-123", "trace_ids": ["trace-123"]},
+                }
+            )
         if url.endswith("/api/contracts"):
             return _FakeResponse([{"table": "silver.orders"}])
         if url.endswith("/api/contracts/silver.orders"):
@@ -151,6 +159,7 @@ def test_api_client_wraps_observability_routes(monkeypatch) -> None:
     assert client.get_service_info("dagster")["name"] == "dagster"
     assert client.get_assets()[0]["id"] == "silver/orders"
     assert client.get_asset_details("silver/orders")["asset"]["id"] == "silver/orders"
+    assert client.get_operation_context("op-123")["identifiers"]["trace_ids"] == ["trace-123"]
     assert client.get_contracts()[0]["table"] == "silver.orders"
     assert client.get_contract("silver.orders")["table"] == "silver.orders"
     assert client.get_platform_health()["overall_status"] == "healthy"
@@ -198,6 +207,7 @@ def test_create_server_registers_resources() -> None:
         "phlo://docs/packages/{package_name}",
         "phlo://runtime/assets/{asset_key_path}",
         "phlo://runtime/contracts/{table_name}",
+        "phlo://runtime/operations/{operation_id}",
         "phlo://runtime/schemas/{asset_key_path}",
         "phlo://runtime/services/{service_name}",
     ]
@@ -349,6 +359,7 @@ def test_create_server_registers_expected_tools() -> None:
         "get_service_status",
         "get_recent_alerts",
         "get_dashboard_links",
+        "get_operation_context",
         "get_logs_query_link",
         "get_metrics_query_link",
         "get_materialization_history",


### PR DESCRIPTION
## Summary
- add a v1 operation observability contract to journaled Observatory v2 operations
- expose stable operation/trace/log/metric/incident context through phlo-api and phlo-mcp
- add filtered operation discovery so agents can find the right operation ID before fetching full context
- document the agent-context endpoint and MCP operation discovery flow

## Example
When an agent investigates failures in a busy project, it should first narrow the journal instead of guessing an operation id or fetching every operation:

```http
GET /api/observatory/v2/operations?status=failed&kind=workflow.apply&q=orders&limit=20
```

or, through MCP:

```json
{
  "tool": "list_operations",
  "arguments": {
    "status": "failed",
    "kind": "workflow.apply",
    "query": "orders",
    "limit": 20
  }
}
```

That returns a small candidate set containing stable operation IDs, even if the backing journal is large:

```json
{
  "items": [
    {
      "id": "op-orders-20260531-091500",
      "name": "Apply orders workflow",
      "kind": "workflow.apply",
      "status": "failed"
    }
  ]
}
```

The agent then fetches the full context for the selected candidate:

```http
GET /api/observatory/v2/operations/op-orders-20260531-091500/agent-context
```

and receives stable identifiers instead of scraping provider-specific names:

```json
{
  "schema_version": "phlo.operation_observability.v1",
  "operation": {
    "id": "op-orders-20260531-091500",
    "name": "Apply orders workflow",
    "kind": "workflow.apply",
    "status": "failed"
  },
  "identifiers": {
    "operation_id": "op-orders-20260531-091500",
    "trace_ids": ["trace-123"],
    "log_ids": ["log-456"],
    "metric_ids": ["metric-789"],
    "incident_ids": ["incident-001"]
  },
  "incident": {
    "status": "open",
    "severity": "error",
    "message": "Validation failed"
  }
}
```

The same context is available to MCP clients through `get_operation_context`, so an agent can correlate logs, metrics, traces, and incidents without knowing whether the backing system is Dagster, Observatory, or another provider.

## Tests
- uv run ruff check packages/phlo-api/src/phlo_api/observatory_api/v2.py packages/phlo-api/tests/test_observatory_v2_api.py packages/phlo-mcp/src/phlo_mcp/api_client.py packages/phlo-mcp/src/phlo_mcp/server.py packages/phlo-mcp/tests/test_phlo_mcp.py
- uv run pytest packages/phlo-api/tests/test_observatory_v2_api.py packages/phlo-mcp/tests/test_phlo_mcp.py -q
