### PR TITLE
feat: improve workflow author ergonomics

### DIFF
--- a/packages/phlo-dbt/src/phlo_dbt/cli_publishing.py
+++ b/packages/phlo-dbt/src/phlo_dbt/cli_publishing.py
@@ -169,6 +169,7 @@ def scaffold_publishing_config(
     group: str,
     asset_name: str,
     description: str,
+    logical_refs: bool = False,
 ) -> dict[str, Any]:
     """Merge scaffolded publishing config into an existing mapping.
 
@@ -180,6 +181,8 @@ def scaffold_publishing_config(
         group: Dagster group name for generated entry.
         asset_name: Asset name for generated entry.
         description: Human-readable entry description.
+        logical_refs: Store dbt-style logical references instead of physical
+            schema.table strings in the generated table mapping.
 
     Returns:
         Updated publishing configuration mapping.
@@ -210,7 +213,12 @@ def scaffold_publishing_config(
 
     tables: dict[str, str] = {str(k): str(v) for k, v in tables_existing.items()}
     for model_name in model_names:
-        tables.setdefault(model_name, f"{iceberg_schema}.{model_name}")
+        tables.setdefault(
+            model_name,
+            _publishing_table_reference(
+                model_name, iceberg_schema=iceberg_schema, logical_refs=logical_refs
+            ),
+        )
     entry["tables"] = tables
 
     deps_existing = entry.get("dependencies", []) or []
@@ -225,6 +233,18 @@ def scaffold_publishing_config(
     publishing[source_key] = entry
     config["publishing"] = publishing
     return config
+
+
+def _publishing_table_reference(
+    model_name: str,
+    *,
+    iceberg_schema: str,
+    logical_refs: bool,
+) -> str:
+    """Return the generated source reference used in publishing table mappings."""
+    if logical_refs:
+        return f"ref:{model_name}"
+    return f"{iceberg_schema}.{model_name}"
 
 
 @click.group()
@@ -263,7 +283,13 @@ def publishing():
     "--iceberg-schema",
     default="marts",
     show_default=True,
-    help="Iceberg schema to reference in tables mapping",
+    help="Iceberg schema to reference when writing physical table mappings",
+)
+@click.option(
+    "--logical-refs/--physical-tables",
+    default=True,
+    show_default=True,
+    help="Write dbt logical refs in table mappings instead of physical schema.table names.",
 )
 @click.option(
     "--group",
@@ -287,6 +313,7 @@ def scaffold_cmd(
     select_patterns: tuple[str, ...],
     source_key: str | None,
     iceberg_schema: str,
+    logical_refs: bool,
     group: str,
     asset_name: str | None,
     dry_run: bool,
@@ -340,6 +367,7 @@ def scaffold_cmd(
         model_names=selected_model_names,
         source_key=resolved_source_key,
         iceberg_schema=iceberg_schema,
+        logical_refs=logical_refs,
         group=group,
         asset_name=resolved_asset_name,
         description=resolved_description,

--- a/packages/phlo-dbt/src/phlo_dbt/cli_publishing.py
+++ b/packages/phlo-dbt/src/phlo_dbt/cli_publishing.py
@@ -16,7 +16,7 @@ Example:
     ...     existing_config={},
     ...     model_names=["mrt_orders", "mrt_customers"],
     ...     source_key="analytics",
-    ...     iceberg_schema="marts",
+    ...     physical_schema="marts",
     ...     group="publishing",
     ...     asset_name="publish_analytics_marts",
     ...     description="Published analytics marts"
@@ -165,7 +165,7 @@ def scaffold_publishing_config(
     existing_config: dict[str, Any],
     model_names: list[str],
     source_key: str,
-    iceberg_schema: str,
+    physical_schema: str,
     group: str,
     asset_name: str,
     description: str,
@@ -177,7 +177,7 @@ def scaffold_publishing_config(
         existing_config: Existing publishing configuration.
         model_names: dbt model names to include.
         source_key: Source key under ``publishing``.
-        iceberg_schema: Iceberg schema for table mapping values.
+        physical_schema: Physical source schema for table mapping values.
         group: Dagster group name for generated entry.
         asset_name: Asset name for generated entry.
         description: Human-readable entry description.
@@ -216,7 +216,7 @@ def scaffold_publishing_config(
         tables.setdefault(
             model_name,
             _publishing_table_reference(
-                model_name, iceberg_schema=iceberg_schema, logical_refs=logical_refs
+                model_name, physical_schema=physical_schema, logical_refs=logical_refs
             ),
         )
     entry["tables"] = tables
@@ -238,13 +238,13 @@ def scaffold_publishing_config(
 def _publishing_table_reference(
     model_name: str,
     *,
-    iceberg_schema: str,
+    physical_schema: str,
     logical_refs: bool,
 ) -> str:
     """Return the generated source reference used in publishing table mappings."""
     if logical_refs:
         return f"ref:{model_name}"
-    return f"{iceberg_schema}.{model_name}"
+    return f"{physical_schema}.{model_name}"
 
 
 @click.group()
@@ -280,10 +280,16 @@ def publishing():
     help="publishing.<source> key to write under (default: project name)",
 )
 @click.option(
-    "--iceberg-schema",
+    "--physical-schema",
+    "physical_schema",
     default="marts",
     show_default=True,
-    help="Iceberg schema to reference when writing physical table mappings",
+    help="Physical source schema to reference when writing physical table mappings",
+)
+@click.option(
+    "--iceberg-schema",
+    "physical_schema",
+    hidden=True,
 )
 @click.option(
     "--logical-refs/--physical-tables",
@@ -312,7 +318,7 @@ def scaffold_cmd(
     output: Path,
     select_patterns: tuple[str, ...],
     source_key: str | None,
-    iceberg_schema: str,
+    physical_schema: str,
     logical_refs: bool,
     group: str,
     asset_name: str | None,
@@ -366,7 +372,7 @@ def scaffold_cmd(
         existing_config=existing_config,
         model_names=selected_model_names,
         source_key=resolved_source_key,
-        iceberg_schema=iceberg_schema,
+        physical_schema=physical_schema,
         logical_refs=logical_refs,
         group=group,
         asset_name=resolved_asset_name,

--- a/packages/phlo-dbt/tests/test_publishing_scaffold.py
+++ b/packages/phlo-dbt/tests/test_publishing_scaffold.py
@@ -55,6 +55,21 @@ def test_scaffold_publishing_config_is_idempotent() -> None:
     assert entry["dependencies"] == ["mrt_existing", "mrt_new"]
 
 
+def test_scaffold_publishing_config_can_emit_logical_refs() -> None:
+    updated = scaffold_publishing_config(
+        existing_config={},
+        model_names=["mrt_orders"],
+        source_key="demo",
+        iceberg_schema="marts",
+        group="publishing",
+        asset_name="publish_demo_marts",
+        description="demo",
+        logical_refs=True,
+    )
+
+    assert updated["publishing"]["demo"]["tables"] == {"mrt_orders": "ref:mrt_orders"}
+
+
 def test_scaffold_command_writes_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Verify scaffold CLI writes filtered publishing config.
 
@@ -94,5 +109,39 @@ def test_scaffold_command_writes_file(tmp_path: Path, monkeypatch: pytest.Monkey
     contents = output_path.read_text()
     assert "publishing:" in contents
     assert "demo:" in contents
-    assert "mrt_a:" in contents
+    assert "mrt_a: ref:mrt_a" in contents
     assert "stg_b" not in contents
+
+
+def test_scaffold_command_can_write_physical_table_mappings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from click.testing import CliRunner
+
+    from phlo_dbt.cli_publishing import publishing
+
+    monkeypatch.chdir(tmp_path)
+
+    manifest_path = tmp_path / "manifest.json"
+    _write_manifest(manifest_path, ["mrt_a"])
+
+    result = CliRunner().invoke(
+        publishing,
+        [
+            "scaffold",
+            "--manifest",
+            str(manifest_path),
+            "--output",
+            "publishing.yaml",
+            "--select",
+            "mrt_*",
+            "--source",
+            "demo",
+            "--physical-tables",
+            "--iceberg-schema",
+            "gold",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "mrt_a: gold.mrt_a" in (tmp_path / "publishing.yaml").read_text()

--- a/packages/phlo-dbt/tests/test_publishing_scaffold.py
+++ b/packages/phlo-dbt/tests/test_publishing_scaffold.py
@@ -42,7 +42,7 @@ def test_scaffold_publishing_config_is_idempotent() -> None:
         existing_config=existing,
         model_names=["mrt_existing", "mrt_new"],
         source_key="demo",
-        iceberg_schema="marts",
+        physical_schema="marts",
         group="publishing",
         asset_name="publish_demo_marts",
         description="ignored",
@@ -60,7 +60,7 @@ def test_scaffold_publishing_config_can_emit_logical_refs() -> None:
         existing_config={},
         model_names=["mrt_orders"],
         source_key="demo",
-        iceberg_schema="marts",
+        physical_schema="marts",
         group="publishing",
         asset_name="publish_demo_marts",
         description="demo",
@@ -114,6 +114,40 @@ def test_scaffold_command_writes_file(tmp_path: Path, monkeypatch: pytest.Monkey
 
 
 def test_scaffold_command_can_write_physical_table_mappings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from click.testing import CliRunner
+
+    from phlo_dbt.cli_publishing import publishing
+
+    monkeypatch.chdir(tmp_path)
+
+    manifest_path = tmp_path / "manifest.json"
+    _write_manifest(manifest_path, ["mrt_a"])
+
+    result = CliRunner().invoke(
+        publishing,
+        [
+            "scaffold",
+            "--manifest",
+            str(manifest_path),
+            "--output",
+            "publishing.yaml",
+            "--select",
+            "mrt_*",
+            "--source",
+            "demo",
+            "--physical-tables",
+            "--physical-schema",
+            "gold",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "mrt_a: gold.mrt_a" in (tmp_path / "publishing.yaml").read_text()
+
+
+def test_scaffold_command_keeps_legacy_iceberg_schema_alias(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from click.testing import CliRunner

--- a/packages/phlo-dlt/src/phlo_dlt/plugin.py
+++ b/packages/phlo-dlt/src/phlo_dlt/plugin.py
@@ -304,6 +304,7 @@ class DltWorkflowAuthoringProvider:
         )
         api_base_url = values.get("api_base_url", request.get("api_base_url"))
         fields = values.get("fields", request.get("fields") or [])
+        source_kind = str(values.get("source_kind") or request.get("source_kind") or "rest-api")
 
         if not domain or not table or not unique_key:
             raise ValueError("DLT workflow creation requires domain, table, and unique_key.")
@@ -317,6 +318,7 @@ class DltWorkflowAuthoringProvider:
                 cron=cron,
                 api_base_url=str(api_base_url) if api_base_url else None,
                 fields=list(fields or []),
+                source_kind=source_kind,
             )
 
         return {

--- a/packages/phlo-dlt/src/phlo_dlt/scaffold.py
+++ b/packages/phlo-dlt/src/phlo_dlt/scaffold.py
@@ -355,6 +355,151 @@ def _minimal_test_value(type_name: str) -> str:
     return _MINIMAL_TEST_VALUES.get(type_name, '"test-001"')
 
 
+def _render_rest_api_asset_template(
+    *,
+    domain: str,
+    domain_snake: str,
+    table_name: str,
+    table_snake: str,
+    unique_key_normalized: str,
+    cron: str,
+    base_url_literal: str,
+    schema_import_path: str,
+    schema_class: str,
+) -> str:
+    """Render a REST API ingestion asset scaffold."""
+    return f'''"""
+{domain.capitalize()} {table_name} ingestion asset.
+
+Ingests {table_name} from a REST API via `dlt.sources.rest_api`.
+"""
+
+from dlt.sources.rest_api import rest_api
+from phlo_dlt import phlo_ingestion
+
+from {schema_import_path} import {schema_class}
+
+
+@phlo_ingestion(
+    table_name="{table_snake}",
+    unique_key="{unique_key_normalized}",
+    validation_schema={schema_class},
+    group="{domain_snake}",
+    cron="{cron}",
+    freshness_hours=(1, 24),
+)
+def {table_snake}(partition_date: str):
+    start_time = f"{{partition_date}}T00:00:00.000Z"
+    end_time = f"{{partition_date}}T23:59:59.999Z"
+
+    base_url = "{base_url_literal}"
+    if not base_url:
+        raise RuntimeError(
+            "Missing API base URL. Re-run scaffold with --api-base-url or set it in the asset."
+        )
+
+    return rest_api(
+        client={{
+            "base_url": base_url,
+        }},
+        resources=[
+            {{
+                "name": "{table_snake}",
+                "endpoint": {{
+                    "path": "{table_name}",
+                    "params": {{
+                        "start_date": start_time,
+                        "end_date": end_time,
+                    }},
+                }},
+            }}
+        ],
+    )
+'''
+
+
+def _render_partitioned_sql_asset_template(
+    *,
+    domain: str,
+    domain_snake: str,
+    table_name: str,
+    table_snake: str,
+    unique_key_normalized: str,
+    cron: str,
+    schema_import_path: str,
+    schema_class: str,
+) -> str:
+    """Render a partitioned SQL ingestion asset scaffold."""
+    return f'''"""
+{domain.capitalize()} {table_name} ingestion asset.
+
+Ingests {table_name} from SQL using a partition window.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from phlo_dlt import (
+    PartitionWindow,
+    PartitionedSqlConfig,
+    partitioned_sql_resource,
+    phlo_ingestion,
+)
+
+from {schema_import_path} import {schema_class}
+
+
+def connect_source():
+    raise RuntimeError("Configure the source database connection for {domain_snake}.{table_snake}.")
+
+
+@phlo_ingestion(
+    table_name="{table_snake}",
+    unique_key="{unique_key_normalized}",
+    validation_schema={schema_class},
+    group="{domain_snake}",
+    cron="{cron}",
+    freshness_hours=(1, 24),
+)
+def {table_snake}(partition_date: str):
+    partition_start = datetime.fromisoformat(partition_date).replace(tzinfo=timezone.utc)
+    partition_end = partition_start + timedelta(days=1)
+    window = PartitionWindow(start=partition_start, end=partition_end)
+
+    config = PartitionedSqlConfig(
+        sql_template_path="workflows/sql/{domain_snake}/{table_snake}.sql",
+        row_defaults={{"source_system": "{domain_snake}"}},
+        fetch_size=1000,
+    )
+
+    return partitioned_sql_resource(
+        config,
+        window=window,
+        connect=connect_source,
+        name="{table_snake}",
+        primary_key="{unique_key_normalized}",
+        merge_key="{unique_key_normalized}",
+        write_disposition="merge",
+    )
+'''
+
+
+def _render_partitioned_sql_query_template(
+    *,
+    table_name: str,
+    table_snake: str,
+    unique_key_normalized: str,
+) -> str:
+    """Render an editable SQL template for partitioned ingestion."""
+    return f"""SELECT
+    {unique_key_normalized},
+    *
+FROM source_schema.{table_snake}
+WHERE updated_at >= :partition_start
+  AND updated_at < :partition_end
+-- Source table requested as: {table_name}
+"""
+
+
 def parse_field_specs(raw_specs: list[str] | None) -> list[FieldSpec]:
     """Parse raw CLI field specifications.
 
@@ -431,6 +576,7 @@ def create_ingestion_workflow(
     cron: str = "0 */1 * * *",
     api_base_url: Optional[str] = None,
     fields: list[str] | None = None,
+    source_kind: str = "rest-api",
 ) -> List[str]:
     """Create ingestion workflow files.
 
@@ -482,6 +628,8 @@ def create_ingestion_workflow(
     """
     domain_snake = _to_snake_case(domain)
     table_snake = _to_snake_case(table_name)
+    if source_kind not in {"rest-api", "partitioned-sql"}:
+        raise ValueError("source_kind must be 'rest-api' or 'partitioned-sql'")
     schema_class = f"Raw{_to_pascal_case(table_snake)}"
     field_specs = parse_field_specs(fields)
 
@@ -489,19 +637,28 @@ def create_ingestion_workflow(
 
     schema_dir = project_root / "workflows" / "schemas"
     asset_dir = project_root / "workflows" / "ingestion" / domain_snake
+    sql_dir = project_root / "workflows" / "sql" / domain_snake
     test_dir = project_root / "tests"
     schema_import_path = f"workflows.schemas.{domain_snake}"
 
     schema_file = schema_dir / f"{domain_snake}.py"
     asset_file = asset_dir / f"{table_snake}.py"
+    sql_file = sql_dir / f"{table_snake}.sql"
     test_file = test_dir / f"test_{domain_snake}_{table_snake}.py"
 
-    existing = [str(f) for f in (asset_file, test_file) if f.exists()]
+    candidate_files = (
+        (asset_file, test_file, sql_file)
+        if source_kind == "partitioned-sql"
+        else (asset_file, test_file)
+    )
+    existing = [str(f) for f in candidate_files if f.exists()]
     if existing:
         raise FileExistsError("Files already exist:\n" + "\n".join(f"  - {f}" for f in existing))
 
     asset_dir.mkdir(parents=True, exist_ok=True)
     test_dir.mkdir(parents=True, exist_ok=True)
+    if source_kind == "partitioned-sql":
+        sql_dir.mkdir(parents=True, exist_ok=True)
 
     domain_init = asset_dir / "__init__.py"
     if not domain_init.exists():
@@ -579,55 +736,36 @@ def create_ingestion_workflow(
 
     _ensure_project_dependencies(project_root, ("phlo-dlt", "phlo-pandera"))
 
-    base_url_literal = api_base_url or ""
-    asset_content = f'''"""
-{domain.capitalize()} {table_name} ingestion asset.
-
-Ingests {table_name} from a REST API via `dlt.sources.rest_api`.
-"""
-
-from dlt.sources.rest_api import rest_api
-from phlo_dlt import phlo_ingestion
-
-from {schema_import_path} import {schema_class}
-
-
-@phlo_ingestion(
-    table_name="{table_snake}",
-    unique_key="{unique_key_normalized}",
-    validation_schema={schema_class},
-    group="{domain_snake}",
-    cron="{cron}",
-    freshness_hours=(1, 24),
-)
-def {table_snake}(partition_date: str):
-    start_time = f"{{partition_date}}T00:00:00.000Z"
-    end_time = f"{{partition_date}}T23:59:59.999Z"
-
-    base_url = "{base_url_literal}"
-    if not base_url:
-        raise RuntimeError(
-            "Missing API base URL. Re-run scaffold with --api-base-url or set it in the asset."
+    if source_kind == "partitioned-sql":
+        asset_content = _render_partitioned_sql_asset_template(
+            domain=domain,
+            domain_snake=domain_snake,
+            table_name=table_name,
+            table_snake=table_snake,
+            unique_key_normalized=unique_key_normalized,
+            cron=cron,
+            schema_import_path=schema_import_path,
+            schema_class=schema_class,
         )
-
-    return rest_api(
-        client={{
-            "base_url": base_url,
-        }},
-        resources=[
-            {{
-                "name": "{table_snake}",
-                "endpoint": {{
-                    "path": "{table_name}",
-                    "params": {{
-                        "start_date": start_time,
-                        "end_date": end_time,
-                    }},
-                }},
-            }}
-        ],
-    )
-'''
+        sql_file.write_text(
+            _render_partitioned_sql_query_template(
+                table_name=table_name,
+                table_snake=table_snake,
+                unique_key_normalized=unique_key_normalized,
+            )
+        )
+    else:
+        asset_content = _render_rest_api_asset_template(
+            domain=domain,
+            domain_snake=domain_snake,
+            table_name=table_name,
+            table_snake=table_snake,
+            unique_key_normalized=unique_key_normalized,
+            cron=cron,
+            base_url_literal=api_base_url or "",
+            schema_import_path=schema_import_path,
+            schema_class=schema_class,
+        )
 
     asset_file.write_text(asset_content)
 
@@ -668,8 +806,11 @@ def test_schema_validates_minimal_row() -> None:
 
     test_file.write_text(test_content)
 
-    return [
+    created_files = [
         str(schema_file.relative_to(project_root)),
         str(asset_file.relative_to(project_root)),
         str(test_file.relative_to(project_root)),
     ]
+    if source_kind == "partitioned-sql":
+        created_files.insert(2, str(sql_file.relative_to(project_root)))
+    return created_files

--- a/packages/phlo-dlt/src/phlo_dlt/scaffold.py
+++ b/packages/phlo-dlt/src/phlo_dlt/scaffold.py
@@ -437,6 +437,7 @@ Ingests {table_name} from SQL using a partition window.
 """
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 from phlo_dlt import (
     PartitionWindow,
@@ -466,7 +467,9 @@ def {table_snake}(partition_date: str):
     window = PartitionWindow(start=partition_start, end=partition_end)
 
     config = PartitionedSqlConfig(
-        sql_template_path="workflows/sql/{domain_snake}/{table_snake}.sql",
+        sql_template_path=str(
+            Path(__file__).resolve().parents[2] / "sql" / "{domain_snake}" / "{table_snake}.sql"
+        ),
         row_defaults={{"source_system": "{domain_snake}"}},
         fetch_size=1000,
     )
@@ -812,5 +815,5 @@ def test_schema_validates_minimal_row() -> None:
         str(test_file.relative_to(project_root)),
     ]
     if source_kind == "partitioned-sql":
-        created_files.insert(2, str(sql_file.relative_to(project_root)))
+        created_files.append(str(sql_file.relative_to(project_root)))
     return created_files

--- a/packages/phlo-trino/src/phlo_trino/publishing.py
+++ b/packages/phlo-trino/src/phlo_trino/publishing.py
@@ -63,6 +63,7 @@ from phlo.hooks import (
 )
 from phlo.config.base import BaseConfig
 from phlo.logging import get_logger
+from phlo.references import ref
 from phlo.utils import dedupe_preserve_order
 from phlo_trino._errors import iter_exception_chain
 from pydantic import Field
@@ -443,7 +444,8 @@ def _copy_table(
     batch_size: int,
 ) -> tuple[int, int]:
     """Copy a single Trino table into Postgres and return row/column counts."""
-    columns, source_table_ref = _describe_trino_table(trino, source_table)
+    resolved_source_table = _resolve_source_table_reference(source_table)
+    columns, source_table_ref = _describe_trino_table(trino, resolved_source_table)
     column_defs = [
         sql.SQL("{} {}").format(sql.Identifier(name), sql.SQL(pg_type))
         for name, pg_type, _expr in columns
@@ -486,6 +488,16 @@ def _copy_table(
     postgres.commit()
 
     return row_count, len(columns)
+
+
+def _resolve_source_table_reference(source_table: str) -> str:
+    """Resolve logical publishing table tokens into concrete Trino relations."""
+    if not source_table.startswith("ref:"):
+        return source_table
+    model_name = source_table.removeprefix("ref:").strip()
+    if not model_name:
+        raise ValueError("Publishing table reference 'ref:' must include a dbt model name.")
+    return ref(model_name).render()
 
 
 def _trino_table_ref_candidates(name: str) -> list[str]:

--- a/packages/phlo-trino/tests/test_publishing.py
+++ b/packages/phlo-trino/tests/test_publishing.py
@@ -365,6 +365,12 @@ def test_resolve_source_table_reference_preserves_physical_table() -> None:
     assert publishing._resolve_source_table_reference("marts.orders") == "marts.orders"
 
 
+@pytest.mark.parametrize("source_table", ["ref:", "ref:   "])
+def test_resolve_source_table_reference_rejects_empty_model_name(source_table: str) -> None:
+    with pytest.raises(ValueError, match="must include a dbt model name"):
+        publishing._resolve_source_table_reference(source_table)
+
+
 def test_resolve_partition_key_does_not_swallow_runtime_specific_errors() -> None:
     class _ContextWithProviderError:
         @property

--- a/packages/phlo-trino/tests/test_publishing.py
+++ b/packages/phlo-trino/tests/test_publishing.py
@@ -343,6 +343,28 @@ def test_publish_marts_emits_correlation(monkeypatch) -> None:
     assert lineage_event.correlation.partition_key is None
 
 
+def test_resolve_source_table_reference_uses_logical_ref(monkeypatch) -> None:
+    class _Relation:
+        def render(self) -> str:
+            return '"iceberg"."marts"."orders"'
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        publishing,
+        "ref",
+        lambda model_name: calls.append(model_name) or _Relation(),
+    )
+
+    assert publishing._resolve_source_table_reference("ref:mrt_orders") == (
+        '"iceberg"."marts"."orders"'
+    )
+    assert calls == ["mrt_orders"]
+
+
+def test_resolve_source_table_reference_preserves_physical_table() -> None:
+    assert publishing._resolve_source_table_reference("marts.orders") == "marts.orders"
+
+
 def test_resolve_partition_key_does_not_swallow_runtime_specific_errors() -> None:
     class _ContextWithProviderError:
         @property

--- a/src/phlo/__init__.py
+++ b/src/phlo/__init__.py
@@ -140,7 +140,7 @@ _FLOW_EXPORTS = {
 _CONFIG_EXPORTS = {"settings"}
 _REFERENCE_EXPORTS = {"LogicalRelation", "quote_identifier", "ref", "source"}
 _SUBMODULE_EXPORTS = {"helpers", "ingest", "ingestion", "metrics", "quality", "transform"}
-_HELPER_EXPORTS = {"synthetic_key"}
+_HELPER_EXPORTS = {"read_dataframe", "synthetic_key"}
 
 __all__ = [
     "__version__",
@@ -174,9 +174,9 @@ def __getattr__(name: str) -> Any:
         globals()[name] = module
         return module
     if name in _HELPER_EXPORTS:
-        from phlo.helpers import synthetic_key
+        from phlo.helpers import read_dataframe, synthetic_key
 
-        globals()["synthetic_key"] = synthetic_key
+        globals().update({"read_dataframe": read_dataframe, "synthetic_key": synthetic_key})
         return globals()[name]
     if name in _CONTRACT_EXPORTS:
         from phlo.contracts import SLA, Consumer

--- a/src/phlo/cli/commands/workflow.py
+++ b/src/phlo/cli/commands/workflow.py
@@ -73,6 +73,7 @@ def _create_workflow(
     api_base_url: str | None = None,
     fields: list[str] | None = None,
     provider: str | None = None,
+    source_kind: str | None = None,
 ) -> WorkflowCreateResult:
     """Create a workflow scaffold through the active workflow authoring provider."""
     return create_workflow_with_provider(
@@ -85,6 +86,7 @@ def _create_workflow(
         api_base_url=api_base_url or None,
         fields=fields or [],
         provider=provider,
+        source_kind=source_kind,
     )
 
 
@@ -122,6 +124,13 @@ def _create_workflow(
     help="Additional schema field (name:type, name:type?, name:type!)",
 )
 @click.option("--provider", help="Workflow authoring provider capability to use.")
+@click.option(
+    "--source-kind",
+    type=click.Choice(["rest-api", "partitioned-sql"]),
+    default="rest-api",
+    show_default=True,
+    help="Source template style for providers that support multiple ingestion patterns.",
+)
 @click.option("--json", "output_json", is_flag=True, help="Emit machine-readable JSON.")
 def create_workflow_cmd(
     workflow_type: str,
@@ -132,6 +141,7 @@ def create_workflow_cmd(
     api_base_url: str,
     fields: tuple[str, ...],
     provider: str | None,
+    source_kind: str,
     output_json: bool,
 ) -> None:
     """Create a workflow scaffold."""
@@ -156,6 +166,7 @@ def create_workflow_cmd(
                 api_base_url=api_base_url or None,
                 fields=list(fields),
                 provider=provider,
+                source_kind=source_kind,
             )
 
             if output_json:

--- a/src/phlo/helpers/__init__.py
+++ b/src/phlo/helpers/__init__.py
@@ -81,6 +81,7 @@ from phlo.helpers.ingestion import (
 from phlo.helpers.io import (
     query_exists,
     query_scalar,
+    read_dataframe,
     read_partition,
     read_table,
     safe_query,
@@ -321,6 +322,7 @@ __all__ = [
     "query_exists",
     "query_scalar",
     "quote_identifier",
+    "read_dataframe",
     "read_partition",
     "read_table",
     "records_to_dataframe",

--- a/src/phlo/helpers/io.py
+++ b/src/phlo/helpers/io.py
@@ -14,6 +14,7 @@ from phlo.helpers.sql import (
     render_partition_predicate,
     validate_read_only_sql,
 )
+from phlo.references import LogicalRelation, quote_identifier
 
 
 def resolve_query_engine(name: str | None = None, *, runtime: Any = None) -> Any:
@@ -41,6 +42,33 @@ def safe_query(
     return engine.execute(final_sql, schema=schema)
 
 
+def read_dataframe(
+    query: str | LogicalRelation,
+    *,
+    params: list[object] | tuple[object, ...] | None = None,
+    query_engine: Any = None,
+    runtime: Any = None,
+    schema: str | None = None,
+    schema_class: type[Any] | None = None,
+) -> Any:
+    """Read a query or logical relation as a DataFrame through the active query engine."""
+    engine = query_engine or resolve_query_engine(runtime=runtime)
+    if not hasattr(engine, "read_dataframe"):
+        raise PhloConfigError(
+            message=f"Query engine {type(engine).__name__} does not support DataFrame reads",
+            suggestions=[
+                "Use a query engine with read_dataframe support, such as phlo-trino.",
+                "Use phlo.helpers.safe_query for row-oriented query results.",
+            ],
+        )
+    return engine.read_dataframe(
+        query,
+        params=params,
+        schema=schema,
+        schema_class=schema_class,
+    )
+
+
 def query_scalar(sql: str, *, query_engine: Any = None, runtime: Any = None) -> Any:
     """Execute a query expected to return one scalar value."""
     result = safe_query(sql, query_engine=query_engine, runtime=runtime, limit=1)
@@ -62,7 +90,7 @@ def query_exists(sql: str, *, query_engine: Any = None, runtime: Any = None) -> 
 
 
 def read_table(
-    table_name: str,
+    table_name: str | LogicalRelation,
     *,
     columns: list[str] | None = None,
     scope: PartitionScope | None = None,
@@ -71,11 +99,21 @@ def read_table(
     runtime: Any = None,
 ) -> Any:
     """Read a table through the active query engine."""
-    selected = ", ".join(columns or ["*"])
-    sql = f"SELECT {selected} FROM {table_name}"
+    engine = query_engine
+    if scope is None:
+        engine = query_engine or resolve_query_engine(runtime=runtime)
+    if scope is None and hasattr(engine, "read_table"):
+        return engine.read_table(
+            table_name,
+            columns=columns,
+            limit=limit,
+        )
+    selected = ", ".join(quote_identifier(column) for column in columns) if columns else "*"
+    rendered_table = table_name.render() if isinstance(table_name, LogicalRelation) else table_name
+    sql = f"SELECT {selected} FROM {rendered_table}"
     if scope is not None:
         sql = apply_where(sql, render_partition_predicate(scope))
-    return safe_query(sql, query_engine=query_engine, runtime=runtime, limit=limit)
+    return safe_query(sql, query_engine=engine, runtime=runtime, limit=limit)
 
 
 def read_partition(

--- a/src/phlo/workflow_authoring.py
+++ b/src/phlo/workflow_authoring.py
@@ -40,6 +40,7 @@ def create_workflow_with_provider(
     fields: list[str] | None = None,
     provider: str | None = None,
     contribution_id: str | None = None,
+    source_kind: str | None = None,
     values: Mapping[str, Any] | None = None,
 ) -> WorkflowCreateResult:
     """Create a workflow through the resolved workflow authoring capability."""
@@ -54,6 +55,7 @@ def create_workflow_with_provider(
         "fields": list(fields or []),
         "provider": provider,
         "contribution_id": contribution_id,
+        "source_kind": source_kind,
         "values": dict(values or {}),
     }
     try:

--- a/tests/cli/test_cli_workflow.py
+++ b/tests/cli/test_cli_workflow.py
@@ -120,6 +120,7 @@ def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
         cron: str,
         api_base_url: str | None,
         fields: list[str] | None,
+        source_kind: str,
     ) -> list[str]:
         """Captures scaffold arguments and returns mocked output paths.
 
@@ -130,6 +131,7 @@ def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
             cron: Cron schedule passed from CLI option.
             api_base_url: Optional API base URL from CLI option.
             fields: Optional field spec list from CLI option.
+            source_kind: Source template style from CLI option.
 
         Returns:
             list[str]: Relative paths representing scaffolded files.
@@ -142,6 +144,7 @@ def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
                 "cron": cron,
                 "api_base_url": api_base_url,
                 "fields": fields,
+                "source_kind": source_kind,
             }
         )
         return [
@@ -188,8 +191,51 @@ def test_workflow_create_invokes_scaffold(monkeypatch) -> None:
         "cron": "0 */1 * * *",
         "api_base_url": "https://api.example.com",
         "fields": ["id:int"],
+        "source_kind": "rest-api",
     }
     assert "Materialize: phlo materialize dlt_observations" in result.output
+
+
+def test_workflow_create_passes_source_kind(monkeypatch) -> None:
+    calls: dict[str, object] = {}
+
+    def fake_create_ingestion_workflow(**kwargs) -> list[str]:
+        calls.update(kwargs)
+        return [
+            "workflows/schemas/warehouse.py",
+            "workflows/ingestion/warehouse/orders.py",
+            "workflows/sql/warehouse/orders.sql",
+            "tests/test_warehouse_orders.py",
+        ]
+
+    monkeypatch.setattr(
+        "phlo_dlt.scaffold.create_ingestion_workflow",
+        fake_create_ingestion_workflow,
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "workflow",
+            "create",
+            "--type",
+            "ingestion",
+            "--provider",
+            "dlt",
+            "--domain",
+            "warehouse",
+            "--table",
+            "orders",
+            "--unique-key",
+            "id",
+            "--source-kind",
+            "partitioned-sql",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["source_kind"] == "partitioned-sql"
+    assert "workflows/sql/warehouse/orders.sql" in result.output
 
 
 def test_workflow_create_converts_blank_api_base_url_to_none(monkeypatch) -> None:

--- a/tests/tooling/test_scaffold.py
+++ b/tests/tooling/test_scaffold.py
@@ -190,14 +190,15 @@ def test_scaffold_can_generate_partitioned_sql_source(
         source_kind="partitioned-sql",
     )
 
-    assert "workflows/sql/warehouse/orders.sql" in created
+    assert created[2] == "tests/test_warehouse_orders.py"
+    assert created[-1] == "workflows/sql/warehouse/orders.sql"
     asset_text = (tmp_path / "workflows" / "ingestion" / "warehouse" / "orders.py").read_text()
     sql_text = (tmp_path / "workflows" / "sql" / "warehouse" / "orders.sql").read_text()
 
     compile(asset_text, "orders.py", "exec")
     assert "partitioned_sql_resource(" in asset_text
     assert "PartitionedSqlConfig(" in asset_text
-    assert 'sql_template_path="workflows/sql/warehouse/orders.sql"' in asset_text
+    assert 'Path(__file__).resolve().parents[2] / "sql" / "warehouse" / "orders.sql"' in asset_text
     assert "WHERE updated_at >= :partition_start" in sql_text
     assert "AND updated_at < :partition_end" in sql_text
 

--- a/tests/tooling/test_scaffold.py
+++ b/tests/tooling/test_scaffold.py
@@ -174,6 +174,34 @@ def test_scaffold_generates_no_todos_and_is_syntax_valid(
     assert "resources=[" in asset_contents
 
 
+def test_scaffold_can_generate_partitioned_sql_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Generates the asset and editable SQL template for partitioned SQL ingestion."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "workflows" / "schemas").mkdir(parents=True)
+    (tmp_path / "workflows" / "ingestion").mkdir(parents=True)
+
+    created = create_ingestion_workflow(
+        domain="warehouse",
+        table_name="orders",
+        unique_key="order_id",
+        fields=["order_id:int", "updated_at:datetime"],
+        source_kind="partitioned-sql",
+    )
+
+    assert "workflows/sql/warehouse/orders.sql" in created
+    asset_text = (tmp_path / "workflows" / "ingestion" / "warehouse" / "orders.py").read_text()
+    sql_text = (tmp_path / "workflows" / "sql" / "warehouse" / "orders.sql").read_text()
+
+    compile(asset_text, "orders.py", "exec")
+    assert "partitioned_sql_resource(" in asset_text
+    assert "PartitionedSqlConfig(" in asset_text
+    assert 'sql_template_path="workflows/sql/warehouse/orders.sql"' in asset_text
+    assert "WHERE updated_at >= :partition_start" in sql_text
+    assert "AND updated_at < :partition_end" in sql_text
+
+
 def test_scaffold_uses_unique_key_field_type_when_declared(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/helpers/test_helpers_core.py
+++ b/tests/unit/helpers/test_helpers_core.py
@@ -30,6 +30,7 @@ from phlo.helpers import (
     partition_scope,
     partition_where_clause,
     previous_partition,
+    read_dataframe,
     reconcile_counts,
     redacted_url,
     render_partition_predicate,
@@ -85,6 +86,44 @@ def test_sql_helpers_validate_read_only_queries() -> None:
 
     with pytest.raises(PhloConfigError):
         validate_read_only_sql("DROP TABLE raw.events")
+
+
+def test_read_dataframe_delegates_to_query_engine() -> None:
+    class FakeQueryEngine:
+        def read_dataframe(self, query, *, params=None, schema=None, schema_class=None):
+            return {
+                "query": query,
+                "params": params,
+                "schema": schema,
+                "schema_class": schema_class,
+            }
+
+    class Schema:
+        pass
+
+    result = read_dataframe(
+        "SELECT * FROM raw.events WHERE id > ?",
+        params=[10],
+        query_engine=FakeQueryEngine(),
+        schema="raw",
+        schema_class=Schema,
+    )
+
+    assert result == {
+        "query": "SELECT * FROM raw.events WHERE id > ?",
+        "params": [10],
+        "schema": "raw",
+        "schema_class": Schema,
+    }
+
+
+def test_read_dataframe_reports_query_engines_without_dataframe_support() -> None:
+    class RowOnlyQueryEngine:
+        def execute(self, sql):
+            return []
+
+    with pytest.raises(PhloConfigError, match="does not support DataFrame reads"):
+        read_dataframe("SELECT 1", query_engine=RowOnlyQueryEngine())
 
 
 def test_synthetic_key_renders_oracle_sha256_expression() -> None:

--- a/tests/unit/helpers/test_helpers_core.py
+++ b/tests/unit/helpers/test_helpers_core.py
@@ -126,6 +126,10 @@ def test_read_dataframe_reports_query_engines_without_dataframe_support() -> Non
         read_dataframe("SELECT 1", query_engine=RowOnlyQueryEngine())
 
 
+def test_read_dataframe_is_exported_from_top_level_phlo() -> None:
+    assert phlo.read_dataframe is read_dataframe
+
+
 def test_synthetic_key_renders_oracle_sha256_expression() -> None:
     assert synthetic_key(
         dialect="oracle",


### PR DESCRIPTION
## Summary
- expose `read_dataframe` as a provider-neutral helper and support logical relations in table reads
- scaffold dbt publishing mappings with logical `ref:` sources by default, with Trino publishing resolving them at copy time
- add a partitioned SQL source-kind workflow scaffold that creates both an asset and editable SQL template

## Verification
- `uv run pytest tests/unit/helpers/test_helpers_core.py packages/phlo-dbt/tests/test_publishing_scaffold.py packages/phlo-trino/tests/test_publishing.py tests/cli/test_cli_workflow.py tests/tooling/test_scaffold.py -q`
- `uv run ruff check packages/phlo-dbt/src/phlo_dbt/cli_publishing.py packages/phlo-dlt/src/phlo_dlt/scaffold.py packages/phlo-dlt/src/phlo_dlt/plugin.py packages/phlo-trino/src/phlo_trino/publishing.py src/phlo/__init__.py src/phlo/cli/commands/workflow.py src/phlo/helpers/__init__.py src/phlo/helpers/io.py src/phlo/workflow_authoring.py tests/unit/helpers/test_helpers_core.py packages/phlo-dbt/tests/test_publishing_scaffold.py packages/phlo-trino/tests/test_publishing.py tests/cli/test_cli_workflow.py tests/tooling/test_scaffold.py`
- `uv run ruff format --check packages/phlo-dbt/src/phlo_dbt/cli_publishing.py packages/phlo-dlt/src/phlo_dlt/scaffold.py packages/phlo-dlt/src/phlo_dlt/plugin.py packages/phlo-trino/src/phlo_trino/publishing.py src/phlo/__init__.py src/phlo/cli/commands/workflow.py src/phlo/helpers/__init__.py src/phlo/helpers/io.py src/phlo/workflow_authoring.py tests/unit/helpers/test_helpers_core.py packages/phlo-dbt/tests/test_publishing_scaffold.py packages/phlo-trino/tests/test_publishing.py tests/cli/test_cli_workflow.py tests/tooling/test_scaffold.py`