### PR TITLE
fix: resolve package service hosts

### DIFF
--- a/packages/phlo-clickhouse/src/phlo_clickhouse/settings.py
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/settings.py
@@ -20,6 +20,7 @@ from functools import lru_cache
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.network import resolve_host
 
 
 class ClickHouseSettings(BaseConfig):
@@ -63,6 +64,15 @@ class ClickHouseSettings(BaseConfig):
     clickhouse_password: str = Field(default="", description="ClickHouse password")
     clickhouse_db: str = Field(default="default", description="Default ClickHouse database")
     clickhouse_secure: bool = Field(default=False, description="Use TLS for ClickHouse connections")
+
+    def model_post_init(self, __context: object) -> None:
+        host, port = resolve_host(
+            self.clickhouse_host,
+            self.clickhouse_http_port,
+            port_env_var="CLICKHOUSE_HTTP_PORT",
+        )
+        object.__setattr__(self, "clickhouse_host", host)
+        object.__setattr__(self, "clickhouse_http_port", port)
 
     def clickhouse_http_endpoint(self) -> str:
         """Return host:port endpoint for ClickHouse HTTP interface.

--- a/packages/phlo-clickhouse/tests/test_clickhouse_settings.py
+++ b/packages/phlo-clickhouse/tests/test_clickhouse_settings.py
@@ -1,6 +1,15 @@
 """Tests for ClickHouse settings."""
 
+import socket
+
+import pytest
+
 from phlo_clickhouse.settings import ClickHouseSettings, get_settings
+
+
+@pytest.fixture(autouse=True)
+def resolvable_hosts(monkeypatch):
+    monkeypatch.setattr("phlo.config.network.socket.gethostbyname", lambda _host: "127.0.0.1")
 
 
 def test_clickhouse_settings_defaults():
@@ -53,6 +62,23 @@ def test_clickhouse_settings_with_overrides():
     assert settings.clickhouse_password == "secret"
     assert settings.clickhouse_db == "mydb"
     assert settings.clickhouse_secure is True
+
+
+def test_clickhouse_settings_resolves_unreachable_host(tmp_path, monkeypatch):
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / ".env.local").write_text("CLICKHOUSE_HTTP_PORT=18123\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CLICKHOUSE_HTTP_PORT", raising=False)
+
+    def raise_unresolvable(_host: str) -> str:
+        raise socket.gaierror()
+
+    monkeypatch.setattr("phlo.config.network.socket.gethostbyname", raise_unresolvable)
+
+    settings = ClickHouseSettings()
+
+    assert settings.clickhouse_http_endpoint() == "localhost:18123"
 
 
 def test_get_settings_returns_cached():

--- a/packages/phlo-dbt/src/phlo_dbt/settings.py
+++ b/packages/phlo-dbt/src/phlo_dbt/settings.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from pydantic import Field, computed_field
 
 from phlo.config.base import BaseConfig
+from phlo.config.network import resolve_host
 
 
 def _project_root() -> Path:
@@ -140,6 +141,11 @@ class DbtSettings(BaseConfig):
             __context: Pydantic post-init context.
 
         """
+        host, port = resolve_host(
+            self.dbt_query_host, self.dbt_query_port, port_env_var="TRINO_PORT"
+        )
+        object.__setattr__(self, "dbt_query_host", host)
+        object.__setattr__(self, "dbt_query_port", port)
         if not self.dbt_manifest_path:
             object.__setattr__(
                 self, "dbt_manifest_path", f"{self.dbt_project_dir}/target/manifest.json"

--- a/packages/phlo-dbt/tests/test_runtime_config.py
+++ b/packages/phlo-dbt/tests/test_runtime_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 import yaml
 from types import SimpleNamespace
 
@@ -127,6 +128,26 @@ def test_resolve_dbt_runtime_config_uses_project_profile_name(tmp_path, monkeypa
     config = resolve_dbt_runtime_config()
 
     assert config.profile_name == "workshop_transforms"
+
+
+def test_resolve_dbt_runtime_config_resolves_unreachable_trino_host(tmp_path, monkeypatch) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / ".env.local").write_text("TRINO_PORT=18080\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("TRINO_PORT", raising=False)
+    runtime_config.get_dbt_settings.cache_clear()
+
+    def raise_unresolvable(_host: str) -> str:
+        raise socket.gaierror()
+
+    monkeypatch.setattr("phlo.config.network.socket.gethostbyname", raise_unresolvable)
+
+    config = resolve_dbt_runtime_config()
+
+    assert config.host == "localhost"
+    assert config.port == 18080
+    runtime_config.get_dbt_settings.cache_clear()
 
 
 def test_resolve_dbt_target_name_defaults_to_canonical_default() -> None:

--- a/packages/phlo-hasura/src/phlo_hasura/track.py
+++ b/packages/phlo-hasura/src/phlo_hasura/track.py
@@ -21,14 +21,13 @@ Example:
 
 """
 
-import os
-import socket
 from typing import Any
 
 import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 from phlo.config.base import BaseConfig
+from phlo.config.network import resolve_host
 from phlo.logging import get_logger
 from phlo_hasura.client import HasuraClient
 from pydantic import Field
@@ -63,45 +62,14 @@ class HasuraPostgresSettings(BaseConfig):
     postgres_password: str = Field(default="phlo", description="PostgreSQL password")
     postgres_db: str = Field(default="phlo", description="PostgreSQL database name")
 
-
-def _resolve_db_host(host: str, port: int) -> tuple[str, int]:
-    """Resolve database host, falling back to localhost if Docker hostname unreachable.
-
-    When running hooks from the host machine, Docker internal hostnames like 'postgres'
-    won't resolve. In that case, use localhost with the exposed port.
-
-    Args:
-        host: Database host (may be Docker internal hostname like 'postgres').
-        port: Database port (may be internal port).
-
-    Returns:
-        Tuple of (resolved_host, resolved_port) suitable for connection.
-        If Docker hostname fails to resolve, returns ('localhost', POSTGRES_PORT).
-
-    Example:
-        >>> host, port = _resolve_db_host("postgres", 5432)
-        >>> # If running outside Docker:
-        >>> # host = "localhost", port = 5432 (or from POSTGRES_PORT env)
-
-    """
-    # If already localhost, use as-is
-    if host in ("localhost", "127.0.0.1"):
-        return host, port
-
-    # Try to resolve the hostname
-    try:
-        socket.gethostbyname(host)
-        return host, port
-    except socket.gaierror:
-        # Can't resolve - we're likely running on the host, not in Docker
-        # Use localhost with the exposed port from environment
-        exposed_port = int(os.environ.get("POSTGRES_PORT", port))
-        logger.debug(
-            "Cannot resolve '%s', using localhost:%s (running outside Docker)",
-            host,
-            exposed_port,
+    def model_post_init(self, __context: object) -> None:
+        host, port = resolve_host(
+            self.postgres_host,
+            self.postgres_port,
+            port_env_var="POSTGRES_PORT",
         )
-        return "localhost", exposed_port
+        object.__setattr__(self, "postgres_host", host)
+        object.__setattr__(self, "postgres_port", port)
 
 
 class HasuraTableTracker:
@@ -159,11 +127,11 @@ class HasuraTableTracker:
         self.client = hasura_client or HasuraClient()
 
         settings = HasuraPostgresSettings()
-        raw_host = db_host or settings.postgres_host
-        raw_port = db_port or settings.postgres_port
-
-        # Resolve host - handle running outside Docker
-        self.db_host, self.db_port = _resolve_db_host(raw_host, raw_port)
+        self.db_host, self.db_port = resolve_host(
+            db_host or settings.postgres_host,
+            db_port or settings.postgres_port,
+            port_env_var="POSTGRES_PORT",
+        )
         self.db_name = db_name or settings.postgres_db
         self.db_user = db_user or settings.postgres_user
         self.db_password = db_password or settings.postgres_password

--- a/packages/phlo-hasura/tests/test_hasura.py
+++ b/packages/phlo-hasura/tests/test_hasura.py
@@ -1,6 +1,7 @@
 """Tests for Hasura metadata and table tracking."""
 
 import json
+import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -252,6 +253,22 @@ class TestHasuraClient:
 
 class TestHasuraTableTracker:
     """Tests for HasuraTableTracker."""
+
+    def test_tracker_resolves_unreachable_postgres_host(self, tmp_path, monkeypatch):
+        phlo_dir = tmp_path / ".phlo"
+        phlo_dir.mkdir()
+        (phlo_dir / ".env.local").write_text("POSTGRES_PORT=15432\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("POSTGRES_PORT", raising=False)
+
+        def raise_unresolvable(_host: str) -> str:
+            raise socket.gaierror()
+
+        monkeypatch.setattr("phlo.config.network.socket.gethostbyname", raise_unresolvable)
+
+        tracker = HasuraTableTracker(hasura_client=HasuraClient(admin_secret="test-secret"))
+
+        assert (tracker.db_host, tracker.db_port) == ("localhost", 15432)
 
     @patch("phlo_hasura.track.psycopg2.connect")
     def test_get_tables_in_schema(self, mock_connect):

--- a/packages/phlo-nessie/src/phlo_nessie/catalog_backend.py
+++ b/packages/phlo-nessie/src/phlo_nessie/catalog_backend.py
@@ -20,6 +20,7 @@ import os
 from functools import lru_cache
 from typing import Any
 
+from phlo.config.network import resolve_url
 from phlo.logging import get_logger
 from phlo_nessie.settings import get_settings
 
@@ -49,8 +50,11 @@ def _pyiceberg_catalog_config(ref: str) -> dict[str, Any]:
         "type": "rest",
         "uri": f"{settings.nessie_iceberg_rest_uri()}/{ref}",
         "warehouse": os.environ.get("ICEBERG_WAREHOUSE_PATH", "s3://lake/warehouse"),
-        "s3.endpoint": os.environ.get("ICEBERG_S3_ENDPOINT")
-        or os.environ.get("S3_ENDPOINT", "http://minio:10001"),
+        "s3.endpoint": resolve_url(
+            os.environ.get("ICEBERG_S3_ENDPOINT")
+            or os.environ.get("S3_ENDPOINT", "http://minio:10001"),
+            port_env_var="MINIO_API_PORT",
+        ),
         "s3.access-key-id": os.environ.get("ICEBERG_S3_ACCESS_KEY", "minio"),
         "s3.secret-access-key": os.environ.get("ICEBERG_S3_SECRET_KEY", "minio123"),
         "s3.path-style-access": "true",

--- a/packages/phlo-nessie/tests/test_cli_catalog.py
+++ b/packages/phlo-nessie/tests/test_cli_catalog.py
@@ -1,3 +1,4 @@
+import socket
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -5,6 +6,27 @@ import pytest
 
 from phlo_nessie import cli_catalog
 from phlo_nessie import catalog_backend
+
+
+def test_pyiceberg_catalog_config_resolves_unreachable_minio_endpoint(
+    tmp_path, monkeypatch
+) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / ".env.local").write_text("MINIO_API_PORT=19001\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("MINIO_API_PORT", raising=False)
+    monkeypatch.delenv("ICEBERG_S3_ENDPOINT", raising=False)
+    monkeypatch.delenv("S3_ENDPOINT", raising=False)
+
+    def raise_unresolvable(_host: str) -> str:
+        raise socket.gaierror()
+
+    monkeypatch.setattr("phlo.config.network.socket.gethostbyname", raise_unresolvable)
+
+    config = catalog_backend._pyiceberg_catalog_config("main")
+
+    assert config["s3.endpoint"] == "http://localhost:19001"
 
 
 def test_get_iceberg_catalog_loads_catalog_backend(monkeypatch) -> None:

--- a/packages/phlo-openmetadata/src/phlo_openmetadata/settings.py
+++ b/packages/phlo-openmetadata/src/phlo_openmetadata/settings.py
@@ -18,6 +18,7 @@ from functools import lru_cache
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.network import resolve_host
 from phlo_openmetadata.capabilities import (
     resolve_query_engine_catalog,
     resolve_query_engine_service_type,
@@ -96,6 +97,15 @@ class OpenMetadataSettings(BaseConfig):
     openmetadata_sync_interval_seconds: int = Field(
         default=300, description="Minimum interval between metadata syncs (seconds)"
     )
+
+    def model_post_init(self, __context: object) -> None:
+        host, port = resolve_host(
+            self.openmetadata_host,
+            self.openmetadata_port,
+            port_env_var="OPENMETADATA_PORT",
+        )
+        object.__setattr__(self, "openmetadata_host", host)
+        object.__setattr__(self, "openmetadata_port", port)
 
     def openmetadata_uri(self) -> str:
         """Build the OpenMetadata API base URI.

--- a/packages/phlo-openmetadata/tests/test_openmetadata_settings.py
+++ b/packages/phlo-openmetadata/tests/test_openmetadata_settings.py
@@ -1,5 +1,6 @@
 """Tests for OpenMetadata settings."""
 
+import socket
 from unittest.mock import Mock, patch
 
 from phlo_openmetadata.settings import OpenMetadataSettings
@@ -11,6 +12,23 @@ def test_openmetadata_settings_defaults() -> None:
 
     assert settings.openmetadata_username == "admin"
     assert settings.openmetadata_password == "admin"
+
+
+def test_openmetadata_settings_resolves_unreachable_host(tmp_path, monkeypatch) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / ".env.local").write_text("OPENMETADATA_PORT=18585\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("OPENMETADATA_PORT", raising=False)
+
+    def raise_unresolvable(_host: str) -> str:
+        raise socket.gaierror()
+
+    monkeypatch.setattr("phlo.config.network.socket.gethostbyname", raise_unresolvable)
+
+    settings = OpenMetadataSettings()
+
+    assert settings.openmetadata_uri() == "http://localhost:18585/api"
 
 
 def test_openmetadata_database_prefers_explicit_name():

--- a/packages/phlo-postgrest/src/phlo_postgrest/views.py
+++ b/packages/phlo-postgrest/src/phlo_postgrest/views.py
@@ -32,6 +32,7 @@ import psycopg2
 from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 from phlo.config.base import BaseConfig
+from phlo.config.network import resolve_host
 from phlo.logging import get_logger
 from pydantic import Field
 
@@ -77,6 +78,15 @@ class PostgrestViewsSettings(BaseConfig):
         description="PostgreSQL password (required; set PHLO_POSTGRES_PASSWORD or POSTGRES_PASSWORD env var)",
     )
     postgres_db: str = Field(default="phlo", description="PostgreSQL database name")
+
+    def model_post_init(self, __context: object) -> None:
+        host, port = resolve_host(
+            self.postgres_host,
+            self.postgres_port,
+            port_env_var="POSTGRES_PORT",
+        )
+        object.__setattr__(self, "postgres_host", host)
+        object.__setattr__(self, "postgres_port", port)
 
 
 @dataclass
@@ -574,8 +584,11 @@ class PostgreSTViewManager:
 
         """
         settings = PostgrestViewsSettings()
-        self.host = host or settings.postgres_host
-        self.port = int(port or settings.postgres_port)
+        self.host, self.port = resolve_host(
+            host or settings.postgres_host,
+            int(port or settings.postgres_port),
+            port_env_var="POSTGRES_PORT",
+        )
         self.database = database or settings.postgres_db
         self.user = user or settings.postgres_user
         self.password = password or settings.postgres_password

--- a/packages/phlo-postgrest/tests/test_postgrest_views.py
+++ b/packages/phlo-postgrest/tests/test_postgrest_views.py
@@ -1,6 +1,7 @@
 """Tests for PostgREST view generation."""
 
 import json
+import socket
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -236,6 +237,22 @@ class TestViewGenerator:
 
 class TestPostgreSQLViewManager:
     """Tests for PostgreSTViewManager."""
+
+    def test_manager_resolves_unreachable_postgres_host(self, tmp_path, monkeypatch):
+        phlo_dir = tmp_path / ".phlo"
+        phlo_dir.mkdir()
+        (phlo_dir / ".env.local").write_text("POSTGRES_PORT=15433\n")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("POSTGRES_PORT", raising=False)
+
+        def raise_unresolvable(_host: str) -> str:
+            raise socket.gaierror()
+
+        monkeypatch.setattr("phlo.config.network.socket.gethostbyname", raise_unresolvable)
+
+        manager = PostgreSTViewManager(password="test-password")
+
+        assert (manager.host, manager.port) == ("localhost", 15433)
 
     @patch("phlo_postgrest.views.psycopg2.connect")
     def test_execute_sql(self, mock_connect):


### PR DESCRIPTION
## Summary
- resolve dbt, ClickHouse, OpenMetadata, Hasura, PostGREST, and Nessie host-side service endpoints through shared config helpers
- replace Hasura's bespoke Postgres host fallback with `resolve_host`
- add regression coverage for unreachable Docker service hostnames using `.phlo/.env.local` port overrides

## Root Cause
Several package paths still used Docker-internal service names such as `trino`, `postgres`, `clickhouse`, and `openmetadata-server` directly when running on the host. That fails when the actual container names are prefixed or when only the host-exposed service port is reachable.

## Validation
- `uv run ruff format ...`
- `uv run ruff check ...`
- `uv run pytest packages/phlo-hasura/tests packages/phlo-postgrest/tests packages/phlo-nessie/tests packages/phlo-dbt/tests packages/phlo-clickhouse/tests packages/phlo-openmetadata/tests`
- `uv run pytest -m 'not integration'` (`2591 passed, 2 skipped, 478 deselected`)
