### PR TITLE
feat: add Trino DataFrame read helpers

### DIFF
--- a/packages/phlo-trino/pyproject.toml
+++ b/packages/phlo-trino/pyproject.toml
@@ -8,6 +8,7 @@ requires = [
 [project]
 dependencies = [
     "phlo>=0.1.0",
+    "pandas>=2.0.0",
     "psycopg2-binary>=2.9.11",
     "trino>=0.336.0",
     "pyyaml>=6.0.1",

--- a/packages/phlo-trino/src/phlo_trino/resource.py
+++ b/packages/phlo-trino/src/phlo_trino/resource.py
@@ -27,14 +27,17 @@ from __future__ import annotations
 from contextlib import contextmanager
 from dataclasses import dataclass
 import time
-from typing import Iterable
+from typing import Any, Iterable
 
+import pandas as pd
 from trino.dbapi import connect
 
 from phlo.capabilities import CapabilitySupport, RuntimeContext, resolve_runtime_ref
 from phlo.logging import get_logger
+from phlo.references import LogicalRelation, quote_identifier
 from phlo_trino._errors import iter_exception_chain
 from phlo_trino.settings import get_settings as get_trino_settings
+from phlo_trino.type_mapping import apply_schema_types
 
 logger = get_logger(__name__)
 
@@ -168,12 +171,14 @@ class TrinoResource:
 
         """
         conn = self.get_connection(schema=schema)
-        cursor = conn.cursor()
+        cursor = None
         try:
+            cursor = conn.cursor()
             yield cursor
         finally:
             try:
-                cursor.close()
+                if cursor is not None:
+                    cursor.close()
             finally:
                 conn.close()
 
@@ -195,6 +200,93 @@ class TrinoResource:
             if cursor.description is None:
                 return []
             return cursor.fetchall()
+
+    def read_dataframe(
+        self,
+        query: str | LogicalRelation,
+        params: Iterable[object] | None = None,
+        *,
+        schema: str | None = None,
+        schema_class: type[Any] | None = None,
+    ) -> pd.DataFrame:
+        """Execute a read query and return results as a pandas DataFrame.
+
+        Args:
+            query: SQL string or logical relation to read with ``SELECT *``.
+            params: Optional positional query parameters.
+            schema: Optional schema name for the connection.
+            schema_class: Optional Pandera-style schema class used for lightweight
+                DataFrame type coercion.
+
+        Returns:
+            Query results as a pandas DataFrame.
+
+        Raises:
+            RuntimeError: If Trino query execution fails, with SQL/relation context.
+
+        """
+        sql = self._read_dataframe_sql(query)
+        params_list = list(params or [])
+        context = _query_context(query, sql)
+        try:
+            with self.cursor(schema=schema) as cursor:
+                cursor.execute(sql, params_list)
+                columns = _columns_from_description(cursor.description)
+                rows = [] if cursor.description is None else cursor.fetchall()
+        except Exception as exc:  # noqa: BLE001 - attach query context for workflow authors
+            raise RuntimeError(f"Trino query failed for {context}: {exc}") from exc
+
+        try:
+            frame = pd.DataFrame(rows, columns=columns)
+            if schema_class is not None:
+                frame = apply_schema_types(frame, schema_class)
+            return frame
+        except Exception as exc:  # noqa: BLE001 - attach query context for workflow authors
+            schema_context = (
+                f" with schema {schema_class.__name__}" if schema_class is not None else ""
+            )
+            raise RuntimeError(
+                f"Trino DataFrame conversion failed for {context}{schema_context}: {exc}"
+            ) from exc
+
+    def read_table(
+        self,
+        table: str | LogicalRelation,
+        *,
+        columns: Iterable[str] | None = None,
+        limit: int | None = None,
+        params: Iterable[object] | None = None,
+        schema: str | None = None,
+        schema_class: type[Any] | None = None,
+    ) -> pd.DataFrame:
+        """Read a table or logical relation into a pandas DataFrame.
+
+        Args:
+            table: Physical table identifier or logical relation.
+            columns: Optional column names to select. Defaults to all columns.
+            limit: Optional row limit.
+            params: Optional positional query parameters.
+            schema: Optional schema name for the connection.
+            schema_class: Optional Pandera-style schema class used for lightweight
+                DataFrame type coercion.
+
+        Returns:
+            Table contents as a pandas DataFrame.
+
+        """
+        selected = _render_columns(columns)
+        relation = _render_table(table)
+        sql = f"SELECT {selected} FROM {relation}"
+        if limit is not None:
+            if limit < 0:
+                raise ValueError("limit must be non-negative")
+            sql = f"{sql} LIMIT {limit}"
+        return self.read_dataframe(sql, params=params, schema=schema, schema_class=schema_class)
+
+    def _read_dataframe_sql(self, query: str | LogicalRelation) -> str:
+        if isinstance(query, LogicalRelation):
+            return f"SELECT * FROM {query.render()}"
+        return query
 
     def wait_ready(
         self,
@@ -311,3 +403,62 @@ def _is_transient_trino_error(exc: Exception) -> bool:
         if "connectionerror" in class_name or "connection" in class_name:
             return True
     return False
+
+
+def _columns_from_description(description: Any) -> list[str] | None:
+    if description is None:
+        return None
+    columns: list[str] = []
+    for column in description:
+        name = getattr(column, "name", None)
+        if name is None:
+            name = column[0]
+        columns.append(str(name))
+    return columns
+
+
+def _render_columns(columns: Iterable[str] | None) -> str:
+    if columns is None:
+        return "*"
+    rendered = list(columns)
+    if not rendered:
+        return "*"
+    return ", ".join("*" if column == "*" else quote_identifier(column) for column in rendered)
+
+
+def _render_table(table: str | LogicalRelation) -> str:
+    if isinstance(table, LogicalRelation):
+        return table.render()
+    return ".".join(quote_identifier(part) for part in table.split("."))
+
+
+def _query_context(query: str | LogicalRelation, sql: str) -> str:
+    if isinstance(query, LogicalRelation):
+        return f"relation {query!r}"
+    return f"SQL {_sanitize_sql_context(sql)!r}"
+
+
+def _sanitize_sql_context(sql: str, *, max_length: int = 300) -> str:
+    sanitized: list[str] = []
+    in_string = False
+    index = 0
+    while index < len(sql):
+        char = sql[index]
+        if in_string:
+            if char == "'":
+                if index + 1 < len(sql) and sql[index + 1] == "'":
+                    index += 2
+                    continue
+                in_string = False
+            index += 1
+            continue
+        if char == "'":
+            sanitized.append("'?'")
+            in_string = True
+        else:
+            sanitized.append(char)
+        index += 1
+    rendered = "".join(sanitized)
+    if len(rendered) > max_length:
+        return f"{rendered[: max_length - 3]}..."
+    return rendered

--- a/packages/phlo-trino/tests/test_resource_dataframe.py
+++ b/packages/phlo-trino/tests/test_resource_dataframe.py
@@ -1,0 +1,230 @@
+"""Unit tests for TrinoResource DataFrame read helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from phlo.references import LogicalRelation
+from phlo_trino import TrinoResource
+
+
+class FakeCursor:
+    def __init__(
+        self,
+        *,
+        description: list[tuple[str]] | None = None,
+        rows: list[tuple[object, ...]] | None = None,
+        error: Exception | None = None,
+        fetch_error: Exception | None = None,
+    ) -> None:
+        self.description = description
+        self.rows = rows or []
+        self.error = error
+        self.fetch_error = fetch_error
+        self.executed: tuple[str, list[object]] | None = None
+        self.closed = False
+
+    def execute(self, sql: str, params: list[object]) -> None:
+        self.executed = (sql, params)
+        if self.error is not None:
+            raise self.error
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        if self.fetch_error is not None:
+            raise self.fetch_error
+        return self.rows
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@dataclass
+class FakeConnection:
+    fake_cursor: FakeCursor
+    closed: bool = False
+    cursor_error: Exception | None = None
+
+    def cursor(self) -> FakeCursor:
+        if self.cursor_error is not None:
+            raise self.cursor_error
+        return self.fake_cursor
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_read_dataframe_returns_pandas_dataframe_and_forwards_params() -> None:
+    cursor = FakeCursor(
+        description=[("id",), ("name",)],
+        rows=[(1, "alpha"), (2, "beta")],
+    )
+    connection = FakeConnection(cursor)
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        result = resource.read_dataframe("SELECT id, name FROM raw.events WHERE id > ?", [1])
+
+    assert result.equals(pd.DataFrame({"id": [1, 2], "name": ["alpha", "beta"]}))
+    assert cursor.executed == ("SELECT id, name FROM raw.events WHERE id > ?", [1])
+    assert cursor.closed is True
+    assert connection.closed is True
+
+
+def test_read_dataframe_accepts_logical_relation() -> None:
+    cursor = FakeCursor(description=[("id",)], rows=[(1,)])
+    connection = FakeConnection(cursor)
+    relation = LogicalRelation(
+        asset_key="orders",
+        catalog="iceberg",
+        schema="gold",
+        table='order"facts',
+    )
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        result = resource.read_dataframe(relation)
+
+    assert result.to_dict(orient="records") == [{"id": 1}]
+    assert cursor.executed == (
+        'SELECT * FROM "iceberg"."gold"."order""facts"',
+        [],
+    )
+
+
+def test_read_table_renders_columns_and_limit_for_relation() -> None:
+    cursor = FakeCursor(description=[("order_id",)], rows=[(1,)])
+    connection = FakeConnection(cursor)
+    relation = LogicalRelation(asset_key="orders", schema="gold", table="orders")
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        result = resource.read_table(relation, columns=["order_id"], limit=10)
+
+    assert result.to_dict(orient="records") == [{"order_id": 1}]
+    assert cursor.executed == ('SELECT "order_id" FROM "gold"."orders" LIMIT 10', [])
+
+
+def test_read_table_quotes_string_table_identifiers() -> None:
+    cursor = FakeCursor(description=[("order id",)], rows=[(1,)])
+    connection = FakeConnection(cursor)
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        result = resource.read_table("gold.order facts", columns=["order id"])
+
+    assert result.to_dict(orient="records") == [{"order id": 1}]
+    assert cursor.executed == ('SELECT "order id" FROM "gold"."order facts"', [])
+
+
+def test_read_table_rejects_negative_limit_before_opening_connection() -> None:
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection") as get_connection:
+        with pytest.raises(ValueError, match="limit must be non-negative"):
+            resource.read_table("gold.orders", limit=-1)
+
+    get_connection.assert_not_called()
+
+
+def test_read_dataframe_returns_empty_dataframe_for_statements_without_results() -> None:
+    cursor = FakeCursor(description=None)
+    connection = FakeConnection(cursor)
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        result = resource.read_dataframe("CREATE TABLE raw.events (id INT)")
+
+    assert result.empty
+    assert list(result.columns) == []
+
+
+def test_read_dataframe_forwards_connection_schema() -> None:
+    cursor = FakeCursor(description=[("id",)], rows=[(1,)])
+    connection = FakeConnection(cursor)
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection) as get_connection:
+        resource.read_dataframe("SELECT id FROM events", schema="raw")
+
+    get_connection.assert_called_once_with(schema="raw")
+
+
+def test_read_dataframe_closes_resources_and_adds_query_context_on_error() -> None:
+    cursor = FakeCursor(error=ValueError("syntax error near FROM"))
+    connection = FakeConnection(cursor)
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        with pytest.raises(RuntimeError, match="Trino query failed") as exc_info:
+            resource.read_dataframe("SELECT * FROM")
+
+    assert "SELECT * FROM" in str(exc_info.value)
+    assert "syntax error near FROM" in str(exc_info.value)
+    assert cursor.closed is True
+    assert connection.closed is True
+
+
+def test_read_dataframe_redacts_string_literals_in_error_context() -> None:
+    cursor = FakeCursor(error=ValueError("permission denied"))
+    connection = FakeConnection(cursor)
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        with pytest.raises(RuntimeError) as exc_info:
+            resource.read_dataframe("SELECT * FROM raw.events WHERE token = 'secret-token'")
+
+    message = str(exc_info.value)
+    assert "secret-token" not in message
+    assert "token = '?'" in message
+
+
+def test_read_dataframe_closes_connection_when_cursor_creation_fails() -> None:
+    cursor = FakeCursor(description=[("id",)], rows=[(1,)])
+    connection = FakeConnection(cursor, cursor_error=RuntimeError("cursor failed"))
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        with pytest.raises(RuntimeError, match="cursor failed"):
+            resource.read_dataframe("SELECT id FROM raw.events")
+
+    assert cursor.closed is False
+    assert connection.closed is True
+
+
+def test_read_dataframe_closes_resources_and_adds_context_on_fetch_error() -> None:
+    cursor = FakeCursor(
+        description=[("id",)],
+        fetch_error=ValueError("network interrupted"),
+    )
+    connection = FakeConnection(cursor)
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        with pytest.raises(RuntimeError, match="Trino query failed") as exc_info:
+            resource.read_dataframe("SELECT id FROM raw.events")
+
+    assert "SELECT id FROM raw.events" in str(exc_info.value)
+    assert "network interrupted" in str(exc_info.value)
+    assert cursor.closed is True
+    assert connection.closed is True
+
+
+def test_read_dataframe_applies_optional_schema_types() -> None:
+    cursor = FakeCursor(description=[("id",), ("name",)], rows=[("1", 2)])
+    connection = FakeConnection(cursor)
+
+    class Schema:
+        id: int
+        name: str
+
+    resource = TrinoResource(host="test", port=8080)
+
+    with patch.object(resource, "get_connection", return_value=connection):
+        result = resource.read_dataframe("SELECT id, name FROM raw.events", schema_class=Schema)
+
+    assert result["id"].dtype.name in ("Int64", "int64")
+    assert result["name"].dtype.name == "string"

--- a/uv.lock
+++ b/uv.lock
@@ -4260,6 +4260,7 @@ name = "phlo-trino"
 version = "0.3.2"
 source = { editable = "packages/phlo-trino" }
 dependencies = [
+    { name = "pandas" },
     { name = "phlo" },
     { name = "psycopg2-binary" },
     { name = "pyyaml" },
@@ -4280,6 +4281,7 @@ postgres = [
 
 [package.metadata]
 requires-dist = [
+    { name = "pandas", specifier = ">=2.0.0" },
     { name = "phlo", editable = "." },
     { name = "phlo-observatory", marker = "extra == 'observatory'", editable = "packages/phlo-observatory" },
     { name = "phlo-postgres", marker = "extra == 'postgres'", editable = "packages/phlo-postgres" },


### PR DESCRIPTION
## Summary
- Add TrinoResource.read_dataframe(...) for SQL strings and phlo LogicalRelation inputs
- Add TrinoResource.read_table(...) convenience with quoted identifiers, optional params, limits, schema passthrough, and optional schema coercion
- Harden cursor cleanup and query/DataFrame error context for export/analysis workflows

Closes #541

## Verification
- uv run pytest packages/phlo-trino/tests/test_resource_dataframe.py -q
- uv run pytest packages/phlo-trino/tests -m 'not integration' -q
- uv run ruff check packages/phlo-trino/src/phlo_trino/resource.py packages/phlo-trino/tests/test_resource_dataframe.py

Stacked on #543 / GWP/logical-references-foundation.