### PR TITLE
fix(trino): include node properties in package data

### DIFF
--- a/packages/phlo-trino/pyproject.toml
+++ b/packages/phlo-trino/pyproject.toml
@@ -61,6 +61,7 @@ phlo_trino = [
     "service.yaml",
     "jvm.config",
     "config.properties",
+    "node.properties",
     "catalog/*.properties",
     "observatory_assets/*",
 ]

--- a/packages/phlo-trino/tests/test_trino_plugin.py
+++ b/packages/phlo-trino/tests/test_trino_plugin.py
@@ -1,5 +1,9 @@
 """Tests for Trino service plugin."""
 
+from pathlib import Path
+from fnmatch import fnmatch
+import tomllib
+
 from phlo_trino.plugin import TrinoServicePlugin
 
 
@@ -11,3 +15,19 @@ def test_trino_service_definition():
 
     assert service_definition["name"] == "trino"
     assert service_definition["category"] == "core"
+
+
+def test_trino_runtime_files_are_included_in_package_data():
+    """Every file copied into .phlo/trino must be present in installed wheels."""
+
+    project_root = Path(__file__).parents[1]
+    pyproject = tomllib.loads((project_root / "pyproject.toml").read_text())
+    package_data = set(pyproject["tool"]["setuptools"]["package-data"]["phlo_trino"])
+
+    service_definition = TrinoServicePlugin().service_definition
+    file_sources = {file_spec["source"] for file_spec in service_definition["files"]}
+
+    for source in file_sources:
+        if "*" in source:
+            continue
+        assert any(fnmatch(source, pattern) for pattern in package_data)


### PR DESCRIPTION
## Summary

- Include `node.properties` in the `phlo-trino` package data so installed wheels can copy it into `.phlo/trino/node.properties` during `phlo services init`.
- Add regression coverage that every static file listed by the Trino service manifest is included in package data.

## Root Cause

`packages/phlo-trino/src/phlo_trino/service.yaml` already listed `node.properties` as a file to copy into `.phlo/trino/node.properties`, but `packages/phlo-trino/pyproject.toml` omitted it from `tool.setuptools.package-data`. Installed users therefore had a service manifest that requested the file, but no packaged source file for the init copier to find.

## Validation

- `uv run pytest packages/phlo-trino/tests/test_trino_plugin.py -q`
- `uv run pytest packages/phlo-trino/tests/test_trino_plugin.py tests/cli/test_cli_services_init.py::test_compose_generator_passthrough_compose_keys tests/cli/test_cli_services_init.py::test_compose_generator_declares_named_volumes -q`
- `uv run ruff check packages/phlo-trino/tests/test_trino_plugin.py`