### PR TITLE
feat: add logical relation references

### DIFF
--- a/src/phlo/__init__.py
+++ b/src/phlo/__init__.py
@@ -137,6 +137,7 @@ _FLOW_EXPORTS = {
     "publish",
     "schedule",
 }
+_REFERENCE_EXPORTS = {"LogicalRelation", "quote_identifier", "ref", "source"}
 _SUBMODULE_EXPORTS = {"helpers", "ingest", "ingestion", "metrics", "quality", "transform"}
 
 __all__ = [
@@ -147,6 +148,7 @@ __all__ = [
     *_QUALITY_EXPORTS,
     *_QUALITY_RULE_EXPORTS,
     *_FLOW_EXPORTS,
+    *_REFERENCE_EXPORTS,
 ]
 
 
@@ -239,6 +241,18 @@ def __getattr__(name: str) -> Any:
                 "observe": observe,
                 "publish": publish,
                 "schedule": schedule,
+            }
+        )
+        return globals()[name]
+    if name in _REFERENCE_EXPORTS:
+        from phlo.references import LogicalRelation, quote_identifier, ref, source
+
+        globals().update(
+            {
+                "LogicalRelation": LogicalRelation,
+                "quote_identifier": quote_identifier,
+                "ref": ref,
+                "source": source,
             }
         )
         return globals()[name]

--- a/src/phlo/references.py
+++ b/src/phlo/references.py
@@ -1,0 +1,126 @@
+"""Logical relation references for workflow authors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from phlo.capabilities.registry import CapabilityRegistry, get_capability_registry
+from phlo.capabilities.specs import AssetSpec
+
+
+def quote_identifier(identifier: str) -> str:
+    """Render one SQL identifier segment with ANSI double-quote escaping."""
+    escaped = identifier.replace('"', '""')
+    return f'"{escaped}"'
+
+
+@dataclass(frozen=True, slots=True)
+class LogicalRelation:
+    """A logical asset reference plus optional physical relation metadata."""
+
+    asset_key: str
+    catalog: str | None = None
+    schema: str | None = None
+    table: str | None = None
+    relation: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_resolved(self) -> bool:
+        """Whether this reference has physical relation metadata."""
+        return any((self.catalog, self.schema, self.table, self.relation))
+
+    def render(self) -> str:
+        """Render a SQL relation identifier using known physical metadata."""
+        if self.relation:
+            return self.relation
+        parts = [part for part in (self.catalog, self.schema, self.table) if part]
+        if not parts:
+            return self.asset_key
+        return ".".join(quote_identifier(part) for part in parts)
+
+    def __str__(self) -> str:
+        return self.render()
+
+    def __repr__(self) -> str:
+        parts = [f"asset_key={self.asset_key!r}"]
+        if self.catalog is not None:
+            parts.append(f"catalog={self.catalog!r}")
+        if self.schema is not None:
+            parts.append(f"schema={self.schema!r}")
+        if self.table is not None:
+            parts.append(f"table={self.table!r}")
+        if self.relation is not None:
+            parts.append(f"relation={self.relation!r}")
+        return f"{type(self).__name__}({', '.join(parts)})"
+
+
+def ref(
+    name: str,
+    *,
+    registry: CapabilityRegistry | None = None,
+    discover: bool = True,
+) -> LogicalRelation:
+    """Create a logical reference to a named asset."""
+    return _resolve_logical_relation(name, registry=registry, discover=discover)
+
+
+def source(
+    source_name: str,
+    table_name: str,
+    *,
+    registry: CapabilityRegistry | None = None,
+    discover: bool = True,
+) -> LogicalRelation:
+    """Create a logical reference to a dbt-style source table."""
+    return _resolve_logical_relation(
+        f"{source_name}.{table_name}", registry=registry, discover=discover
+    )
+
+
+def _resolve_logical_relation(
+    asset_key: str,
+    *,
+    registry: CapabilityRegistry | None,
+    discover: bool,
+) -> LogicalRelation:
+    capability_registry = registry or get_capability_registry()
+    if discover:
+        _discover_capabilities()
+
+    for spec in capability_registry.list("asset"):
+        if isinstance(spec, AssetSpec) and spec.key == asset_key:
+            return _relation_from_asset_spec(spec)
+    return LogicalRelation(asset_key=asset_key)
+
+
+def _relation_from_asset_spec(spec: AssetSpec) -> LogicalRelation:
+    metadata = dict(spec.metadata)
+    catalog = _first_metadata_value(metadata, "catalog", "database")
+    schema = _first_metadata_value(metadata, "schema", "namespace")
+    table = _first_metadata_value(metadata, "table", "table_name")
+    relation = _first_metadata_value(metadata, "relation", "relation_name")
+    return LogicalRelation(
+        asset_key=spec.key,
+        catalog=catalog,
+        schema=schema,
+        table=table,
+        relation=relation,
+        metadata=metadata,
+    )
+
+
+def _first_metadata_value(metadata: Mapping[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = metadata.get(key)
+        if value is not None and str(value):
+            return str(value)
+    return None
+
+
+def _discover_capabilities() -> None:
+    from phlo.capabilities.discovery import discover_capabilities
+
+    discover_capabilities()

--- a/tests/plugins/test_logical_references.py
+++ b/tests/plugins/test_logical_references.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from phlo.capabilities.registry import CapabilityRegistry
+from phlo.capabilities.specs import AssetSpec
+from phlo.references import LogicalRelation, ref, source
+
+
+def test_unresolved_logical_ref_is_stable() -> None:
+    relation = ref("fct_orders", discover=False)
+
+    assert relation.asset_key == "fct_orders"
+    assert relation.is_resolved is False
+    assert str(relation) == "fct_orders"
+    assert repr(relation) == "LogicalRelation(asset_key='fct_orders')"
+
+
+def test_ref_resolves_dbt_model_metadata_from_registry() -> None:
+    registry = CapabilityRegistry()
+    registry.register(
+        "asset",
+        AssetSpec(
+            key="fct_orders",
+            group="gold",
+            description=None,
+            kinds={"dbt", "table"},
+            metadata={
+                "catalog": "iceberg",
+                "schema": "analytics",
+                "table": "fct_orders_v2",
+                "relation": '"iceberg"."analytics"."fct_orders_v2"',
+            },
+        ),
+    )
+
+    relation = ref("fct_orders", registry=registry, discover=False)
+
+    assert relation == LogicalRelation(
+        asset_key="fct_orders",
+        catalog="iceberg",
+        schema="analytics",
+        table="fct_orders_v2",
+        relation='"iceberg"."analytics"."fct_orders_v2"',
+        metadata={
+            "catalog": "iceberg",
+            "schema": "analytics",
+            "table": "fct_orders_v2",
+            "relation": '"iceberg"."analytics"."fct_orders_v2"',
+        },
+    )
+    assert relation.is_resolved is True
+    assert str(relation) == '"iceberg"."analytics"."fct_orders_v2"'
+
+
+def test_source_uses_dbt_source_asset_key_mapping() -> None:
+    registry = CapabilityRegistry()
+    registry.register(
+        "asset",
+        AssetSpec(
+            key="raw.orders",
+            group="raw",
+            description=None,
+            kinds={"dbt", "table"},
+            metadata={"database": "iceberg", "namespace": "raw", "table_name": "orders"},
+        ),
+    )
+
+    relation = source("raw", "orders", registry=registry, discover=False)
+
+    assert relation.asset_key == "raw.orders"
+    assert relation.catalog == "iceberg"
+    assert relation.schema == "raw"
+    assert relation.table == "orders"
+    assert relation.render() == '"iceberg"."raw"."orders"'
+
+
+def test_render_quotes_catalog_schema_table_identifiers() -> None:
+    relation = LogicalRelation(
+        asset_key="orders",
+        catalog="iceberg",
+        schema="sales data",
+        table='orders"2026',
+    )
+
+    assert relation.render() == '"iceberg"."sales data"."orders""2026"'
+
+
+def test_top_level_ref_and_source_are_lazy_exports() -> None:
+    import phlo
+
+    assert "ref" in phlo.__all__
+    assert "source" in phlo.__all__
+    assert phlo.ref("orders", discover=False) == ref("orders", discover=False)
+    assert phlo.source("raw", "orders", discover=False) == source("raw", "orders", discover=False)


### PR DESCRIPTION
## Summary
- add public `phlo.ref()` and `phlo.source()` helpers backed by a structured `LogicalRelation` model
- resolve logical refs from registered/discovered `AssetSpec` metadata, including dbt `catalog`/`database`, `schema`/`namespace`, `table`/`table_name`, and `relation` fields
- add SQL identifier rendering primitives and stable unresolved string/repr behavior

Closes #536

## Verification
- `uv run pytest tests/plugins/test_logical_references.py`
- `uv run pytest tests/plugins/test_logical_references.py tests/plugins/test_capability_catalog.py packages/phlo-dbt/tests/test_transform.py`
- `uv run ruff check src/phlo/references.py src/phlo/__init__.py tests/plugins/test_logical_references.py`