### PR TITLE
feat: add WAP reports and Observatory evidence

### DIFF
--- a/docs/packages/phlo-dagster.md
+++ b/docs/packages/phlo-dagster.md
@@ -66,6 +66,9 @@ hard-wiring Dagster to a specific catalog implementation.
 In the bundled stack, Nessie is the versioned catalog provider. In profiles
 without versioning, the same Dagster adapter still works, but WAP branch
 creation/promotion/cleanup is not enabled.
+Set `PHLO_WAP_ENABLED=false` to keep WAP off even when a versioned catalog is
+available. WAP executions write `.phlo/wap-reports/<run_id>.json`, and
+Observatory exposes those reports in the operations and branch history views.
 
 ## Usage
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -507,6 +507,7 @@ BRANCH_CLEANUP_ENABLED=false
 Dagster WAP sensor intervals:
 
 ```bash
+PHLO_WAP_ENABLED=true
 PHLO_WAP_BRANCH_CREATION_INTERVAL_SECONDS=30
 PHLO_WAP_PROMOTION_INTERVAL_SECONDS=60
 PHLO_WAP_CLEANUP_INTERVAL_SECONDS=3600
@@ -514,6 +515,10 @@ PHLO_WAP_CLEANUP_INTERVAL_SECONDS=3600
 
 These settings only matter when the active profile includes a versioned catalog
 capability.
+Set `PHLO_WAP_ENABLED=false` to disable WAP sensors even when Nessie/Iceberg
+branching is available. Each WAP run writes `.phlo/wap-reports/<run_id>.json`
+with the branch, source hash, target hash before/after promotion, and cleanup
+result.
 
 ### Validation Configuration
 

--- a/packages/phlo-api/src/phlo_api/observatory_api/v2.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/v2.py
@@ -570,9 +570,51 @@ def _operation_from_maintenance_status(status: Any) -> V2Operation:
     )
 
 
+def _load_wap_report_operations() -> list[V2Operation]:
+    reports_dir = _project_root() / ".phlo" / "wap-reports"
+    if not reports_dir.exists():
+        return []
+
+    operations: list[V2Operation] = []
+    for path in reports_dir.glob("*.json"):
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, Mapping):
+            continue
+        run_id = _coerce_str(payload.get("run_id"), path.stem)
+        branch = _coerce_str(payload.get("branch"), "unknown")
+        status = _coerce_str(payload.get("status"), "unknown")
+        succeeded = status == "promoted"
+        failed = status.endswith("_failed")
+        operations.append(
+            V2Operation(
+                id=f"wap:{run_id}",
+                name="WAP publish" if succeeded else "WAP lifecycle",
+                kind="wap",
+                status="succeeded" if succeeded else "failed" if failed else "running",
+                health=V2Health(
+                    state="ok" if succeeded else "error" if failed else "warning",
+                    message=status.replace("_", " "),
+                ),
+                target=V2ResourceRef(kind="branch", id=branch, label=branch),
+                started_at=payload.get("created_at")
+                if isinstance(payload.get("created_at"), str)
+                else None,
+                completed_at=payload.get("updated_at")
+                if isinstance(payload.get("updated_at"), str)
+                else None,
+                metadata=_safe_metadata(payload),
+            )
+        )
+    return operations
+
+
 def _load_operations() -> list[V2Operation]:
     operations = [
         *list(load_operation_journal(_project_root())),
+        *_load_wap_report_operations(),
         *_manifest_records("operations", V2Operation),
     ]
     registry = _load_capability_registry()
@@ -1757,6 +1799,8 @@ def _load_branch_detail(branch_name: str) -> V2BranchDetail:
         raise _not_found("branch", branch_name)
 
     tables = [table for table in _load_tables() if table.branch in {None, "", branch.name}]
+    if not tables:
+        tables = _tables_from_branch_operations(branch.name)
     contents = [V2ResourceRef(kind="table", id=table.id, label=table.name) for table in tables]
     commits = [
         operation
@@ -1796,6 +1840,70 @@ def _load_branch_detail(branch_name: str) -> V2BranchDetail:
         compare=compare,
         tables=tables,
     )
+
+
+def _tables_from_branch_operations(branch_name: str) -> list[V2Table]:
+    tables: dict[str, V2Table] = {}
+    for operation in _load_operations():
+        if operation.target is None or operation.target.kind != "branch":
+            continue
+        if operation.target.id != branch_name:
+            continue
+        for table in _tables_from_metadata(operation.metadata, branch_name):
+            tables.setdefault(table.id, table)
+    return sorted(tables.values(), key=lambda item: item.id)
+
+
+def _tables_from_metadata(metadata: Mapping[str, Any], branch_name: str) -> list[V2Table]:
+    raw_tables = metadata.get("tables") or metadata.get("changed_tables")
+    if not isinstance(raw_tables, list):
+        return []
+
+    tables: list[V2Table] = []
+    for item in raw_tables:
+        if isinstance(item, str):
+            table_id = item
+            namespace, _, name = item.rpartition(".")
+            tables.append(
+                V2Table(
+                    id=table_id,
+                    name=name or item,
+                    namespace=namespace or None,
+                    branch=branch_name,
+                    metadata={"source": "wap_report"},
+                )
+            )
+        elif isinstance(item, Mapping):
+            name = _coerce_str(item.get("name") or item.get("id"), "")
+            if not name:
+                continue
+            namespace = _coerce_str(item.get("namespace"), "") or None
+            table_id = _coerce_str(item.get("id"), "") or ".".join(
+                part for part in (namespace, name) if part
+            )
+            tables.append(
+                V2Table(
+                    id=table_id,
+                    name=name,
+                    namespace=namespace,
+                    asset_id=_coerce_str(item.get("asset_id"), "") or None,
+                    format=_coerce_str(item.get("format"), "") or None,
+                    branch=branch_name,
+                    schema_name=_coerce_str(item.get("schema_name"), "") or namespace,
+                    metadata={
+                        **(
+                            _safe_metadata(dict(item["metadata"]))
+                            if isinstance(item.get("metadata"), Mapping)
+                            else {}
+                        ),
+                        **_safe_metadata(
+                            {key: value for key, value in item.items() if key != "metadata"}
+                        ),
+                        "source": "wap_report",
+                    },
+                )
+            )
+    return tables
 
 
 def _search_results(query: str) -> list[V2SearchResult]:

--- a/packages/phlo-api/tests/test_observatory_v2_api.py
+++ b/packages/phlo-api/tests/test_observatory_v2_api.py
@@ -1960,6 +1960,81 @@ def test_v2_branch_action_skip_is_recorded(
     assert operations[0]["metadata"]["action_id"] == "branch:create:experiment"
 
 
+def test_v2_operations_include_wap_reports(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    reports_dir = tmp_path / ".phlo" / "wap-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "run-1.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "phlo.wap_report.v1",
+                "run_id": "run-1",
+                "status": "promoted",
+                "branch": "pipeline-run-1",
+                "source_hash": "source",
+                "target_branch": "main",
+                "target_hash_before": "before",
+                "target_hash_after": "after",
+                "updated_at": "2026-06-17T10:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    v2._clear_read_model_cache()
+
+    payload = TestClient(app).get("/api/observatory/v2/operations").json()
+
+    wap = next(item for item in payload["items"] if item["id"] == "wap:run-1")
+    assert wap["status"] == "succeeded"
+    assert wap["target"]["id"] == "pipeline-run-1"
+    assert wap["metadata"]["target_hash_after"] == "after"
+
+
+def test_v2_branch_detail_uses_wap_report_tables_when_catalog_tables_missing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    reports_dir = tmp_path / ".phlo" / "wap-reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "run-1.json").write_text(
+        json.dumps(
+            {
+                "run_id": "run-1",
+                "status": "promoted",
+                "branch": "pipeline-run-1",
+                "tables": [
+                    {
+                        "id": "analytics.orders",
+                        "name": "orders",
+                        "namespace": "analytics",
+                        "format": "iceberg",
+                        "records": 128,
+                    }
+                ],
+                "updated_at": "2026-06-17T10:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "phlo_api.observatory_api.v2._load_branches",
+        lambda: [
+            V2Branch(
+                id="pipeline-run-1",
+                name="pipeline-run-1",
+                metadata={"changed": 1, "tables": 1},
+            )
+        ],
+    )
+    monkeypatch.setattr("phlo_api.observatory_api.v2._load_tables", lambda: [])
+    v2._clear_read_model_cache()
+
+    payload = TestClient(app).get("/api/observatory/v2/branches/pipeline-run-1").json()
+
+    assert payload["tables"][0]["id"] == "analytics.orders"
+    assert payload["contents"][0]["label"] == "orders"
+
+
 def test_v2_branch_actions_use_registered_catalog_provider(
     monkeypatch,
     tmp_path: Path,

--- a/packages/phlo-dagster/src/phlo_dagster/framework/definitions.py
+++ b/packages/phlo-dagster/src/phlo_dagster/framework/definitions.py
@@ -91,6 +91,10 @@ def _collect_wap_definitions() -> dg.Definitions | None:
         No explicit exceptions raised. Logs warnings for incompatible providers.
 
     """
+    if not get_settings().phlo_wap_enabled:
+        logger.info("dagster_wap_definitions_disabled")
+        return None
+
     wap_sensors_raw = os.getenv("PHLO_WAP_SENSORS_ENABLED", "")
     wap_sensors_enabled = wap_sensors_raw.lower() in {"1", "true", "yes"}
     if os.getenv("PHLO_DAGSTER_DEV") == "1" and not wap_sensors_enabled:

--- a/packages/phlo-dagster/src/phlo_dagster/settings.py
+++ b/packages/phlo-dagster/src/phlo_dagster/settings.py
@@ -69,6 +69,10 @@ class DagsterSettings(BaseConfig):
         description="Host platform for executor selection (Darwin/Linux/Windows). "
         "Auto-detected in CLI; set explicitly for daemon/webserver on macOS.",
     )
+    phlo_wap_enabled: bool = Field(
+        default=True,
+        description="Enable Write-Audit-Publish lifecycle sensors when a versioned catalog exists.",
+    )
 
     @model_validator(mode="after")
     def validate_executor_flags(self) -> "DagsterSettings":

--- a/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
@@ -93,16 +93,21 @@ def write_wap_report(run_id: str, **updates: Any) -> None:
         payload = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
     except (OSError, json.JSONDecodeError):
         payload = {}
+    now = datetime.now(timezone.utc).isoformat()
+    payload.update(updates)
     payload.update(
         {
+            "created_at": payload.get("created_at", now),
             "schema_version": "phlo.wap_report.v1",
             "run_id": run_id,
-            "updated_at": datetime.now(timezone.utc).isoformat(),
-            **updates,
+            "updated_at": now,
         }
     )
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError:
+        logger.warning("wap_report_write_failed", path=str(path), run_id=run_id, exc_info=True)
 
 
 def _load_versioned_catalog() -> VersionedCatalog:

--- a/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
@@ -46,8 +46,10 @@ Example:
 
 from __future__ import annotations
 
+import json
 import os
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 import dagster as dg
@@ -66,6 +68,41 @@ DEFAULT_BRANCH_CREATION_INTERVAL_SECONDS = int(
 )
 DEFAULT_CLEANUP_INTERVAL_SECONDS = int(os.getenv("PHLO_WAP_CLEANUP_INTERVAL_SECONDS", "3600"))
 DEFAULT_PROMOTION_INTERVAL_SECONDS = int(os.getenv("PHLO_WAP_PROMOTION_INTERVAL_SECONDS", "60"))
+
+
+def _report_path(run_id: str) -> Path:
+    root = Path(os.getenv("PHLO_PROJECT_PATH", "."))
+    return root / ".phlo" / "wap-reports" / f"{run_id}.json"
+
+
+def _branch_hash(catalog: VersionedCatalog, branch: str) -> str | None:
+    get_branch_hash = getattr(catalog, "get_branch_hash", None)
+    if not callable(get_branch_hash):
+        return None
+    try:
+        value = get_branch_hash(branch)
+    except Exception:
+        logger.warning("wap_report_branch_hash_failed", branch_name=branch, exc_info=True)
+        return None
+    return str(value) if value else None
+
+
+def write_wap_report(run_id: str, **updates: Any) -> None:
+    path = _report_path(run_id)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    payload.update(
+        {
+            "schema_version": "phlo.wap_report.v1",
+            "run_id": run_id,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            **updates,
+        }
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
 
 def _load_versioned_catalog() -> VersionedCatalog:
@@ -174,6 +211,12 @@ def wap_branch_creation_sensor(context: dg.SensorEvaluationContext):
 
         branch_hash = catalog.create_branch(branch_name, from_ref="main")
         if branch_hash is None:
+            write_wap_report(
+                run.run_id,
+                status="branch_creation_failed",
+                branch=branch_name,
+                target_branch="main",
+            )
             logger.warning(
                 "wap_branch_creation_skipped",
                 run_id=run.run_id,
@@ -182,6 +225,14 @@ def wap_branch_creation_sensor(context: dg.SensorEvaluationContext):
             continue
 
         instance.add_run_tags(run.run_id, {WAP_TAG_KEY: branch_name})
+        write_wap_report(
+            run.run_id,
+            status="branch_created",
+            branch=branch_name,
+            branch_hash=str(branch_hash),
+            target_branch="main",
+            target_hash_before=_branch_hash(catalog, "main"),
+        )
         branches_created += 1
         logger.info(
             "wap_branch_created",
@@ -264,6 +315,15 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
             continue
 
         if not _all_checks_passed(instance, run.run_id):
+            write_wap_report(
+                run.run_id,
+                status="promotion_blocked",
+                branch=branch_name,
+                source_hash=_branch_hash(catalog, branch_name),
+                target_branch="main",
+                target_hash_before=_branch_hash(catalog, "main"),
+                failure_reason="asset_checks_failed",
+            )
             blocked += 1
             logger.info(
                 "wap_promotion_blocked_quality",
@@ -272,8 +332,19 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
             )
             continue
 
+        source_hash = _branch_hash(catalog, branch_name)
+        target_hash_before = _branch_hash(catalog, "main")
         merged = catalog.merge_branch(source=branch_name, target="main")
         if not merged:
+            write_wap_report(
+                run.run_id,
+                status="promotion_failed",
+                branch=branch_name,
+                source_hash=source_hash,
+                target_branch="main",
+                target_hash_before=target_hash_before,
+                failure_reason="merge_branch_returned_false",
+            )
             logger.error(
                 "wap_promotion_merge_failed",
                 run_id=run.run_id,
@@ -281,8 +352,19 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
             )
             continue
 
-        catalog.delete_branch(branch_name)
+        target_hash_after = _branch_hash(catalog, "main")
+        source_deleted = catalog.delete_branch(branch_name)
         instance.add_run_tags(run.run_id, {"phlo/wap_promoted": "true"})
+        write_wap_report(
+            run.run_id,
+            status="promoted",
+            branch=branch_name,
+            source_hash=source_hash,
+            target_branch="main",
+            target_hash_before=target_hash_before,
+            target_hash_after=target_hash_after,
+            source_deleted=source_deleted,
+        )
         promoted += 1
         logger.info(
             "wap_branch_promoted",

--- a/packages/phlo-dagster/tests/test_wap_sensors.py
+++ b/packages/phlo-dagster/tests/test_wap_sensors.py
@@ -12,6 +12,7 @@ from phlo_dagster.wap_sensors import (
     wap_auto_promotion_sensor,
     wap_branch_creation_sensor,
     wap_branch_cleanup_sensor,
+    write_wap_report,
 )
 
 
@@ -28,6 +29,25 @@ def test_wap_sensors_default_to_running() -> None:
     assert wap_branch_creation_sensor.default_status == dg.DefaultSensorStatus.RUNNING
     assert wap_auto_promotion_sensor.default_status == dg.DefaultSensorStatus.RUNNING
     assert wap_branch_cleanup_sensor.default_status == dg.DefaultSensorStatus.RUNNING
+
+
+def test_write_wap_report_updates_run_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+
+    write_wap_report("run-1", status="branch_created", branch="pipeline-run-1")
+    write_wap_report(
+        "run-1",
+        status="promoted",
+        branch="pipeline-run-1",
+        source_hash="source",
+        target_hash_before="before",
+        target_hash_after="after",
+    )
+
+    payload = (tmp_path / ".phlo" / "wap-reports" / "run-1.json").read_text()
+    assert '"status": "promoted"' in payload
+    assert '"branch": "pipeline-run-1"' in payload
+    assert '"target_hash_after": "after"' in payload
 
 
 # ---------------------------------------------------------------------------

--- a/packages/phlo-dagster/tests/test_wap_sensors.py
+++ b/packages/phlo-dagster/tests/test_wap_sensors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import dagster as dg
@@ -44,10 +45,37 @@ def test_write_wap_report_updates_run_json(monkeypatch, tmp_path):
         target_hash_after="after",
     )
 
-    payload = (tmp_path / ".phlo" / "wap-reports" / "run-1.json").read_text()
-    assert '"status": "promoted"' in payload
-    assert '"branch": "pipeline-run-1"' in payload
-    assert '"target_hash_after": "after"' in payload
+    payload = json.loads((tmp_path / ".phlo" / "wap-reports" / "run-1.json").read_text())
+    assert payload["status"] == "promoted"
+    assert payload["branch"] == "pipeline-run-1"
+    assert payload["target_hash_after"] == "after"
+    assert payload["run_id"] == "run-1"
+    assert payload["created_at"]
+
+
+def test_write_wap_report_keeps_identity_fields_and_ignores_write_failure(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+
+    write_wap_report(
+        "run-1",
+        schema_version="wrong",
+        updated_at="wrong",
+        status="branch_created",
+    )
+
+    payload = json.loads((tmp_path / ".phlo" / "wap-reports" / "run-1.json").read_text())
+    assert payload["run_id"] == "run-1"
+    assert payload["schema_version"] == "phlo.wap_report.v1"
+    assert payload["updated_at"] != "wrong"
+
+    def raise_write_error(*args, **kwargs):
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr("pathlib.Path.write_text", raise_write_error)
+    write_wap_report("run-2", status="branch_created")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/branches.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/branches.tsx
@@ -19,8 +19,9 @@ import type {
   V2Table,
 } from '@/v2/api/types'
 import {
-  getV2BranchDetail,
+  getV2BranchDetailDirect,
   getV2BranchRecords,
+  getV2OperationRecords,
   runV2BranchAction,
 } from '@/v2/api/resources'
 import { V2Page } from '@/v2/components/V2Page'
@@ -28,6 +29,8 @@ import {
   invalidateCachedResources,
   useLiveResource,
 } from '@/v2/routes/liveResource'
+import { V2FlowCanvas } from '@/v2/components/V2FlowCanvas'
+import type { V2FlowEdge, V2FlowNode } from '@/v2/components/V2FlowCanvas'
 
 export const Route = createFileRoute('/v2/branches')({
   component: Branches,
@@ -73,6 +76,11 @@ function branchesReducer(
 
 export function Branches() {
   const result = useLiveResource(getV2BranchRecords, 60_000, 'v2:branches')
+  const operationsResult = useLiveResource(
+    getV2OperationRecords,
+    60_000,
+    'v2:operations',
+  )
   const [
     { actionMessage, activePanel, createdBranches, detail, selectedId },
     dispatch,
@@ -94,7 +102,14 @@ export function Branches() {
   const selectedCompare = detail.data?.compare ?? branchCompare(selected)
   const selectedTableCount =
     detail.data?.tables.length ?? metadataNumber(selected, 'tables')
-  const selectedEvidenceCount = detail.data?.commits.length ?? 0
+  const branchOperations = branchRelatedOperations(
+    selected,
+    operationsResult.data ?? [],
+  )
+  const selectedEvidenceCount = mergeOperations(
+    branchOperations,
+    detail.data?.commits ?? [],
+  ).length
 
   useEffect(() => {
     const branchId = selected?.id
@@ -104,7 +119,7 @@ export function Branches() {
     }
     let cancelled = false
     dispatch({ type: 'detail', detail: { data: null, error: null } })
-    void getV2BranchDetail({ data: { branchName: branchId } }).then((next) => {
+    void getV2BranchDetailDirect({ branchName: branchId }).then((next) => {
       if (!cancelled) dispatch({ type: 'detail', detail: next })
     })
     return () => {
@@ -119,146 +134,170 @@ export function Branches() {
       description="Review branch state, table drift, and guarded change workflows."
       action={<span className="phlo-v2-pill">{branches.length} branches</span>}
     >
-      <section className="phlo-v2-surface-grid">
-        <div className="phlo-v2-list-surface">
-          <div className="phlo-v2-browser-toolbar">
-            <span>
-              <GitBranch className="size-4" />
-              Branches
-            </span>
-            <button
-              onClick={() => {
-                const branchName = window.prompt('New branch name')
-                if (!branchName) return
-                if (
-                  !window.confirm(
-                    `Create branch ${branchName}? This writes Observatory branch state through phlo-api.`,
-                  )
-                ) {
-                  return
-                }
-                void runV2BranchAction({
-                  data: { actionId: `branch:create:${branchName}` },
-                }).then((next) => {
-                  invalidateCachedResources(['v2:operations', 'v2:branches'])
-                  const message =
-                    next.data?.message ??
-                    next.error ??
-                    'Branch action completed'
-                  if (next.data?.status === 'succeeded') {
-                    dispatch({
-                      type: 'branchCreated',
-                      branch: {
-                        current: false,
-                        id: branchName,
-                        metadata: { source: 'local' },
-                        name: branchName,
-                        protected: false,
-                      },
-                      message,
-                    })
-                  } else {
-                    dispatch({ type: 'actionMessage', message })
-                  }
-                })
-              }}
-              type="button"
-            >
-              <Plus className="size-3.5" />
-              Branch
-            </button>
-          </div>
-          {branches.map((branch) => (
-            <button
-              className="phlo-v2-row phlo-v2-select-row"
-              data-active={branch.id === selected?.id}
-              key={branch.id}
-              onClick={() =>
-                dispatch({ type: 'select', selectedId: branch.id })
-              }
-              type="button"
-            >
-              <div className="phlo-v2-row-main">
-                <div className="phlo-v2-row-title">{branch.name}</div>
-                <div className="phlo-v2-row-meta">
-                  {branch.current ? 'Current branch' : 'Review branch'}
-                  {branchDelta(branch) && <> · {branchDelta(branch)}</>}
-                </div>
-              </div>
-              <span className="phlo-v2-pill">
-                {branch.current
-                  ? 'current'
-                  : branch.protected
-                    ? 'protected'
-                    : 'branch'}
+      <section className="phlo-v2-surface-grid phlo-v2-branch-grid">
+        <div className="phlo-v2-branch-main">
+          <div className="phlo-v2-list-surface">
+            <div className="phlo-v2-browser-toolbar">
+              <span>
+                <GitBranch className="size-4" />
+                Branches
               </span>
-            </button>
-          ))}
-        </div>
-        <aside className="phlo-v2-inspector">
-          <div className="phlo-v2-inspector-label">Change controls</div>
-          <h2>{selected?.name ?? 'No branch selected'}</h2>
-          <p>
-            {detail.data
-              ? branchNarrative(detail.data)
-              : selected
-                ? branchNarrativeFromBranch(selected)
-                : 'Branch state, compare summary, and commit history for the selected catalog branch.'}
-          </p>
-          <div className="phlo-v2-action-row">
-            <button
-              data-active={activePanel === 'compare'}
-              onClick={() =>
-                dispatch({ type: 'activePanel', panel: 'compare' })
-              }
-              type="button"
-            >
-              <GitCompare className="size-3.5" />
-              Compare
-            </button>
-            <button
-              data-active={activePanel === 'history'}
-              onClick={() =>
-                dispatch({ type: 'activePanel', panel: 'history' })
-              }
-              type="button"
-            >
-              <History className="size-3.5" />
-              History
-            </button>
-            <button
-              data-active={activePanel === 'contents'}
-              onClick={() =>
-                dispatch({ type: 'activePanel', panel: 'contents' })
-              }
-              type="button"
-            >
-              <Table2 className="size-3.5" />
-              Contents
-            </button>
+              <button
+                onClick={() => {
+                  const branchName = window.prompt('New branch name')
+                  if (!branchName) return
+                  if (
+                    !window.confirm(
+                      `Create branch ${branchName}? This writes Observatory branch state through phlo-api.`,
+                    )
+                  ) {
+                    return
+                  }
+                  void runV2BranchAction({
+                    data: { actionId: `branch:create:${branchName}` },
+                  }).then((next) => {
+                    invalidateCachedResources(['v2:operations', 'v2:branches'])
+                    const message =
+                      next.data?.message ??
+                      next.error ??
+                      'Branch action completed'
+                    if (next.data?.status === 'succeeded') {
+                      dispatch({
+                        type: 'branchCreated',
+                        branch: {
+                          current: false,
+                          id: branchName,
+                          metadata: { source: 'local' },
+                          name: branchName,
+                          protected: false,
+                        },
+                        message,
+                      })
+                    } else {
+                      dispatch({ type: 'actionMessage', message })
+                    }
+                  })
+                }}
+                type="button"
+              >
+                <Plus className="size-3.5" />
+                Branch
+              </button>
+            </div>
+            {branches.map((branch) => (
+              <button
+                className="phlo-v2-row phlo-v2-select-row"
+                data-active={branch.id === selected?.id}
+                key={branch.id}
+                onClick={() =>
+                  dispatch({ type: 'select', selectedId: branch.id })
+                }
+                type="button"
+              >
+                <div className="phlo-v2-row-main">
+                  <div className="phlo-v2-row-title">{branch.name}</div>
+                  <div className="phlo-v2-row-meta">
+                    {branch.current ? 'Current branch' : 'Review branch'}
+                    {branchDelta(branch) && <> · {branchDelta(branch)}</>}
+                  </div>
+                </div>
+                <span className="phlo-v2-pill">
+                  {branch.current
+                    ? 'current'
+                    : branch.protected
+                      ? 'protected'
+                      : 'branch'}
+                </span>
+              </button>
+            ))}
           </div>
           {selected && (
             <>
-              <dl className="phlo-v2-facts">
-                <dt>Tables</dt>
-                <dd>{selectedTableCount}</dd>
-                <dt>Evidence</dt>
-                <dd>{selectedEvidenceCount}</dd>
-                <dt>Added</dt>
-                <dd>{selectedCompare.added ?? 0}</dd>
-                <dt>Changed</dt>
-                <dd>{selectedCompare.changed ?? 0}</dd>
-                <dt>Ahead / behind</dt>
-                <dd>
-                  {selectedCompare.ahead ?? 0} / {selectedCompare.behind ?? 0}
-                </dd>
-                <dt>Protected</dt>
-                <dd>{selected.protected ? 'yes' : 'no'}</dd>
-              </dl>
+              <section className="phlo-v2-branch-summary">
+                <div className="phlo-v2-branch-summary-copy">
+                  <div className="phlo-v2-inspector-label">Selected branch</div>
+                  <h2>{selected.name}</h2>
+                  <p>
+                    {detail.data
+                      ? branchNarrative(detail.data)
+                      : branchNarrativeFromBranch(selected)}
+                  </p>
+                </div>
+                <div className="phlo-v2-action-row">
+                  <button
+                    data-active={activePanel === 'compare'}
+                    onClick={() =>
+                      dispatch({ type: 'activePanel', panel: 'compare' })
+                    }
+                    type="button"
+                  >
+                    <GitCompare className="size-3.5" />
+                    Compare
+                  </button>
+                  <button
+                    data-active={activePanel === 'history'}
+                    onClick={() =>
+                      dispatch({ type: 'activePanel', panel: 'history' })
+                    }
+                    type="button"
+                  >
+                    <History className="size-3.5" />
+                    History
+                  </button>
+                  <button
+                    data-active={activePanel === 'contents'}
+                    onClick={() =>
+                      dispatch({ type: 'activePanel', panel: 'contents' })
+                    }
+                    type="button"
+                  >
+                    <Table2 className="size-3.5" />
+                    Contents
+                  </button>
+                </div>
+                <dl className="phlo-v2-branch-facts">
+                  <div>
+                    <dt>Tables</dt>
+                    <dd>{selectedTableCount}</dd>
+                  </div>
+                  <div>
+                    <dt>Evidence</dt>
+                    <dd>{selectedEvidenceCount}</dd>
+                  </div>
+                  <div>
+                    <dt>Added</dt>
+                    <dd>{selectedCompare.added ?? 0}</dd>
+                  </div>
+                  <div>
+                    <dt>Changed</dt>
+                    <dd>{selectedCompare.changed ?? 0}</dd>
+                  </div>
+                  <div>
+                    <dt>Ahead / behind</dt>
+                    <dd>
+                      {selectedCompare.ahead ?? 0} /{' '}
+                      {selectedCompare.behind ?? 0}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Protected</dt>
+                    <dd>{selected.protected ? 'yes' : 'no'}</dd>
+                  </div>
+                </dl>
+              </section>
+              <WapReport operations={branchOperations} />
               {detail.data ? (
-                <BranchPanelView active={activePanel} detail={detail.data} />
+                <BranchPanelView
+                  active={activePanel}
+                  detail={detail.data}
+                  operations={branchOperations}
+                />
               ) : (
-                <BranchPanelFallback active={activePanel} branch={selected} />
+                <BranchPanelFallback
+                  active={activePanel}
+                  branch={selected}
+                  operations={branchOperations}
+                />
               )}
             </>
           )}
@@ -271,7 +310,10 @@ export function Branches() {
           {result.error && (
             <div className="phlo-v2-panel-footer">{result.error}</div>
           )}
-        </aside>
+          {operationsResult.error && (
+            <div className="phlo-v2-panel-footer">{operationsResult.error}</div>
+          )}
+        </div>
       </section>
     </V2Page>
   )
@@ -290,12 +332,42 @@ function mergeBranches(
   return Array.from(merged.values())
 }
 
+function mergeOperations(
+  left: Array<V2Operation>,
+  right: Array<V2Operation>,
+): Array<V2Operation> {
+  const merged = new Map<string, V2Operation>()
+  for (const operation of [...left, ...right]) {
+    merged.set(operation.id, operation)
+  }
+  return Array.from(merged.values())
+}
+
+function branchRelatedOperations(
+  branch: V2Branch | undefined,
+  operations: Array<V2Operation>,
+): Array<V2Operation> {
+  if (!branch) return []
+  return operations.filter((operation) => {
+    const metadataBranch = metadataString(operation.metadata, 'branch')
+    return (
+      operation.target?.kind === 'branch' &&
+      (operation.target.id === branch.id ||
+        operation.target.id === branch.name ||
+        metadataBranch === branch.id ||
+        metadataBranch === branch.name)
+    )
+  })
+}
+
 function BranchPanelView({
   active,
   detail,
+  operations,
 }: {
   active: BranchPanel
   detail: V2BranchDetail
+  operations: Array<V2Operation>
 }) {
   if (active === 'compare') {
     return (
@@ -317,16 +389,21 @@ function BranchPanelView({
             value={detail.compare.removed ?? 0}
           />
         </div>
-        <TableEvidence tables={detail.tables} />
+        <BranchReviewEvidence
+          branch={detail.branch}
+          operations={operations}
+          tables={detail.tables}
+        />
       </div>
     )
   }
 
   if (active === 'history') {
+    const commits = mergeOperations(operations, detail.commits)
     return (
       <div className="phlo-v2-detail-list">
-        {detail.commits.length > 0 ? (
-          detail.commits
+        {commits.length > 0 ? (
+          commits
             .slice(0, 8)
             .map((commit) => <CommitRow commit={commit} key={commit.id} />)
         ) : (
@@ -349,9 +426,11 @@ function BranchPanelView({
 function BranchPanelFallback({
   active,
   branch,
+  operations,
 }: {
   active: BranchPanel
   branch: V2Branch
+  operations: Array<V2Operation>
 }) {
   if (active === 'compare') {
     const compare = branchCompare(branch)
@@ -374,15 +453,65 @@ function BranchPanelFallback({
             value={compare.removed ?? 0}
           />
         </div>
-        <p>Loading table-level evidence for this branch.</p>
+        <BranchReviewEvidence
+          branch={branch}
+          operations={operations}
+          tables={[]}
+        />
+      </div>
+    )
+  }
+
+  if (active === 'history' && operations.length > 0) {
+    return (
+      <div className="phlo-v2-detail-list">
+        {operations.slice(0, 8).map((operation) => (
+          <CommitRow commit={operation} key={operation.id} />
+        ))}
       </div>
     )
   }
 
   return (
     <div className="phlo-v2-detail-list">
-      <p>Loading branch detail for this panel.</p>
+      <p>
+        No branch contents returned by the API yet. WAP evidence is shown above.
+      </p>
     </div>
+  )
+}
+
+function WapReport({ operations }: { operations: Array<V2Operation> }) {
+  const report = operations.find((operation) => operation.kind === 'wap')
+  if (!report) return null
+  const metadata = report.metadata
+  const fields = [
+    ['Run', metadataString(metadata, 'run_id') ?? report.id],
+    ['Branch', metadataString(metadata, 'branch') ?? report.target?.id],
+    ['Source hash', metadataString(metadata, 'source_hash')],
+    ['Target before', metadataString(metadata, 'target_hash_before')],
+    ['Target after', metadataString(metadata, 'target_hash_after')],
+    ['WAP branch deleted', metadataBoolean(metadata, 'source_deleted')],
+  ].filter((field): field is [string, string] => Boolean(field[1]))
+
+  return (
+    <section className="phlo-v2-wap-report">
+      <div className="phlo-v2-inspector-label">WAP report</div>
+      <h3>{report.name}</h3>
+      <p>
+        {[report.status, formatDateTime(report.completed_at)]
+          .filter(Boolean)
+          .join(' · ')}
+      </p>
+      <dl>
+        {fields.map(([label, value]) => (
+          <div key={label}>
+            <dt>{label}</dt>
+            <dd>{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
   )
 }
 
@@ -404,15 +533,100 @@ function BranchMetric({
   )
 }
 
-function TableEvidence({ tables }: { tables: Array<V2Table> }) {
+function BranchReviewEvidence({
+  branch,
+  operations,
+  tables,
+}: {
+  branch: V2Branch
+  operations: Array<V2Operation>
+  tables: Array<V2Table>
+}) {
+  const flow = branchFlow(branch, operations, tables)
   return (
-    <div className="phlo-v2-detail-list">
-      {tables.slice(0, 6).map((table) => (
-        <TableRow key={table.id} table={table} />
-      ))}
-      {tables.length === 0 && <p>No tables are attached to this branch.</p>}
+    <div className="phlo-v2-branch-evidence">
+      <div className="phlo-v2-branch-flow">
+        <V2FlowCanvas edges={flow.edges} nodes={flow.nodes} />
+      </div>
+      <div className="phlo-v2-branch-table-list">
+        {tables.length > 0 ? (
+          tables
+            .slice(0, 8)
+            .map((table) => <TableRow key={table.id} table={table} />)
+        ) : (
+          <p>
+            WAP reported a changed table count, but the report did not include
+            table refs.
+          </p>
+        )}
+      </div>
     </div>
   )
+}
+
+function branchFlow(
+  branch: V2Branch,
+  operations: Array<V2Operation>,
+  tables: Array<V2Table>,
+): { nodes: Array<V2FlowNode>; edges: Array<V2FlowEdge> } {
+  const report = operations.find((operation) => operation.kind === 'wap')
+  const sourceHash = metadataString(report?.metadata ?? {}, 'source_hash')
+  const targetHash = metadataString(report?.metadata ?? {}, 'target_hash_after')
+  const tableNodes = tables.slice(0, 6).map(
+    (table): V2FlowNode => ({
+      id: `table:${table.id}`,
+      kind: 'table',
+      label: table.name,
+      lane: 'table',
+      metric:
+        tableRecordCount(table) === 'n/a'
+          ? undefined
+          : `${tableRecordCount(table)} rows`,
+      subtitle: table.namespace ?? undefined,
+    }),
+  )
+  const nodes: Array<V2FlowNode> = [
+    {
+      id: 'branch',
+      kind: 'branch',
+      label: branch.name,
+      lane: 'branch',
+      metric: sourceHash ?? undefined,
+    },
+    ...tableNodes,
+    {
+      id: 'publish',
+      kind: 'operation',
+      label: report?.name ?? 'WAP publish',
+      lane: 'publish',
+      metric: targetHash ?? undefined,
+    },
+  ]
+  const edges: Array<V2FlowEdge> =
+    tableNodes.length > 0
+      ? [
+          ...tableNodes.map((table) => ({
+            id: `branch:${table.id}`,
+            source: 'branch',
+            target: table.id,
+            label: 'writes',
+          })),
+          ...tableNodes.map((table) => ({
+            id: `${table.id}:publish`,
+            source: table.id,
+            target: 'publish',
+            label: 'promotes',
+          })),
+        ]
+      : [
+          {
+            id: 'branch:publish',
+            source: 'branch',
+            target: 'publish',
+            label: 'promotes',
+          },
+        ]
+  return { edges, nodes }
 }
 
 function TableRow({ table }: { table: V2Table }) {
@@ -432,11 +646,25 @@ function TableRow({ table }: { table: V2Table }) {
 }
 
 function CommitRow({ commit }: { commit: V2Operation }) {
+  const reason = operationReason(commit)
+  const sourceHash = metadataString(commit.metadata, 'source_hash')
+  const targetHash = metadataString(commit.metadata, 'target_hash_after')
+  const hashMovement =
+    sourceHash && targetHash ? `${sourceHash} -> ${targetHash}` : null
   return (
-    <div className="phlo-v2-mini-row">
+    <div
+      className={`phlo-v2-mini-row${
+        commit.kind === 'wap' ? ' phlo-v2-wap-history-row' : ''
+      }`}
+    >
       <span>{commit.name}</span>
       <small>
-        {[commit.status, commit.completed_at, operationReason(commit)]
+        {[
+          commit.status,
+          formatDateTime(commit.completed_at),
+          hashMovement,
+          reason,
+        ]
           .filter(Boolean)
           .join(' · ')}
       </small>
@@ -501,6 +729,37 @@ function metadataNumber(item: V2Branch | undefined, key: string): number {
     return Number.isNaN(parsed) ? 0 : parsed
   }
   return 0
+}
+
+function metadataString(
+  metadata: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = metadata[key]
+  if (typeof value === 'string' && value.length > 0) return value
+  if (typeof value === 'number') return String(value)
+  return null
+}
+
+function metadataBoolean(
+  metadata: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = metadata[key]
+  if (typeof value === 'boolean') return value ? 'yes' : 'no'
+  if (typeof value === 'string' && value.length > 0) return value
+  return null
+}
+
+function formatDateTime(value?: string | null): string | null {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return `${new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+  }).format(date)} UTC`
 }
 
 function operationReason(operation: V2Operation): string | null {

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/branches.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/branches.tsx
@@ -18,19 +18,19 @@ import type {
   V2ResourceResult,
   V2Table,
 } from '@/v2/api/types'
+import type { V2FlowEdge, V2FlowNode } from '@/v2/components/V2FlowCanvas'
 import {
   getV2BranchDetailDirect,
   getV2BranchRecords,
   getV2OperationRecords,
   runV2BranchAction,
 } from '@/v2/api/resources'
+import { V2FlowCanvas } from '@/v2/components/V2FlowCanvas'
 import { V2Page } from '@/v2/components/V2Page'
 import {
   invalidateCachedResources,
   useLiveResource,
 } from '@/v2/routes/liveResource'
-import { V2FlowCanvas } from '@/v2/components/V2FlowCanvas'
-import type { V2FlowEdge, V2FlowNode } from '@/v2/components/V2FlowCanvas'
 
 export const Route = createFileRoute('/v2/branches')({
   component: Branches,

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/operations.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/operations.tsx
@@ -14,6 +14,7 @@ import type {
   V2OperationDetail,
   V2ResourceResult,
 } from '@/v2/api/types'
+import type { V2FlowEdge, V2FlowNode } from '@/v2/components/V2FlowCanvas'
 import {
   getV2OperationDetail,
   getV2OperationRecords,
@@ -21,7 +22,6 @@ import {
 } from '@/v2/api/resources'
 import { ActionButton } from '@/v2/components/ActionButton'
 import { V2FlowCanvas } from '@/v2/components/V2FlowCanvas'
-import type { V2FlowEdge, V2FlowNode } from '@/v2/components/V2FlowCanvas'
 import { V2Page } from '@/v2/components/V2Page'
 import {
   invalidateCachedResources,

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/operations.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/v2/operations.tsx
@@ -1,5 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router'
-import { CheckCircle2, Clock3, RotateCcw, ShieldAlert } from 'lucide-react'
+import {
+  CheckCircle2,
+  Clock3,
+  Database,
+  RotateCcw,
+  ShieldAlert,
+} from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 
@@ -14,6 +20,8 @@ import {
   runV2Action,
 } from '@/v2/api/resources'
 import { ActionButton } from '@/v2/components/ActionButton'
+import { V2FlowCanvas } from '@/v2/components/V2FlowCanvas'
+import type { V2FlowEdge, V2FlowNode } from '@/v2/components/V2FlowCanvas'
 import { V2Page } from '@/v2/components/V2Page'
 import {
   invalidateCachedResources,
@@ -61,6 +69,7 @@ export function Operations() {
   )
   const selectedFailure = latest ? operationFailure(latest) : null
   const selectedMetadata = latest ? operationMetadata(latest) : []
+  const selectedIsWap = latest?.kind === 'wap'
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -91,39 +100,51 @@ export function Operations() {
 
   return (
     <V2Page
-      kicker="Actions"
-      title="Recovery activity"
-      description="Phlo-owned actions, maintenance status, and service-impacting work."
+      kicker="Operations"
+      title={selectedIsWap && latest ? latest.name : 'Recovery activity'}
+      description={
+        selectedIsWap && latest
+          ? 'WAP branch publish evidence, affected tables, and target hash movement.'
+          : 'Phlo-owned actions, maintenance status, and service-impacting work.'
+      }
       action={
         <span className="phlo-v2-pill">{visibleOperations.length} actions</span>
       }
     >
-      <section className="phlo-v2-command">
+      <section
+        className={`phlo-v2-command${
+          selectedIsWap ? ' phlo-v2-wap-operation-shell' : ''
+        }`}
+      >
         <div className="phlo-v2-command-primary">
           {visibleOperations.length > 0 ? (
             <>
-              <div className="phlo-v2-command-strip">
-                <Metric
-                  icon={<CheckCircle2 className="size-4" />}
-                  label="Recovered"
-                  value={recovered}
-                />
-                <Metric
-                  icon={<ShieldAlert className="size-4" />}
-                  label="Failed"
-                  value={failed}
-                />
-                <Metric
-                  icon={<Clock3 className="size-4" />}
-                  label="Last duration"
-                  value={
-                    latest?.duration_seconds
-                      ? `${latest.duration_seconds}s`
-                      : 'n/a'
-                  }
-                />
-              </div>
-              {latest && (
+              {!selectedIsWap && (
+                <div className="phlo-v2-command-strip">
+                  <Metric
+                    icon={<CheckCircle2 className="size-4" />}
+                    label="Recovered"
+                    value={recovered}
+                  />
+                  <Metric
+                    icon={<ShieldAlert className="size-4" />}
+                    label="Failed"
+                    value={failed}
+                  />
+                  <Metric
+                    icon={<Clock3 className="size-4" />}
+                    label="Last duration"
+                    value={
+                      latest?.duration_seconds
+                        ? `${latest.duration_seconds}s`
+                        : 'n/a'
+                    }
+                  />
+                </div>
+              )}
+              {latest && selectedIsWap ? (
+                <WapOperationFocus operation={latest} />
+              ) : latest ? (
                 <div
                   className="phlo-v2-operation-focus"
                   data-state={latest.health.state}
@@ -158,7 +179,7 @@ export function Operations() {
                       />
                       <Fact
                         label="Completed"
-                        value={latest.completed_at ?? 'not completed'}
+                        value={formatDateTime(latest.completed_at)}
                       />
                     </dl>
                   </div>
@@ -173,56 +194,64 @@ export function Operations() {
                     </div>
                   )}
                 </div>
-              )}
-              <div className="phlo-v2-operation-ledger">
-                <div className="phlo-v2-workspace-toolbar">
-                  <span>Target ledger</span>
-                  <span className="phlo-v2-pill">{ledger.length} targets</span>
-                </div>
-                <div className="phlo-v2-operation-ledger-grid">
-                  {ledger.map((item) => (
-                    <button
-                      className="phlo-v2-operation-ledger-card"
-                      data-state={item.state}
-                      key={item.id}
-                      onClick={() => setSelectedId(item.latest.id)}
-                      type="button"
-                    >
-                      <span>{item.kind}</span>
-                      <strong>{item.label}</strong>
-                      <small>
-                        {item.succeeded} succeeded · {item.failed} failed ·{' '}
-                        {item.lastSeen}
-                      </small>
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div className="phlo-v2-workspace-toolbar">
-                <span>Activity stream</span>
-                <span className="phlo-v2-pill">
-                  showing {displayedOperations.length}
-                  {hiddenOperationCount > 0
-                    ? ` of ${visibleOperations.length}`
-                    : ''}
-                </span>
-              </div>
-              <div className="phlo-v2-timeline">
-                {displayedOperations.map((operation) => (
-                  <OperationLine
-                    key={operation.id}
-                    onSelect={setSelectedId}
-                    operation={operation}
-                    selected={operation.id === latest?.id}
-                  />
-                ))}
-                {hiddenOperationCount > 0 && (
-                  <div className="phlo-v2-noise-row">
-                    {hiddenOperationCount} older operations kept out of the DOM.
-                    Use target selection to narrow the working set.
+              ) : null}
+              {!selectedIsWap && (
+                <div className="phlo-v2-operation-ledger">
+                  <div className="phlo-v2-workspace-toolbar">
+                    <span>Target ledger</span>
+                    <span className="phlo-v2-pill">
+                      {ledger.length} targets
+                    </span>
                   </div>
-                )}
-              </div>
+                  <div className="phlo-v2-operation-ledger-grid">
+                    {ledger.map((item) => (
+                      <button
+                        className="phlo-v2-operation-ledger-card"
+                        data-state={item.state}
+                        key={item.id}
+                        onClick={() => setSelectedId(item.latest.id)}
+                        type="button"
+                      >
+                        <span>{item.kind}</span>
+                        <strong>{item.label}</strong>
+                        <small>
+                          {item.succeeded} succeeded · {item.failed} failed ·{' '}
+                          {item.lastSeen}
+                        </small>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {!selectedIsWap && (
+                <>
+                  <div className="phlo-v2-workspace-toolbar">
+                    <span>Activity stream</span>
+                    <span className="phlo-v2-pill">
+                      showing {displayedOperations.length}
+                      {hiddenOperationCount > 0
+                        ? ` of ${visibleOperations.length}`
+                        : ''}
+                    </span>
+                  </div>
+                  <div className="phlo-v2-timeline">
+                    {displayedOperations.map((operation) => (
+                      <OperationLine
+                        key={operation.id}
+                        onSelect={setSelectedId}
+                        operation={operation}
+                        selected={operation.id === latest?.id}
+                      />
+                    ))}
+                    {hiddenOperationCount > 0 && (
+                      <div className="phlo-v2-noise-row">
+                        {hiddenOperationCount} older operations kept out of the
+                        DOM. Use target selection to narrow the working set.
+                      </div>
+                    )}
+                  </div>
+                </>
+              )}
             </>
           ) : (
             <div className="phlo-v2-operation-empty">
@@ -255,100 +284,204 @@ export function Operations() {
           )}
         </div>
 
-        <aside className="phlo-v2-inspector">
-          <div className="phlo-v2-inspector-label">Selected operation</div>
-          {latest ? (
-            <>
-              <h2>{latest.name}</h2>
-              <p>{latest.target?.label ?? latest.kind}</p>
-              <dl className="phlo-v2-facts">
-                <Fact label="Status" value={latest.status} />
-                <Fact
-                  label="Namespace"
-                  value={readMetric(latest.metadata, 'namespace')}
-                />
-                <Fact
-                  label="Tables"
-                  value={readMetric(latest.metadata, 'tables_processed')}
-                />
-                <Fact
-                  label="Records"
-                  value={readMetric(latest.metadata, 'total_records')}
-                />
-                <Fact
-                  label="Size"
-                  value={`${readMetric(latest.metadata, 'total_size_mb') ?? 0} MB`}
-                />
-                <Fact
-                  label="Completed"
-                  value={latest.completed_at ?? 'not completed'}
-                />
-              </dl>
-              <div className="phlo-v2-action-row">
-                {(detail.data?.actions ?? []).map((action) => (
-                  <ActionButton
-                    action={action}
-                    key={action.id}
-                    onRun={(actionId) => {
-                      void runV2Action({ data: { actionId } }).then((next) => {
-                        const operation = next.data?.operation
-                        if (operation) {
-                          setLocalOperations((current) =>
-                            mergeOperations([operation], current),
-                          )
-                        }
-                        invalidateCachedResources(['v2:operations'])
-                        setActionMessage(
-                          next.data?.message ??
-                            next.error ??
-                            'Action requested',
-                        )
-                      })
-                    }}
+        {!selectedIsWap && (
+          <aside className="phlo-v2-inspector">
+            <div className="phlo-v2-inspector-label">Selected operation</div>
+            {latest ? (
+              <>
+                <h2>{latest.name}</h2>
+                <p>{latest.target?.label ?? latest.kind}</p>
+                <dl className="phlo-v2-facts">
+                  <Fact label="Status" value={latest.status} />
+                  <Fact
+                    label="Namespace"
+                    value={readMetric(latest.metadata, 'namespace')}
                   />
-                ))}
-              </div>
-              {actionMessage && (
-                <div className="phlo-v2-panel-footer">{actionMessage}</div>
-              )}
-              {selectedFailure && (
+                  <Fact
+                    label="Tables"
+                    value={readMetric(latest.metadata, 'tables_processed')}
+                  />
+                  <Fact
+                    label="Records"
+                    value={readMetric(latest.metadata, 'total_records')}
+                  />
+                  <Fact
+                    label="Size"
+                    value={`${readMetric(latest.metadata, 'total_size_mb') ?? 0} MB`}
+                  />
+                  <Fact
+                    label="Completed"
+                    value={formatDateTime(latest.completed_at)}
+                  />
+                </dl>
+                <div className="phlo-v2-action-row">
+                  {(detail.data?.actions ?? []).map((action) => (
+                    <ActionButton
+                      action={action}
+                      key={action.id}
+                      onRun={(actionId) => {
+                        void runV2Action({ data: { actionId } }).then(
+                          (next) => {
+                            const operation = next.data?.operation
+                            if (operation) {
+                              setLocalOperations((current) =>
+                                mergeOperations([operation], current),
+                              )
+                            }
+                            invalidateCachedResources(['v2:operations'])
+                            setActionMessage(
+                              next.data?.message ??
+                                next.error ??
+                                'Action requested',
+                            )
+                          },
+                        )
+                      }}
+                    />
+                  ))}
+                </div>
+                {actionMessage && (
+                  <div className="phlo-v2-panel-footer">{actionMessage}</div>
+                )}
+                {selectedFailure && (
+                  <div className="phlo-v2-detail-list">
+                    <div className="phlo-v2-mini-row" data-state="error">
+                      <span>{selectedFailure.title}</span>
+                      <small>{selectedFailure.message}</small>
+                    </div>
+                  </div>
+                )}
                 <div className="phlo-v2-detail-list">
-                  <div className="phlo-v2-mini-row" data-state="error">
-                    <span>{selectedFailure.title}</span>
-                    <small>{selectedFailure.message}</small>
+                  <div className="phlo-v2-mini-row">
+                    <span>Related</span>
+                    <small>
+                      {detail.data?.related
+                        .map((item) => item.label)
+                        .join(', ') || 'none'}
+                    </small>
+                  </div>
+                  <div className="phlo-v2-mini-row">
+                    <span>Logs</span>
+                    <small>{detail.data?.logs.length ?? 0} linked events</small>
                   </div>
                 </div>
-              )}
-              <div className="phlo-v2-detail-list">
-                <div className="phlo-v2-mini-row">
-                  <span>Related</span>
-                  <small>
-                    {detail.data?.related
-                      .map((item) => item.label)
-                      .join(', ') || 'none'}
-                  </small>
-                </div>
-                <div className="phlo-v2-mini-row">
-                  <span>Logs</span>
-                  <small>{detail.data?.logs.length ?? 0} linked events</small>
-                </div>
-              </div>
-            </>
-          ) : (
-            <>
-              <h2>No operation selected</h2>
-              <p>There are no Phlo operation records for this lakehouse yet.</p>
-            </>
-          )}
-          {detail.error && (
-            <div className="phlo-v2-panel-footer">{detail.error}</div>
-          )}
-          {result.error && (
-            <div className="phlo-v2-panel-footer">{result.error}</div>
-          )}
-        </aside>
+              </>
+            ) : (
+              <>
+                <h2>No operation selected</h2>
+                <p>
+                  There are no Phlo operation records for this lakehouse yet.
+                </p>
+              </>
+            )}
+            {detail.error && (
+              <div className="phlo-v2-panel-footer">{detail.error}</div>
+            )}
+            {result.error && (
+              <div className="phlo-v2-panel-footer">{result.error}</div>
+            )}
+          </aside>
+        )}
       </section>
     </V2Page>
+  )
+}
+
+function WapOperationFocus({ operation }: { operation: V2Operation }) {
+  const metadata = operation.metadata
+  const tables = wapTables(operation)
+  const flow = wapOperationFlow(operation, tables)
+  const branch = textMetric(metadata, 'branch') ?? operation.target?.label
+  const fields = [
+    ['Run', textMetric(metadata, 'run_id') ?? operation.id],
+    ['Branch', branch],
+    ['Source hash', textMetric(metadata, 'source_hash')],
+    ['Target before', textMetric(metadata, 'target_hash_before')],
+    ['Target after', textMetric(metadata, 'target_hash_after')],
+    ['Completed', formatDateTime(operation.completed_at)],
+  ].filter((field): field is [string, string] => Boolean(field[1]))
+
+  return (
+    <div className="phlo-v2-wap-operation">
+      <div className="phlo-v2-wap-operation-header">
+        <div>
+          <span className="phlo-v2-inspector-label">WAP execution</span>
+          <strong>Execution report</strong>
+          <p>
+            {operation.status} · {branch ?? 'branch unknown'} · {tables.length}{' '}
+            table{tables.length === 1 ? '' : 's'}
+          </p>
+        </div>
+        <span className="phlo-v2-pill">{operation.status}</span>
+      </div>
+      <dl className="phlo-v2-wap-operation-fields">
+        {fields.map(([label, value]) => (
+          <div key={label}>
+            <dt>{label}</dt>
+            <dd>{value}</dd>
+          </div>
+        ))}
+      </dl>
+      <div className="phlo-v2-wap-operation-evidence">
+        <div className="phlo-v2-wap-operation-steps">
+          <div>
+            <span>Branch</span>
+            <strong>{branch ?? 'branch unknown'}</strong>
+            <small>
+              {textMetric(metadata, 'source_hash') ?? 'source unknown'}
+            </small>
+          </div>
+          <div>
+            <span>Table</span>
+            <strong>{tables[0]?.name ?? 'table refs missing'}</strong>
+            <small>
+              {tables[0]?.records
+                ? `${tables[0].records} rows`
+                : 'records unknown'}
+            </small>
+          </div>
+          <div>
+            <span>Publish</span>
+            <strong>{operation.name}</strong>
+            <small>
+              {textMetric(metadata, 'target_hash_after') ?? 'target unknown'}
+            </small>
+          </div>
+        </div>
+        <div className="phlo-v2-wap-operation-flow">
+          <V2FlowCanvas edges={flow.edges} nodes={flow.nodes} />
+        </div>
+        <div className="phlo-v2-wap-operation-tables">
+          <div className="phlo-v2-workspace-toolbar">
+            <span>Affected tables</span>
+            <span className="phlo-v2-pill">{tables.length}</span>
+          </div>
+          {tables.map((table) => (
+            <div className="phlo-v2-mini-row" key={table.id}>
+              <span>
+                <Database className="size-3.5" />
+                {table.name}
+              </span>
+              <small>
+                {[
+                  table.namespace,
+                  table.format,
+                  table.records ? `${table.records} records` : null,
+                ]
+                  .filter(Boolean)
+                  .join(' · ')}
+              </small>
+            </div>
+          ))}
+          {tables.length === 0 && (
+            <p>
+              Report has no table refs. Branch and hash evidence are still
+              shown.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }
 
@@ -395,7 +528,7 @@ function OperationLine({
         </div>
         <div className="phlo-v2-row-meta">
           {operation.kind} · {operation.target?.label ?? 'platform'} ·{' '}
-          {operation.completed_at ?? 'in progress'}
+          {formatDateTime(operation.completed_at) ?? 'in progress'}
         </div>
         {failure && (
           <div className="phlo-v2-row-meta phlo-v2-row-evidence">
@@ -423,6 +556,112 @@ function mergeOperations(
 
 function operationTimestamp(operation: V2Operation): string {
   return operation.completed_at ?? operation.started_at ?? operation.id
+}
+
+function wapTables(operation: V2Operation): Array<{
+  id: string
+  name: string
+  namespace: string | null
+  format: string | null
+  records: string | null
+}> {
+  const rawTables = operation.metadata.tables
+  if (!Array.isArray(rawTables)) return []
+  return rawTables
+    .map((item) => {
+      if (typeof item === 'string') {
+        const namespace = item.includes('.')
+          ? item.split('.').slice(0, -1).join('.')
+          : null
+        return {
+          id: item,
+          name: item.split('.').at(-1) ?? item,
+          namespace,
+          format: null,
+          records: null,
+        }
+      }
+      if (!item || typeof item !== 'object') return null
+      const table = item as Record<string, unknown>
+      const metadata =
+        table.metadata && typeof table.metadata === 'object'
+          ? (table.metadata as Record<string, unknown>)
+          : {}
+      const id = String(table.id ?? table.asset_id ?? table.name ?? '')
+      if (!id) return null
+      const name = String(table.name ?? id.split('.').at(-1) ?? id)
+      return {
+        id,
+        name,
+        namespace: textValue(table.namespace ?? table.schema_name),
+        format: textValue(table.format),
+        records: textValue(metadata.records ?? table.records),
+      }
+    })
+    .filter((item): item is NonNullable<typeof item> => Boolean(item))
+}
+
+function wapOperationFlow(
+  operation: V2Operation,
+  tables: ReturnType<typeof wapTables>,
+): { nodes: Array<V2FlowNode>; edges: Array<V2FlowEdge> } {
+  const branch =
+    textMetric(operation.metadata, 'branch') ??
+    operation.target?.label ??
+    'branch'
+  const sourceHash = textMetric(operation.metadata, 'source_hash')
+  const targetHash = textMetric(operation.metadata, 'target_hash_after')
+  const tableNodes = tables.slice(0, 6).map(
+    (table): V2FlowNode => ({
+      id: `table:${table.id}`,
+      kind: 'table',
+      label: table.name,
+      lane: 'table',
+      metric: table.records ? `${table.records} rows` : undefined,
+    }),
+  )
+  const nodes: Array<V2FlowNode> = [
+    {
+      id: 'branch',
+      kind: 'branch',
+      label: branch,
+      lane: 'branch',
+      metric: sourceHash ?? undefined,
+    },
+    ...tableNodes,
+    {
+      id: 'publish',
+      kind: 'operation',
+      label: operation.name,
+      lane: 'publish',
+      metric: targetHash ?? undefined,
+    },
+  ]
+  const edges: Array<V2FlowEdge> =
+    tableNodes.length > 0
+      ? [
+          ...tableNodes.map((table) => ({
+            id: `branch:${table.id}`,
+            source: 'branch',
+            target: table.id,
+            label: 'writes',
+          })),
+          ...tableNodes.map((table) => ({
+            id: `${table.id}:publish`,
+            source: table.id,
+            target: 'publish',
+            label: 'promotes',
+          })),
+        ]
+      : [
+          {
+            id: 'branch:publish',
+            source: 'branch',
+            target: 'publish',
+            label: 'promotes',
+          },
+        ]
+  return { edges, nodes }
 }
 
 function buildOperationLedger(operations: Array<V2Operation>) {
@@ -539,6 +778,23 @@ function textMetric(
 ): string | null {
   const value = metadata[key]
   return typeof value === 'string' && value.trim() ? value : null
+}
+
+function textValue(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) return value
+  if (typeof value === 'number') return String(value)
+  return null
+}
+
+function formatDateTime(value?: string | null): string | null {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return `${new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+  }).format(date)} UTC`
 }
 
 function humanizeKey(key: string): string {

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/api/resources.ts
@@ -493,6 +493,21 @@ export const getV2BranchDetail = createServerFn()
     },
   )
 
+export async function getV2BranchDetailDirect({
+  branchName,
+}: {
+  branchName: string
+}): Promise<V2ResourceResult<V2BranchDetail>> {
+  try {
+    const data = await browserApiGet<V2BranchDetail>(
+      `${V2_API_PREFIX}/branches/${encodeURIComponent(branchName)}`,
+    )
+    return { data, error: null }
+  } catch (error) {
+    return apiUnavailable<V2BranchDetail>(error)
+  }
+}
+
 export function getV2Extensions() {
   return getRawCollection<V2Extension>('extensions')
 }

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/components/V2FlowCanvas.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/components/V2FlowCanvas.tsx
@@ -64,6 +64,7 @@ const laneX: Record<string, number> = {
   marts: 900,
   branch: 0,
   table: 260,
+  publish: 540,
   quality: 540,
   operation: 260,
   service: 0,

--- a/packages/phlo-observatory/src/phlo_observatory/src/v2/design/tokens.css
+++ b/packages/phlo-observatory/src/phlo_observatory/src/v2/design/tokens.css
@@ -414,6 +414,10 @@ html[data-phlo-v2-route='true'][data-phlo-v2-theme='dark']
   margin-top: 18px;
 }
 
+.phlo-v2-command.phlo-v2-wap-operation-shell {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .phlo-v2-lineage-shell {
   grid-template-columns: minmax(0, 1fr) 320px;
   align-items: start;
@@ -666,6 +670,16 @@ html[data-phlo-v2-route='true'][data-phlo-v2-theme='dark']
   grid-template-columns: minmax(0, 1fr) 320px;
   gap: 22px;
   align-items: start;
+}
+
+.phlo-v2-branch-grid {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.phlo-v2-branch-main {
+  display: grid;
+  gap: 16px;
+  min-width: 0;
 }
 
 .phlo-v2-service-list,
@@ -1564,9 +1578,354 @@ html[data-phlo-v2-route='true'][data-phlo-v2-theme='dark']
   font-size: 18px;
 }
 
+.phlo-v2-branch-summary {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto;
+  gap: 14px 18px;
+  min-width: 0;
+  align-items: start;
+  border: 1px solid var(--v2-sheet-border);
+  border-radius: 8px;
+  background: var(--v2-sheet);
+  padding: 16px;
+}
+
+.phlo-v2-branch-summary-copy {
+  min-width: 0;
+}
+
+.phlo-v2-branch-summary h2 {
+  margin: 6px 0 0;
+  color: var(--v2-text);
+  font-size: 20px;
+  font-weight: 760;
+  line-height: 1.15;
+  text-wrap: balance;
+}
+
+.phlo-v2-branch-summary p {
+  max-width: 72ch;
+  margin: 7px 0 0;
+  color: var(--v2-muted);
+  font-size: 13px;
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+
+.phlo-v2-branch-summary > .phlo-v2-action-row {
+  justify-content: flex-end;
+  margin-top: 0;
+}
+
+.phlo-v2-branch-facts {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1px;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--v2-sheet-border);
+  border-radius: 7px;
+  background: var(--v2-sheet-border);
+}
+
+.phlo-v2-branch-facts div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  background: var(--v2-tile);
+  padding: 10px 12px;
+}
+
+.phlo-v2-branch-facts dt,
+.phlo-v2-branch-facts dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  line-height: 1.35;
+}
+
+.phlo-v2-branch-facts dt {
+  color: var(--v2-muted);
+  font-size: 12px;
+}
+
+.phlo-v2-branch-facts dd {
+  color: var(--v2-text);
+  font-size: 14px;
+  font-weight: 720;
+}
+
+.phlo-v2-wap-report {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  border: 1px solid var(--v2-sheet-border);
+  border-radius: 8px;
+  background: var(--v2-sheet);
+  padding: 16px;
+}
+
+.phlo-v2-wap-report h3 {
+  margin: 0;
+  color: var(--v2-text);
+  font-size: 18px;
+  font-weight: 780;
+  letter-spacing: 0;
+}
+
+.phlo-v2-wap-report p {
+  margin: 0;
+  color: var(--v2-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.phlo-v2-wap-report dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  border: 1px solid var(--v2-sheet-border);
+  border-radius: 7px;
+  background: var(--v2-sheet-border);
+  overflow: hidden;
+}
+
+.phlo-v2-wap-report dl div {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  background: var(--v2-tile);
+  padding: 10px 12px;
+}
+
+.phlo-v2-wap-report dt,
+.phlo-v2-wap-report dd {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.phlo-v2-wap-report dt {
+  color: var(--v2-muted);
+}
+
+.phlo-v2-wap-report dd {
+  overflow-wrap: anywhere;
+  color: var(--v2-text);
+  font-family: var(--v2-mono);
+}
+
+.phlo-v2-branch-main > .phlo-v2-branch-review,
+.phlo-v2-branch-main > .phlo-v2-detail-list {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--v2-sheet-border);
+  border-radius: 8px;
+  background: var(--v2-sheet);
+}
+
+.phlo-v2-branch-main > .phlo-v2-detail-list,
+.phlo-v2-branch-review > p {
+  padding: 12px 14px;
+}
+
+.phlo-v2-branch-evidence-strip {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.phlo-v2-branch-evidence {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  gap: 1px;
+  border-top: 1px solid var(--v2-sheet-border);
+  background: var(--v2-sheet-border);
+}
+
+.phlo-v2-branch-flow,
+.phlo-v2-branch-table-list {
+  min-width: 0;
+  background: var(--v2-sheet);
+}
+
+.phlo-v2-branch-flow .phlo-v2-flow-canvas {
+  height: 280px;
+  min-height: 280px;
+  border: 0;
+  border-radius: 0;
+}
+
+.phlo-v2-branch-table-list {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.phlo-v2-branch-table-list p {
+  margin: 0;
+  color: var(--v2-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
 .phlo-v2-operation-focus {
   border-bottom: 1px solid var(--v2-sheet-border);
   background: color-mix(in oklch, var(--v2-tile), transparent 46%);
+}
+
+.phlo-v2-wap-operation {
+  display: grid;
+  gap: 0;
+  min-width: 0;
+}
+
+.phlo-v2-wap-operation-header {
+  display: flex;
+  gap: 16px;
+  align-items: start;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--v2-sheet-border);
+  background: color-mix(in oklch, var(--v2-tile), transparent 46%);
+  padding: 14px 16px;
+}
+
+.phlo-v2-wap-operation-header strong {
+  display: block;
+  margin: 6px 0 0;
+  color: var(--v2-text);
+  font-size: 15px;
+  font-weight: 760;
+  line-height: 1.2;
+}
+
+.phlo-v2-wap-operation-header p {
+  margin: 7px 0 0;
+  color: var(--v2-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.phlo-v2-wap-operation-fields {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  border-bottom: 1px solid var(--v2-sheet-border);
+  background: var(--v2-sheet-border);
+}
+
+.phlo-v2-wap-operation-fields div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  background: var(--v2-tile);
+  padding: 10px 12px;
+}
+
+.phlo-v2-wap-operation-fields dt,
+.phlo-v2-wap-operation-fields dd {
+  margin: 0;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.phlo-v2-wap-operation-fields dt {
+  color: var(--v2-muted);
+}
+
+.phlo-v2-wap-operation-fields dd {
+  color: var(--v2-text);
+  font-family: var(--v2-mono);
+}
+
+.phlo-v2-wap-operation-evidence {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
+  gap: 1px;
+  min-width: 0;
+  background: var(--v2-sheet-border);
+}
+
+.phlo-v2-wap-operation-flow,
+.phlo-v2-wap-operation-tables {
+  min-width: 0;
+  background: var(--v2-sheet);
+}
+
+.phlo-v2-wap-operation-steps {
+  display: none;
+}
+
+.phlo-v2-wap-operation-flow .phlo-v2-flow-canvas {
+  height: 340px;
+}
+
+.phlo-v2-wap-operation-tables {
+  display: grid;
+  align-content: start;
+}
+
+.phlo-v2-wap-operation-tables .phlo-v2-mini-row {
+  padding: 12px 14px;
+}
+
+.phlo-v2-wap-operation-tables p {
+  margin: 0;
+  padding: 12px 14px;
+  color: var(--v2-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+@media (max-width: 760px) {
+  .phlo-v2-wap-operation-header {
+    display: grid;
+  }
+
+  .phlo-v2-wap-operation-fields {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .phlo-v2-wap-operation-evidence {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .phlo-v2-wap-operation-flow {
+    display: none;
+  }
+
+  .phlo-v2-wap-operation-steps {
+    display: grid;
+    gap: 1px;
+    background: var(--v2-sheet-border);
+  }
+
+  .phlo-v2-wap-operation-steps div {
+    display: grid;
+    gap: 4px;
+    background: var(--v2-sheet);
+    padding: 12px 14px;
+  }
+
+  .phlo-v2-wap-operation-steps span,
+  .phlo-v2-wap-operation-steps small {
+    color: var(--v2-muted);
+    font-size: 12px;
+    line-height: 1.35;
+  }
+
+  .phlo-v2-wap-operation-steps strong {
+    color: var(--v2-text);
+    font-size: 14px;
+    line-height: 1.25;
+  }
 }
 
 .phlo-v2-operation-focus[data-state='error'] {
@@ -2062,6 +2421,10 @@ html[data-phlo-v2-route='true'][data-phlo-v2-theme='dark']
   text-align: left;
 }
 
+.phlo-v2-mini-row:first-child {
+  border-top: 0;
+}
+
 button.phlo-v2-mini-row {
   width: 100%;
   color: inherit;
@@ -2085,6 +2448,30 @@ button.phlo-v2-mini-row {
   white-space: nowrap;
 }
 
+.phlo-v2-wap-history-row {
+  gap: 6px;
+  padding: 12px 14px;
+}
+
+.phlo-v2-wap-history-row span {
+  white-space: normal;
+}
+
+.phlo-v2-wap-history-row small {
+  overflow: visible;
+  overflow-wrap: anywhere;
+  font-family: var(--v2-mono);
+  line-height: 1.45;
+  white-space: normal;
+}
+
+.phlo-v2-wap-history-row span,
+.phlo-v2-wap-history-row small {
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
+}
+
 .phlo-v2-browser-toolbar,
 .phlo-v2-console-toolbar {
   min-height: 48px;
@@ -2101,6 +2488,15 @@ button.phlo-v2-mini-row {
   min-width: 0;
   align-items: center;
   gap: 8px;
+}
+
+.phlo-v2-browser-toolbar > button {
+  display: inline-flex;
+  min-width: max-content;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  white-space: nowrap;
 }
 
 .phlo-v2-table-grid {
@@ -2445,6 +2841,26 @@ button.phlo-v2-mini-row {
     border-top: 1px solid var(--v2-sheet-border);
     border-left: 0;
     padding: 16px 0 0;
+  }
+
+  .phlo-v2-branch-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .phlo-v2-branch-summary > .phlo-v2-action-row {
+    justify-content: flex-start;
+  }
+
+  .phlo-v2-branch-facts {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .phlo-v2-wap-report dl {
+    grid-template-columns: 1fr;
+  }
+
+  .phlo-v2-branch-evidence {
+    grid-template-columns: 1fr;
   }
 
   .phlo-v2-settings-panel {
@@ -3738,6 +4154,39 @@ html[data-phlo-v2-route='true'][data-phlo-v2-theme='dark']
 
   .phlo-v2-integration-grid {
     grid-template-columns: 1fr;
+  }
+
+  .phlo-v2-operation-focus-body {
+    grid-template-columns: 1fr;
+  }
+
+  .phlo-v2-operation-evidence-grid {
+    grid-template-columns: max-content minmax(0, 1fr);
+  }
+
+  .phlo-v2-operation-evidence-grid dd {
+    overflow-wrap: anywhere;
+  }
+
+  .phlo-v2-operation-ledger-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .phlo-v2-operation-ledger-card {
+    border-right: 0;
+    border-bottom: 1px solid var(--v2-sheet-border);
+  }
+
+  .phlo-v2-operation-ledger-card:last-child {
+    border-bottom: 0;
+  }
+
+  .phlo-v2-operation-ledger-card span,
+  .phlo-v2-operation-ledger-card small,
+  .phlo-v2-operation-ledger-card strong {
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+    white-space: normal;
   }
 }
 

--- a/tests/runtime/test_definitions.py
+++ b/tests/runtime/test_definitions.py
@@ -21,6 +21,7 @@ class _Settings:
     phlo_force_multiprocess_executor: bool = False
     phlo_host_platform: str | None = None
     phlo_orchestrator: str = "dagster"
+    phlo_wap_enabled: bool = True
 
 
 def test_default_executor_honors_platform() -> None:
@@ -133,6 +134,20 @@ def test_wap_sensors_dev_flag_requires_truthy_opt_in(monkeypatch: pytest.MonkeyP
     monkeypatch.setenv("PHLO_WAP_SENSORS_ENABLED", "false")
 
     with patch("phlo_dagster.framework.definitions.resolve_capability") as resolve_capability:
+        from phlo_dagster.framework.definitions import _collect_wap_definitions
+
+        assert _collect_wap_definitions() is None
+        resolve_capability.assert_not_called()
+
+
+def test_wap_sensors_can_be_disabled_in_config() -> None:
+    with (
+        patch(
+            "phlo_dagster.framework.definitions.get_settings",
+            return_value=_Settings(phlo_wap_enabled=False),
+        ),
+        patch("phlo_dagster.framework.definitions.resolve_capability") as resolve_capability,
+    ):
         from phlo_dagster.framework.definitions import _collect_wap_definitions
 
         assert _collect_wap_definitions() is None


### PR DESCRIPTION
## Summary
- add a phlo WAP enable switch and per-run WAP report writer
- expose WAP reports through Observatory v2 operations and branch detail data
- redesign branch and operation WAP evidence views with report fields, affected tables, and React Flow evidence

## Verification
- uv run pytest -q packages/phlo-dagster/tests/test_wap_sensors.py tests/runtime/test_definitions.py packages/phlo-api/tests/test_observatory_v2_api.py::test_v2_branch_detail_uses_wap_report_tables_when_catalog_tables_missing packages/phlo-api/tests/test_observatory_v2_api.py::test_v2_operations_include_wap_reports packages/phlo-api/tests/test_observatory_v2_api.py::test_v2_branch_detail_endpoint_returns_provider_neutral_payload
- npm run build (packages/phlo-observatory/src/phlo_observatory)
- visual acceptance screenshots for /operations?operationId=wap%3Arun-1 desktop and mobile