### PR TITLE
fix(dagster): discover project assets consistently

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/Dockerfile
+++ b/packages/phlo-dagster/src/phlo_dagster/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /opt/dagster
 

--- a/packages/phlo-dagster/src/phlo_dagster/cli_dev.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_dev.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 import click
 
+from phlo.config.env import load_project_env
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
@@ -90,7 +91,11 @@ def dev(host: str, port: int, workflows_path: str) -> None:
         (workflows_dir / "__init__.py").write_text('"""User workflows."""\n')
 
     os.environ["PHLO_WORKFLOWS_PATH"] = workflows_path
+    os.environ["WORKFLOWS_PATH"] = workflows_path
     os.environ.setdefault("PHLO_DAGSTER_DEV", "1")
+    os.environ.setdefault("PHLO_PROJECT_PATH", str(Path.cwd().resolve()))
+    for key, value in load_project_env(include_os=False).items():
+        os.environ.setdefault(key, value)
 
     click.echo(f"Workflows directory: {workflows_path}")
     click.echo(f"Starting server at http://{host}:{port}\n")

--- a/packages/phlo-dagster/src/phlo_dagster/dagster-daemon.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/dagster-daemon.yaml
@@ -44,7 +44,7 @@ compose:
     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-phlo}
     POSTGRES_DB: ${POSTGRES_DB:-phlo}
     WORKFLOWS_PATH: /app/workflows
-    DBT_PROJECT_DIR: /app/workflows/transforms/dbt
+    PHLO_WORKFLOWS_PATH: /app/workflows
     PHLO_PROJECT_PATH: /app
     SUPERSET_ADMIN_PASSWORD: ${SUPERSET_ADMIN_PASSWORD:-admin}
     PHLO_HOST_PLATFORM: ${PHLO_HOST_PLATFORM:-}
@@ -52,9 +52,4 @@ compose:
   command: ["dagster-daemon", "run", "-w", "/opt/dagster/workspace.yaml"]
   volumes:
     - ./dagster:/opt/dagster
-    - ../phlo.yaml:/app/phlo.yaml:ro
-    - ../contracts:/app/contracts
-    - ../data:/app/data
-    - ../plugins:/app/plugins
-    - ../workflows:/app/workflows
-    - ../tests:/app/tests:ro
+    - ../:/app

--- a/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
+++ b/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
@@ -67,6 +67,14 @@ if [ "$PHLO_DEV_MODE" = "true" ] && [ -n "$PHLO_DEV_EXTRA_PACKAGES" ]; then
     done
 fi
 
+# Install the mounted user project so workflow imports and project dependencies
+# are available before Dagster loads Definitions.
+if [ -f /app/pyproject.toml ]; then
+    echo "Installing mounted Phlo project..."
+    uv pip install --system -e /app
+    echo "Mounted Phlo project installed"
+fi
+
 # Create sitecustomize.py to suppress Dagster SupersessionWarning at Python startup
 # This runs before any Python script and filters out deprecated CLI warnings
 SITE_PACKAGES=$(python -c "import site; print(site.getsitepackages()[0])")

--- a/packages/phlo-dagster/src/phlo_dagster/service.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/service.yaml
@@ -61,7 +61,7 @@ compose:
     POSTGRES_PASSWORD: ${DAGSTER_POSTGRES_PASSWORD:-${POSTGRES_PASSWORD:-phlo}}
     POSTGRES_DB: ${POSTGRES_DB:-phlo}
     WORKFLOWS_PATH: /app/workflows
-    DBT_PROJECT_DIR: /app/workflows/transforms/dbt
+    PHLO_WORKFLOWS_PATH: /app/workflows
     PHLO_PROJECT_PATH: /app
     SUPERSET_ADMIN_PASSWORD: ${SUPERSET_ADMIN_PASSWORD:-admin}
     PHLO_HOST_PLATFORM: ${PHLO_HOST_PLATFORM:-}
@@ -80,12 +80,7 @@ compose:
     - "${DAGSTER_PORT:-10006}:3000"
   volumes:
     - ./dagster:/opt/dagster
-    - ../phlo.yaml:/app/phlo.yaml:ro
-    - ../contracts:/app/contracts
-    - ../data:/app/data
-    - ../plugins:/app/plugins
-    - ../workflows:/app/workflows
-    - ../tests:/app/tests:ro
+    - ../:/app
 
 env_vars:
   DAGSTER_PORT:

--- a/packages/phlo-dagster/src/phlo_dagster/settings.py
+++ b/packages/phlo-dagster/src/phlo_dagster/settings.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-from pydantic import Field, model_validator
+from pydantic import AliasChoices, Field, model_validator
 
 from phlo.config.base import BaseConfig
 
@@ -55,6 +55,7 @@ class DagsterSettings(BaseConfig):
     dagster_port: int = Field(default=10006, description="Dagster webserver port")
     workflows_path: str = Field(
         default="workflows",
+        validation_alias=AliasChoices("PHLO_WORKFLOWS_PATH", "WORKFLOWS_PATH", "workflows_path"),
         description="Path to user workflows directory (for external projects)",
     )
     phlo_force_in_process_executor: bool = Field(

--- a/packages/phlo-dagster/tests/test_cli_dev.py
+++ b/packages/phlo-dagster/tests/test_cli_dev.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from subprocess import CompletedProcess
+
+from click.testing import CliRunner
+
+from phlo_dagster.cli_dev import dev
+
+
+def test_phlo_dev_loads_project_env_for_dagster_subprocess(monkeypatch, tmp_path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\nversion = '0.1.0'\n")
+    (tmp_path / "phlo.yaml").write_text(
+        "env:\n  CLIENT_EXPORTS_KE_QC_OUTPUT_DIR: data/client_exports/ke_qc\n"
+    )
+    workflows_dir = tmp_path / "workflows"
+    workflows_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CLIENT_EXPORTS_KE_QC_OUTPUT_DIR", raising=False)
+
+    captured_env: dict[str, str | None] = {}
+
+    def fake_run(cmd: list[str], check: bool) -> CompletedProcess[str]:
+        captured_env["PHLO_WORKFLOWS_PATH"] = __import__("os").environ.get("PHLO_WORKFLOWS_PATH")
+        captured_env["WORKFLOWS_PATH"] = __import__("os").environ.get("WORKFLOWS_PATH")
+        captured_env["PHLO_PROJECT_PATH"] = __import__("os").environ.get("PHLO_PROJECT_PATH")
+        captured_env["CLIENT_EXPORTS_KE_QC_OUTPUT_DIR"] = __import__("os").environ.get(
+            "CLIENT_EXPORTS_KE_QC_OUTPUT_DIR"
+        )
+        return CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("phlo_dagster.cli_dev.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(dev, ["--workflows-path", "workflows"])
+
+    assert result.exit_code == 0
+    assert captured_env == {
+        "PHLO_WORKFLOWS_PATH": "workflows",
+        "WORKFLOWS_PATH": "workflows",
+        "PHLO_PROJECT_PATH": str(tmp_path),
+        "CLIENT_EXPORTS_KE_QC_OUTPUT_DIR": "data/client_exports/ke_qc",
+    }

--- a/packages/phlo-dagster/tests/test_dagster_plugin.py
+++ b/packages/phlo-dagster/tests/test_dagster_plugin.py
@@ -1,5 +1,7 @@
 """Tests for Dagster service plugin."""
 
+from importlib import resources
+
 from phlo_dagster.plugin import DagsterServicePlugin
 
 
@@ -11,3 +13,19 @@ def test_dagster_service_definition():
     assert service_definition["name"] == "dagster"
     assert service_definition["category"] == "orchestration"
     assert "profile" not in service_definition
+
+
+def test_dagster_service_uses_discoverable_dbt_project_and_mounts_project_metadata() -> None:
+    service_yaml = resources.files("phlo_dagster").joinpath("service.yaml").read_text()
+
+    assert "PHLO_WORKFLOWS_PATH: /app/workflows" in service_yaml
+    assert "DBT_PROJECT_DIR:" not in service_yaml
+    assert "../:/app" in service_yaml
+
+
+def test_dagster_daemon_uses_same_project_discovery_contract() -> None:
+    daemon_yaml = resources.files("phlo_dagster").joinpath("dagster-daemon.yaml").read_text()
+
+    assert "PHLO_WORKFLOWS_PATH: /app/workflows" in daemon_yaml
+    assert "DBT_PROJECT_DIR:" not in daemon_yaml
+    assert "../:/app" in daemon_yaml

--- a/packages/phlo-dagster/tests/test_runtime_image_contract.py
+++ b/packages/phlo-dagster/tests/test_runtime_image_contract.py
@@ -6,6 +6,7 @@ from importlib import resources
 def test_dagster_runtime_image_installs_prerelease_phlo_with_postgres_driver() -> None:
     dockerfile = resources.files("phlo_dagster").joinpath("Dockerfile").read_text()
 
+    assert dockerfile.startswith("FROM python:3.12-slim")
     assert (
         'uv pip install --system --no-deps --prerelease explicit "phlo==$PHLO_VERSION"'
         in dockerfile
@@ -16,3 +17,10 @@ def test_dagster_runtime_image_installs_prerelease_phlo_with_postgres_driver() -
         in dockerfile
     )
     assert 'dagster-postgres "psycopg[binary]"' in dockerfile
+
+
+def test_dagster_runtime_entrypoint_installs_mounted_project() -> None:
+    entrypoint = resources.files("phlo_dagster").joinpath("entrypoint.sh").read_text()
+
+    assert "if [ -f /app/pyproject.toml ]; then" in entrypoint
+    assert "uv pip install --system -e /app" in entrypoint

--- a/packages/phlo-dagster/tests/test_settings.py
+++ b/packages/phlo-dagster/tests/test_settings.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from phlo_dagster.settings import DagsterSettings
+
+
+def test_dagster_settings_accepts_phlo_workflows_path_alias(monkeypatch) -> None:
+    monkeypatch.setenv("PHLO_WORKFLOWS_PATH", "/app/workflows")
+    monkeypatch.delenv("WORKFLOWS_PATH", raising=False)
+
+    assert DagsterSettings().workflows_path == "/app/workflows"
+
+
+def test_dagster_settings_accepts_legacy_workflows_path_alias(monkeypatch) -> None:
+    monkeypatch.delenv("PHLO_WORKFLOWS_PATH", raising=False)
+    monkeypatch.setenv("WORKFLOWS_PATH", "/legacy/workflows")
+
+    assert DagsterSettings().workflows_path == "/legacy/workflows"

--- a/packages/phlo-dbt/src/phlo_dbt/assets.py
+++ b/packages/phlo-dbt/src/phlo_dbt/assets.py
@@ -52,7 +52,7 @@ def _raise_required_dbt_setup_error(
         suggestions=[
             f"Check the dbt project at {dbt_project_path}",
             f"Check generated profiles at {dbt_profiles_path}",
-            f"Ensure dbt can compile a valid manifest at {manifest_path}",
+            f"Ensure dbt can parse or compile a valid manifest at {manifest_path}",
         ],
     )
 

--- a/packages/phlo-dbt/src/phlo_dbt/settings.py
+++ b/packages/phlo-dbt/src/phlo_dbt/settings.py
@@ -37,6 +37,18 @@ def _resolve_project_path(value: str) -> Path:
     return _project_root() / path
 
 
+def _discover_dbt_project_path(root: Path) -> Path | None:
+    workflows_root = root / "workflows"
+    if not workflows_root.exists():
+        return None
+
+    candidates = sorted(
+        (path.parent for path in workflows_root.rglob("dbt_project.yml")),
+        key=lambda path: (len(path.parts), str(path)),
+    )
+    return candidates[0] if candidates else None
+
+
 class DbtSettings(BaseConfig):
     """dbt project configuration settings.
 
@@ -156,7 +168,10 @@ class DbtSettings(BaseConfig):
             Filesystem path to the dbt project root.
 
         """
-        return _resolve_project_path(self.dbt_project_dir)
+        configured_path = _resolve_project_path(self.dbt_project_dir)
+        if self.dbt_project_dir != "workflows/transforms/dbt" or configured_path.exists():
+            return configured_path
+        return _discover_dbt_project_path(_project_root()) or configured_path
 
     @property
     def dbt_profiles_path(self) -> Path:
@@ -166,6 +181,10 @@ class DbtSettings(BaseConfig):
             Filesystem path to the dbt profiles directory.
 
         """
+        if self.dbt_project_dir == "workflows/transforms/dbt":
+            discovered_project = self.dbt_project_path
+            if discovered_project != _resolve_project_path(self.dbt_project_dir):
+                return discovered_project / "profiles"
         return _resolve_project_path(self.dbt_profiles_dir)
 
 

--- a/packages/phlo-dbt/src/phlo_dbt/transformer.py
+++ b/packages/phlo-dbt/src/phlo_dbt/transformer.py
@@ -203,34 +203,34 @@ def ensure_dbt_manifest(dbt_project_path: Path, profiles_path: Path) -> bool:
         profiles_path: Path to the dbt profiles directory.
 
     Returns:
-        ``True`` when a valid manifest is present after checks/compile.
+        ``True`` when a valid manifest is present after checks/parse.
 
     """
     manifest_path = dbt_project_path / "target" / "manifest.json"
     ensure_dbt_profile(profiles_path)
 
-    needs_compile = not manifest_path.exists()
-    if not needs_compile:
+    needs_parse = not manifest_path.exists()
+    if not needs_parse:
         try:
-            needs_compile = _latest_project_mtime(dbt_project_path) > manifest_path.stat().st_mtime
+            needs_parse = _latest_project_mtime(dbt_project_path) > manifest_path.stat().st_mtime
         except OSError:
-            needs_compile = True
+            needs_parse = True
 
-    if not needs_compile:
+    if not needs_parse:
         try:
             manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
         except (OSError, ValueError):
-            needs_compile = True
+            needs_parse = True
         else:
             if not isinstance(manifest_payload, Mapping):
-                needs_compile = True
+                needs_parse = True
 
-    if not needs_compile:
+    if not needs_parse:
         return True
 
     try:
         result = subprocess.run(
-            ["dbt", "compile", "--profiles-dir", str(profiles_path)],
+            ["dbt", "parse", "--profiles-dir", str(profiles_path)],
             cwd=str(dbt_project_path),
             capture_output=True,
             text=True,

--- a/packages/phlo-dbt/src/phlo_dbt/translator.py
+++ b/packages/phlo-dbt/src/phlo_dbt/translator.py
@@ -222,9 +222,14 @@ class DbtSpecTranslator:
         )
 
         if is_source:
-            source_name = dbt_resource_props["source_name"]
-            table_name = dbt_resource_props["name"]
-            if source_name == "dagster_assets":
+            source_name = str(dbt_resource_props["source_name"])
+            table_name = str(dbt_resource_props["name"])
+            meta = dbt_resource_props.get("meta")
+            if isinstance(meta, Mapping):
+                explicit_key = meta.get("phlo_asset_key") or meta.get("asset_key")
+                if explicit_key:
+                    return str(explicit_key)
+            if source_name == "dagster_assets" or source_name.startswith("raw_"):
                 return f"dlt_{table_name}"
             return f"{source_name}.{table_name}"
 

--- a/packages/phlo-dbt/tests/test_settings.py
+++ b/packages/phlo-dbt/tests/test_settings.py
@@ -3,12 +3,27 @@ from __future__ import annotations
 from phlo_dbt.settings import DbtSettings
 
 
-def test_dbt_project_paths_resolve_from_phlo_project_path(monkeypatch, tmp_path) -> None:
-    project_root = tmp_path / "project"
-    project_root.mkdir()
-    monkeypatch.setenv("PHLO_PROJECT_PATH", str(project_root))
+def test_dbt_settings_discovers_nested_project_when_default_path_missing(
+    monkeypatch, tmp_path
+) -> None:
+    dbt_project = tmp_path / "workflows" / "client_exports" / "transforms" / "dbt"
+    dbt_project.mkdir(parents=True)
+    (dbt_project / "dbt_project.yml").write_text("name: client_exports\n")
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.delenv("DBT_PROJECT_DIR", raising=False)
 
     settings = DbtSettings()
 
-    assert settings.dbt_project_path == project_root / "workflows/transforms/dbt"
-    assert settings.dbt_profiles_path == project_root / "workflows/transforms/dbt/profiles"
+    assert settings.dbt_project_path == dbt_project
+    assert settings.dbt_profiles_path == dbt_project / "profiles"
+
+
+def test_dbt_settings_keeps_explicit_project_dir(monkeypatch, tmp_path) -> None:
+    configured = tmp_path / "analytics" / "dbt"
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv("DBT_PROJECT_DIR", "analytics/dbt")
+
+    settings = DbtSettings()
+
+    assert settings.dbt_project_path == configured
+    assert settings.dbt_profiles_path == configured / "profiles"

--- a/packages/phlo-dbt/tests/test_transform.py
+++ b/packages/phlo-dbt/tests/test_transform.py
@@ -11,7 +11,7 @@ import pytest
 from phlo.hooks.events import TelemetryEvent, TransformEvent
 from phlo.logging import get_logger
 from phlo_dbt.runtime_config import resolve_dbt_target_name
-from phlo_dbt.transformer import DbtTransformer
+from phlo_dbt.transformer import DbtTransformer, ensure_dbt_manifest
 from phlo_dbt.translator import DbtSpecTranslator
 
 
@@ -31,6 +31,29 @@ def test_custom_dbt_translator_asset_key_source_dagster_assets_maps_to_dlt() -> 
         {"resource_type": "source", "source_name": "dagster_assets", "name": "entries"}
     )
     assert asset_key == "dlt_entries"
+
+
+def test_custom_dbt_translator_asset_key_raw_source_maps_to_dlt() -> None:
+    """Verifies raw dbt sources map to corresponding Phlo DLT assets."""
+    translator = DbtSpecTranslator()
+    asset_key = translator.get_asset_key(
+        {"resource_type": "source", "source_name": "raw_lims", "name": "qc_safe_results"}
+    )
+    assert asset_key == "dlt_qc_safe_results"
+
+
+def test_custom_dbt_translator_asset_key_source_meta_override() -> None:
+    """Verifies projects can explicitly map dbt sources to non-default asset keys."""
+    translator = DbtSpecTranslator()
+    asset_key = translator.get_asset_key(
+        {
+            "resource_type": "source",
+            "source_name": "warehouse",
+            "name": "orders",
+            "meta": {"phlo_asset_key": "external_orders"},
+        }
+    )
+    assert asset_key == "external_orders"
 
 
 def test_resolve_dbt_target_name_prefers_canonical_environment() -> None:
@@ -67,6 +90,29 @@ def test_resolve_dbt_target_name_defaults_to_dev() -> None:
     )
 
     assert resolve_dbt_target_name(runtime) == "dev"
+
+
+def test_ensure_dbt_manifest_uses_parse_for_discovery(monkeypatch, tmp_path: Path) -> None:
+    """dbt asset discovery should not require a live query engine connection."""
+    project_dir = tmp_path / "dbt"
+    profiles_dir = project_dir / "profiles"
+    target_dir = project_dir / "target"
+    profiles_dir.mkdir(parents=True)
+    target_dir.mkdir()
+    (project_dir / "dbt_project.yml").write_text("name: demo\n")
+
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs):
+        captured.append(cmd)
+        (target_dir / "manifest.json").write_text('{"nodes": {}, "sources": {}}')
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("phlo_dbt.transformer.subprocess.run", fake_run)
+    monkeypatch.setattr("phlo_dbt.transformer.ensure_dbt_profile", lambda _profiles_dir: None)
+
+    assert ensure_dbt_manifest(project_dir, profiles_dir) is True
+    assert captured == [["dbt", "parse", "--profiles-dir", str(profiles_dir)]]
 
 
 @pytest.mark.parametrize(

--- a/src/phlo/config/env.py
+++ b/src/phlo/config/env.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import yaml
+
 
 def parse_project_env_file(path: Path) -> dict[str, str]:
     """Parse a simple dotenv file into key/value pairs."""
@@ -26,12 +28,36 @@ def parse_project_env_file(path: Path) -> dict[str, str]:
     return values
 
 
+def parse_project_config_env(path: Path) -> dict[str, str]:
+    """Parse top-level ``env:`` values from ``phlo.yaml``."""
+    if not path.exists():
+        return {}
+
+    try:
+        config = yaml.safe_load(path.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+
+    if not isinstance(config, dict):
+        return {}
+
+    values = config.get("env", {})
+    if not isinstance(values, dict):
+        return {}
+
+    return {str(key): str(value) for key, value in values.items() if isinstance(key, str)}
+
+
 def load_project_env(
     project_root: Path | None = None, *, include_os: bool = True
 ) -> dict[str, str]:
-    """Load `.phlo/.env` and `.phlo/.env.local`, with OS env taking precedence."""
+    """Load ``phlo.yaml env:``, `.phlo/.env`, and `.phlo/.env.local`.
+
+    Later sources override earlier sources, with OS env taking final precedence
+    when requested.
+    """
     root = project_root or Path.cwd()
-    env: dict[str, str] = {}
+    env: dict[str, str] = parse_project_config_env(root / "phlo.yaml")
     for path in (root / ".phlo" / ".env", root / ".phlo" / ".env.local"):
         env.update(parse_project_env_file(path))
     if include_os:

--- a/tests/runtime/test_config_network.py
+++ b/tests/runtime/test_config_network.py
@@ -2,13 +2,21 @@ from __future__ import annotations
 
 import socket
 
-from phlo.config.env import load_project_env, parse_project_env_file, project_env_value
+from phlo.config.env import (
+    load_project_env,
+    parse_project_config_env,
+    parse_project_env_file,
+    project_env_value,
+)
 from phlo.config.network import resolve_host, resolve_url
 
 
 def test_project_env_files_load_with_local_and_os_precedence(tmp_path, monkeypatch) -> None:
     phlo_dir = tmp_path / ".phlo"
     phlo_dir.mkdir()
+    (tmp_path / "phlo.yaml").write_text(
+        "env:\n  TRINO_PORT: 7777\n  CLIENT_EXPORTS_OUTPUT: data/exports\n"
+    )
     (phlo_dir / ".env").write_text("TRINO_PORT=8080\nPOSTGRES_DB=phlo\n")
     (phlo_dir / ".env.local").write_text("TRINO_PORT=18080\n")
     monkeypatch.chdir(tmp_path)
@@ -18,7 +26,18 @@ def test_project_env_files_load_with_local_and_os_precedence(tmp_path, monkeypat
 
     assert env["TRINO_PORT"] == "18080"
     assert env["POSTGRES_DB"] == "override"
+    assert env["CLIENT_EXPORTS_OUTPUT"] == "data/exports"
     assert project_env_value("TRINO_PORT") == "18080"
+
+
+def test_parse_project_config_env_reads_phlo_yaml_env(tmp_path) -> None:
+    config_path = tmp_path / "phlo.yaml"
+    config_path.write_text("env:\n  STRING_VALUE: hello\n  NUMBER_VALUE: 42\n")
+
+    assert parse_project_config_env(config_path) == {
+        "STRING_VALUE": "hello",
+        "NUMBER_VALUE": "42",
+    }
 
 
 def test_resolve_url_uses_project_env_port_for_unresolvable_service(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- load `phlo.yaml env:` and project env files into `phlo dev` so local Dagster sees the same runtime variables as services
- align Dagster webserver/daemon project discovery by using `PHLO_WORKFLOWS_PATH`, mounting/installing the project at `/app`, and moving the runtime image to Python 3.12
- auto-discover nested dbt projects, refresh manifests with `dbt parse`, and map raw dbt sources back to matching DLT assets

## Verification
- `uv run pytest tests/runtime/test_config_network.py packages/phlo-dagster/tests/test_cli_dev.py packages/phlo-dagster/tests/test_settings.py packages/phlo-dagster/tests/test_dagster_plugin.py packages/phlo-dagster/tests/test_runtime_image_contract.py packages/phlo-dbt/tests/test_settings.py packages/phlo-dbt/tests/test_assets.py packages/phlo-dbt/tests/test_transform.py tests/cli/test_cli_services_utils.py tests/runtime/test_container_backend.py`
- `uv run ruff check src/phlo/config/env.py packages/phlo-dagster/src/phlo_dagster/cli_dev.py packages/phlo-dagster/src/phlo_dagster/settings.py packages/phlo-dbt/src/phlo_dbt/settings.py packages/phlo-dbt/src/phlo_dbt/assets.py packages/phlo-dbt/src/phlo_dbt/transformer.py packages/phlo-dbt/src/phlo_dbt/translator.py tests/runtime/test_config_network.py packages/phlo-dagster/tests/test_cli_dev.py packages/phlo-dagster/tests/test_settings.py packages/phlo-dbt/tests/test_settings.py packages/phlo-dbt/tests/test_transform.py packages/phlo-dagster/tests/test_dagster_plugin.py packages/phlo-dagster/tests/test_runtime_image_contract.py`
- DH4 Lakehouse smoke: `phlo dev --port 3001` served Dagster and GraphQL showed staging dbt assets depending on `dlt_*` assets

## Notes
- commit hook `hadolint-docker` was skipped locally because Docker/Colima was intentionally removed; other pre-commit hooks passed
