### PR TITLE
feat(cli): make logs command package-selectable

### DIFF
--- a/src/phlo/cli/commands/services/logs.py
+++ b/src/phlo/cli/commands/services/logs.py
@@ -2,7 +2,7 @@
 
 import click
 
-from phlo.cli.commands.services.common import run_compose
+from phlo.cli.commands.services.common import parse_service_args, run_compose
 from phlo.cli.commands.services.utils import ensure_phlo_dir, require_container_backend
 from phlo.cli.infrastructure.compose import compose_base_cmd
 from phlo.cli.infrastructure.utils import get_project_name
@@ -12,9 +12,30 @@ logger = get_logger(__name__)
 
 
 @click.command("logs", help="View logs from Phlo infrastructure services.")
-@click.argument("service", required=False)
+@click.argument("services", nargs=-1)
+@click.option(
+    "-s",
+    "--service",
+    "--package",
+    "service_options",
+    multiple=True,
+    help="Service/package to include. Repeat or use commas to select several.",
+)
 @click.option("-f", "--follow", is_flag=True, help="Follow log output")
-@click.option("-n", "--tail", default=100, help="Number of lines to show")
+@click.option(
+    "-n",
+    "--tail",
+    "--lines",
+    "tail",
+    default=100,
+    type=click.IntRange(min=0),
+    show_default=True,
+    help="Number of recent lines to show before streaming.",
+)
+@click.option("--since", help="Show logs since a timestamp or duration supported by Compose.")
+@click.option("--until", help="Show logs before a timestamp or duration supported by Compose.")
+@click.option("--timestamps", is_flag=True, help="Show log timestamps.")
+@click.option("--no-color", is_flag=True, help="Disable colored log output where supported.")
 @click.option(
     "--backend",
     "backend_name",
@@ -22,23 +43,38 @@ logger = get_logger(__name__)
     default=None,
     help="Container backend for this command.",
 )
-def logs_cmd(service: str | None, follow: bool, tail: int, backend_name: str | None):
+def logs_cmd(
+    services: tuple[str, ...],
+    service_options: tuple[str, ...],
+    follow: bool,
+    tail: int,
+    since: str | None,
+    until: str | None,
+    timestamps: bool,
+    no_color: bool,
+    backend_name: str | None,
+):
     """View logs from Phlo infrastructure services.
 
     Examples:
         phlo services logs
-        phlo services logs dagster
-        phlo services logs -f
+        phlo services logs dagster trino
+        phlo logs --service dagster --service trino --follow --lines 200
+        phlo logs --backend podman --since 10m postgres
     """
     require_container_backend(backend_name)
     phlo_dir = ensure_phlo_dir()
     project_name = get_project_name()
+    selected_services = parse_service_args((*service_options, *services))
     logger.info(
         "services_logs_requested",
         project_name=project_name,
-        service_name=service,
+        service_names=selected_services,
         follow=follow,
         tail=tail,
+        since=since,
+        until=until,
+        timestamps=timestamps,
     )
 
     cmd = compose_base_cmd(
@@ -47,12 +83,19 @@ def logs_cmd(service: str | None, follow: bool, tail: int, backend_name: str | N
         backend_name=backend_name,
     )
     cmd.extend(["logs", "--tail", str(tail)])
+    if since:
+        cmd.extend(["--since", since])
+    if until:
+        cmd.extend(["--until", until])
+    if timestamps:
+        cmd.append("--timestamps")
+    if no_color:
+        cmd.append("--no-color")
 
     if follow:
         cmd.append("-f")
 
-    if service:
-        cmd.append(service)
+    cmd.extend(selected_services)
 
     try:
         result = run_compose(cmd, check=False, capture_output=False)
@@ -60,7 +103,7 @@ def logs_cmd(service: str | None, follow: bool, tail: int, backend_name: str | N
             logger.warning(
                 "services_logs_failed",
                 project_name=project_name,
-                service_name=service,
+                service_names=selected_services,
                 returncode=result.returncode,
             )
             exc = click.ClickException(
@@ -71,11 +114,11 @@ def logs_cmd(service: str | None, follow: bool, tail: int, backend_name: str | N
         logger.info(
             "services_logs_completed",
             project_name=project_name,
-            service_name=service,
+            service_names=selected_services,
         )
     except KeyboardInterrupt:
         logger.warning(
             "services_logs_interrupted",
             project_name=project_name,
-            service_name=service,
+            service_names=selected_services,
         )

--- a/src/phlo/cli/main.py
+++ b/src/phlo/cli/main.py
@@ -58,6 +58,7 @@ if not _DOCTOR_INVOCATION:
     from phlo.cli.commands.schema_registry_cli import contracts
     from phlo.cli.commands.services import _register_commands as _register_service_commands
     from phlo.cli.commands.services import services_group
+    from phlo.cli.commands.services.logs import logs_cmd
     from phlo.cli.commands.workflow import workflow_group
     from phlo.cli.config import config
     from phlo.cli.env import env
@@ -87,6 +88,7 @@ cli.add_command(doctor_cmd)
 
 if not _DOCTOR_INVOCATION:
     cli.add_command(audit_group)
+    cli.add_command(logs_cmd)
     cli.add_command(services_group)
     cli.add_command(workflow_group)
     cli.add_command(mcp_group)

--- a/tests/cli/test_cli_services_logs.py
+++ b/tests/cli/test_cli_services_logs.py
@@ -25,8 +25,9 @@ def test_services_logs_accepts_multiple_services_and_log_options(monkeypatch) ->
     )
     monkeypatch.setattr(
         "phlo.cli.commands.services.logs.run_compose",
-        lambda cmd, check=False, capture_output=False: captured.append(cmd)
-        or CompletedProcess(cmd, 0),
+        lambda cmd, check=False, capture_output=False: (
+            captured.append(cmd) or CompletedProcess(cmd, 0)
+        ),
     )
 
     result = CliRunner().invoke(
@@ -83,8 +84,9 @@ def test_services_logs_uses_requested_podman_backend(monkeypatch) -> None:
     monkeypatch.setattr("phlo.cli.commands.services.logs.compose_base_cmd", fake_compose_base_cmd)
     monkeypatch.setattr(
         "phlo.cli.commands.services.logs.run_compose",
-        lambda cmd, check=False, capture_output=False: captured_cmd.extend(cmd)
-        or CompletedProcess(cmd, 0),
+        lambda cmd, check=False, capture_output=False: (
+            captured_cmd.extend(cmd) or CompletedProcess(cmd, 0)
+        ),
     )
 
     result = CliRunner().invoke(logs_cmd, ["--backend", "podman", "postgres"])
@@ -112,8 +114,9 @@ def test_services_logs_accepts_package_selector_alias(monkeypatch) -> None:
     )
     monkeypatch.setattr(
         "phlo.cli.commands.services.logs.run_compose",
-        lambda cmd, check=False, capture_output=False: captured.append(cmd)
-        or CompletedProcess(cmd, 0),
+        lambda cmd, check=False, capture_output=False: (
+            captured.append(cmd) or CompletedProcess(cmd, 0)
+        ),
     )
 
     result = CliRunner().invoke(logs_cmd, ["--package", "dagster,trino", "--package", "postgres"])

--- a/tests/cli/test_cli_services_logs.py
+++ b/tests/cli/test_cli_services_logs.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CompletedProcess
+
+from click.testing import CliRunner
+
+from phlo.cli.commands.services.logs import logs_cmd
+
+
+def test_services_logs_accepts_multiple_services_and_log_options(monkeypatch) -> None:
+    captured: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.require_container_backend",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.ensure_phlo_dir", lambda: Path("/tmp/.phlo")
+    )
+    monkeypatch.setattr("phlo.cli.commands.services.logs.get_project_name", lambda: "demo")
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.compose_base_cmd",
+        lambda **_kwargs: ["docker", "compose", "-p", "demo"],
+    )
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.run_compose",
+        lambda cmd, check=False, capture_output=False: captured.append(cmd)
+        or CompletedProcess(cmd, 0),
+    )
+
+    result = CliRunner().invoke(
+        logs_cmd,
+        [
+            "--follow",
+            "--lines",
+            "250",
+            "--since",
+            "10m",
+            "--timestamps",
+            "dagster",
+            "trino",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == [
+        [
+            "docker",
+            "compose",
+            "-p",
+            "demo",
+            "logs",
+            "--tail",
+            "250",
+            "--since",
+            "10m",
+            "--timestamps",
+            "-f",
+            "dagster",
+            "trino",
+        ]
+    ]
+
+
+def test_services_logs_uses_requested_podman_backend(monkeypatch) -> None:
+    captured_base_kwargs: dict[str, object] = {}
+    captured_cmd: list[str] = []
+
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.require_container_backend",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.ensure_phlo_dir", lambda: Path("/tmp/.phlo")
+    )
+    monkeypatch.setattr("phlo.cli.commands.services.logs.get_project_name", lambda: "demo")
+
+    def fake_compose_base_cmd(**kwargs):
+        captured_base_kwargs.update(kwargs)
+        return ["podman", "compose", "-p", "demo"]
+
+    monkeypatch.setattr("phlo.cli.commands.services.logs.compose_base_cmd", fake_compose_base_cmd)
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.run_compose",
+        lambda cmd, check=False, capture_output=False: captured_cmd.extend(cmd)
+        or CompletedProcess(cmd, 0),
+    )
+
+    result = CliRunner().invoke(logs_cmd, ["--backend", "podman", "postgres"])
+
+    assert result.exit_code == 0, result.output
+    assert captured_base_kwargs["backend_name"] == "podman"
+    assert captured_cmd[:5] == ["podman", "compose", "-p", "demo", "logs"]
+    assert captured_cmd[-1] == "postgres"
+
+
+def test_services_logs_accepts_package_selector_alias(monkeypatch) -> None:
+    captured: list[list[str]] = []
+
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.require_container_backend",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.ensure_phlo_dir", lambda: Path("/tmp/.phlo")
+    )
+    monkeypatch.setattr("phlo.cli.commands.services.logs.get_project_name", lambda: "demo")
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.compose_base_cmd",
+        lambda **_kwargs: ["docker", "compose", "-p", "demo"],
+    )
+    monkeypatch.setattr(
+        "phlo.cli.commands.services.logs.run_compose",
+        lambda cmd, check=False, capture_output=False: captured.append(cmd)
+        or CompletedProcess(cmd, 0),
+    )
+
+    result = CliRunner().invoke(logs_cmd, ["--package", "dagster,trino", "--package", "postgres"])
+
+    assert result.exit_code == 0, result.output
+    assert captured[0][-3:] == ["dagster", "trino", "postgres"]
+
+
+def test_top_level_logs_is_generic_services_command() -> None:
+    from phlo.cli.main import cli
+
+    assert cli.commands["logs"] is logs_cmd


### PR DESCRIPTION
## Summary
- make top-level `phlo logs` use the generic Compose-backed services logs command
- allow selecting multiple services/packages via positional args, repeated `--service`, or `--package` aliases
- add follow, tail/lines, since/until, timestamp, no-color, and Docker/Podman backend coverage

## Tests
- `uv run pytest tests/cli/test_cli_services_logs.py tests/cli/test_cli_services_help.py tests/cli/test_cli_services_exec.py tests/cli/test_cli_services_list.py tests/cli/test_cli_services_status.py -q`
- `uv run ruff check src/phlo/cli/commands/services/logs.py src/phlo/cli/main.py tests/cli/test_cli_services_logs.py`