### PR TITLE
fix(config): make project configuration test isolation deterministic

### DIFF
--- a/packages/phlo-alerting/src/phlo_alerting/settings.py
+++ b/packages/phlo-alerting/src/phlo_alerting/settings.py
@@ -5,8 +5,8 @@ using Pydantic models. It supports configuration via environment variables
 with automatic type validation and default values.
 
 All configuration values are read from environment variables with the
-"PHLO_ALERT_" prefix. The get_settings() function provides a cached
-singleton instance for efficient repeated access.
+"PHLO_ALERT_" prefix. The get_settings() function provides cached
+per-project-root settings for efficient repeated access.
 
 Examples:
     Retrieving settings:
@@ -87,11 +87,13 @@ class AlertingSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> AlertingSettings:
-    """Return cached alerting settings instance.
+    """Return cached alerting settings for the selected project root.
 
-    Provides a singleton AlertingSettings instance with caching for
-    efficient repeated access. The instance is created once and reused
-    across the application lifecycle.
+    Settings are cached per resolved project root, with up to 16 entries,
+    and reused across the application lifecycle.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         AlertingSettings instance with loaded configuration.
@@ -99,7 +101,7 @@ def get_settings(project_root: Path) -> AlertingSettings:
     Examples:
         >>> settings1 = get_settings()
         >>> settings2 = get_settings()
-        >>> settings1 is settings2
+        >>> settings1 is settings2  # For the same project root
         True
 
     """

--- a/packages/phlo-alerting/src/phlo_alerting/settings.py
+++ b/packages/phlo-alerting/src/phlo_alerting/settings.py
@@ -33,11 +33,12 @@ Environment Variables:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 
 
 class AlertingSettings(BaseConfig):
@@ -84,8 +85,8 @@ class AlertingSettings(BaseConfig):
     )
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> AlertingSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> AlertingSettings:
     """Return cached alerting settings instance.
 
     Provides a singleton AlertingSettings instance with caching for

--- a/packages/phlo-clickhouse/src/phlo_clickhouse/settings.py
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/settings.py
@@ -106,10 +106,13 @@ class ClickHouseSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> ClickHouseSettings:
-    """Return cached ClickHouse settings instance.
+    """Return cached ClickHouse settings for the selected project root.
 
-    Uses functools.lru_cache to ensure settings are loaded only once
+    Settings are cached per resolved project root, with up to 16 entries,
     and reused across the application lifecycle.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         ClickHouseSettings instance with loaded configuration.
@@ -118,7 +121,7 @@ def get_settings(project_root: Path) -> ClickHouseSettings:
         >>> settings = get_settings()
         >>> settings.clickhouse_host
         'clickhouse'
-        >>> # Subsequent calls return the same cached instance
+        >>> # Subsequent calls for the same root return the same cached instance
         >>> get_settings() is settings
         True
 

--- a/packages/phlo-clickhouse/src/phlo_clickhouse/settings.py
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/settings.py
@@ -15,11 +15,12 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_host
 
 
@@ -103,8 +104,8 @@ class ClickHouseSettings(BaseConfig):
         return f"{self.clickhouse_host}:{self.clickhouse_native_port}"
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> ClickHouseSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> ClickHouseSettings:
     """Return cached ClickHouse settings instance.
 
     Uses functools.lru_cache to ensure settings are loaded only once

--- a/packages/phlo-dagster/src/phlo_dagster/cli_dev.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_dev.py
@@ -90,12 +90,14 @@ def dev(host: str, port: int, workflows_path: str) -> None:
         workflows_dir.mkdir(parents=True, exist_ok=True)
         (workflows_dir / "__init__.py").write_text('"""User workflows."""\n')
 
-    os.environ["PHLO_WORKFLOWS_PATH"] = workflows_path
-    os.environ["WORKFLOWS_PATH"] = workflows_path
-    os.environ.setdefault("PHLO_DAGSTER_DEV", "1")
-    os.environ.setdefault("PHLO_PROJECT_PATH", str(Path.cwd().resolve()))
-    for key, value in load_project_env(include_os=False).items():
-        os.environ.setdefault(key, value)
+    project_root = Path.cwd().resolve()
+    child_env = os.environ.copy()
+    for key, value in load_project_env(project_root, include_os=False).items():
+        child_env.setdefault(key, value)
+    child_env["PHLO_WORKFLOWS_PATH"] = workflows_path
+    child_env["WORKFLOWS_PATH"] = workflows_path
+    child_env.setdefault("PHLO_DAGSTER_DEV", "1")
+    child_env["PHLO_PROJECT_PATH"] = str(project_root)
 
     click.echo(f"Workflows directory: {workflows_path}")
     click.echo(f"Starting server at http://{host}:{port}\n")
@@ -118,7 +120,7 @@ def dev(host: str, port: int, workflows_path: str) -> None:
     )
 
     try:
-        subprocess.run(cmd, check=True)
+        subprocess.run(cmd, check=True, env=child_env)
         logger.info("dagster_dev_process_exited_cleanly")
     except KeyboardInterrupt:
         logger.info("dagster_dev_process_interrupted")

--- a/packages/phlo-dagster/src/phlo_dagster/settings.py
+++ b/packages/phlo-dagster/src/phlo_dagster/settings.py
@@ -42,11 +42,12 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import AliasChoices, Field, model_validator
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 
 
 class DagsterSettings(BaseConfig):
@@ -96,7 +97,7 @@ class DagsterSettings(BaseConfig):
         return self
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> DagsterSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> DagsterSettings:
     """Return cached Dagster settings."""
     return DagsterSettings()

--- a/packages/phlo-dagster/tests/test_cli_dev.py
+++ b/packages/phlo-dagster/tests/test_cli_dev.py
@@ -19,12 +19,17 @@ def test_phlo_dev_loads_project_env_for_dagster_subprocess(monkeypatch, tmp_path
 
     captured_env: dict[str, str | None] = {}
 
-    def fake_run(cmd: list[str], check: bool) -> CompletedProcess[str]:
-        captured_env["PHLO_WORKFLOWS_PATH"] = __import__("os").environ.get("PHLO_WORKFLOWS_PATH")
-        captured_env["WORKFLOWS_PATH"] = __import__("os").environ.get("WORKFLOWS_PATH")
-        captured_env["PHLO_PROJECT_PATH"] = __import__("os").environ.get("PHLO_PROJECT_PATH")
-        captured_env["CLIENT_EXPORTS_KE_QC_OUTPUT_DIR"] = __import__("os").environ.get(
-            "CLIENT_EXPORTS_KE_QC_OUTPUT_DIR"
+    def fake_run(cmd: list[str], check: bool, env: dict[str, str]) -> CompletedProcess[str]:
+        captured_env.update(
+            {
+                key: env.get(key)
+                for key in (
+                    "PHLO_WORKFLOWS_PATH",
+                    "WORKFLOWS_PATH",
+                    "PHLO_PROJECT_PATH",
+                    "CLIENT_EXPORTS_KE_QC_OUTPUT_DIR",
+                )
+            }
         )
         return CompletedProcess(cmd, 0)
 
@@ -39,3 +44,24 @@ def test_phlo_dev_loads_project_env_for_dagster_subprocess(monkeypatch, tmp_path
         "PHLO_PROJECT_PATH": str(tmp_path),
         "CLIENT_EXPORTS_KE_QC_OUTPUT_DIR": "data/client_exports/ke_qc",
     }
+
+
+def test_phlo_dev_does_not_mutate_parent_environment(monkeypatch, tmp_path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\nversion = '0.1.0'\n")
+    (tmp_path / "workflows").mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("PHLO_PROJECT_PATH", "/previous/project")
+    monkeypatch.setenv("PHLO_WORKFLOWS_PATH", "previous_workflows")
+
+    def fake_run(cmd: list[str], check: bool, env: dict[str, str]) -> CompletedProcess[str]:
+        assert env["PHLO_PROJECT_PATH"] == str(tmp_path)
+        assert env["PHLO_WORKFLOWS_PATH"] == "workflows"
+        return CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("phlo_dagster.cli_dev.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(dev, [])
+
+    assert result.exit_code == 0
+    assert __import__("os").environ["PHLO_PROJECT_PATH"] == "/previous/project"
+    assert __import__("os").environ["PHLO_WORKFLOWS_PATH"] == "previous_workflows"

--- a/packages/phlo-dbt/src/phlo_dbt/settings.py
+++ b/packages/phlo-dbt/src/phlo_dbt/settings.py
@@ -17,13 +17,13 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
 import os
 from pathlib import Path
 
 from pydantic import Field, computed_field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_host
 
 
@@ -194,12 +194,7 @@ class DbtSettings(BaseConfig):
         return _resolve_project_path(self.dbt_profiles_dir)
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> DbtSettings:
-    """Return cached dbt settings.
-
-    Returns:
-        Singleton dbt settings instance.
-
-    """
+@project_root_cached
+def get_settings(project_root: Path) -> DbtSettings:
+    """Return cached dbt settings for the selected project root."""
     return DbtSettings()

--- a/packages/phlo-delta/src/phlo_delta/settings.py
+++ b/packages/phlo-delta/src/phlo_delta/settings.py
@@ -13,12 +13,13 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from pydantic import AliasChoices, Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_url
 
 
@@ -122,8 +123,8 @@ class DeltaSettings(BaseConfig):
         return opts
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> DeltaSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> DeltaSettings:
     """Get cached Delta Lake settings.
 
     Returns a singleton instance of DeltaSettings, cached for performance.

--- a/packages/phlo-delta/src/phlo_delta/settings.py
+++ b/packages/phlo-delta/src/phlo_delta/settings.py
@@ -125,13 +125,16 @@ class DeltaSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> DeltaSettings:
-    """Get cached Delta Lake settings.
+    """Get cached Delta Lake settings for the selected project root.
 
-    Returns a singleton instance of DeltaSettings, cached for performance.
-    The cached instance ensures consistent configuration across the application.
+    Settings are cached per resolved project root, with up to 16 entries,
+    and reused across the application lifecycle.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
-        DeltaSettings: Cached Delta Lake settings instance.
+        DeltaSettings: Cached settings for the selected project root.
 
     Example:
         settings = get_settings()

--- a/packages/phlo-delta/tests/test_delta_settings.py
+++ b/packages/phlo-delta/tests/test_delta_settings.py
@@ -3,21 +3,21 @@
 from phlo_delta.settings import DeltaSettings
 
 
-def test_delta_settings_default_to_localhost_for_host_side_usage() -> None:
+def test_delta_settings_default_to_localhost_for_host_side_usage(tmp_path) -> None:
     """Delta settings should default to a host-reachable MinIO endpoint."""
-    settings = DeltaSettings()
+    settings = DeltaSettings(_project_root=tmp_path)
 
     assert settings.delta_s3_endpoint == "http://localhost:9000"
 
 
-def test_delta_settings_use_standard_aws_aliases(monkeypatch) -> None:
+def test_delta_settings_use_standard_aws_aliases(monkeypatch, tmp_path) -> None:
     """Delta settings should honor the shared AWS env vars exposed in services."""
     monkeypatch.setenv("AWS_S3_ENDPOINT", "http://minio:9000")
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "example-key")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "example-secret")
     monkeypatch.setenv("AWS_REGION", "eu-west-2")
 
-    settings = DeltaSettings()
+    settings = DeltaSettings(_project_root=tmp_path)
 
     assert settings.delta_s3_endpoint == "http://localhost:9000"
     assert settings.delta_s3_access_key == "example-key"

--- a/packages/phlo-dlt/src/phlo_dlt/settings.py
+++ b/packages/phlo-dlt/src/phlo_dlt/settings.py
@@ -80,14 +80,16 @@ class DltSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> DltSettings:
-    """Return cached DLT settings instance.
+    """Return cached DLT settings for the selected project root.
 
-    Factory function that returns a singleton DltSettings instance.
-    Uses functools.lru_cache to ensure only one settings object is created
-    per process, improving performance and ensuring consistency.
+    Settings are cached per resolved project root, with up to 16 entries,
+    improving performance while keeping project configuration isolated.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
-        DltSettings: The cached settings instance.
+        DltSettings: The cached settings instance for the selected root.
 
     Example:
         ```python
@@ -96,7 +98,7 @@ def get_settings(project_root: Path) -> DltSettings:
         # First call creates the instance
         settings = get_settings()
 
-        # Subsequent calls return the same instance
+        # Subsequent calls for the same root return the same instance
         settings2 = get_settings()
         assert settings is settings2  # True
         ```

--- a/packages/phlo-dlt/src/phlo_dlt/settings.py
+++ b/packages/phlo-dlt/src/phlo_dlt/settings.py
@@ -32,11 +32,12 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 
 
 class DltSettings(BaseConfig):
@@ -77,8 +78,8 @@ class DltSettings(BaseConfig):
     )
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> DltSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> DltSettings:
     """Return cached DLT settings instance.
 
     Factory function that returns a singleton DltSettings instance.

--- a/packages/phlo-hasura/src/phlo_hasura/client.py
+++ b/packages/phlo-hasura/src/phlo_hasura/client.py
@@ -22,12 +22,13 @@ Environment Variables:
 
 import json
 import os
-from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 import requests
 from pydantic import Field
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_url
 from phlo.logging import get_logger
 
@@ -43,8 +44,8 @@ class HasuraClientSettings(BaseConfig):
     )
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> HasuraClientSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> HasuraClientSettings:
     """Return cached Hasura client settings loaded from env and `.phlo` env files."""
     return HasuraClientSettings()
 

--- a/packages/phlo-iceberg/src/phlo_iceberg/settings.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/settings.py
@@ -35,11 +35,12 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import AliasChoices, Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_url as _resolve_service_url
 from phlo_iceberg.compatibility import validate_pyiceberg_rest_catalog_config
 
@@ -223,8 +224,8 @@ class IcebergSettings(BaseConfig):
         return config
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> IcebergSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> IcebergSettings:
     """Get cached Iceberg settings instance.
 
     Uses LRU cache to avoid repeatedly loading and parsing configuration.

--- a/packages/phlo-iceberg/src/phlo_iceberg/settings.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/settings.py
@@ -226,13 +226,16 @@ class IcebergSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> IcebergSettings:
-    """Get cached Iceberg settings instance.
+    """Get cached Iceberg settings for the selected project root.
 
-    Uses LRU cache to avoid repeatedly loading and parsing configuration.
-    The cache has size 1, meaning only one settings instance is kept.
+    Settings are cached per resolved project root, with up to 16 entries,
+    to avoid repeatedly loading and parsing configuration.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
-        IcebergSettings: Cached Iceberg settings instance with all
+        IcebergSettings: Cached settings with all
             configuration values resolved from environment and files.
 
     Example:
@@ -245,8 +248,8 @@ def get_settings(project_root: Path) -> IcebergSettings:
             print(f"Default namespace: {settings.iceberg_default_namespace}")
 
     Note:
-        Settings are cached. To force reload after configuration changes,
-        restart the Python process or clear the cache with::
+        Settings are cached per project root. To force a reload after
+        configuration changes, clear the cache with::
 
             get_settings.cache_clear()
 

--- a/packages/phlo-lineage/src/phlo_lineage/settings.py
+++ b/packages/phlo-lineage/src/phlo_lineage/settings.py
@@ -40,11 +40,12 @@ See Also:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import AliasChoices, Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 
 
 class LineageSettings(BaseConfig):
@@ -93,8 +94,8 @@ class LineageSettings(BaseConfig):
     )
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> LineageSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> LineageSettings:
     """Get cached LineageSettings instance.
 
     This function returns a singleton LineageSettings instance that is

--- a/packages/phlo-lineage/src/phlo_lineage/settings.py
+++ b/packages/phlo-lineage/src/phlo_lineage/settings.py
@@ -15,7 +15,7 @@ Priority Order for lineage_db_url:
 
 Usage:
     Settings are accessed via the cached get_settings() function, which returns
-    a singleton instance parsed from the environment.
+    a project-root-scoped instance parsed from the environment.
 
 Example:
     >>> from phlo_lineage.settings import get_settings, LineageSettings
@@ -96,19 +96,21 @@ class LineageSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> LineageSettings:
-    """Get cached LineageSettings instance.
+    """Get cached LineageSettings for the selected project root.
 
-    This function returns a singleton LineageSettings instance that is
-    cached after first access using functools.lru_cache. This ensures
-    consistent settings across the application while avoiding repeated
-    environment variable parsing.
+    Settings are cached after first access per resolved project root, with
+    up to 16 entries, avoiding repeated environment variable parsing while
+    keeping project configuration isolated.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         LineageSettings instance loaded from environment variables.
 
     Caching:
-        Settings are cached with maxsize=1, meaning only one instance is
-        stored. The cache is process-local and thread-safe.
+        Settings are cached with up to 16 resolved project roots. The cache
+        is process-local and thread-safe.
 
         To reload settings (e.g., after environment changes):
         >>> get_settings.cache_clear()
@@ -124,15 +126,15 @@ def get_settings(project_root: Path) -> LineageSettings:
         ...     print("No lineage database URL found")
 
     Thread Safety:
-        lru_cache provides thread-safe caching. The LineageSettings
-        instance itself is immutable after creation (frozen dataclass).
+        The project-root cache provides thread-safe caching. The
+        LineageSettings instance itself is immutable after creation.
 
     Performance:
         First call: Parses environment variables (~0.1-1ms)
-        Subsequent calls: Returns cached instance (O(1))
+        Subsequent calls for the same root: Returns cached instance (O(1))
 
     See Also:
-        functools.lru_cache for caching behavior details.
+        phlo.config.cache.project_root_cached for caching behavior details.
 
     """
     return LineageSettings()

--- a/packages/phlo-minio/src/phlo_minio/settings.py
+++ b/packages/phlo-minio/src/phlo_minio/settings.py
@@ -141,18 +141,19 @@ class MinioSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> MinioSettings:
-    """Return a cached MinIO settings instance.
+    """Return cached MinIO settings for the selected project root.
 
-    Creates and caches a single MinioSettings instance to avoid
-    repeated environment resolution and configuration loading.
-    The cache ensures consistent settings across the application
-    lifecycle.
+    Settings are cached per resolved project root, with up to 16 entries,
+    avoiding repeated environment resolution and configuration loading.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         MinioSettings: Cached settings instance.
 
     Examples:
-        Singleton pattern:
+        Same-root cache reuse:
             >>> settings1 = get_settings()
             >>> settings2 = get_settings()
             >>> settings1 is settings2  # Same instance
@@ -174,8 +175,8 @@ def get_settings(project_root: Path) -> MinioSettings:
             ... }
 
     Warning:
-        Settings are cached for the process lifetime. To refresh
-        settings, restart the application process.
+        Settings are cached per project root. To refresh settings after
+        configuration changes, call ``get_settings.cache_clear()``.
 
     """
     return MinioSettings()

--- a/packages/phlo-minio/src/phlo_minio/settings.py
+++ b/packages/phlo-minio/src/phlo_minio/settings.py
@@ -22,12 +22,13 @@ Examples:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_host
 
 
@@ -138,8 +139,8 @@ class MinioSettings(BaseConfig):
         return f"{self.minio_host}:{self.minio_api_port}"
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> MinioSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> MinioSettings:
     """Return a cached MinIO settings instance.
 
     Creates and caches a single MinioSettings instance to avoid

--- a/packages/phlo-nessie/src/phlo_nessie/settings.py
+++ b/packages/phlo-nessie/src/phlo_nessie/settings.py
@@ -14,12 +14,13 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_host
 
 
@@ -73,12 +74,7 @@ class NessieSettings(BaseConfig):
         return f"http://{self.nessie_host}:{self.nessie_port}/iceberg"
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> NessieSettings:
-    """Return cached Nessie settings.
-
-    Returns:
-        NessieSettings: Singleton settings instance.
-
-    """
+@project_root_cached
+def get_settings(project_root: Path) -> NessieSettings:
+    """Return cached Nessie settings for the selected project root."""
     return NessieSettings()

--- a/packages/phlo-observatory/src/phlo_observatory/settings.py
+++ b/packages/phlo-observatory/src/phlo_observatory/settings.py
@@ -6,11 +6,12 @@ including database connection configuration for persistent settings storage.
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import AliasChoices, Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 
 
 class ObservatorySettings(BaseConfig):
@@ -34,8 +35,8 @@ class ObservatorySettings(BaseConfig):
     )
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> ObservatorySettings:
+@project_root_cached
+def get_settings(project_root: Path) -> ObservatorySettings:
     """Return cached Observatory settings instance.
 
     Settings are parsed from environment variables using PHLO_OBSERVATORY_*

--- a/packages/phlo-observatory/src/phlo_observatory/settings.py
+++ b/packages/phlo-observatory/src/phlo_observatory/settings.py
@@ -37,10 +37,13 @@ class ObservatorySettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> ObservatorySettings:
-    """Return cached Observatory settings instance.
+    """Return cached Observatory settings for the selected project root.
 
     Settings are parsed from environment variables using PHLO_OBSERVATORY_*
-    prefixes and cached for the lifetime of the process.
+    prefixes and cached per resolved project root, with up to 16 entries.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         ObservatorySettings: Parsed and validated Observatory settings.

--- a/packages/phlo-openmetadata/src/phlo_openmetadata/settings.py
+++ b/packages/phlo-openmetadata/src/phlo_openmetadata/settings.py
@@ -154,10 +154,13 @@ class OpenMetadataSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> OpenMetadataSettings:
-    """Get cached OpenMetadata settings.
+    """Get cached OpenMetadata settings for the selected project root.
 
-    Returns a cached instance to avoid repeated configuration loading.
-    The cache is limited to 1 entry as settings are typically global.
+    Settings are cached per resolved project root, with up to 16 entries,
+    to avoid repeated configuration loading while isolating project state.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         OpenMetadataSettings: Cached OpenMetadata settings instance.

--- a/packages/phlo-openmetadata/src/phlo_openmetadata/settings.py
+++ b/packages/phlo-openmetadata/src/phlo_openmetadata/settings.py
@@ -13,11 +13,12 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_host
 from phlo_openmetadata.capabilities import (
     resolve_query_engine_catalog,
@@ -151,8 +152,8 @@ class OpenMetadataSettings(BaseConfig):
         return resolve_query_engine_service_type(self.openmetadata_query_engine)
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> OpenMetadataSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> OpenMetadataSettings:
     """Get cached OpenMetadata settings.
 
     Returns a cached instance to avoid repeated configuration loading.

--- a/packages/phlo-postgres/src/phlo_postgres/settings.py
+++ b/packages/phlo-postgres/src/phlo_postgres/settings.py
@@ -15,13 +15,14 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 from typing import Any
 from urllib.parse import quote_plus
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_host
 
 
@@ -123,8 +124,8 @@ class PostgresSettings(BaseConfig):
         return f"postgresql://{user}:{password}@{self.postgres_host}:{self.postgres_port}{db_part}"
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> PostgresSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> PostgresSettings:
     """Return cached PostgreSQL settings instance.
 
     Provides a singleton-style access to PostgreSQL settings with LRU caching

--- a/packages/phlo-postgres/src/phlo_postgres/settings.py
+++ b/packages/phlo-postgres/src/phlo_postgres/settings.py
@@ -126,23 +126,25 @@ class PostgresSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> PostgresSettings:
-    """Return cached PostgreSQL settings instance.
+    """Return cached PostgreSQL settings for the selected project root.
 
-    Provides a singleton-style access to PostgreSQL settings with LRU caching
-    to avoid repeated parsing of environment variables and configuration files.
+    Settings are cached per resolved project root, with up to 16 entries,
+    to avoid repeated parsing while isolating project configuration.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         PostgresSettings: Cached settings instance.
 
     Note:
-        The cache size of 1 ensures the same settings object is returned
-        throughout the process lifetime. Settings are loaded once on first
-        call and reused thereafter.
+        Calls for the same project root return the same settings object.
+        Call ``get_settings.cache_clear()`` after changing configuration.
 
     Example:
         >>> settings1 = get_settings()
         >>> settings2 = get_settings()
-        >>> settings1 is settings2  # Same cached instance
+        >>> settings1 is settings2  # Same cached instance for this root
         True
         >>>
         >>> # Access connection parameters

--- a/packages/phlo-rustfs/src/phlo_rustfs/settings.py
+++ b/packages/phlo-rustfs/src/phlo_rustfs/settings.py
@@ -13,12 +13,13 @@ Functions:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_host
 
 
@@ -86,8 +87,8 @@ class RustfsSettings(BaseConfig):
         return f"{self.rustfs_host}:{self.rustfs_api_port}"
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> RustfsSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> RustfsSettings:
     """Return cached RustFS settings.
 
     Factory function returning a singleton RustfsSettings instance.

--- a/packages/phlo-rustfs/src/phlo_rustfs/settings.py
+++ b/packages/phlo-rustfs/src/phlo_rustfs/settings.py
@@ -89,14 +89,16 @@ class RustfsSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> RustfsSettings:
-    """Return cached RustFS settings.
+    """Return cached RustFS settings for the selected project root.
 
-    Factory function returning a singleton RustfsSettings instance.
-    Uses functools.lru_cache to ensure only one instance is created
-    per process, improving performance and consistency.
+    Settings are cached per resolved project root, with up to 16 entries,
+    improving performance while keeping project configuration isolated.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
-        Cached RustfsSettings instance.
+        Cached RustfsSettings instance for the selected root.
 
     Example:
         >>> settings = get_settings()

--- a/packages/phlo-sling/src/phlo_sling/settings.py
+++ b/packages/phlo-sling/src/phlo_sling/settings.py
@@ -14,11 +14,12 @@ Functions:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 
 
 class SlingSettings(BaseConfig):
@@ -76,8 +77,8 @@ class SlingSettings(BaseConfig):
     )
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> SlingSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> SlingSettings:
     """Return cached Sling settings instance.
 
     Returns a singleton instance of SlingSettings using LRU caching to

--- a/packages/phlo-sling/src/phlo_sling/settings.py
+++ b/packages/phlo-sling/src/phlo_sling/settings.py
@@ -79,11 +79,15 @@ class SlingSettings(BaseConfig):
 
 @project_root_cached
 def get_settings(project_root: Path) -> SlingSettings:
-    """Return cached Sling settings instance.
+    """Return cached Sling settings for the selected project root.
 
-    Returns a singleton instance of SlingSettings using LRU caching to
-    avoid repeated configuration loading. The settings are loaded from
-    environment variables and configuration files on first access.
+    Settings are cached per resolved project root, with up to 16 entries,
+    avoiding repeated configuration loading while isolating project state.
+    Settings are loaded from environment variables and configuration files
+    on first access for each root.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         Cached SlingSettings instance with loaded configuration values.

--- a/packages/phlo-superset/src/phlo_superset/settings.py
+++ b/packages/phlo-superset/src/phlo_superset/settings.py
@@ -14,11 +14,12 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 
 
 class SupersetSettings(BaseConfig):
@@ -55,29 +56,7 @@ class SupersetSettings(BaseConfig):
     )
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> SupersetSettings:
-    """Get cached Superset settings.
-
-    This function returns a cached instance of SupersetSettings to avoid
-    repeated configuration loading and parsing. The cache ensures that
-    settings are loaded once per process and reused thereafter.
-
-    Returns:
-        Loaded Superset configuration settings instance.
-
-    Raises:
-        None
-
-    Example:
-        >>> settings = get_settings()
-        >>> settings2 = get_settings()
-        >>> settings is settings2  # Same cached instance
-        True
-
-    Note:
-        The LRU cache ensures only one settings instance exists per process.
-        For testing purposes, use functools.cache_clear() if needed.
-
-    """
+@project_root_cached
+def get_settings(project_root: Path) -> SupersetSettings:
+    """Return cached Superset settings for the selected project root."""
     return SupersetSettings()

--- a/packages/phlo-superset/tests/test_superset_hooks.py
+++ b/packages/phlo-superset/tests/test_superset_hooks.py
@@ -77,10 +77,11 @@ def test_superset_database_uri_fails_without_config_or_metadata(monkeypatch) -> 
         hooks._discover_query_engine_database_uri()
 
 
-def test_superset_admin_credentials_fall_back_to_settings(monkeypatch) -> None:
+def test_superset_admin_credentials_fall_back_to_settings(monkeypatch, tmp_path) -> None:
     """Hook should use standard settings defaults when env vars are absent."""
     monkeypatch.delenv("SUPERSET_ADMIN_USER", raising=False)
     monkeypatch.delenv("SUPERSET_ADMIN_PASSWORD", raising=False)
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     hooks.get_settings.cache_clear()
 
     assert hooks._superset_admin_credentials() == ("admin", "admin")
@@ -119,10 +120,11 @@ def test_add_query_engine_database_handles_database_uri_resolution_failure(monke
     assert session.post.call_count == 1
 
 
-def test_add_query_engine_database_uses_settings_when_env_missing(monkeypatch) -> None:
+def test_add_query_engine_database_uses_settings_when_env_missing(monkeypatch, tmp_path) -> None:
     """Hook startup should still log in with generated default settings."""
     monkeypatch.delenv("SUPERSET_ADMIN_USER", raising=False)
     monkeypatch.delenv("SUPERSET_ADMIN_PASSWORD", raising=False)
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     hooks.get_settings.cache_clear()
     session = Mock()
     session.headers = {}

--- a/packages/phlo-superset/tests/test_superset_plugin.py
+++ b/packages/phlo-superset/tests/test_superset_plugin.py
@@ -21,9 +21,9 @@ def test_superset_plugin_metadata():
     assert "bi" in meta.tags
 
 
-def test_superset_settings_defaults():
+def test_superset_settings_defaults(tmp_path):
     """Verify Superset settings defaults match expected local development values."""
-    settings = SupersetSettings()
+    settings = SupersetSettings(_project_root=tmp_path)
 
     assert settings.superset_port == 10007
     assert settings.superset_admin_user == "admin"

--- a/packages/phlo-trino/src/phlo_trino/settings.py
+++ b/packages/phlo-trino/src/phlo_trino/settings.py
@@ -21,12 +21,13 @@ Example:
 
 from __future__ import annotations
 
-from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from pydantic import Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.config.network import resolve_host
 
 
@@ -73,8 +74,8 @@ class TrinoSettings(BaseConfig):
         return build_trino_dsn(self.trino_host, self.trino_port, self.trino_catalog)
 
 
-@lru_cache(maxsize=1)
-def get_settings() -> TrinoSettings:
+@project_root_cached
+def get_settings(project_root: Path) -> TrinoSettings:
     """Return cached Trino settings.
 
     Returns:

--- a/src/phlo/config/__init__.py
+++ b/src/phlo/config/__init__.py
@@ -27,7 +27,15 @@ Example:
 """
 
 from phlo.config.base import BaseConfig
-from phlo.config.env import load_project_env, parse_project_env_file, project_env_value
+from phlo.config.cache import project_root_cached
+from phlo.config.env import (
+    load_project_env,
+    parse_project_env_file,
+    project_env_files,
+    project_env_value,
+    resolve_project_root,
+    use_project_root,
+)
 from phlo.config.network import resolve_host, resolve_url
 from phlo.config.settings import Settings, _get_config, get_settings
 from phlo.config.workflow import WorkflowSettingsError, settings, workflow_settings
@@ -40,9 +48,13 @@ __all__ = [
     "get_settings",
     "load_project_env",
     "parse_project_env_file",
+    "project_root_cached",
+    "project_env_files",
     "project_env_value",
+    "resolve_project_root",
     "resolve_host",
     "resolve_url",
     "settings",
+    "use_project_root",
     "workflow_settings",
 ]

--- a/src/phlo/config/base.py
+++ b/src/phlo/config/base.py
@@ -7,6 +7,8 @@ settings for environment variable loading and validation.
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from phlo.config.env import project_env_files, resolve_project_root, use_project_root
+
 
 class BaseConfig(BaseSettings):
     """Base configuration class with common settings for all config domains.
@@ -16,8 +18,9 @@ class BaseConfig(BaseSettings):
     `.phlo/.env.local` files with case-insensitive matching.
 
     Attributes:
-        model_config: Pydantic settings configuration with env file paths,
-            case-insensitive matching, and extra field ignoring.
+        model_config: Pydantic settings configuration with case-insensitive
+            matching and extra field ignoring. Project env files are selected
+            per instance by ``_project_root``.
 
     Example:
         ```python
@@ -32,7 +35,19 @@ class BaseConfig(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        env_file=(".phlo/.env", ".phlo/.env.local"),
+        env_file=None,
         case_sensitive=False,
         extra="ignore",
     )
+
+    def __init__(self, _project_root=None, **values):
+        """Load settings from the selected project's generated environment files.
+
+        ``_project_root`` is intentionally an initialization-only argument so
+        callers and tests can select a project without changing process-wide
+        working-directory state. When omitted, ``PHLO_PROJECT_PATH`` is used,
+        followed by the current working directory for CLI compatibility.
+        """
+        project_root = resolve_project_root(_project_root)
+        with use_project_root(project_root):
+            super().__init__(_env_file=project_env_files(project_root), **values)

--- a/src/phlo/config/cache.py
+++ b/src/phlo/config/cache.py
@@ -1,0 +1,43 @@
+"""Project-root-aware caches for configuration entry points."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import lru_cache, wraps
+from pathlib import Path
+from typing import Any, Protocol, TypeVar, cast
+
+from phlo.config.env import resolve_project_root, use_project_root
+
+T = TypeVar("T")
+
+
+class ProjectRootCached(Protocol[T]):
+    """Callable configuration cache with the standard invalidation hook."""
+
+    def __call__(self, project_root: Path | str | None = None) -> T: ...
+
+    def cache_clear(self) -> None: ...
+
+    def cache_info(self) -> Any: ...
+
+
+def project_root_cached(factory: Callable[[Path], T]) -> ProjectRootCached[T]:
+    """Cache a configuration factory by its resolved project root.
+
+    The returned callable accepts an optional ``project_root`` argument and
+    keeps the usual ``cache_clear`` and ``cache_info`` methods used by tests
+    and long-running processes to invalidate configuration deliberately.
+    """
+    cached = lru_cache(maxsize=16)(factory)
+
+    @wraps(factory)
+    def get_cached(project_root: Path | str | None = None) -> T:
+        root = resolve_project_root(project_root)
+        with use_project_root(root):
+            return cached(root)
+
+    result = cast(Any, get_cached)
+    result.cache_clear = cached.cache_clear
+    result.cache_info = cached.cache_info
+    return cast(ProjectRootCached[T], result)

--- a/src/phlo/config/env.py
+++ b/src/phlo/config/env.py
@@ -3,9 +3,54 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 
 import yaml
+
+_PROJECT_ROOT: ContextVar[Path | None] = ContextVar("phlo_project_root", default=None)
+
+
+def _normalise_project_root(project_root: Path | str) -> Path:
+    """Resolve a project root while rejecting traversal components."""
+    raw_path = Path(project_root).expanduser()
+    if ".." in raw_path.parts:
+        raise ValueError(f"project root contains path traversal: {project_root}")
+    return raw_path.resolve()
+
+
+def resolve_project_root(project_root: Path | str | None = None) -> Path:
+    """Resolve an explicit project root for configuration loading."""
+    if project_root is not None:
+        return _normalise_project_root(project_root)
+
+    active_root = _PROJECT_ROOT.get()
+    if active_root is not None:
+        return active_root
+
+    configured_root = os.environ.get("PHLO_PROJECT_PATH")
+    if configured_root:
+        return _normalise_project_root(configured_root)
+    return Path.cwd().resolve()
+
+
+def project_env_files(project_root: Path | str | None = None) -> tuple[Path, Path]:
+    """Return the generated environment files for a project root."""
+    root = resolve_project_root(project_root)
+    return root / ".phlo" / ".env", root / ".phlo" / ".env.local"
+
+
+@contextmanager
+def use_project_root(project_root: Path | str | None) -> Iterator[Path]:
+    """Make a project root explicit while constructing nested settings."""
+    root = resolve_project_root(project_root)
+    token = _PROJECT_ROOT.set(root)
+    try:
+        yield root
+    finally:
+        _PROJECT_ROOT.reset(token)
 
 
 def parse_project_env_file(path: Path) -> dict[str, str]:
@@ -49,14 +94,14 @@ def parse_project_config_env(path: Path) -> dict[str, str]:
 
 
 def load_project_env(
-    project_root: Path | None = None, *, include_os: bool = True
+    project_root: Path | str | None = None, *, include_os: bool = True
 ) -> dict[str, str]:
     """Load ``phlo.yaml env:``, `.phlo/.env`, and `.phlo/.env.local`.
 
     Later sources override earlier sources, with OS env taking final precedence
     when requested.
     """
-    root = project_root or Path(os.environ.get("PHLO_PROJECT_PATH", Path.cwd()))
+    root = resolve_project_root(project_root)
     env: dict[str, str] = parse_project_config_env(root / "phlo.yaml")
     for path in (root / ".phlo" / ".env", root / ".phlo" / ".env.local"):
         env.update(parse_project_env_file(path))
@@ -65,6 +110,8 @@ def load_project_env(
     return env
 
 
-def project_env_value(name: str, default: str | None = None) -> str | None:
+def project_env_value(
+    name: str, default: str | None = None, project_root: Path | str | None = None
+) -> str | None:
     """Read a value from project env files or OS environment."""
-    return load_project_env().get(name, default)
+    return load_project_env(project_root).get(name, default)

--- a/src/phlo/config/settings.py
+++ b/src/phlo/config/settings.py
@@ -8,11 +8,12 @@ All settings can be customized through environment variables or by creating
 a `.phlo/.env` file in your project root.
 """
 
-from functools import lru_cache
+from pathlib import Path
 
 from pydantic import AliasChoices, Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 
 
 class Settings(BaseConfig):
@@ -138,8 +139,8 @@ class Settings(BaseConfig):
     )
 
 
-@lru_cache
-def _get_config() -> Settings:
+@project_root_cached
+def _get_config(project_root: Path) -> Settings:
     """Get cached config instance.
 
     Uses lru_cache to ensure config is loaded once and reused across
@@ -156,7 +157,7 @@ def _get_config() -> Settings:
     return Settings()
 
 
-def get_settings() -> Settings:
+def get_settings(project_root: Path | str | None = None) -> Settings:
     """Get application settings.
 
     This is the recommended way to access configuration in application code.
@@ -177,4 +178,4 @@ def get_settings() -> Settings:
         ```
 
     """
-    return _get_config()
+    return _get_config(project_root)

--- a/src/phlo/config/settings.py
+++ b/src/phlo/config/settings.py
@@ -141,11 +141,14 @@ class Settings(BaseConfig):
 
 @project_root_cached
 def _get_config(project_root: Path) -> Settings:
-    """Get cached config instance.
+    """Get cached config for the selected project root.
 
-    Uses lru_cache to ensure config is loaded once and reused across
-    the application lifecycle. This provides efficient access to settings
-    without repeated file I/O or parsing.
+    Configuration is cached per resolved project root, with up to 16 entries,
+    and reused across the application lifecycle. This avoids repeated file
+    I/O and parsing while keeping project configuration isolated.
+
+    Args:
+        project_root: Resolved project root used for cache selection.
 
     Returns:
         Settings: Validated Settings instance with all configuration values.
@@ -161,8 +164,13 @@ def get_settings(project_root: Path | str | None = None) -> Settings:
     """Get application settings.
 
     This is the recommended way to access configuration in application code.
-    It returns a cached Settings instance and supports future dependency
-    injection patterns for testing.
+    It returns a cached Settings instance for the selected project root and
+    supports future dependency injection patterns for testing.
+
+    Args:
+        project_root: Optional project root to select configuration for. When
+            omitted, the active project root context, ``PHLO_PROJECT_PATH``,
+            or current working directory is used.
 
     Returns:
         Settings: Validated Settings instance with all configuration values.

--- a/src/phlo/infrastructure/config.py
+++ b/src/phlo/infrastructure/config.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 
 import os
 import time
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 import yaml
 from pydantic import ValidationError
 
+from phlo.config.cache import project_root_cached
 from phlo.config_schema import (
     ApiAuthorizationConfig,
     ApiConfig,
@@ -42,13 +42,10 @@ def _default_project_root() -> Path:
     return Path.cwd()
 
 
-@lru_cache(maxsize=16)
-def load_project_config(project_root: Path | None = None) -> dict[str, Any]:
+@project_root_cached
+def load_project_config(project_root: Path) -> dict[str, Any]:
     """Load raw project configuration from phlo.yaml."""
     started = time.perf_counter()
-    if project_root is None:
-        project_root = _default_project_root()
-
     config_path = project_root / "phlo.yaml"
     logger.debug(
         "project_config_load_started",
@@ -90,12 +87,10 @@ def load_project_config(project_root: Path | None = None) -> dict[str, Any]:
     return project_config
 
 
-@lru_cache(maxsize=16)
-def load_infrastructure_config(project_root: Path | None = None) -> InfrastructureConfig:
+@project_root_cached
+def load_infrastructure_config(project_root: Path) -> InfrastructureConfig:
     """Load infrastructure configuration from phlo.yaml."""
     started = time.perf_counter()
-    if project_root is None:
-        project_root = _default_project_root()
     logger.debug("infrastructure_config_load_started", project_root=str(project_root))
 
     try:

--- a/src/phlo/plugins/observatory_settings.py
+++ b/src/phlo/plugins/observatory_settings.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
-from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 from jsonschema import ValidationError, validate
 from pydantic import AliasChoices, Field
 
 from phlo.config.base import BaseConfig
+from phlo.config.cache import project_root_cached
 from phlo.logging import get_logger
 
 logger = get_logger(__name__)
@@ -184,8 +185,8 @@ class InMemorySettingsService:
         return record
 
 
-@lru_cache(maxsize=1)
-def get_settings_service() -> SettingsService | InMemorySettingsService:
+@project_root_cached
+def get_settings_service(project_root: Path) -> SettingsService | InMemorySettingsService:
     """Build and cache the settings service instance."""
     config = ObservatorySettingsStorageConfig()
     if config.observatory_settings_db_url:
@@ -198,7 +199,7 @@ def get_settings_service() -> SettingsService | InMemorySettingsService:
         logger.warning("observatory_settings_falling_back_to_memory")
         return InMemorySettingsService()
 
-    postgres_settings = get_postgres_settings()
+    postgres_settings = get_postgres_settings(project_root)
     db_url = postgres_settings.get_postgres_connection_string()
     psycopg2 = _get_psycopg2()
     try:

--- a/tests/runtime/test_config.py
+++ b/tests/runtime/test_config.py
@@ -60,6 +60,7 @@ def test_cached_config_isolated_between_project_roots(tmp_path, monkeypatch, sel
 
     _get_config.cache_clear()
     monkeypatch.delenv("PHLO_LOG_LEVEL", raising=False)
+    monkeypatch.delenv("PHLO_PROJECT_PATH", raising=False)
 
     if selection == "cwd":
         monkeypatch.chdir(project_a)

--- a/tests/runtime/test_config.py
+++ b/tests/runtime/test_config.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import BaseModel
 
 import phlo
-from phlo.config import Settings, _get_config, workflow_settings
+from phlo.config import Settings, _get_config, get_settings, workflow_settings
 
 pytestmark = pytest.mark.core_regression
 
@@ -47,6 +47,36 @@ class TestConfigUnitTests:
 
             assert config1 is config2
             assert id(config1) == id(config2)
+
+
+@pytest.mark.parametrize("selection", ["cwd", "env"])
+def test_cached_config_isolated_between_project_roots(tmp_path, monkeypatch, selection) -> None:
+    """Configuration caches must distinguish projects selected by cwd or env."""
+    project_a = tmp_path / "project-a"
+    project_b = tmp_path / "project-b"
+    for project, level in ((project_a, "INFO"), (project_b, "DEBUG")):
+        (project / ".phlo").mkdir(parents=True)
+        (project / ".phlo" / ".env.local").write_text(f"PHLO_LOG_LEVEL={level}\n")
+
+    _get_config.cache_clear()
+    monkeypatch.delenv("PHLO_LOG_LEVEL", raising=False)
+
+    if selection == "cwd":
+        monkeypatch.chdir(project_a)
+        first = get_settings()
+        monkeypatch.chdir(project_b)
+        second = get_settings()
+    else:
+        monkeypatch.setenv("PHLO_PROJECT_PATH", str(project_a))
+        first = get_settings()
+        monkeypatch.setenv("PHLO_PROJECT_PATH", str(project_b))
+        second = get_settings()
+
+    assert first.phlo_log_level == "INFO"
+    assert second.phlo_log_level == "DEBUG"
+    assert first is not second
+    assert get_settings(project_root=project_a) is first
+    assert get_settings(project_root=project_b) is second
 
 
 class WorkflowSettings(BaseModel):


### PR DESCRIPTION
## Summary

Implements REL-002 by making project configuration selection explicit and resettable across the common Python configuration boundary.

- Adds a root-aware configuration cache used by every cached `BaseConfig` settings entry point, core settings, infrastructure config, and Observatory settings. Existing no-argument callers keep working, `get_settings(project_root=...)` is available at the core public boundary, and `cache_clear()`/`cache_info()` compatibility is preserved.
- Loads `.phlo/.env` and `.phlo/.env.local` from absolute, selected project roots and carries the root through nested network/environment resolution.
- Passes Dagster development variables to the child process without mutating the parent environment.
- Isolates Superset and Delta default tests from generated repository state and adds parameterized two-project coverage for cwd and `PHLO_PROJECT_PATH` changes.

## Roadmap acceptance criteria satisfied

- Project configuration roots are explicit, resettable, and cache keys include the resolved root, so BaseConfig settings cannot be returned from another selected project.
- Repository `.phlo` state no longer changes the dbt, Nessie/MinIO, Superset, or default settings test outcomes.
- The full non-integration suite passes from both clean and initialized-project checkout states with pytest cache provider disabled.

## Risk

The configuration cache now retains up to 16 project-root entries instead of one process-wide settings entry. Existing no-argument behavior remains cwd/`PHLO_PROJECT_PATH` based, while callers that need deterministic selection can pass an explicit root. Project roots containing `..` remain rejected.

## Security implications

No authentication or authorization behavior changes. The change reduces cross-project endpoint, port, and credential bleed in a process and stops `phlo dev` from leaking project environment values into its parent process; generated project secrets are still passed only to the intended child process environment.

## Tests run

- Clean checkout: `uv run pytest -m 'not integration' -p no:cacheprovider --tb=short` — 2624 passed, 2 skipped, 478 deselected.
- Initialized checkout from `/Users/garethprice/Developer/phlo`: same suite via the worktree project — 2624 passed, 2 skipped, 478 deselected.
- Focused regression suite — 49 passed.
- `uv run ruff check .` — passed.
- `uv run ruff format --check .` — passed.
- `make typecheck-python` — exited successfully with the repository baseline of 98 warning diagnostics.
- Pre-commit hooks — passed.

Do not merge this PR; it is ready for review.