### PR TITLE
feat: bridge dbt lineage into Python assets

### DIFF
--- a/src/phlo/_flow_authoring.py
+++ b/src/phlo/_flow_authoring.py
@@ -10,6 +10,9 @@ from typing import Any
 from phlo.capabilities import AssetSpec, MaterializeResult, RunSpec
 from phlo.capabilities.runtime import RuntimeContext
 from phlo.contracts import SLA, Consumer, normalize_consumers, serialize_consumers, serialize_sla
+from phlo.references import LogicalRelation
+
+AssetDependency = str | LogicalRelation
 
 
 def asset_key(prefix: str, name: str) -> str:
@@ -74,3 +77,13 @@ def _call_with_optional_context(fn: Callable[..., Any], context: RuntimeContext)
 def append_asset(registry: list[AssetSpec], asset: AssetSpec) -> None:
     """Register an asset in a module-local registry."""
     registry.append(asset)
+
+
+def normalize_asset_deps(deps: Iterable[AssetDependency] | None) -> list[str]:
+    """Normalize authored dependency references into stable asset keys."""
+    if deps is None:
+        return []
+    return [
+        dependency.asset_key if isinstance(dependency, LogicalRelation) else dependency
+        for dependency in deps
+    ]

--- a/src/phlo/flow.py
+++ b/src/phlo/flow.py
@@ -6,7 +6,14 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from phlo._flow_authoring import append_asset, asset_key, build_run, contract_metadata
+from phlo._flow_authoring import (
+    AssetDependency,
+    append_asset,
+    asset_key,
+    build_run,
+    contract_metadata,
+    normalize_asset_deps,
+)
 from phlo.capabilities import AssetCheckSpec, AssetSpec
 from phlo.contracts import SLA, Consumer, normalize_consumers, serialize_consumers, serialize_sla
 
@@ -66,7 +73,7 @@ def publish(
     audience: list[str] | None = None,
     owner: str | None = None,
     freshness_hours: int | None = None,
-    depends_on: list[str] | None = None,
+    depends_on: list[AssetDependency] | None = None,
     group: str = "publish",
     consumers: list[Consumer | str] | None = None,
     sla: SLA | None = None,
@@ -89,7 +96,7 @@ def publish(
                     "freshness_hours": freshness_hours,
                     **contract_metadata(owner=owner, consumers=consumers, sla=sla),
                 },
-                deps=list(depends_on or []),
+                deps=normalize_asset_deps(depends_on),
                 run=build_run(fn),
             ),
         )
@@ -103,7 +110,7 @@ def observe(
     table: str,
     freshness_hours: int | None = None,
     row_count_change: dict[str, float] | None = None,
-    depends_on: list[str] | None = None,
+    depends_on: list[AssetDependency] | None = None,
     group: str = "observe",
     description: str | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
@@ -150,7 +157,7 @@ def observe(
                     "freshness_hours": freshness_hours,
                     "row_count_change": dict(row_count_change or {}),
                 },
-                deps=list(depends_on or []),
+                deps=normalize_asset_deps(depends_on),
                 run=build_run(fn),
                 checks=checks,
             ),
@@ -165,7 +172,7 @@ def backfill(
     target: str,
     partitions: dict[str, Any],
     mode: str = "replace-partitions",
-    depends_on: list[str] | None = None,
+    depends_on: list[AssetDependency] | None = None,
     group: str = "backfill",
     owner: str | None = None,
     description: str | None = None,
@@ -187,7 +194,7 @@ def backfill(
                     "mode": mode,
                     "owner": owner,
                 },
-                deps=list(depends_on or []),
+                deps=normalize_asset_deps(depends_on),
                 run=build_run(fn),
             ),
         )

--- a/src/phlo/transform.py
+++ b/src/phlo/transform.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import inspect
 from collections.abc import Callable
 
-from phlo._flow_authoring import append_asset, asset_key, build_run, contract_metadata
+from phlo._flow_authoring import (
+    AssetDependency,
+    append_asset,
+    asset_key,
+    build_run,
+    contract_metadata,
+    normalize_asset_deps,
+)
 from phlo.capabilities import AssetSpec
 from phlo.contracts import SLA, Consumer
 
@@ -15,7 +22,7 @@ _TRANSFORM_ASSETS: list[AssetSpec] = []
 def sql(
     *,
     table: str,
-    depends_on: list[str] | None = None,
+    depends_on: list[AssetDependency] | None = None,
     materialized: str = "table",
     group: str = "transform",
     owner: str | None = None,
@@ -46,7 +53,7 @@ def sql(
                     "materialized": materialized,
                     **contract_metadata(owner=owner, consumers=consumers, sla=sla),
                 },
-                deps=list(depends_on or []),
+                deps=normalize_asset_deps(depends_on),
                 run=build_run(fn),
             ),
         )

--- a/tests/plugins/test_flow_authoring_decorators.py
+++ b/tests/plugins/test_flow_authoring_decorators.py
@@ -58,6 +58,68 @@ def test_transform_sql_registers_provider_neutral_asset() -> None:
     }
 
 
+def test_transform_sql_accepts_ref_dependencies() -> None:
+    """SQL transform deps should use logical relation asset keys."""
+    import phlo
+
+    transform = importlib.import_module("phlo.transform")
+    transform.clear_transform_assets()
+
+    @phlo.transform.sql(
+        table="gold.orders",
+        depends_on=[phlo.ref("fct_orders", discover=False)],
+    )
+    def orders_sql() -> str:
+        return "select * from {{ ref('fct_orders') }}"
+
+    assets = transform.get_transform_assets()
+
+    assert orders_sql() == "select * from {{ ref('fct_orders') }}"
+    assert assets[0].deps == ["fct_orders"]
+
+
+def test_publish_accepts_source_dependencies() -> None:
+    """Publish deps should use dbt-style source relation asset keys."""
+    import phlo
+
+    phlo.clear_publish_assets()
+
+    @phlo.publish(
+        table="gold.orders",
+        depends_on=[phlo.source("raw", "orders", discover=False)],
+    )
+    def orders_publish() -> str:
+        return "gold.orders"
+
+    assets = phlo.get_publish_assets()
+
+    assert orders_publish() == "gold.orders"
+    assert assets[0].deps == ["raw.orders"]
+
+
+def test_observe_preserves_mixed_string_and_relation_dependencies() -> None:
+    """Existing string dependencies should compose with logical references."""
+    import phlo
+
+    phlo.clear_observe_assets()
+
+    @phlo.observe(
+        table="gold.orders",
+        depends_on=[
+            "legacy.asset",
+            phlo.ref("fct_orders", discover=False),
+            phlo.source("raw", "orders", discover=False),
+        ],
+    )
+    def orders_observe() -> None:
+        return None
+
+    assets = phlo.get_observe_assets()
+
+    assert orders_observe() is None
+    assert assets[0].deps == ["legacy.asset", "fct_orders", "raw.orders"]
+
+
 def test_transform_sql_defers_context_aware_sql_rendering() -> None:
     """Context-aware SQL transforms should not execute during decoration."""
     import phlo


### PR DESCRIPTION
## Summary
- normalize decorator `depends_on` entries from `phlo.ref()` and `phlo.source()` into `AssetSpec.deps` asset keys
- keep existing string dependencies compatible across transform, publish, observe, and backfill authoring decorators
- add regression coverage for dbt refs, dbt-style sources, and mixed string/logical dependencies

## Validation
- `uv run pytest tests/plugins/test_flow_authoring_decorators.py tests/plugins/test_logical_references.py`
- `uv run pytest packages/phlo-dagster/tests/test_integration_dagster.py -m integration`
- `uv run pytest tests/test_dependency_boundaries.py tests/plugins/test_flow_authoring_decorators.py tests/plugins/test_logical_references.py packages/phlo-dagster/tests/test_integration_dagster.py -m 'not integration'`\n- `uv run ruff check src/phlo/_flow_authoring.py src/phlo/flow.py src/phlo/transform.py tests/plugins/test_flow_authoring_decorators.py`\n- `uv run ruff format --check src/phlo/_flow_authoring.py src/phlo/flow.py src/phlo/transform.py tests/plugins/test_flow_authoring_decorators.py`\n- `git diff --check`\n\nCloses #542