### PR TITLE
fix: diagnose duplicate dagster assets

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/adapter.py
+++ b/packages/phlo-dagster/src/phlo_dagster/adapter.py
@@ -64,6 +64,7 @@ from phlo.capabilities.specs import (
 )
 from phlo.logging import get_logger
 from phlo.plugins.base import OrchestratorAdapterPlugin, PluginMetadata
+from phlo_dagster.framework.asset_diagnostics import raise_duplicate_asset_specs_if_present
 
 logger = get_logger(__name__)
 
@@ -311,6 +312,7 @@ class DagsterOrchestratorAdapter(OrchestratorAdapterPlugin):
             check_spec_count=len(checks_list),
             resource_spec_count=len(resources_list),
         )
+        raise_duplicate_asset_specs_if_present(assets_list)
 
         resources_map: dict[str, Any] = {}
         for resource in resources_list:

--- a/packages/phlo-dagster/src/phlo_dagster/framework/asset_diagnostics.py
+++ b/packages/phlo-dagster/src/phlo_dagster/framework/asset_diagnostics.py
@@ -1,0 +1,182 @@
+"""Diagnostics for ambiguous Dagster asset definition failures."""
+
+from __future__ import annotations
+
+import inspect
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import dagster as dg
+
+from phlo.capabilities.specs import AssetSpec
+from phlo.exceptions import PhloDiscoveryError
+
+
+_PROVIDER_METADATA_KEYS = ("provider", "phlo/provider", "provider_name", "source")
+_MODULE_METADATA_KEYS = ("module", "phlo/module", "source_module")
+_FILE_METADATA_KEYS = ("file", "phlo/file", "source_file", "path", "source_path")
+
+
+@dataclass(frozen=True)
+class AssetOrigin:
+    """Best-effort source details for one asset provider."""
+
+    provider: str | None = None
+    module: str | None = None
+    file: str | None = None
+    object_name: str | None = None
+
+    def describe(self) -> str:
+        parts: list[str] = []
+        if self.provider:
+            parts.append(f"provider={self.provider}")
+        if self.module:
+            parts.append(f"module={self.module}")
+        if self.file:
+            parts.append(f"file={self.file}")
+        if self.object_name:
+            parts.append(f"object={self.object_name}")
+        return ", ".join(parts) if parts else "origin unavailable"
+
+
+def raise_duplicate_asset_specs_if_present(asset_specs: Iterable[AssetSpec]) -> None:
+    """Raise a clear discovery error when capability specs repeat an asset key."""
+    by_key: dict[str, list[AssetSpec]] = defaultdict(list)
+    for spec in asset_specs:
+        by_key[spec.key].append(spec)
+
+    for key, duplicates in by_key.items():
+        if len(duplicates) < 2:
+            continue
+        origins = [_origin_from_asset_spec(spec).describe() for spec in duplicates]
+        raise _duplicate_asset_error(key=key, origins=origins)
+
+
+def merge_definitions_with_duplicate_diagnostics(*definitions: dg.Definitions) -> dg.Definitions:
+    """Merge Dagster definitions and replace duplicate-key errors with Phlo guidance."""
+    duplicate = _find_duplicate_definition_asset(definitions)
+    if duplicate is not None:
+        key, origins = duplicate
+        raise _duplicate_asset_error(key=key, origins=origins)
+
+    try:
+        return dg.Definitions.merge(*definitions)
+    except Exception as exc:
+        duplicate = _find_duplicate_definition_asset(definitions)
+        if duplicate is None:
+            raise
+        key, origins = duplicate
+        raise _duplicate_asset_error(key=key, origins=origins, cause=exc) from exc
+
+
+def _duplicate_asset_error(
+    *,
+    key: str,
+    origins: list[str],
+    cause: Exception | None = None,
+) -> PhloDiscoveryError:
+    origin_lines = "\n".join(f"  - {origin}" for origin in origins)
+    message = (
+        f"Duplicate Dagster asset key discovered: {key}\n\n"
+        f"Asset providers:\n{origin_lines}\n\n"
+        "Likely cause: the same asset is being supplied by auto-discovery and by "
+        "explicit Dagster Definitions or imported module-level assets."
+    )
+    return PhloDiscoveryError(
+        message=message,
+        suggestions=[
+            "Rely on Phlo auto-discovery for this asset, or keep it only in explicit Dagster Definitions.",
+            "Do not include the same asset through both imported workflow modules and Definitions.merge.",
+        ],
+        cause=cause,
+    )
+
+
+def _find_duplicate_definition_asset(
+    definitions: Iterable[dg.Definitions],
+) -> tuple[str, list[str]] | None:
+    origins_by_key: dict[str, list[str]] = defaultdict(list)
+    for definition in definitions:
+        for asset_def in list(definition.assets or []):
+            for key in _asset_definition_keys(asset_def):
+                origins_by_key[key].append(_origin_from_asset_definition(asset_def).describe())
+
+    for key, origins in origins_by_key.items():
+        if len(origins) > 1:
+            return key, origins
+    return None
+
+
+def _asset_definition_keys(asset_def: Any) -> list[str]:
+    keys = getattr(asset_def, "keys", None)
+    if keys:
+        return [_format_asset_key(key) for key in keys]
+    key = getattr(asset_def, "key", None)
+    return [_format_asset_key(key)] if key is not None else []
+
+
+def _format_asset_key(key: Any) -> str:
+    path = getattr(key, "path", None)
+    if path:
+        return ".".join(str(part) for part in path)
+    to_user_string = getattr(key, "to_user_string", None)
+    if callable(to_user_string):
+        return str(to_user_string())
+    return str(key)
+
+
+def _origin_from_asset_spec(spec: AssetSpec) -> AssetOrigin:
+    metadata = dict(spec.metadata or {})
+    run_fn = spec.run.fn if spec.run else None
+    inspected = _origin_from_object(run_fn)
+    return AssetOrigin(
+        provider=_first_metadata_value(metadata, _PROVIDER_METADATA_KEYS),
+        module=_first_metadata_value(metadata, _MODULE_METADATA_KEYS) or inspected.module,
+        file=_first_metadata_value(metadata, _FILE_METADATA_KEYS) or inspected.file,
+        object_name=inspected.object_name,
+    )
+
+
+def _origin_from_asset_definition(asset_def: Any) -> AssetOrigin:
+    node_def = getattr(asset_def, "node_def", None)
+    compute_fn = getattr(node_def, "compute_fn", None)
+    decorated_fn = getattr(compute_fn, "decorated_fn", None)
+    return _origin_from_object(decorated_fn or compute_fn or asset_def)
+
+
+def _origin_from_object(value: Any) -> AssetOrigin:
+    if value is None:
+        return AssetOrigin()
+    module = getattr(value, "__module__", None)
+    object_name = getattr(value, "__qualname__", None) or getattr(value, "__name__", None)
+    if object_name:
+        object_name = str(object_name).split(".")[-1]
+    try:
+        file = inspect.getsourcefile(value) or inspect.getfile(value)
+    except (TypeError, OSError):
+        file = None
+    return AssetOrigin(
+        module=str(module) if module else None,
+        file=_relative_file(file),
+        object_name=object_name,
+    )
+
+
+def _first_metadata_value(metadata: dict[str, Any], keys: tuple[str, ...]) -> str | None:
+    for key in keys:
+        value = metadata.get(key)
+        if value is not None:
+            return str(value)
+    return None
+
+
+def _relative_file(file: str | None) -> str | None:
+    if not file:
+        return None
+    path = Path(file)
+    try:
+        return str(path.resolve().relative_to(Path.cwd().resolve()))
+    except ValueError:
+        return str(path)

--- a/packages/phlo-dagster/src/phlo_dagster/framework/definitions.py
+++ b/packages/phlo-dagster/src/phlo_dagster/framework/definitions.py
@@ -70,6 +70,7 @@ from phlo_dagster.framework.discovery import (
     _ensure_core_resources,
     discover_user_workflows,
 )
+from phlo_dagster.framework.asset_diagnostics import merge_definitions_with_duplicate_diagnostics
 from phlo_dagster.framework.schema_contracts import maybe_refresh_contracts
 from phlo_dagster.settings import get_settings
 from phlo.logging import get_logger, setup_logging
@@ -265,7 +266,7 @@ def build_definitions(
     if wap_defs is not None:
         definitions_to_merge.append(wap_defs)
 
-    merged = dg.Definitions.merge(*definitions_to_merge)
+    merged = merge_definitions_with_duplicate_diagnostics(*definitions_to_merge)
     merged = _ensure_core_resources(merged)
 
     executor = _default_executor()

--- a/packages/phlo-dagster/src/phlo_dagster/framework/discovery.py
+++ b/packages/phlo-dagster/src/phlo_dagster/framework/discovery.py
@@ -61,6 +61,7 @@ from phlo.capabilities.registry import clear_all_capabilities, get_capability_re
 from phlo.exceptions import PhloConfigError
 from phlo.logging import get_logger
 from phlo.orchestrators import get_active_orchestrator
+from phlo_dagster.framework.asset_diagnostics import merge_definitions_with_duplicate_diagnostics
 
 logger = get_logger(__name__)
 
@@ -241,7 +242,11 @@ def _collect_dagster_extension_definitions() -> Any:
                 exc_info=True,
             )
 
-    return dg.Definitions.merge(*definitions) if definitions else dg.Definitions()
+    return (
+        merge_definitions_with_duplicate_diagnostics(*definitions)
+        if definitions
+        else dg.Definitions()
+    )
 
 
 def _collect_module_dagster_definitions(imported_modules: list[Any]) -> Any | None:
@@ -319,7 +324,7 @@ def _merge_dagster_definitions(*, capability_defs: Any, module_defs: Any | None)
         return capability_defs
     if not isinstance(module_defs, dg.Definitions):
         return capability_defs
-    return dg.Definitions.merge(capability_defs, module_defs)
+    return merge_definitions_with_duplicate_diagnostics(capability_defs, module_defs)
 
 
 def _ensure_core_resources(definitions: Any) -> Any:

--- a/packages/phlo-dagster/tests/test_asset_diagnostics.py
+++ b/packages/phlo-dagster/tests/test_asset_diagnostics.py
@@ -1,0 +1,84 @@
+"""Tests for duplicate Dagster asset diagnostics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import dagster as dg
+import pytest
+
+from phlo.capabilities import AssetSpec, MaterializeResult, RunSpec
+from phlo.exceptions import PhloDiscoveryError
+from phlo_dagster.adapter import DagsterOrchestratorAdapter
+from phlo_dagster.framework.asset_diagnostics import merge_definitions_with_duplicate_diagnostics
+
+
+def _run(_context: Any) -> list[MaterializeResult]:
+    return [MaterializeResult(metadata={}, status="success")]
+
+
+def test_duplicate_asset_specs_include_key_and_metadata_origins() -> None:
+    adapter = DagsterOrchestratorAdapter()
+    assets = [
+        AssetSpec(
+            key="warehouse.orders",
+            group=None,
+            description=None,
+            metadata={
+                "provider": "dbt",
+                "module": "workflows.transforms.orders",
+                "file": "workflows/transforms/orders.py",
+            },
+            run=RunSpec(fn=_run),
+        ),
+        AssetSpec(
+            key="warehouse.orders",
+            group=None,
+            description=None,
+            metadata={
+                "provider": "sling",
+                "module": "workflows.ingestion.orders",
+                "file": "workflows/ingestion/orders.py",
+            },
+            run=RunSpec(fn=_run),
+        ),
+    ]
+
+    with pytest.raises(PhloDiscoveryError) as exc_info:
+        adapter.build_definitions(assets=assets, checks=[], resources=[])
+
+    message = str(exc_info.value)
+    assert "Duplicate Dagster asset key discovered: warehouse.orders" in message
+    assert "provider=dbt" in message
+    assert "module=workflows.transforms.orders" in message
+    assert "file=workflows/transforms/orders.py" in message
+    assert "provider=sling" in message
+    assert "module=workflows.ingestion.orders" in message
+    assert "file=workflows/ingestion/orders.py" in message
+    assert "auto-discovery" in message
+    assert "explicit Dagster Definitions" in message
+    assert "Rely on Phlo auto-discovery" in message
+
+
+def test_duplicate_definition_assets_include_object_origins() -> None:
+    @dg.asset(key=["warehouse", "orders"])
+    def auto_discovered_orders() -> int:
+        return 1
+
+    @dg.asset(key=["warehouse", "orders"])
+    def explicit_orders() -> int:
+        return 1
+
+    with pytest.raises(PhloDiscoveryError) as exc_info:
+        merge_definitions_with_duplicate_diagnostics(
+            dg.Definitions(assets=[auto_discovered_orders]),
+            dg.Definitions(assets=[explicit_orders]),
+        )
+
+    message = str(exc_info.value)
+    assert "Duplicate Dagster asset key discovered: warehouse.orders" in message
+    assert "object=auto_discovered_orders" in message
+    assert "object=explicit_orders" in message
+    assert "test_asset_diagnostics.py" in message
+    assert "auto-discovery" in message
+    assert "explicit Dagster Definitions" in message

--- a/src/phlo/exceptions.py
+++ b/src/phlo/exceptions.py
@@ -154,17 +154,24 @@ class PhloError(Exception):
 class PhloDiscoveryError(PhloError):
     """Raised when assets cannot be discovered by Dagster."""
 
-    def __init__(self, message: str, suggestions: list[str] | None = None):
+    def __init__(
+        self,
+        message: str,
+        suggestions: list[str] | None = None,
+        cause: Exception | None = None,
+    ):
         """Initialize a discovery error.
 
         Args:
             message: Description of the discovery failure.
             suggestions: Optional remediation suggestions.
+            cause: Optional underlying exception.
         """
         super().__init__(
             message=message,
             code=PhloErrorCode.ASSET_NOT_DISCOVERED,
             suggestions=suggestions,
+            cause=cause,
         )
 
 


### PR DESCRIPTION
## Summary
- add duplicate asset diagnostics for repeated Phlo AssetSpec keys before Dagster asset construction
- wrap Dagster Definitions merges to report duplicate keys with best-effort provider/module/file/object origins
- include guidance for mixed auto-discovery and explicit Definitions/imported assets

Closes #540

## Verification
- uv run pytest packages/phlo-dagster/tests/test_asset_diagnostics.py
- uv run ruff check src/phlo/exceptions.py packages/phlo-dagster/src/phlo_dagster/adapter.py packages/phlo-dagster/src/phlo_dagster/framework/asset_diagnostics.py packages/phlo-dagster/src/phlo_dagster/framework/discovery.py packages/phlo-dagster/src/phlo_dagster/framework/definitions.py packages/phlo-dagster/tests/test_asset_diagnostics.py
- uv run pytest -m integration tests/runtime/test_definitions.py tests/runtime/test_framework_integration.py::test_discover_workflows_collects_plain_dagster_assets
