### PR TITLE
fix: align package-owned port defaults

### DIFF
--- a/docs/guides/compose-generation.md
+++ b/docs/guides/compose-generation.md
@@ -36,6 +36,18 @@ Variables are grouped by category (`core`, `orchestration`, `bi`, `admin`, `api`
 take precedence over package defaults. Existing `.env.local` values are preserved
 on regeneration.
 
+Port variables in `phlo.yaml` are host ports. Generated Compose mappings keep the
+container port explicit on the right-hand side, for example:
+
+```yaml
+ports:
+  - "${DAGSTER_PORT:-10006}:3000"
+```
+
+When `phlo-dagster` is selected, its package-owned default publishes
+`localhost:10006` to container port `3000`. The right-hand side remains the
+service-native container port even when the host port is different.
+
 ### generator.py — compose YAML generation
 
 `ComposeGenerator` builds `docker-compose.yml` from service definitions.
@@ -174,9 +186,10 @@ Generated files in `.phlo/`:
 
 Override precedence (highest to lowest):
 
-1. Existing `.env.local` values (secrets preserved on regeneration)
-2. `phlo.yaml` `env:` section overrides
-3. Package `service.yaml` defaults
+1. Shell environment values passed to Docker Compose or Phlo commands
+2. `.phlo/.env.local` local overrides
+3. `phlo.yaml` `env:` section overrides, materialized into `.phlo/.env`
+4. Package `service.yaml` defaults
 
 ## Native mode
 

--- a/docs/packages/phlo-dagster.md
+++ b/docs/packages/phlo-dagster.md
@@ -18,7 +18,7 @@ phlo plugin install dagster
 
 | Variable         | Default     | Description            |
 | ---------------- | ----------- | ---------------------- |
-| `DAGSTER_PORT`   | `3000`      | Dagster webserver port |
+| `DAGSTER_PORT`   | `10006`     | Dagster webserver host port in generated projects |
 | `WORKFLOWS_PATH` | `workflows` | Path to workflow files |
 | `PHLO_WAP_BRANCH_CREATION_INTERVAL_SECONDS` | `30`   | WAP branch creation sensor interval |
 | `PHLO_WAP_PROMOTION_INTERVAL_SECONDS`       | `60`   | WAP promotion sensor interval       |

--- a/docs/packages/phlo-minio.md
+++ b/docs/packages/phlo-minio.md
@@ -20,8 +20,8 @@ phlo plugin install minio
 | ----------------------- | ---------- | ------------------------ |
 | `MINIO_ROOT_USER`       | `minio`    | Root username            |
 | `MINIO_ROOT_PASSWORD`   | `minio123` | Root password            |
-| `MINIO_API_PORT`        | `10001`    | S3 API port              |
-| `MINIO_CONSOLE_PORT`    | `10002`    | Web console port         |
+| `MINIO_API_PORT`        | `10001`    | S3 API host port in generated projects |
+| `MINIO_CONSOLE_PORT`    | `10002`    | Web console host port in generated projects |
 | `MINIO_SERVER_URL`      | -          | TLS server URL           |
 | `MINIO_OIDC_CONFIG_URL` | -          | OIDC provider config URL |
 | `MINIO_AUTO_ENCRYPTION` | `off`      | Auto-encryption mode     |
@@ -106,7 +106,7 @@ MinIO metrics are automatically scraped by Prometheus:
 compose:
   labels:
     phlo.metrics.enabled: "true"
-    phlo.metrics.port: "minio:10001"
+    phlo.metrics.port: "minio:9000"
     phlo.metrics.path: "/minio/v2/metrics/cluster"
 ```
 

--- a/docs/packages/phlo-nessie.md
+++ b/docs/packages/phlo-nessie.md
@@ -21,7 +21,7 @@ pip install 'phlo-nessie[trino]'
 
 | Variable               | Default   | Description                |
 | ---------------------- | --------- | -------------------------- |
-| `NESSIE_PORT`          | `19120`   | Nessie API port            |
+| `NESSIE_PORT`          | `10003`   | Nessie API host port       |
 | `NESSIE_VERSION`       | `0.107.2` | Nessie version             |
 | `NESSIE_OIDC_ENABLED`  | `false`   | Enable OIDC authentication |
 | `NESSIE_AUTHZ_ENABLED` | `false`   | Enable authorization       |
@@ -128,22 +128,22 @@ nessie.delete_branch("feature/new-data")
 
 | Endpoint         | URL                                |
 | ---------------- | ---------------------------------- |
-| **API v1**       | `http://localhost:19120/api/v1`    |
-| **API v2**       | `http://localhost:19120/api/v2`    |
-| **Iceberg REST** | `http://localhost:19120/iceberg`   |
-| **Metrics**      | `http://localhost:19120/q/metrics` |
+| **API v1**       | `http://localhost:10003/api/v1`    |
+| **API v2**       | `http://localhost:10003/api/v2`    |
+| **Iceberg REST** | `http://localhost:10003/iceberg`   |
+| **Metrics**      | `http://localhost:10003/q/metrics` |
 
 ## API Examples
 
 ```bash
 # Get server config
-curl http://localhost:19120/api/v2/config
+curl http://localhost:10003/api/v2/config
 
 # List branches
-curl http://localhost:19120/api/v2/trees
+curl http://localhost:10003/api/v2/trees
 
 # Get branch details
-curl http://localhost:19120/api/v2/trees/main
+curl http://localhost:10003/api/v2/trees/main
 ```
 
 ## Entry Points

--- a/docs/packages/phlo-postgres.md
+++ b/docs/packages/phlo-postgres.md
@@ -21,7 +21,7 @@ phlo plugin install postgres
 
 | Variable                 | Default  | Description            |
 | ------------------------ | -------- | ---------------------- |
-| `POSTGRES_PORT`          | `5432`   | PostgreSQL port        |
+| `POSTGRES_PORT`          | `10000` | PostgreSQL host port   |
 | `POSTGRES_USER`          | `phlo`   | Database username      |
 | `POSTGRES_PASSWORD`      | `phlo`   | Database password      |
 | `POSTGRES_DB`            | `phlo`   | Database name          |
@@ -87,7 +87,7 @@ phlo postgres vacuum --analyze
 from sqlalchemy import create_engine
 
 engine = create_engine(
-    "postgresql://phlo:phlo@localhost:5432/phlo"
+    "postgresql://phlo:phlo@localhost:10000/phlo"
 )
 
 with engine.connect() as conn:
@@ -134,7 +134,7 @@ That means:
 
 | Endpoint             | URL                             |
 | -------------------- | ------------------------------- |
-| **PostgreSQL**       | `localhost:5432`                |
+| **PostgreSQL**       | `localhost:10000`               |
 | **Exporter Metrics** | `http://localhost:9187/metrics` |
 
 ## Grafana Integration

--- a/docs/packages/phlo-trino.md
+++ b/docs/packages/phlo-trino.md
@@ -18,7 +18,7 @@ phlo plugin install trino
 
 | Variable        | Default    | Description     |
 | --------------- | ---------- | --------------- |
-| `TRINO_PORT`    | `10005`    | Trino HTTP port |
+| `TRINO_PORT`    | `10005`    | Trino HTTP host port in generated projects |
 | `TRINO_VERSION` | `477`      | Trino version   |
 | `TRINO_HOST`    | `trino`    | Trino hostname  |
 | `TRINO_CATALOG` | `iceberg`  | Default catalog |
@@ -126,9 +126,9 @@ results = cursor.fetchall()
 
 | Endpoint     | URL                             |
 | ------------ | ------------------------------- |
-| **HTTP API** | `http://localhost:8080`         |
-| **Web UI**   | `http://localhost:8080/ui`      |
-| **Metrics**  | `http://localhost:8080/v1/info` |
+| **HTTP API** | `http://localhost:10005`         |
+| **Web UI**   | `http://localhost:10005/ui`      |
+| **Metrics**  | `http://localhost:10005/v1/info` |
 
 ## Grafana Integration
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -234,7 +234,7 @@ PostgreSQL database settings:
 
 ```bash
 # Host and port
-POSTGRES_HOST=postgres
+POSTGRES_HOST=localhost
 POSTGRES_PORT=10000
 
 # Credentials
@@ -246,14 +246,14 @@ POSTGRES_DB=lakehouse
 POSTGRES_MART_SCHEMA=marts
 
 # Lineage tracking database (optional, defaults to Dagster Postgres connection)
-PHLO_LINEAGE_DB_URL=postgresql://lake:phlo@postgres:10000/lakehouse
+PHLO_LINEAGE_DB_URL=postgresql://lake:phlo@localhost:10000/lakehouse
 # Alternative: DAGSTER_PG_DB_CONNECTION_STRING (alias for lineage_db_url)
 ```
 
 **Connection string format**:
 
 ```
-postgresql://lake:phlo@postgres:10000/lakehouse
+postgresql://lake:phlo@localhost:10000/lakehouse
 ```
 
 ### Storage Configuration
@@ -262,7 +262,7 @@ MinIO S3-compatible object storage:
 
 ```bash
 # Host and ports
-MINIO_HOST=minio
+MINIO_HOST=localhost
 MINIO_API_PORT=10001
 MINIO_CONSOLE_PORT=10002
 
@@ -274,7 +274,7 @@ MINIO_ROOT_PASSWORD=minioadmin
 **MinIO endpoint**:
 
 ```
-http://minio:10001
+http://localhost:10001
 ```
 
 **Console UI**: http://localhost:10002
@@ -316,15 +316,15 @@ Nessie Git-like catalog:
 # Version and connectivity
 NESSIE_VERSION=0.107.2
 NESSIE_PORT=10003
-NESSIE_HOST=nessie
+NESSIE_HOST=localhost
 NESSIE_API_VERSION=v1
 ```
 
 **API endpoints**:
 
-- v1 API: `http://nessie:10003/api/v1`
-- v2 API: `http://nessie:10003/api/v2`
-- Iceberg REST: `http://nessie:10003/iceberg`
+- v1 API: `http://localhost:10003/api/v1`
+- v2 API: `http://localhost:10003/api/v2`
+- Iceberg REST: `http://localhost:10003/iceberg`
 
 ### Query Engine Configuration
 
@@ -334,7 +334,7 @@ Trino distributed SQL engine:
 # Version and connectivity
 TRINO_VERSION=477
 TRINO_PORT=10005
-TRINO_HOST=trino
+TRINO_HOST=localhost
 
 # Catalog
 TRINO_CATALOG=iceberg
@@ -343,7 +343,7 @@ TRINO_CATALOG=iceberg
 **Connection string**:
 
 ```
-trino://trino:10005/iceberg_dev
+trino://localhost:10005/iceberg_dev
 ```
 
 ### ClickHouse Configuration
@@ -475,7 +475,7 @@ DELTA_STAGING_PATH=s3://lake/stage
 DELTA_DEFAULT_NAMESPACE=raw
 
 # S3 endpoint
-DELTA_S3_ENDPOINT=http://minio:10001
+DELTA_S3_ENDPOINT=http://localhost:10001
 
 # Allow unsafe rename for S3
 DELTA_S3_ALLOW_UNSAFE_RENAME=true
@@ -870,48 +870,28 @@ infrastructure:
   # Container naming pattern
   container_naming_pattern: "{{project}}-{{service}}-1"
 
-  # Service-specific configuration
+  # Optional runtime service-name metadata for commands that inspect containers
   services:
-    dagster_webserver:
+    dagster:
       container_name: null # Use pattern
-      service_name: dagster-webserver
+      service_name: dagster
       host: localhost
-      internal_host: dagster-webserver
-      port: 10006
+      internal_host: dagster
 
     postgres:
       container_name: null
       service_name: postgres
       host: localhost
       internal_host: postgres
-      port: 10000
-      credentials:
-        user: postgres
-        password: postgres
-        database: cascade
-
-    minio:
-      container_name: null
-      service_name: minio
-      host: localhost
-      internal_host: minio
-      api_port: 10001
-      console_port: 10002
-
-    nessie:
-      container_name: null
-      service_name: nessie
-      host: localhost
-      internal_host: nessie
-      port: 10003
-
-    trino:
-      container_name: null
-      service_name: trino
-      host: localhost
-      internal_host: trino
-      port: 10005
 ```
+
+Service enablement, Compose port replacement, environment, volume, dependency,
+command, and healthcheck overrides live in the top-level `services:` section, not
+under `infrastructure.services`.
+
+Service packages own their default ports. When a package is selected by
+`phlo services init`, its non-secret defaults are materialized into `.phlo/.env`;
+project-specific overrides belong in top-level `env:`.
 
 ### `infrastructure.container_backend`
 

--- a/packages/phlo-api/src/phlo_api/service.yaml
+++ b/packages/phlo-api/src/phlo_api/service.yaml
@@ -69,9 +69,9 @@ dev:
     environment:
         PYTHONUNBUFFERED: "1"
         PHLO_DEV_MODE: "true"
-        DAGSTER_GRAPHQL_URL: "http://127.0.0.1:${DAGSTER_PORT:-3000}/graphql"
-        NESSIE_URL: "http://127.0.0.1:${NESSIE_PORT:-19120}/api/v2"
-        TRINO_URL: "http://127.0.0.1:${TRINO_PORT:-8080}"
+        DAGSTER_GRAPHQL_URL: "http://127.0.0.1:${DAGSTER_PORT:-10006}/graphql"
+        NESSIE_URL: "http://127.0.0.1:${NESSIE_PORT:-10003}/api/v2"
+        TRINO_URL: "http://127.0.0.1:${TRINO_PORT:-10005}"
         TRINO_USER: ${PHLO_API_TRINO_USER:-phlo-api}
         TRINO_ROLE: ${PHLO_API_TRINO_ROLE:-}
         CLICKSTACK_QUERY_URL: ${CLICKSTACK_QUERY_URL:-}

--- a/packages/phlo-dagster/README.md
+++ b/packages/phlo-dagster/README.md
@@ -18,7 +18,7 @@ phlo plugin install dagster
 
 | Variable                           | Default     | Description                 |
 | ---------------------------------- | ----------- | --------------------------- |
-| `DAGSTER_PORT`                     | `3000`      | Dagster webserver port      |
+| `DAGSTER_PORT`                     | `10006`     | Dagster webserver host port |
 | `PHLO_FORCE_IN_PROCESS_EXECUTOR`   | `false`     | Force in-process executor   |
 | `PHLO_FORCE_MULTIPROCESS_EXECUTOR` | `false`     | Force multiprocess executor |
 | `WORKFLOWS_PATH`                   | `workflows` | Path to workflow files      |
@@ -63,9 +63,9 @@ phlo services start --dev
 
 ## Endpoints
 
-- **Web UI**: `http://localhost:3000`
-- **GraphQL**: `http://localhost:3000/graphql`
-- **Metrics**: `http://localhost:3000/metrics`
+- **Web UI**: `http://localhost:10006`
+- **GraphQL**: `http://localhost:10006/graphql`
+- **Metrics**: `http://localhost:10006/metrics`
 
 ## Entry Points
 

--- a/packages/phlo-dagster/src/phlo_dagster/service.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/service.yaml
@@ -77,7 +77,7 @@ compose:
       "/opt/dagster/workspace.yaml",
     ]
   ports:
-    - "${DAGSTER_PORT:-3000}:3000"
+    - "${DAGSTER_PORT:-10006}:3000"
   volumes:
     - ./dagster:/opt/dagster
     - ../phlo.yaml:/app/phlo.yaml:ro
@@ -89,8 +89,8 @@ compose:
 
 env_vars:
   DAGSTER_PORT:
-    default: 3000
-    description: Dagster webserver port
+    default: 10006
+    description: Dagster webserver host port
   PHLO_VERSION:
     default: ""
     description: Phlo version to install (empty for latest)

--- a/packages/phlo-minio/README.md
+++ b/packages/phlo-minio/README.md
@@ -20,8 +20,8 @@ phlo plugin install minio
 | ----------------------- | ---------- | ------------------------ |
 | `MINIO_ROOT_USER`       | `minio`    | Root username            |
 | `MINIO_ROOT_PASSWORD`   | `minio123` | Root password            |
-| `MINIO_API_PORT`        | `9000`     | S3 API port              |
-| `MINIO_CONSOLE_PORT`    | `9001`     | Web console port         |
+| `MINIO_API_PORT`        | `10001`    | S3 API host port         |
+| `MINIO_CONSOLE_PORT`    | `10002`    | Web console host port    |
 | `MINIO_SERVER_URL`      | -          | TLS server URL           |
 | `MINIO_OIDC_CONFIG_URL` | -          | OIDC provider config URL |
 | `MINIO_AUTO_ENCRYPTION` | `off`      | Auto-encryption mode     |
@@ -66,8 +66,8 @@ Route audit events to a durable backend and correlate them with centralized appl
 
 ## Endpoints
 
-- **S3 API**: `http://localhost:9000`
-- **Console**: `http://localhost:9001`
+- **S3 API**: `http://localhost:10001`
+- **Console**: `http://localhost:10002`
 
 ## Entry Points
 

--- a/packages/phlo-minio/src/phlo_minio/service.yaml
+++ b/packages/phlo-minio/src/phlo_minio/service.yaml
@@ -44,8 +44,8 @@ compose:
     MINIO_AUDIT_WEBHOOK_ENDPOINT: ${MINIO_AUDIT_ENDPOINT:-}
   command: ["server", "/data", "--console-address", ":9001"]
   ports:
-    - "${MINIO_API_PORT:-9000}:9000"
-    - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    - "${MINIO_API_PORT:-10001}:9000"
+    - "${MINIO_CONSOLE_PORT:-10002}:9001"
   volumes:
     - minio-data:/data
   healthcheck:
@@ -63,11 +63,11 @@ env_vars:
     description: MinIO root password
     secret: true
   MINIO_API_PORT:
-    default: 9000
-    description: MinIO API port
+    default: 10001
+    description: MinIO API host port
   MINIO_CONSOLE_PORT:
-    default: 9001
-    description: MinIO console port
+    default: 10002
+    description: MinIO console host port
   # TLS
   MINIO_SERVER_URL:
     default: ""

--- a/packages/phlo-nessie/README.md
+++ b/packages/phlo-nessie/README.md
@@ -21,7 +21,7 @@ pip install 'phlo-nessie[trino]'
 
 | Variable               | Default   | Description                |
 | ---------------------- | --------- | -------------------------- |
-| `NESSIE_PORT`          | `19120`   | Nessie API port            |
+| `NESSIE_PORT`          | `10003`   | Nessie API host port       |
 | `NESSIE_VERSION`       | `0.107.2` | Nessie version             |
 | `NESSIE_OIDC_ENABLED`  | `false`   | Enable OIDC authentication |
 | `NESSIE_AUTHZ_ENABLED` | `false`   | Enable authorization       |
@@ -61,8 +61,8 @@ phlo nessie branch create feature/my-feature
 
 ## Endpoints
 
-- **API**: `http://localhost:19120/api/v1`
-- **Iceberg REST**: `http://localhost:19120/iceberg`
+- **API**: `http://localhost:10003/api/v1`
+- **Iceberg REST**: `http://localhost:10003/iceberg`
 
 ## Entry Points
 

--- a/packages/phlo-nessie/src/phlo_nessie/service.yaml
+++ b/packages/phlo-nessie/src/phlo_nessie/service.yaml
@@ -41,7 +41,7 @@ compose:
     # Authorization
     NESSIE_SERVER_AUTHORIZATION_ENABLED: ${NESSIE_AUTHZ_ENABLED:-false}
   ports:
-    - "${NESSIE_PORT:-19120}:19120"
+    - "${NESSIE_PORT:-10003}:19120"
   healthcheck:
     test: ["CMD", "curl", "-f", "http://localhost:19120/api/v1/config"]
     interval: 10s
@@ -54,8 +54,8 @@ env_vars:
     default: "0.107.2"
     description: Nessie version
   NESSIE_PORT:
-    default: 19120
-    description: Nessie API port
+    default: 10003
+    description: Nessie API host port
   # OIDC Authentication
   NESSIE_OIDC_ENABLED:
     default: "false"

--- a/packages/phlo-observatory/src/phlo_observatory/service.yaml
+++ b/packages/phlo-observatory/src/phlo_observatory/service.yaml
@@ -63,9 +63,9 @@ dev:
     NODE_ENV: development
     PHLO_API_URL: http://127.0.0.1:${PHLO_API_PORT:-4000}
     PHLO_API_BROWSER_URL: http://127.0.0.1:${PHLO_API_PORT:-4000}
-    DAGSTER_GRAPHQL_URL: http://127.0.0.1:${DAGSTER_PORT:-3000}/graphql
-    NESSIE_URL: http://127.0.0.1:${NESSIE_PORT:-19120}/api/v2
-    TRINO_URL: http://127.0.0.1:${TRINO_PORT:-8080}
+    DAGSTER_GRAPHQL_URL: http://127.0.0.1:${DAGSTER_PORT:-10006}/graphql
+    NESSIE_URL: http://127.0.0.1:${NESSIE_PORT:-10003}/api/v2
+    TRINO_URL: http://127.0.0.1:${TRINO_PORT:-10005}
   volumes:
     - '{source_path}:/app'
     - '/app/node_modules'

--- a/packages/phlo-postgres/README.md
+++ b/packages/phlo-postgres/README.md
@@ -18,7 +18,7 @@ phlo plugin install postgres
 
 | Variable                 | Default  | Description            |
 | ------------------------ | -------- | ---------------------- |
-| `POSTGRES_PORT`          | `5432`   | PostgreSQL port        |
+| `POSTGRES_PORT`          | `10000`  | PostgreSQL host port   |
 | `POSTGRES_USER`          | `phlo`   | Database username      |
 | `POSTGRES_PASSWORD`      | `phlo`   | Database password      |
 | `POSTGRES_DB`            | `phlo`   | Database name          |
@@ -57,7 +57,7 @@ phlo services start --service postgres,postgres-exporter
 
 ## Endpoints
 
-- **PostgreSQL**: `localhost:5432`
+- **PostgreSQL**: `localhost:10000`
 - **Exporter Metrics**: `http://localhost:9187/metrics`
 
 ## Entry Points

--- a/packages/phlo-postgres/src/phlo_postgres/service.yaml
+++ b/packages/phlo-postgres/src/phlo_postgres/service.yaml
@@ -24,7 +24,7 @@ compose:
     # SSL/TLS
     POSTGRES_SSL_MODE: ${POSTGRES_SSL_MODE:-prefer}
   ports:
-    - "${POSTGRES_PORT:-5432}:5432"
+    - "${POSTGRES_PORT:-10000}:5432"
   volumes:
     - postgres-data:/var/lib/postgresql/data
   healthcheck:
@@ -45,7 +45,7 @@ env_vars:
     default: phlo
     description: PostgreSQL database name
   POSTGRES_PORT:
-    default: 5432
+    default: 10000
     description: PostgreSQL host port
   # SSL/TLS
   POSTGRES_SSL_MODE:

--- a/packages/phlo-trino/README.md
+++ b/packages/phlo-trino/README.md
@@ -18,7 +18,7 @@ phlo plugin install trino
 
 | Variable        | Default   | Description     |
 | --------------- | --------- | --------------- |
-| `TRINO_PORT`    | `8080`    | Trino HTTP port |
+| `TRINO_PORT`    | `10005`   | Trino HTTP host port |
 | `TRINO_VERSION` | `467`     | Trino version   |
 | `TRINO_HOST`    | `trino`   | Trino hostname  |
 | `TRINO_CATALOG` | `iceberg` | Default catalog |
@@ -75,8 +75,8 @@ phlo trino --catalog iceberg --schema raw
 
 ## Endpoints
 
-- **HTTP API**: `http://localhost:8080`
-- **Trino UI**: `http://localhost:8080/ui`
+- **HTTP API**: `http://localhost:10005`
+- **Trino UI**: `http://localhost:10005/ui`
 
 ## Entry Points
 

--- a/packages/phlo-trino/src/phlo_trino/service.yaml
+++ b/packages/phlo-trino/src/phlo_trino/service.yaml
@@ -28,7 +28,7 @@ compose:
     S3_ENDPOINT: http://minio:9000
     S3_PATH_STYLE_ACCESS: "true"
   ports:
-    - "${TRINO_PORT:-8080}:8080"
+    - "${TRINO_PORT:-10005}:8080"
   mem_limit: 3g
   volumes:
     - ./trino:/etc/trino:ro
@@ -44,8 +44,8 @@ env_vars:
     default: "467"
     description: Trino version
   TRINO_PORT:
-    default: 8080
-    description: Trino HTTP port
+    default: 10005
+    description: Trino HTTP host port
   # Authentication
   TRINO_AUTH_TYPE:
     default: ""

--- a/src/phlo/cli/commands/services/utils.py
+++ b/src/phlo/cli/commands/services/utils.py
@@ -40,12 +40,6 @@ description: "{description}"
 #       host: custom-host  # Override postgres host
 #   container_naming_pattern: "{{project}}_{{service}}"  # Custom naming
 #
-# Non-secret environment defaults (committed):
-#
-# env:
-#   POSTGRES_PORT: 10000
-#   DAGSTER_PORT: 10006
-#
 # phlo-api authorization policy:
 #
 # api:

--- a/tests/cli/test_quickstart_smoke.py
+++ b/tests/cli/test_quickstart_smoke.py
@@ -78,7 +78,10 @@ class _SmokeComposer:
         _services: list[ServiceDefinition],
         env_overrides: dict[str, str] | None = None,
     ) -> str:
-        return "PHLO_ENV=smoke\n"
+        lines = ["PHLO_ENV=smoke"]
+        if env_overrides:
+            lines.extend(f"{key}={value}" for key, value in sorted(env_overrides.items()))
+        return "\n".join(lines) + "\n"
 
     def generate_env_local(
         self,

--- a/tests/runtime/test_core_service_autoconfig.py
+++ b/tests/runtime/test_core_service_autoconfig.py
@@ -152,3 +152,26 @@ def test_core_service_required_placeholders_defined_in_env_vars() -> None:
     allowed_extras = {"SUPERSET_ADMIN_PASSWORD"}
     missing = placeholders - available_env - allowed_extras
     assert not missing
+
+
+def test_core_service_host_port_defaults_are_package_owned() -> None:
+    """Verify default-stack host ports live with the package service definitions."""
+    expected = {
+        "postgres": {"POSTGRES_PORT": ("10000", "5432")},
+        "minio": {
+            "MINIO_API_PORT": ("10001", "9000"),
+            "MINIO_CONSOLE_PORT": ("10002", "9001"),
+        },
+        "nessie": {"NESSIE_PORT": ("10003", "19120")},
+        "trino": {"TRINO_PORT": ("10005", "8080")},
+        "dagster": {"DAGSTER_PORT": ("10006", "3000")},
+    }
+
+    for service_name, env_specs in expected.items():
+        definition = CORE_SERVICES[service_name].definition
+        env_vars = definition.get("env_vars", {})
+        ports = definition.get("compose", {}).get("ports", [])
+
+        for env_name, (host_port, container_port) in env_specs.items():
+            assert env_vars[env_name]["default"] == int(host_port)
+            assert f"${{{env_name}:-{host_port}}}:{container_port}" in ports


### PR DESCRIPTION
## Summary

- move the documented default-stack host ports into the owning service package manifests
- keep base `phlo.yaml` generation free of package-specific port assumptions
- explain host ports vs container ports in the Compose generation and configuration docs
- sync package docs for Postgres, MinIO, Nessie, Trino, and Dagster host-port defaults

## Root Cause

The port model was split between package service definitions, generated Compose, generated env files, and docs. The confusing part is expected but was under-documented: the host port and container port are different values. For example, `DAGSTER_PORT` controls the localhost port, while the right-hand side of the Compose mapping remains Dagster's container port `3000`.

The correct ownership is package-local: each service package contributes its own host-port default through `service.yaml`, and `phlo services init` materializes only the env vars for services that are selected/discovered.

## Validation

- `uv run pytest tests/runtime/test_core_service_autoconfig.py -m integration`
- `uv run pytest tests/cli/test_cli_services_ports.py tests/runtime/test_config_network.py tests/cli/test_cli_init_templates.py::test_minimal_template_generates_project tests/cli/test_quickstart_smoke.py::test_documented_quickstart_bootstrap_path_reaches_services_start tests/cli/test_cli_services_start.py::test_services_start_preflights_env_local_port_collisions tests/cli/test_cli_services_start.py::test_services_start_preflights_invalid_env_port_values packages/phlo-minio/tests/test_minio_plugin.py packages/phlo-postgres/tests/test_postgres_plugin.py packages/phlo-trino/tests/test_trino_plugin.py packages/phlo-nessie/tests/test_nessie_plugin.py`
- commit hooks: ruff, ruff format, codespell, Python AST checks, YAML lint, whitespace/EOF checks