### PR TITLE
fix: discover nested dbt transform projects

### DIFF
--- a/packages/phlo-dbt/src/phlo_dbt/cli_plugin.py
+++ b/packages/phlo-dbt/src/phlo_dbt/cli_plugin.py
@@ -37,6 +37,11 @@ from phlo_dbt.authorization import get_dbt_adapter
 from phlo_dbt.cli_publishing import publishing
 from phlo_dbt.runtime_config import DEFAULT_DBT_TARGET, ensure_dbt_profile
 
+DBT_PROJECT_HELP = (
+    "Create or copy a dbt project under workflows/, for example "
+    "workflows/transforms/dbt or workflows/<name>/transforms/dbt, or set DBT_PROJECT_DIR."
+)
+
 
 def _container_path(path: Path, *, project_root: Path) -> str:
     """Translate a project-local host path into the orchestrator container mount path.
@@ -138,7 +143,7 @@ def _run_dbt_in_container(
         raise user_error(
             "no dbt project found",
             missing=project_dir / "dbt_project.yml",
-            details=["Create or copy a dbt project under workflows/transforms/dbt."],
+            details=[DBT_PROJECT_HELP],
             run="phlo workflow create --help",
         )
 
@@ -219,7 +224,7 @@ def _run_dbt_local(subcommand: str, target: str, select_expr: str | None = None)
         raise user_error(
             "no dbt project found",
             missing=project_dir / "dbt_project.yml",
-            details=["Create or copy a dbt project under workflows/transforms/dbt."],
+            details=[DBT_PROJECT_HELP],
             run="phlo workflow create --help",
         )
 

--- a/packages/phlo-dbt/src/phlo_dbt/discovery.py
+++ b/packages/phlo-dbt/src/phlo_dbt/discovery.py
@@ -27,10 +27,8 @@ from phlo.logging import get_logger, setup_logging
 
 logger = get_logger(__name__)
 
-# Common locations to search for dbt projects
-DEFAULT_SEARCH_PATHS = [
-    "workflows/transforms/dbt",
-]
+DEFAULT_DBT_PROJECT_DIR = Path("workflows/transforms/dbt")
+DEFAULT_SEARCH_PATHS = [str(DEFAULT_DBT_PROJECT_DIR)]
 
 
 def find_dbt_projects(
@@ -68,16 +66,24 @@ def find_dbt_projects(
     else:
         root_dir = Path(root_dir)
 
-    if search_paths is None:
-        search_paths = DEFAULT_SEARCH_PATHS
+    discovered: list[Path] = []
+    seen: set[Path] = set()
 
-    discovered = []
-
-    for search_path in search_paths:
+    for search_path in search_paths or DEFAULT_SEARCH_PATHS:
         candidate = root_dir / search_path / "dbt_project.yml"
-        if candidate.exists():
+        if candidate.exists() and candidate.parent not in seen:
+            seen.add(candidate.parent)
             discovered.append(candidate.parent)
             logger.info("Discovered dbt project: %s", candidate.parent)
+
+    if search_paths is None:
+        workflows_root = root_dir / "workflows"
+        if workflows_root.exists():
+            for candidate in sorted(workflows_root.rglob("dbt_project.yml")):
+                if candidate.parent not in seen:
+                    seen.add(candidate.parent)
+                    discovered.append(candidate.parent)
+                    logger.info("Discovered dbt project: %s", candidate.parent)
 
     return discovered
 
@@ -118,7 +124,7 @@ def get_dbt_project_dir() -> Path:
         return projects[0]
 
     # Fall back to default
-    return Path("workflows/transforms/dbt")
+    return DEFAULT_DBT_PROJECT_DIR
 
 
 if __name__ == "__main__":

--- a/packages/phlo-dbt/src/phlo_dbt/hooks.py
+++ b/packages/phlo-dbt/src/phlo_dbt/hooks.py
@@ -43,6 +43,14 @@ def _find_dagster_container(project_name: str) -> str:
     )
 
 
+def _container_project_path(local_project: Path, project_root: Path | None = None) -> Path:
+    project_root = (project_root or Path.cwd()).resolve()
+    try:
+        return Path("/app") / local_project.resolve().relative_to(project_root)
+    except ValueError:
+        return local_project
+
+
 def compile_dbt() -> int:
     """Compile dbt models in the Dagster container when a dbt project exists.
 
@@ -73,14 +81,8 @@ def compile_dbt() -> int:
 
     """
     settings = get_settings()
-    dbt_project_dir = Path(settings.dbt_project_dir)
-
-    if dbt_project_dir.is_absolute():
-        local_project = dbt_project_dir
-        if not local_project.exists() and dbt_project_dir.parts[:2] == ("/", "app"):
-            local_project = Path.cwd() / Path(*dbt_project_dir.parts[2:])
-    else:
-        local_project = Path.cwd() / dbt_project_dir
+    local_project = settings.dbt_project_path
+    profiles_dir = settings.dbt_profiles_path
 
     if not (local_project / "dbt_project.yml").exists():
         logger.info(
@@ -89,7 +91,8 @@ def compile_dbt() -> int:
         )
         return 0
 
-    ensure_dbt_profile(local_project / "profiles")
+    ensure_dbt_profile(profiles_dir)
+    container_project = _container_project_path(local_project)
 
     logger.info(
         "dbt_hook_compile_started",
@@ -113,7 +116,7 @@ def compile_dbt() -> int:
                 container_name,
                 "bash",
                 "-c",
-                f"cd {Path('/app') / dbt_project_dir} && dbt deps --profiles-dir profiles",
+                f"cd {container_project} && dbt deps --profiles-dir profiles",
             ],
             timeout_seconds=60,
             check=False,
@@ -134,7 +137,7 @@ def compile_dbt() -> int:
                 container_name,
                 "bash",
                 "-c",
-                f"cd {Path('/app') / dbt_project_dir} && dbt compile --profiles-dir profiles",
+                f"cd {container_project} && dbt compile --profiles-dir profiles",
             ],
             timeout_seconds=120,
             check=False,

--- a/packages/phlo-dbt/src/phlo_dbt/hooks.py
+++ b/packages/phlo-dbt/src/phlo_dbt/hooks.py
@@ -43,12 +43,12 @@ def _find_dagster_container(project_name: str) -> str:
     )
 
 
-def _container_project_path(local_project: Path, project_root: Path | None = None) -> Path:
+def _container_path(local_path: Path, project_root: Path | None = None) -> Path:
     project_root = (project_root or Path.cwd()).resolve()
     try:
-        return Path("/app") / local_project.resolve().relative_to(project_root)
+        return Path("/app") / local_path.resolve().relative_to(project_root)
     except ValueError:
-        return local_project
+        return local_path
 
 
 def compile_dbt() -> int:
@@ -92,7 +92,8 @@ def compile_dbt() -> int:
         return 0
 
     ensure_dbt_profile(profiles_dir)
-    container_project = _container_project_path(local_project)
+    container_project = _container_path(local_project)
+    container_profiles = _container_path(profiles_dir)
 
     logger.info(
         "dbt_hook_compile_started",
@@ -116,7 +117,7 @@ def compile_dbt() -> int:
                 container_name,
                 "bash",
                 "-c",
-                f"cd {container_project} && dbt deps --profiles-dir profiles",
+                f"cd {container_project} && dbt deps --profiles-dir {container_profiles}",
             ],
             timeout_seconds=60,
             check=False,
@@ -137,7 +138,7 @@ def compile_dbt() -> int:
                 container_name,
                 "bash",
                 "-c",
-                f"cd {container_project} && dbt compile --profiles-dir profiles",
+                f"cd {container_project} && dbt compile --profiles-dir {container_profiles}",
             ],
             timeout_seconds=120,
             check=False,

--- a/packages/phlo-dbt/tests/test_dbt_cli_plugin.py
+++ b/packages/phlo-dbt/tests/test_dbt_cli_plugin.py
@@ -156,7 +156,7 @@ def test_dbt_run_missing_project_is_actionable(monkeypatch, tmp_path) -> None:
     assert result.exit_code != 0
     assert "Error: no dbt project found" in result.output
     assert f"Missing: {project_dir / 'dbt_project.yml'}" in result.output
-    assert "Create or copy a dbt project under workflows/transforms/dbt." in result.output
+    assert "workflows/<name>/transforms/dbt" in result.output
     assert "Run: phlo workflow create --help" in result.output
 
 

--- a/packages/phlo-dbt/tests/test_discovery.py
+++ b/packages/phlo-dbt/tests/test_discovery.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from phlo_dbt.discovery import find_dbt_projects, get_dbt_project_dir
+
+
+def test_find_dbt_projects_discovers_nested_transforms_project(tmp_path: Path) -> None:
+    dbt_project = tmp_path / "workflows" / "client_exports" / "transforms" / "dbt"
+    dbt_project.mkdir(parents=True)
+    (dbt_project / "dbt_project.yml").write_text("name: client_exports\n")
+
+    assert find_dbt_projects(tmp_path) == [dbt_project]
+
+
+def test_get_dbt_project_dir_discovers_nested_transforms_project(
+    tmp_path: Path, monkeypatch
+) -> None:
+    dbt_project = tmp_path / "workflows" / "client_exports" / "transforms" / "dbt"
+    dbt_project.mkdir(parents=True)
+    (dbt_project / "dbt_project.yml").write_text("name: client_exports\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DBT_PROJECT_DIR", raising=False)
+
+    assert get_dbt_project_dir() == dbt_project

--- a/packages/phlo-dbt/tests/test_hooks.py
+++ b/packages/phlo-dbt/tests/test_hooks.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from phlo_dbt.hooks import _find_dagster_container
+from pathlib import Path
+from types import SimpleNamespace
+
+from phlo_dbt import hooks
 
 
 def test_find_dagster_container_uses_core_service_lookup(monkeypatch) -> None:
@@ -12,8 +15,40 @@ def test_find_dagster_container_uses_core_service_lookup(monkeypatch) -> None:
 
     monkeypatch.setattr("phlo_dbt.hooks.find_service_container", _fake_find_service_container)
 
-    assert _find_dagster_container("demo") == "demo-dagster-1"
+    assert hooks._find_dagster_container("demo") == "demo-dagster-1"
     assert captured["project_name"] == "demo"
     assert captured["service_name"] == "dagster"
     assert captured["legacy_names"] == ("demo-dagster-webserver-1",)
     assert captured["exclude_substrings"] == ("daemon",)
+
+
+def test_compile_dbt_uses_discovered_nested_project_path(tmp_path: Path, monkeypatch) -> None:
+    dbt_project = tmp_path / "workflows" / "client_exports" / "transforms" / "dbt"
+    profiles_dir = dbt_project / "profiles"
+    dbt_project.mkdir(parents=True)
+    (dbt_project / "dbt_project.yml").write_text("name: client_exports\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(hooks.time, "sleep", lambda _seconds: None)
+    monkeypatch.setattr(hooks, "get_project_name", lambda: "demo")
+    monkeypatch.setattr(hooks, "_find_dagster_container", lambda _project_name: "demo-dagster-1")
+    monkeypatch.setattr(
+        hooks,
+        "get_settings",
+        lambda: SimpleNamespace(dbt_project_path=dbt_project, dbt_profiles_path=profiles_dir),
+    )
+    ensured_profiles: list[Path] = []
+    commands: list[list[str]] = []
+    monkeypatch.setattr(hooks, "ensure_dbt_profile", lambda path: ensured_profiles.append(path))
+    monkeypatch.setattr(
+        hooks,
+        "run_command",
+        lambda command, **_kwargs: (
+            commands.append(command) or SimpleNamespace(returncode=0, stderr="")
+        ),
+    )
+
+    assert hooks.compile_dbt() == 0
+
+    assert ensured_profiles == [profiles_dir]
+    assert commands[0][-1].startswith("cd /app/workflows/client_exports/transforms/dbt &&")
+    assert commands[1][-1].startswith("cd /app/workflows/client_exports/transforms/dbt &&")

--- a/packages/phlo-dbt/tests/test_hooks.py
+++ b/packages/phlo-dbt/tests/test_hooks.py
@@ -24,7 +24,7 @@ def test_find_dagster_container_uses_core_service_lookup(monkeypatch) -> None:
 
 def test_compile_dbt_uses_discovered_nested_project_path(tmp_path: Path, monkeypatch) -> None:
     dbt_project = tmp_path / "workflows" / "client_exports" / "transforms" / "dbt"
-    profiles_dir = dbt_project / "profiles"
+    profiles_dir = tmp_path / ".phlo" / "dbt-profiles"
     dbt_project.mkdir(parents=True)
     (dbt_project / "dbt_project.yml").write_text("name: client_exports\n")
     monkeypatch.chdir(tmp_path)
@@ -50,5 +50,11 @@ def test_compile_dbt_uses_discovered_nested_project_path(tmp_path: Path, monkeyp
     assert hooks.compile_dbt() == 0
 
     assert ensured_profiles == [profiles_dir]
-    assert commands[0][-1].startswith("cd /app/workflows/client_exports/transforms/dbt &&")
-    assert commands[1][-1].startswith("cd /app/workflows/client_exports/transforms/dbt &&")
+    assert commands[0][-1] == (
+        "cd /app/workflows/client_exports/transforms/dbt "
+        "&& dbt deps --profiles-dir /app/.phlo/dbt-profiles"
+    )
+    assert commands[1][-1] == (
+        "cd /app/workflows/client_exports/transforms/dbt "
+        "&& dbt compile --profiles-dir /app/.phlo/dbt-profiles"
+    )


### PR DESCRIPTION
## Summary
- discover nested dbt projects under `workflows/**/dbt_project.yml`
- make the dbt compile hook use resolved `DbtSettings` project/profile paths
- update missing-project help to mention nested workflow transform paths and `DBT_PROJECT_DIR`

## Root Cause
`DbtSettings.dbt_project_path` could already discover layouts like `workflows/client_exports/transforms/dbt`, but `phlo_dbt.discovery.get_dbt_project_dir()` and the compile hook still assumed the fixed default `workflows/transforms/dbt`. That split meant some dbt flows worked with nested transforms while helper/hook paths still looked in the wrong folder.

## Validation
- `uv run ruff check packages/phlo-dbt/src/phlo_dbt/discovery.py packages/phlo-dbt/src/phlo_dbt/hooks.py packages/phlo-dbt/src/phlo_dbt/cli_plugin.py packages/phlo-dbt/tests/test_discovery.py packages/phlo-dbt/tests/test_hooks.py packages/phlo-dbt/tests/test_dbt_cli_plugin.py`
- `uv run pytest packages/phlo-dbt/tests` (`91 passed, 9 deselected`)
