### PR TITLE
fix(security): secure Observatory workflow wizard apply

### DIFF
--- a/packages/phlo-api/src/phlo_api/observatory_api/observatory.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/observatory.py
@@ -4921,17 +4921,24 @@ def get_observatory_workflow_wizard() -> dict[str, Any]:
 @router.post("/workflow-wizard/proposals")
 def post_observatory_workflow_wizard_proposal(
     request: ObservatoryWorkflowProposalRequest,
+    http_request: Request,
 ) -> dict[str, Any]:
-    """Build a side-effect-free workflow proposal."""
+    """Build and persist a server-owned workflow proposal."""
 
+    auth = require_scope(http_request, "project:write")
+    enforce_rate_limit(auth["subject"], "workflow_wizard_proposal")
     return build_workflow_proposal(_project_root(), request)
 
 
 @router.post("/workflow-wizard/actions", response_model=ObservatoryWorkflowActionResult)
 def post_observatory_workflow_wizard_action(
     request: ObservatoryWorkflowActionRequest,
+    http_request: Request,
 ) -> ObservatoryWorkflowActionResult:
     """Run a guarded workflow wizard apply action."""
+
+    auth = require_scope(http_request, "project:write")
+    enforce_rate_limit(auth["subject"], "workflow_wizard_apply")
 
     try:
         result = apply_workflow_action(_project_root(), request)

--- a/packages/phlo-api/src/phlo_api/observatory_api/observatory.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/observatory.py
@@ -4927,7 +4927,7 @@ def post_observatory_workflow_wizard_proposal(
 
     auth = require_scope(http_request, "project:write")
     enforce_rate_limit(auth["subject"], "workflow_wizard_proposal")
-    return build_workflow_proposal(_project_root(), request)
+    return build_workflow_proposal(_project_root(), request, auth["subject"])
 
 
 @router.post("/workflow-wizard/actions", response_model=ObservatoryWorkflowActionResult)
@@ -4941,7 +4941,7 @@ def post_observatory_workflow_wizard_action(
     enforce_rate_limit(auth["subject"], "workflow_wizard_apply")
 
     try:
-        result = apply_workflow_action(_project_root(), request)
+        result = apply_workflow_action(_project_root(), request, auth["subject"])
     except HTTPException as exc:
         message = str(exc.detail)
         append_operation(

--- a/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
@@ -38,6 +38,7 @@ STAGES = ["source", "transform", "quality", "publish"]
 _ALLOWED_PROJECT_ROOTS = ("workflows", "tests")
 _WORKFLOW_ALLOWED_EXTENSIONS = {".json", ".py", ".sql", ".toml", ".yaml", ".yml"}
 _PROPOSAL_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{16,64}$")
+_STATE_DIRECTORY_FLAGS = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
 WORKFLOW_WIZARD_PLUGIN_TYPES = (
     "ingestion_provider",
     "transformation_provider",
@@ -223,43 +224,51 @@ def build_workflow_proposal(
     return _issue_workflow_proposal(project_root, proposal)
 
 
-def _proposal_state_dir(project_root: Path) -> Path:
-    project_root = project_root.resolve()
-    phlo_dir = project_root / ".phlo"
-    wizard_dir = phlo_dir / "workflow-wizard"
-    for directory in (phlo_dir, wizard_dir):
-        try:
-            metadata = os.lstat(directory)
-        except FileNotFoundError:
-            directory.mkdir()
-            metadata = os.lstat(directory)
-        if not stat.S_ISDIR(metadata.st_mode):
-            raise HTTPException(status_code=503, detail="Workflow state directory is not safe.")
-    return wizard_dir
-
-
-def _proposal_storage_dir(project_root: Path, name: str) -> Path:
-    directory = _proposal_state_dir(project_root) / name
+def _open_directory_at(parent_fd: int, name: str, *, create: bool) -> int:
     try:
-        metadata = os.lstat(directory)
+        return os.open(name, _STATE_DIRECTORY_FLAGS, dir_fd=parent_fd)
     except FileNotFoundError:
-        directory.mkdir()
-        metadata = os.lstat(directory)
-    if not stat.S_ISDIR(metadata.st_mode):
-        raise HTTPException(status_code=503, detail="Workflow state directory is not safe.")
-    return directory
+        if not create:
+            raise
+        try:
+            os.mkdir(name, mode=0o700, dir_fd=parent_fd)
+        except FileExistsError:
+            pass
+        return os.open(name, _STATE_DIRECTORY_FLAGS, dir_fd=parent_fd)
 
 
-def _proposal_path(project_root: Path, proposal_id: str) -> Path:
-    if not _PROPOSAL_ID_PATTERN.fullmatch(proposal_id):
-        raise HTTPException(status_code=400, detail="Invalid workflow proposal id.")
-    return _proposal_storage_dir(project_root, "proposals") / f"{proposal_id}.json"
+def _open_workflow_state_fd(project_root: Path) -> int:
+    root_fd = -1
+    phlo_fd = -1
+    try:
+        root_fd = os.open(project_root.resolve(), _STATE_DIRECTORY_FLAGS)
+        phlo_fd = _open_directory_at(root_fd, ".phlo", create=True)
+        return _open_directory_at(phlo_fd, "workflow-wizard", create=True)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=503, detail="Workflow state directory is not safe."
+        ) from exc
+    finally:
+        if phlo_fd >= 0:
+            os.close(phlo_fd)
+        if root_fd >= 0:
+            os.close(root_fd)
 
 
-def _applied_proposal_path(project_root: Path, proposal_id: str) -> Path:
-    if not _PROPOSAL_ID_PATTERN.fullmatch(proposal_id):
-        raise HTTPException(status_code=400, detail="Invalid workflow proposal id.")
-    return _proposal_storage_dir(project_root, "applied") / f"{proposal_id}.json"
+def _open_state_storage_fd(project_root: Path, name: str, *, create: bool) -> int:
+    state_fd = -1
+    try:
+        state_fd = _open_workflow_state_fd(project_root)
+        return _open_directory_at(state_fd, name, create=create)
+    except FileNotFoundError:
+        raise
+    except OSError as exc:
+        raise HTTPException(
+            status_code=503, detail="Workflow state directory is not safe."
+        ) from exc
+    finally:
+        if state_fd >= 0:
+            os.close(state_fd)
 
 
 def _canonical_json(payload: dict[str, Any]) -> bytes:
@@ -277,41 +286,40 @@ def _workflow_integrity_key(project_root: Path) -> bytes:
     if configured:
         return configured.encode("utf-8")
 
-    key_path = _proposal_state_dir(project_root) / "integrity.key"
-    key_path.parent.mkdir(parents=True, exist_ok=True)
+    state_fd = _open_workflow_state_fd(project_root)
+    descriptor = -1
     try:
-        existing = os.lstat(key_path)
-    except FileNotFoundError:
-        existing = None
-    if existing is not None and not stat.S_ISREG(existing.st_mode):
-        raise HTTPException(status_code=503, detail="Workflow integrity key is not a regular file.")
-    if existing is None:
         try:
             descriptor = os.open(
-                key_path,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                "integrity.key",
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
                 0o600,
+                dir_fd=state_fd,
             )
+        except FileExistsError:
+            pass
+        else:
             try:
                 with os.fdopen(descriptor, "wb") as handle:
+                    descriptor = -1
                     handle.write(secrets.token_bytes(32))
                     handle.flush()
                     os.fsync(handle.fileno())
             except BaseException:
                 with contextlib.suppress(OSError):
-                    key_path.unlink()
+                    os.unlink("integrity.key", dir_fd=state_fd)
                 raise
-        except FileExistsError:
-            pass
 
-    read_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
-    try:
-        descriptor = os.open(key_path, read_flags)
-    except OSError as exc:
-        raise HTTPException(
-            status_code=503, detail="Workflow integrity key cannot be read safely."
-        ) from exc
-    try:
+        try:
+            descriptor = os.open(
+                "integrity.key",
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=state_fd,
+            )
+        except OSError as exc:
+            raise HTTPException(
+                status_code=503, detail="Workflow integrity key cannot be read safely."
+            ) from exc
         if not stat.S_ISREG(os.fstat(descriptor).st_mode):
             raise HTTPException(
                 status_code=503, detail="Workflow integrity key is not a regular file."
@@ -322,7 +330,9 @@ def _workflow_integrity_key(project_root: Path) -> bytes:
             raise HTTPException(status_code=503, detail="Workflow integrity key is empty.")
         return key
     finally:
-        os.close(descriptor)
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(state_fd)
 
 
 def _proposal_signature(project_root: Path, proposal_id: str, digest: str) -> str:
@@ -330,18 +340,59 @@ def _proposal_signature(project_root: Path, proposal_id: str, digest: str) -> st
     return hmac.new(_workflow_integrity_key(project_root), message, hashlib.sha256).hexdigest()
 
 
-def _write_json_atomically(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+def _read_state_json(project_root: Path, storage_name: str, filename: str) -> dict[str, Any]:
+    storage_fd = _open_state_storage_fd(project_root, storage_name, create=False)
+    descriptor = -1
     try:
-        temporary.write_text(
-            json.dumps(payload, sort_keys=True, ensure_ascii=False),
-            encoding="utf-8",
+        descriptor = os.open(
+            filename,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=storage_fd,
         )
-        os.replace(temporary, path)
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError("state record is not a regular file")
+        with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+            descriptor = -1
+            payload = json.load(handle)
+        if not isinstance(payload, dict):
+            raise TypeError("state record is not an object")
+        return payload
     finally:
-        if temporary.exists():
-            temporary.unlink()
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(storage_fd)
+
+
+def _write_state_json(
+    project_root: Path, storage_name: str, filename: str, payload: dict[str, Any]
+) -> None:
+    storage_fd = _open_state_storage_fd(project_root, storage_name, create=True)
+    temporary_name = f".{filename}.{secrets.token_hex(8)}.tmp"
+    temporary_fd = -1
+    try:
+        temporary_fd = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=storage_fd,
+        )
+        with os.fdopen(temporary_fd, "w", encoding="utf-8") as handle:
+            temporary_fd = -1
+            handle.write(json.dumps(payload, sort_keys=True, ensure_ascii=False))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(
+            temporary_name,
+            filename,
+            src_dir_fd=storage_fd,
+            dst_dir_fd=storage_fd,
+        )
+    finally:
+        if temporary_fd >= 0:
+            os.close(temporary_fd)
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary_name, dir_fd=storage_fd)
+        os.close(storage_fd)
 
 
 def _issue_workflow_proposal(project_root: Path, proposal: WorkflowProposal) -> dict[str, Any]:
@@ -355,8 +406,10 @@ def _issue_workflow_proposal(project_root: Path, proposal: WorkflowProposal) -> 
         digest=digest,
         signature=signature,
     )
-    _write_json_atomically(
-        _proposal_path(project_root, proposal_id),
+    _write_state_json(
+        project_root,
+        "proposals",
+        f"{proposal_id}.json",
         record.model_dump(mode="json"),
     )
     return {
@@ -434,10 +487,9 @@ def apply_workflow_action(
     if not action.enabled:
         raise HTTPException(status_code=409, detail=action.reason or "Workflow action is disabled.")
 
-    applied_path = _applied_proposal_path(project_root, proposal_id)
     with _workflow_apply_lock(project_root):
         targets = _validated_workflow_targets(project_root, proposal)
-        applied = _load_applied_record(applied_path)
+        applied = _load_applied_record(project_root, proposal_id)
         if applied is not None:
             if (
                 applied.get("action_id") != action.id
@@ -479,7 +531,7 @@ def apply_workflow_action(
                 "status": "applying",
                 "written_files": [],
             }
-            _write_json_atomically(applied_path, applied)
+            _write_state_json(project_root, "applied", f"{proposal_id}.json", applied)
 
         written_files = list(applied.get("written_files") or [])
         for preview, target in targets:
@@ -496,7 +548,7 @@ def apply_workflow_action(
             if preview.path not in written_files:
                 written_files.append(preview.path)
             applied["written_files"] = written_files
-            _write_json_atomically(applied_path, applied)
+            _write_state_json(project_root, "applied", f"{proposal_id}.json", applied)
 
         result = ObservatoryWorkflowActionResult(
             action_id=action.id,
@@ -504,8 +556,10 @@ def apply_workflow_action(
             message=f"Created {len(written_files)} workflow file{'' if len(written_files) == 1 else 's'}.",
             files=written_files,
         )
-        _write_json_atomically(
-            applied_path,
+        _write_state_json(
+            project_root,
+            "applied",
+            f"{proposal_id}.json",
             {
                 **applied,
                 "status": "succeeded",
@@ -518,16 +572,21 @@ def apply_workflow_action(
 def _load_verified_workflow_proposal(
     project_root: Path, proposal_id: str
 ) -> tuple[WorkflowProposal, str]:
-    path = _proposal_path(project_root, proposal_id)
+    if not _PROPOSAL_ID_PATTERN.fullmatch(proposal_id):
+        raise HTTPException(status_code=400, detail="Invalid workflow proposal id.")
     try:
         record = _StoredWorkflowProposal.model_validate(
-            json.loads(path.read_text(encoding="utf-8"))
+            _read_state_json(project_root, "proposals", f"{proposal_id}.json")
         )
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Workflow proposal not found.") from exc
     except (OSError, TypeError, ValueError) as exc:
         raise HTTPException(status_code=409, detail="Workflow proposal is invalid.") from exc
 
+    if record.proposal_id != proposal_id:
+        raise HTTPException(
+            status_code=409, detail="Workflow proposal integrity verification failed."
+        )
     expected_signature = _proposal_signature(project_root, record.proposal_id, record.digest)
     if not hmac.compare_digest(record.signature, expected_signature):
         raise HTTPException(
@@ -540,36 +599,37 @@ def _load_verified_workflow_proposal(
     return _proposal_from_payload(record.proposal), record.digest
 
 
-def _load_applied_record(path: Path) -> dict[str, Any] | None:
-    if not path.exists():
-        return None
+def _load_applied_record(project_root: Path, proposal_id: str) -> dict[str, Any] | None:
     try:
-        record = json.loads(path.read_text(encoding="utf-8"))
+        record = _read_state_json(project_root, "applied", f"{proposal_id}.json")
+    except FileNotFoundError:
+        return None
     except (OSError, TypeError, ValueError) as exc:
         raise HTTPException(
             status_code=409,
             detail="Workflow proposal application record is invalid.",
         ) from exc
-    if not isinstance(record, dict):
-        raise HTTPException(
-            status_code=409, detail="Workflow proposal application record is invalid."
-        )
     return record
 
 
 @contextmanager
 def _workflow_apply_lock(project_root: Path):
-    lock_path = _proposal_state_dir(project_root) / "apply.lock"
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    state_fd = _open_workflow_state_fd(project_root)
+    descriptor = -1
     try:
         descriptor = os.open(
-            lock_path,
+            "apply.lock",
             os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
             0o600,
+            dir_fd=state_fd,
         )
     except OSError as exc:
+        os.close(state_fd)
         raise HTTPException(status_code=503, detail="Workflow apply lock is not safe.") from exc
     try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise HTTPException(status_code=503, detail="Workflow apply lock is not safe.")
+        os.fchmod(descriptor, 0o600)
         handle = os.fdopen(descriptor, "a+", encoding="utf-8")
         descriptor = -1
         with handle:
@@ -583,6 +643,7 @@ def _workflow_apply_lock(project_root: Path):
     finally:
         if descriptor >= 0:
             os.close(descriptor)
+        os.close(state_fd)
 
 
 def _file_matches(path: Path, content: str) -> bool:

--- a/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
@@ -37,6 +37,7 @@ except ImportError:  # pragma: no cover - POSIX is used in production
 STAGES = ["source", "transform", "quality", "publish"]
 _ALLOWED_PROJECT_ROOTS = ("workflows", "tests")
 _WORKFLOW_ALLOWED_EXTENSIONS = {".json", ".py", ".sql", ".toml", ".yaml", ".yml"}
+_WORKFLOW_FILE_MODE = 0o644
 _PROPOSAL_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{16,64}$")
 _STATE_DIRECTORY_FLAGS = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
 WORKFLOW_WIZARD_PLUGIN_TYPES = (
@@ -746,6 +747,8 @@ def _write_text_atomically_at(directory_fd: int, filename: str, content: str) ->
             temporary_fd = -1
             handle.write(content)
             handle.flush()
+            os.fsync(handle.fileno())
+            os.fchmod(handle.fileno(), _WORKFLOW_FILE_MODE)
             os.fsync(handle.fileno())
         os.link(
             temporary_name,

--- a/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib
+import hashlib
+import hmac
+import json
+import os
 import re
+import secrets
+import stat
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal, cast
 
@@ -20,7 +28,16 @@ from phlo.capabilities import (
     validate_proposal_request,
 )
 
+_fcntl: Any = None
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - POSIX is used in production
+    pass
+
 STAGES = ["source", "transform", "quality", "publish"]
+_ALLOWED_PROJECT_ROOTS = ("workflows", "tests")
+_WORKFLOW_ALLOWED_EXTENSIONS = {".json", ".py", ".sql", ".toml", ".yaml", ".yml"}
+_PROPOSAL_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]{16,64}$")
 WORKFLOW_WIZARD_PLUGIN_TYPES = (
     "ingestion_provider",
     "transformation_provider",
@@ -82,7 +99,16 @@ class ObservatoryWorkflowActionRequest(BaseModel):
     """Request body for guarded workflow wizard apply actions."""
 
     action_id: str
+    proposal_id: str
+
+
+class _StoredWorkflowProposal(BaseModel):
+    """Server-owned workflow proposal record."""
+
+    proposal_id: str
     proposal: dict[str, Any]
+    digest: str
+    signature: str
 
 
 class ObservatoryWorkflowActionResult(BaseModel):
@@ -160,7 +186,7 @@ def build_workflow_proposal(
     project_root: Path,
     request: ObservatoryWorkflowProposalRequest,
 ) -> dict[str, Any]:
-    """Build a side-effect-free workflow proposal for the browser."""
+    """Build and persist a server-owned workflow proposal for the browser."""
 
     if not request.graph.nodes:
         raise HTTPException(status_code=422, detail={"graph": ["Add at least one workflow node."]})
@@ -194,7 +220,149 @@ def build_workflow_proposal(
     conflicts = detect_file_conflicts(project_root, proposal)
     if conflicts:
         proposal = _with_conflict_action_disabled(proposal, conflicts)
-    return proposal.to_browser_dict()
+    return _issue_workflow_proposal(project_root, proposal)
+
+
+def _proposal_state_dir(project_root: Path) -> Path:
+    project_root = project_root.resolve()
+    phlo_dir = project_root / ".phlo"
+    wizard_dir = phlo_dir / "workflow-wizard"
+    for directory in (phlo_dir, wizard_dir):
+        try:
+            metadata = os.lstat(directory)
+        except FileNotFoundError:
+            directory.mkdir()
+            metadata = os.lstat(directory)
+        if not stat.S_ISDIR(metadata.st_mode):
+            raise HTTPException(status_code=503, detail="Workflow state directory is not safe.")
+    return wizard_dir
+
+
+def _proposal_storage_dir(project_root: Path, name: str) -> Path:
+    directory = _proposal_state_dir(project_root) / name
+    try:
+        metadata = os.lstat(directory)
+    except FileNotFoundError:
+        directory.mkdir()
+        metadata = os.lstat(directory)
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise HTTPException(status_code=503, detail="Workflow state directory is not safe.")
+    return directory
+
+
+def _proposal_path(project_root: Path, proposal_id: str) -> Path:
+    if not _PROPOSAL_ID_PATTERN.fullmatch(proposal_id):
+        raise HTTPException(status_code=400, detail="Invalid workflow proposal id.")
+    return _proposal_storage_dir(project_root, "proposals") / f"{proposal_id}.json"
+
+
+def _applied_proposal_path(project_root: Path, proposal_id: str) -> Path:
+    if not _PROPOSAL_ID_PATTERN.fullmatch(proposal_id):
+        raise HTTPException(status_code=400, detail="Invalid workflow proposal id.")
+    return _proposal_storage_dir(project_root, "applied") / f"{proposal_id}.json"
+
+
+def _canonical_json(payload: dict[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def _proposal_digest(proposal: dict[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(proposal)).hexdigest()
+
+
+def _workflow_integrity_key(project_root: Path) -> bytes:
+    configured = os.environ.get("PHLO_WORKFLOW_WIZARD_SECRET")
+    if configured:
+        return configured.encode("utf-8")
+
+    key_path = _proposal_state_dir(project_root) / "integrity.key"
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing = os.lstat(key_path)
+    except FileNotFoundError:
+        existing = None
+    if existing is not None and not stat.S_ISREG(existing.st_mode):
+        raise HTTPException(status_code=503, detail="Workflow integrity key is not a regular file.")
+    if existing is None:
+        try:
+            descriptor = os.open(
+                key_path,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+            )
+            try:
+                with os.fdopen(descriptor, "wb") as handle:
+                    handle.write(secrets.token_bytes(32))
+                    handle.flush()
+                    os.fsync(handle.fileno())
+            except BaseException:
+                with contextlib.suppress(OSError):
+                    key_path.unlink()
+                raise
+        except FileExistsError:
+            pass
+
+    read_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(key_path, read_flags)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=503, detail="Workflow integrity key cannot be read safely."
+        ) from exc
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise HTTPException(
+                status_code=503, detail="Workflow integrity key is not a regular file."
+            )
+        os.fchmod(descriptor, 0o600)
+        key = os.read(descriptor, 4096)
+        if not key:
+            raise HTTPException(status_code=503, detail="Workflow integrity key is empty.")
+        return key
+    finally:
+        os.close(descriptor)
+
+
+def _proposal_signature(project_root: Path, proposal_id: str, digest: str) -> str:
+    message = f"{proposal_id}:{digest}".encode("utf-8")
+    return hmac.new(_workflow_integrity_key(project_root), message, hashlib.sha256).hexdigest()
+
+
+def _write_json_atomically(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, sort_keys=True, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _issue_workflow_proposal(project_root: Path, proposal: WorkflowProposal) -> dict[str, Any]:
+    proposal_id = secrets.token_urlsafe(24)
+    proposal_payload = proposal.to_browser_dict()
+    digest = _proposal_digest(proposal_payload)
+    signature = _proposal_signature(project_root, proposal_id, digest)
+    record = _StoredWorkflowProposal(
+        proposal_id=proposal_id,
+        proposal=proposal_payload,
+        digest=digest,
+        signature=signature,
+    )
+    _write_json_atomically(
+        _proposal_path(project_root, proposal_id),
+        record.model_dump(mode="json"),
+    )
+    return {
+        **proposal_payload,
+        "proposal_id": proposal_id,
+    }
 
 
 def _selections_from_graph(
@@ -254,36 +422,282 @@ def _selection_payload(
 def apply_workflow_action(
     project_root: Path, request: ObservatoryWorkflowActionRequest
 ) -> ObservatoryWorkflowActionResult:
-    """Apply a guarded workflow wizard action by writing proposed files."""
+    """Apply a server-issued workflow action within the project workflow root."""
 
-    proposal = _proposal_from_payload(request.proposal)
+    proposal_id = request.proposal_id
+    proposal, proposal_digest = _load_verified_workflow_proposal(project_root, proposal_id)
     action = next((item for item in proposal.actions if item.id == request.action_id), None)
     if action is None:
         raise HTTPException(
             status_code=404, detail=f"Workflow action not found: {request.action_id}"
         )
+    if not action.enabled:
+        raise HTTPException(status_code=409, detail=action.reason or "Workflow action is disabled.")
 
-    conflicts = detect_file_conflicts(project_root, proposal)
-    if conflicts and action.conflict_policy == "fail-on-conflict":
-        raise HTTPException(status_code=409, detail=f"File conflicts: {', '.join(conflicts)}")
+    applied_path = _applied_proposal_path(project_root, proposal_id)
+    with _workflow_apply_lock(project_root):
+        targets = _validated_workflow_targets(project_root, proposal)
+        applied = _load_applied_record(applied_path)
+        if applied is not None:
+            if (
+                applied.get("action_id") != action.id
+                or applied.get("proposal_digest") != proposal_digest
+            ):
+                raise HTTPException(status_code=409, detail="Workflow proposal replay conflicts.")
+            if applied.get("status") == "succeeded":
+                if not all(_file_matches(target, preview.content) for preview, target in targets):
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Applied workflow files changed after completion.",
+                    )
+                try:
+                    return ObservatoryWorkflowActionResult.model_validate(applied["result"])
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise HTTPException(
+                        status_code=409,
+                        detail="Workflow proposal application record is invalid.",
+                    ) from exc
+            if applied.get("status") != "applying":
+                raise HTTPException(
+                    status_code=409,
+                    detail="Workflow proposal application record is invalid.",
+                )
+        else:
+            conflicts = [
+                preview.path
+                for preview, target in targets
+                if preview.mode == "create" and target.exists()
+            ]
+            if conflicts and action.conflict_policy == "fail-on-conflict":
+                raise HTTPException(
+                    status_code=409, detail=f"File conflicts: {', '.join(conflicts)}"
+                )
+            applied = {
+                "action_id": action.id,
+                "proposal_digest": proposal_digest,
+                "proposal_id": proposal_id,
+                "status": "applying",
+                "written_files": [],
+            }
+            _write_json_atomically(applied_path, applied)
 
-    written: list[str] = []
-    for preview in proposal.files:
-        target = project_root / preview.path
-        if target.exists() and action.conflict_policy == "skip-if-exists":
-            continue
-        if target.exists() and action.conflict_policy == "fail-on-conflict":
-            raise HTTPException(status_code=409, detail=f"File conflicts: {preview.path}")
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(preview.content, encoding="utf-8")
-        written.append(preview.path)
+        written_files = list(applied.get("written_files") or [])
+        for preview, target in targets:
+            if target.exists():
+                if _file_matches(target, preview.content):
+                    if preview.path not in written_files:
+                        written_files.append(preview.path)
+                    continue
+                if action.conflict_policy == "skip-if-exists":
+                    continue
+                raise HTTPException(status_code=409, detail=f"File conflicts: {preview.path}")
 
-    return ObservatoryWorkflowActionResult(
-        action_id=action.id,
-        status="succeeded",
-        message=f"Created {len(written)} workflow file{'s' if len(written) != 1 else ''}.",
-        files=written,
+            _write_text_atomically(project_root, preview.path, preview.content)
+            if preview.path not in written_files:
+                written_files.append(preview.path)
+            applied["written_files"] = written_files
+            _write_json_atomically(applied_path, applied)
+
+        result = ObservatoryWorkflowActionResult(
+            action_id=action.id,
+            status="succeeded",
+            message=f"Created {len(written_files)} workflow file{'' if len(written_files) == 1 else 's'}.",
+            files=written_files,
+        )
+        _write_json_atomically(
+            applied_path,
+            {
+                **applied,
+                "status": "succeeded",
+                "result": result.model_dump(mode="json"),
+            },
+        )
+        return result
+
+
+def _load_verified_workflow_proposal(
+    project_root: Path, proposal_id: str
+) -> tuple[WorkflowProposal, str]:
+    path = _proposal_path(project_root, proposal_id)
+    try:
+        record = _StoredWorkflowProposal.model_validate(
+            json.loads(path.read_text(encoding="utf-8"))
+        )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Workflow proposal not found.") from exc
+    except (OSError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=409, detail="Workflow proposal is invalid.") from exc
+
+    expected_signature = _proposal_signature(project_root, record.proposal_id, record.digest)
+    if not hmac.compare_digest(record.signature, expected_signature):
+        raise HTTPException(
+            status_code=409, detail="Workflow proposal integrity verification failed."
+        )
+    if not hmac.compare_digest(record.digest, _proposal_digest(record.proposal)):
+        raise HTTPException(
+            status_code=409, detail="Workflow proposal integrity verification failed."
+        )
+    return _proposal_from_payload(record.proposal), record.digest
+
+
+def _load_applied_record(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=409,
+            detail="Workflow proposal application record is invalid.",
+        ) from exc
+    if not isinstance(record, dict):
+        raise HTTPException(
+            status_code=409, detail="Workflow proposal application record is invalid."
+        )
+    return record
+
+
+@contextmanager
+def _workflow_apply_lock(project_root: Path):
+    lock_path = _proposal_state_dir(project_root) / "apply.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+    except OSError as exc:
+        raise HTTPException(status_code=503, detail="Workflow apply lock is not safe.") from exc
+    try:
+        handle = os.fdopen(descriptor, "a+", encoding="utf-8")
+        descriptor = -1
+        with handle:
+            if _fcntl is not None:
+                _fcntl.flock(handle.fileno(), _fcntl.LOCK_EX)
+            try:
+                yield
+            finally:
+                if _fcntl is not None:
+                    _fcntl.flock(handle.fileno(), _fcntl.LOCK_UN)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _file_matches(path: Path, content: str) -> bool:
+    try:
+        return path.is_file() and path.read_text(encoding="utf-8") == content
+    except (OSError, UnicodeError):
+        return False
+
+
+def _write_text_atomically(project_root: Path, relative_path: str, content: str) -> None:
+    parts = Path(relative_path).parts
+    if not parts:
+        raise HTTPException(status_code=400, detail="Invalid workflow file path.")
+    directory_fd = os.open(
+        project_root,
+        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
     )
+    try:
+        for component in parts[:-1]:
+            try:
+                next_fd = os.open(
+                    component,
+                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=directory_fd,
+                )
+            except FileNotFoundError:
+                os.mkdir(component, mode=0o755, dir_fd=directory_fd)
+                next_fd = os.open(
+                    component,
+                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+                    dir_fd=directory_fd,
+                )
+            os.close(directory_fd)
+            directory_fd = next_fd
+
+        filename = parts[-1]
+        temporary_name = f".{filename}.{secrets.token_hex(8)}.tmp"
+        temporary_fd = os.open(
+            temporary_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=directory_fd,
+        )
+        try:
+            with os.fdopen(temporary_fd, "w", encoding="utf-8") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(
+                temporary_name,
+                filename,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+            )
+        except BaseException:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(temporary_name, dir_fd=directory_fd)
+            raise
+    finally:
+        os.close(directory_fd)
+
+
+def _validated_workflow_targets(
+    project_root: Path, proposal: WorkflowProposal
+) -> list[tuple[WorkflowFilePreview, Path]]:
+    project_root = project_root.resolve()
+    allowed_roots = []
+    for root_name in _ALLOWED_PROJECT_ROOTS:
+        root = project_root / root_name
+        if root.is_symlink() or (root.exists() and not root.is_dir()):
+            raise HTTPException(
+                status_code=400, detail="Workflow root is not a safe project directory."
+            )
+        allowed_roots.append(root.resolve(strict=False))
+
+    targets: list[tuple[WorkflowFilePreview, Path]] = []
+    for preview in proposal.files:
+        try:
+            relative_path = Path(preview.path)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail="Invalid workflow file path.") from exc
+        if (
+            relative_path.is_absolute()
+            or relative_path.anchor
+            or ".." in relative_path.parts
+            or relative_path.suffix.lower() not in _WORKFLOW_ALLOWED_EXTENSIONS
+        ):
+            raise HTTPException(
+                status_code=400, detail=f"Unsafe workflow file path: {preview.path}"
+            )
+
+        target = (project_root / relative_path).resolve(strict=False)
+        if not any(_is_contained(target, root) for root in allowed_roots):
+            raise HTTPException(
+                status_code=400, detail=f"Unsafe workflow file path: {preview.path}"
+            )
+
+        current = project_root
+        for component in relative_path.parts:
+            current /= component
+            if current.is_symlink():
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Symlinked workflow path is not allowed: {preview.path}",
+                )
+        targets.append((preview, target))
+    return targets
+
+
+def _is_contained(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
 
 
 def _proposal_from_request(request: WorkflowProposalRequest) -> WorkflowProposal:
@@ -718,7 +1132,7 @@ def _with_conflict_action_disabled(
         target_files=proposal.actions[0].target_files,
         conflict_policy=proposal.actions[0].conflict_policy,
         enabled=False,
-        reason=f"Resolve file conflicts before applying: {', '.join(conflicts)}",
+        reason=f"File conflicts: {', '.join(conflicts)}",
         expected_evidence=proposal.actions[0].expected_evidence,
     )
     return WorkflowProposal(
@@ -776,6 +1190,31 @@ def _slug(value: str) -> str:
     return slugged or "workflow"
 
 
+def _python_string(value: Any) -> str:
+    """Render caller-provided text as a Python string literal."""
+
+    return repr(str(value))
+
+
+def _integer_literal(value: Any, default: int) -> str:
+    try:
+        return str(int(str(value).strip()))
+    except (TypeError, ValueError):
+        return str(default)
+
+
+def _number_literal(value: Any, default: float) -> str:
+    try:
+        number = float(str(value).strip())
+    except (TypeError, ValueError):
+        number = default
+    return repr(number)
+
+
+def _safe_doc(value: Any) -> str:
+    return str(value).replace('"""', "'''")
+
+
 def _class_name(table_name: str) -> str:
     return "Raw" + "".join(part.capitalize() for part in table_name.split("_"))
 
@@ -820,7 +1259,9 @@ def _render_dlt_asset(
     auth: str,
 ) -> str:
     class_name = _class_name(table_name)
-    response_path_line = f', "data_selector": "{response_path}"' if response_path else ""
+    response_path_line = (
+        f', "data_selector": {_python_string(response_path)}' if response_path else ""
+    )
     pagination_line = ""
     if pagination == "offset-limit":
         pagination_line = ', "paginator": {"type": "offset", "limit": 100}'
@@ -834,7 +1275,7 @@ def _render_dlt_asset(
     else:
         auth_lines = "\n    headers = {}"
     phlo_dlt_import = "from phlo_dlt import phlo_ingestion"
-    return f'''"""Generated DLT ingestion asset for {domain}.{table_name}."""
+    return f'''"""Generated DLT ingestion asset for {_safe_doc(domain)}.{_safe_doc(table_name)}."""
 
 from dlt.sources.rest_api import rest_api
 {phlo_dlt_import}
@@ -847,11 +1288,11 @@ from workflows.schemas.{domain} import {class_name}
     unique_key="{unique_key}",
     validation_schema={class_name},
     group="{domain}",
-    cron="{cron}",
+    cron={_python_string(cron)},
     freshness_hours=(1, 24),
 )
 def {table_name}(partition_date: str):
-    base_url = "{api_base_url}"
+    base_url = {_python_string(api_base_url)}
     if not base_url:
         raise RuntimeError("Missing API base URL. Configure base_url before materializing.")
 {auth_lines}
@@ -887,20 +1328,20 @@ def _render_sling_asset(
 ) -> str:
     resolved_update_key = update_key or primary_key
     phlo_sling_import = "from phlo_sling import phlo_sling_replication"
-    return f'''"""Generated Sling replication asset for {domain}.{table_name}."""
+    return f'''"""Generated Sling replication asset for {_safe_doc(domain)}.{_safe_doc(table_name)}."""
 
 {phlo_sling_import}
 
 
 @phlo_sling_replication(
-    stream_name="{source_stream}",
-    table_name="{table_name}",
-    source_conn="{source_name}",
+    stream_name={_python_string(source_stream)},
+    table_name={_python_string(table_name)},
+    source_conn={_python_string(source_name)},
     group="{domain}",
-    mode="{replication_mode}",
-    primary_key="{primary_key}",
-    update_key="{resolved_update_key}",
-    cron="{cron}",
+    mode={_python_string(replication_mode)},
+    primary_key={_python_string(primary_key)},
+    update_key={_python_string(resolved_update_key)},
+    cron={_python_string(cron)},
     freshness_hours=(4, 24),
 )
 def replicate_{table_name}(context):
@@ -948,9 +1389,9 @@ def _render_pandera_quality(
     min_rows = str(values.get("min_rows") or "1").strip() or "1"
 
     check_lines = [
-        f'        UniqueCheck(columns=["{unique_key}"]),',
+        f"        UniqueCheck(columns=[{_python_string(unique_key)}]),",
         f"        NullCheck(columns={null_columns!r}),",
-        f"        CountCheck(min_rows={min_rows}),",
+        f"        CountCheck(min_rows={_integer_literal(min_rows, 1)}),",
     ]
     for item in range_checks:
         column, _, bounds = item.partition(":")
@@ -958,14 +1399,15 @@ def _render_pandera_quality(
         if column.strip() and minimum.strip() and maximum.strip():
             check_lines.append(
                 "        "
-                f'RangeCheck(column="{_slug(column)}", min_value={minimum.strip()}, '
-                f"max_value={maximum.strip()}),"
+                f"RangeCheck(column={_python_string(_slug(column))}, "
+                f"min_value={_number_literal(minimum, 0)}, "
+                f"max_value={_number_literal(maximum, 0)}),"
             )
     if freshness_column:
         check_lines.append(
             "        "
-            f'FreshnessCheck(timestamp_column="{_slug(freshness_column)}", '
-            f"max_age_hours={freshness_hours}),"
+            f"FreshnessCheck(timestamp_column={_python_string(_slug(freshness_column))}, "
+            f"max_age_hours={_number_literal(freshness_hours, 24)}),"
         )
     checks = "\n".join(check_lines)
     phlo_pandera_import = """from phlo_pandera import (
@@ -976,13 +1418,13 @@ def _render_pandera_quality(
     UniqueCheck,
     phlo_pandera,
 )"""
-    return f'''"""Generated Pandera quality checks for {target_table}."""
+    return f'''"""Generated Pandera quality checks for {_safe_doc(target_table)}."""
 
 {phlo_pandera_import}
 
 
 @phlo_pandera(
-    table="{target_table}",
+    table={_python_string(target_table)},
     group="{domain}",
     checks=[
 {checks}
@@ -1005,8 +1447,8 @@ def _render_dagster_orchestration(
     asset_group = _slug(str(values.get("asset_group") or domain))
     schedule = str(values.get("schedule") or "0 2 * * *")
     include_sensor = str(values.get("include_sensor") or "no") == "yes"
-    asset_list = ", ".join(f'"{item}"' for item in planned_assets)
-    model_list = ", ".join(f'"{item}"' for item in planned_models)
+    asset_list = ", ".join(_python_string(item) for item in planned_assets)
+    model_list = ", ".join(_python_string(item) for item in planned_models)
     sensor = ""
     sensor_names = ""
     if include_sensor:
@@ -1017,14 +1459,14 @@ def {_slug(workflow_name)}_external_sensor(context):
     return dg.SkipReason("Connect this sensor to an external event source.")
 """
         sensor_names = f", sensors=[{_slug(workflow_name)}_external_sensor]"
-    return f'''"""Generated Dagster orchestration scaffold for {workflow_name}."""
+    return f'''"""Generated Dagster orchestration scaffold for {_safe_doc(workflow_name)}."""
 
 import dagster as dg
 
 WORKFLOW_ASSETS = [{asset_list}]
 WORKFLOW_MODELS = [{model_list}]
-ASSET_GROUP = "{asset_group}"
-TARGET_TABLE = "{table_name}"
+ASSET_GROUP = {_python_string(asset_group)}
+TARGET_TABLE = {_python_string(table_name)}
 
 {job_name} = dg.define_asset_job(
     name="{job_name}",
@@ -1033,7 +1475,7 @@ TARGET_TABLE = "{table_name}"
 
 {_slug(workflow_name)}_schedule = dg.ScheduleDefinition(
     job={job_name},
-    cron_schedule="{schedule}",
+    cron_schedule={_python_string(schedule)},
 )
 {sensor}
 

--- a/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
@@ -107,6 +107,7 @@ class _StoredWorkflowProposal(BaseModel):
     """Server-owned workflow proposal record."""
 
     proposal_id: str
+    issuer_subject: str
     proposal: dict[str, Any]
     digest: str
     signature: str
@@ -186,6 +187,7 @@ def build_workflow_wizard_payload() -> dict[str, Any]:
 def build_workflow_proposal(
     project_root: Path,
     request: ObservatoryWorkflowProposalRequest,
+    issuer_subject: str,
 ) -> dict[str, Any]:
     """Build and persist a server-owned workflow proposal for the browser."""
 
@@ -221,7 +223,7 @@ def build_workflow_proposal(
     conflicts = detect_file_conflicts(project_root, proposal)
     if conflicts:
         proposal = _with_conflict_action_disabled(proposal, conflicts)
-    return _issue_workflow_proposal(project_root, proposal)
+    return _issue_workflow_proposal(project_root, proposal, issuer_subject)
 
 
 def _open_directory_at(parent_fd: int, name: str, *, create: bool) -> int:
@@ -335,8 +337,10 @@ def _workflow_integrity_key(project_root: Path) -> bytes:
         os.close(state_fd)
 
 
-def _proposal_signature(project_root: Path, proposal_id: str, digest: str) -> str:
-    message = f"{proposal_id}:{digest}".encode("utf-8")
+def _proposal_signature(
+    project_root: Path, proposal_id: str, issuer_subject: str, digest: str
+) -> str:
+    message = f"{proposal_id}:{issuer_subject}:{digest}".encode("utf-8")
     return hmac.new(_workflow_integrity_key(project_root), message, hashlib.sha256).hexdigest()
 
 
@@ -395,13 +399,16 @@ def _write_state_json(
         os.close(storage_fd)
 
 
-def _issue_workflow_proposal(project_root: Path, proposal: WorkflowProposal) -> dict[str, Any]:
+def _issue_workflow_proposal(
+    project_root: Path, proposal: WorkflowProposal, issuer_subject: str
+) -> dict[str, Any]:
     proposal_id = secrets.token_urlsafe(24)
     proposal_payload = proposal.to_browser_dict()
     digest = _proposal_digest(proposal_payload)
-    signature = _proposal_signature(project_root, proposal_id, digest)
+    signature = _proposal_signature(project_root, proposal_id, issuer_subject, digest)
     record = _StoredWorkflowProposal(
         proposal_id=proposal_id,
+        issuer_subject=issuer_subject,
         proposal=proposal_payload,
         digest=digest,
         signature=signature,
@@ -473,12 +480,14 @@ def _selection_payload(
 
 
 def apply_workflow_action(
-    project_root: Path, request: ObservatoryWorkflowActionRequest
+    project_root: Path, request: ObservatoryWorkflowActionRequest, issuer_subject: str
 ) -> ObservatoryWorkflowActionResult:
     """Apply a server-issued workflow action within the project workflow root."""
 
     proposal_id = request.proposal_id
-    proposal, proposal_digest = _load_verified_workflow_proposal(project_root, proposal_id)
+    proposal, proposal_digest = _load_verified_workflow_proposal(
+        project_root, proposal_id, issuer_subject
+    )
     action = next((item for item in proposal.actions if item.id == request.action_id), None)
     if action is None:
         raise HTTPException(
@@ -497,10 +506,12 @@ def apply_workflow_action(
             ):
                 raise HTTPException(status_code=409, detail="Workflow proposal replay conflicts.")
             if applied.get("status") == "succeeded":
-                if not all(_file_matches(target, preview.content) for preview, target in targets):
-                    raise HTTPException(
-                        status_code=409,
-                        detail="Applied workflow files changed after completion.",
+                for preview, _ in targets:
+                    _apply_workflow_file(
+                        project_root,
+                        preview,
+                        conflict_policy="fail-on-conflict",
+                        verify_only=True,
                     )
                 try:
                     return ObservatoryWorkflowActionResult.model_validate(applied["result"])
@@ -517,8 +528,9 @@ def apply_workflow_action(
         else:
             conflicts = [
                 preview.path
-                for preview, target in targets
-                if preview.mode == "create" and target.exists()
+                for preview, _ in targets
+                if preview.mode == "create"
+                and _workflow_file_state(project_root, preview) != "missing"
             ]
             if conflicts and action.conflict_policy == "fail-on-conflict":
                 raise HTTPException(
@@ -534,18 +546,15 @@ def apply_workflow_action(
             _write_state_json(project_root, "applied", f"{proposal_id}.json", applied)
 
         written_files = list(applied.get("written_files") or [])
-        for preview, target in targets:
-            if target.exists():
-                if _file_matches(target, preview.content):
-                    if preview.path not in written_files:
-                        written_files.append(preview.path)
-                    continue
-                if action.conflict_policy == "skip-if-exists":
-                    continue
-                raise HTTPException(status_code=409, detail=f"File conflicts: {preview.path}")
-
-            _write_text_atomically(project_root, preview.path, preview.content)
-            if preview.path not in written_files:
+        for preview, _ in targets:
+            outcome = _apply_workflow_file(
+                project_root,
+                preview,
+                conflict_policy=cast(
+                    Literal["fail-on-conflict", "skip-if-exists"], action.conflict_policy
+                ),
+            )
+            if outcome != "skipped" and preview.path not in written_files:
                 written_files.append(preview.path)
             applied["written_files"] = written_files
             _write_state_json(project_root, "applied", f"{proposal_id}.json", applied)
@@ -570,7 +579,7 @@ def apply_workflow_action(
 
 
 def _load_verified_workflow_proposal(
-    project_root: Path, proposal_id: str
+    project_root: Path, proposal_id: str, issuer_subject: str
 ) -> tuple[WorkflowProposal, str]:
     if not _PROPOSAL_ID_PATTERN.fullmatch(proposal_id):
         raise HTTPException(status_code=400, detail="Invalid workflow proposal id.")
@@ -587,11 +596,15 @@ def _load_verified_workflow_proposal(
         raise HTTPException(
             status_code=409, detail="Workflow proposal integrity verification failed."
         )
-    expected_signature = _proposal_signature(project_root, record.proposal_id, record.digest)
+    expected_signature = _proposal_signature(
+        project_root, record.proposal_id, record.issuer_subject, record.digest
+    )
     if not hmac.compare_digest(record.signature, expected_signature):
         raise HTTPException(
             status_code=409, detail="Workflow proposal integrity verification failed."
         )
+    if not hmac.compare_digest(record.issuer_subject, issuer_subject):
+        raise HTTPException(status_code=404, detail="Workflow proposal not found.")
     if not hmac.compare_digest(record.digest, _proposal_digest(record.proposal)):
         raise HTTPException(
             status_code=409, detail="Workflow proposal integrity verification failed."
@@ -646,63 +659,167 @@ def _workflow_apply_lock(project_root: Path):
         os.close(state_fd)
 
 
-def _file_matches(path: Path, content: str) -> bool:
-    try:
-        return path.is_file() and path.read_text(encoding="utf-8") == content
-    except (OSError, UnicodeError):
-        return False
-
-
-def _write_text_atomically(project_root: Path, relative_path: str, content: str) -> None:
+def _open_workflow_parent_fd(project_root: Path, relative_path: str) -> tuple[int, str]:
     parts = Path(relative_path).parts
-    if not parts:
+    if (
+        not parts
+        or Path(relative_path).is_absolute()
+        or Path(relative_path).anchor
+        or ".." in parts
+    ):
         raise HTTPException(status_code=400, detail="Invalid workflow file path.")
-    directory_fd = os.open(
-        project_root,
-        os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
-    )
+    directory_fd = -1
     try:
+        directory_fd = os.open(project_root.resolve(), _STATE_DIRECTORY_FLAGS)
         for component in parts[:-1]:
             try:
                 next_fd = os.open(
                     component,
-                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+                    _STATE_DIRECTORY_FLAGS,
                     dir_fd=directory_fd,
                 )
             except FileNotFoundError:
-                os.mkdir(component, mode=0o755, dir_fd=directory_fd)
-                next_fd = os.open(
-                    component,
-                    os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
-                    dir_fd=directory_fd,
-                )
+                try:
+                    os.mkdir(component, mode=0o755, dir_fd=directory_fd)
+                except FileExistsError:
+                    pass
+                next_fd = os.open(component, _STATE_DIRECTORY_FLAGS, dir_fd=directory_fd)
+            except OSError as exc:
+                raise HTTPException(
+                    status_code=409, detail=f"Unsafe workflow file path: {relative_path}"
+                ) from exc
             os.close(directory_fd)
             directory_fd = next_fd
+        return directory_fd, parts[-1]
+    except HTTPException:
+        if directory_fd >= 0:
+            os.close(directory_fd)
+        raise
+    except OSError as exc:
+        if directory_fd >= 0:
+            os.close(directory_fd)
+        raise HTTPException(
+            status_code=409, detail=f"Unsafe workflow file path: {relative_path}"
+        ) from exc
 
-        filename = parts[-1]
-        temporary_name = f".{filename}.{secrets.token_hex(8)}.tmp"
+
+def _workflow_file_state(
+    project_root: Path, preview: WorkflowFilePreview
+) -> Literal["missing", "matching", "conflict"]:
+    directory_fd, filename = _open_workflow_parent_fd(project_root, preview.path)
+    descriptor = -1
+    try:
+        try:
+            descriptor = os.open(
+                filename,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError:
+            return "missing"
+        except OSError:
+            return "conflict"
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            return "conflict"
+        with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+            descriptor = -1
+            return "matching" if handle.read() == preview.content else "conflict"
+    except (OSError, UnicodeError):
+        return "conflict"
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(directory_fd)
+
+
+def _write_text_atomically_at(directory_fd: int, filename: str, content: str) -> None:
+    temporary_name = f".{filename}.{secrets.token_hex(8)}.tmp"
+    temporary_fd = -1
+    try:
         temporary_fd = os.open(
             temporary_name,
             os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
             0o600,
             dir_fd=directory_fd,
         )
-        try:
-            with os.fdopen(temporary_fd, "w", encoding="utf-8") as handle:
-                handle.write(content)
-                handle.flush()
-                os.fsync(handle.fileno())
-            os.replace(
-                temporary_name,
-                filename,
-                src_dir_fd=directory_fd,
-                dst_dir_fd=directory_fd,
-            )
-        except BaseException:
-            with contextlib.suppress(FileNotFoundError):
-                os.unlink(temporary_name, dir_fd=directory_fd)
-            raise
+        with os.fdopen(temporary_fd, "w", encoding="utf-8") as handle:
+            temporary_fd = -1
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(
+            temporary_name,
+            filename,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(temporary_name, dir_fd=directory_fd)
+        raise
     finally:
+        if temporary_fd >= 0:
+            os.close(temporary_fd)
+
+
+def _apply_workflow_file(
+    project_root: Path,
+    preview: WorkflowFilePreview,
+    *,
+    conflict_policy: Literal["fail-on-conflict", "skip-if-exists"],
+    verify_only: bool = False,
+) -> Literal["written", "matching", "skipped"]:
+    directory_fd, filename = _open_workflow_parent_fd(project_root, preview.path)
+    descriptor = -1
+    try:
+        try:
+            descriptor = os.open(
+                filename,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError:
+            if verify_only:
+                raise HTTPException(
+                    status_code=409, detail="Applied workflow files changed after completion."
+                )
+            _write_text_atomically_at(directory_fd, filename, preview.content)
+            return "written"
+        except OSError as exc:
+            if verify_only:
+                raise HTTPException(
+                    status_code=409, detail="Applied workflow files changed after completion."
+                ) from exc
+            if conflict_policy == "skip-if-exists":
+                return "skipped"
+            raise HTTPException(status_code=409, detail=f"File conflicts: {preview.path}") from exc
+
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            state = "conflict"
+        else:
+            with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+                descriptor = -1
+                state = "matching" if handle.read() == preview.content else "conflict"
+        if state == "matching":
+            return "matching"
+        if verify_only:
+            raise HTTPException(
+                status_code=409, detail="Applied workflow files changed after completion."
+            )
+        if conflict_policy == "skip-if-exists":
+            return "skipped"
+        raise HTTPException(status_code=409, detail=f"File conflicts: {preview.path}")
+    except UnicodeError as exc:
+        if verify_only:
+            raise HTTPException(
+                status_code=409, detail="Applied workflow files changed after completion."
+            ) from exc
+        if conflict_policy == "skip-if-exists":
+            return "skipped"
+        raise HTTPException(status_code=409, detail=f"File conflicts: {preview.path}") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
         os.close(directory_fd)
 
 

--- a/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/observatory_workflow_wizard.py
@@ -747,12 +747,15 @@ def _write_text_atomically_at(directory_fd: int, filename: str, content: str) ->
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(
+        os.link(
             temporary_name,
             filename,
             src_dir_fd=directory_fd,
             dst_dir_fd=directory_fd,
+            follow_symlinks=False,
         )
+        os.unlink(temporary_name, dir_fd=directory_fd)
+        os.fsync(directory_fd)
     except BaseException:
         with contextlib.suppress(FileNotFoundError):
             os.unlink(temporary_name, dir_fd=directory_fd)
@@ -783,7 +786,14 @@ def _apply_workflow_file(
                 raise HTTPException(
                     status_code=409, detail="Applied workflow files changed after completion."
                 )
-            _write_text_atomically_at(directory_fd, filename, preview.content)
+            try:
+                _write_text_atomically_at(directory_fd, filename, preview.content)
+            except FileExistsError as exc:
+                if conflict_policy == "skip-if-exists":
+                    return "skipped"
+                raise HTTPException(
+                    status_code=409, detail=f"File conflicts: {preview.path}"
+                ) from exc
             return "written"
         except OSError as exc:
             if verify_only:

--- a/packages/phlo-api/tests/test_observatory_workflow_wizard.py
+++ b/packages/phlo-api/tests/test_observatory_workflow_wizard.py
@@ -486,6 +486,113 @@ def test_workflow_wizard_apply_requires_project_write(
     assert not (tmp_path / "workflows").exists()
 
 
+def test_workflow_wizard_proposal_is_bound_to_issuing_principal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"writer-a":{"subject":"writer-a","scopes":["project:write"]},'
+        '"writer-b":{"subject":"writer-b","scopes":["project:write"]}}',
+    )
+    request = {
+        "workflow_name": "customer_health",
+        "domain": "customers",
+        "graph": {
+            "nodes": [
+                {
+                    "id": "source",
+                    "contribution_id": "dlt.rest-api-source",
+                    "stage": "source",
+                    "values": {"table_name": "orders"},
+                }
+            ],
+            "edges": [],
+        },
+    }
+    proposal = client.post(
+        "/api/observatory/workflow-wizard/proposals",
+        json=request,
+        headers={"Authorization": "Bearer writer-a"},
+    ).json()
+    body = {"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]}
+
+    other_writer = client.post(
+        "/api/observatory/workflow-wizard/actions",
+        json=body,
+        headers={"Authorization": "Bearer writer-b"},
+    )
+    issuing_writer = client.post(
+        "/api/observatory/workflow-wizard/actions",
+        json=body,
+        headers={"Authorization": "Bearer writer-a"},
+    )
+
+    assert other_writer.status_code == 404
+    assert issuing_writer.status_code == 200
+
+
+def test_workflow_wizard_rejects_target_directory_swap_before_safe_open(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"operator","scopes":["project:write"]}}',
+    )
+    workflow_root = tmp_path / "workflows"
+    workflow_root.mkdir()
+    proposal = client.post(
+        "/api/observatory/workflow-wizard/proposals",
+        json={
+            "workflow_name": "customer_health",
+            "domain": "customers",
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "source",
+                        "contribution_id": "dlt.rest-api-source",
+                        "stage": "source",
+                        "values": {"table_name": "orders"},
+                    }
+                ],
+                "edges": [],
+            },
+        },
+        headers={"Authorization": "Bearer project-token"},
+    ).json()
+    target = next(item for item in proposal["files"] if item["path"].endswith("orders.py"))
+    outside = tmp_path / "outside-workflow"
+    outside_target = outside / Path(target["path"]).relative_to("workflows")
+    outside_target.parent.mkdir(parents=True)
+    outside_target.write_text(target["content"], encoding="utf-8")
+
+    original_validate = wizard._validated_workflow_targets
+
+    def swap_after_validation(
+        project_root: Path, workflow_proposal: WorkflowProposal
+    ) -> list[tuple[WorkflowFilePreview, Path]]:
+        targets = original_validate(project_root, workflow_proposal)
+        safe_root = project_root / "workflows-safe"
+        (project_root / "workflows").rename(safe_root)
+        (project_root / "workflows").symlink_to(outside, target_is_directory=True)
+        return targets
+
+    monkeypatch.setattr(wizard, "_validated_workflow_targets", swap_after_validation)
+    body = {"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]}
+    applied = client.post(
+        "/api/observatory/workflow-wizard/actions",
+        json=body,
+        headers={"Authorization": "Bearer project-token"},
+    )
+
+    assert applied.status_code == 409
+    assert outside_target.read_text(encoding="utf-8") == target["content"]
+    assert not (
+        tmp_path / ".phlo" / "workflow-wizard" / "applied" / f"{proposal['proposal_id']}.json"
+    ).exists()
+
+
 def test_workflow_wizard_apply_rejects_tampered_proposal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -668,6 +775,7 @@ def test_workflow_wizard_apply_retries_after_completion_record_failure(
                 ]
             ),
         ),
+        issuer_subject="operator",
     )
     request = wizard.ObservatoryWorkflowActionRequest(
         action_id=proposal["actions"][0]["id"],
@@ -690,10 +798,10 @@ def test_workflow_wizard_apply_retries_after_completion_record_failure(
 
     monkeypatch.setattr(wizard, "_write_state_json", fail_completion)
     with pytest.raises(OSError):
-        wizard.apply_workflow_action(tmp_path, request)
+        wizard.apply_workflow_action(tmp_path, request, "operator")
 
     monkeypatch.setattr(wizard, "_write_state_json", original_write)
-    result = wizard.apply_workflow_action(tmp_path, request)
+    result = wizard.apply_workflow_action(tmp_path, request, "operator")
 
     assert result.status == "succeeded"
     assert len(result.files) == len(proposal["files"])
@@ -769,6 +877,7 @@ def test_workflow_wizard_state_writes_remain_anchored_after_directory_swap(
                 ]
             ),
         ),
+        issuer_subject="operator",
     )
     proposal_files = list(
         (proposal_root / ".phlo" / "workflow-wizard" / "proposals-safe").glob("*.json")
@@ -826,6 +935,7 @@ def test_workflow_wizard_escapes_caller_values_in_generated_python(tmp_path: Pat
                 ]
             ),
         ),
+        issuer_subject="operator",
     )
 
     generated = next(

--- a/packages/phlo-api/tests/test_observatory_workflow_wizard.py
+++ b/packages/phlo-api/tests/test_observatory_workflow_wizard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 from collections.abc import Callable
 from importlib import import_module
 from pathlib import Path
@@ -394,6 +395,9 @@ def test_workflow_wizard_apply_records_operation(
     assert operations[0]["status"] == "succeeded"
     assert operations[0]["metadata"]["action_id"] == proposal["actions"][0]["id"]
     assert "workflows/ingestion/customers/orders.py" in operations[0]["metadata"]["files"]
+    assert (
+        stat.S_IMODE((tmp_path / "workflows/ingestion/customers/orders.py").stat().st_mode) == 0o644
+    )
 
 
 def test_workflow_wizard_conflict_records_failed_operation(

--- a/packages/phlo-api/tests/test_observatory_workflow_wizard.py
+++ b/packages/phlo-api/tests/test_observatory_workflow_wizard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from importlib import import_module
 from pathlib import Path
 
@@ -672,21 +673,26 @@ def test_workflow_wizard_apply_retries_after_completion_record_failure(
         action_id=proposal["actions"][0]["id"],
         proposal_id=proposal["proposal_id"],
     )
-    original_write = wizard._write_json_atomically
+    original_write = wizard._write_state_json
     failed = False
 
-    def fail_completion(path: Path, payload: dict[str, object]) -> None:
+    def fail_completion(
+        project_root: Path,
+        storage_name: str,
+        filename: str,
+        payload: dict[str, object],
+    ) -> None:
         nonlocal failed
-        if path.parent.name == "applied" and payload.get("status") == "succeeded" and not failed:
+        if storage_name == "applied" and payload.get("status") == "succeeded" and not failed:
             failed = True
             raise OSError("simulated completion-record failure")
-        original_write(path, payload)
+        original_write(project_root, storage_name, filename, payload)
 
-    monkeypatch.setattr(wizard, "_write_json_atomically", fail_completion)
+    monkeypatch.setattr(wizard, "_write_state_json", fail_completion)
     with pytest.raises(OSError):
         wizard.apply_workflow_action(tmp_path, request)
 
-    monkeypatch.setattr(wizard, "_write_json_atomically", original_write)
+    monkeypatch.setattr(wizard, "_write_state_json", original_write)
     result = wizard.apply_workflow_action(tmp_path, request)
 
     assert result.status == "succeeded"
@@ -714,9 +720,86 @@ def test_workflow_wizard_state_directory_rejects_symlink(tmp_path: Path) -> None
     (phlo_dir / "workflow-wizard").symlink_to(outside, target_is_directory=True)
 
     with pytest.raises(HTTPException) as error:
-        wizard._proposal_state_dir(tmp_path)
+        wizard._open_workflow_state_fd(tmp_path)
 
     assert error.value.status_code == 503
+
+
+def test_workflow_wizard_state_writes_remain_anchored_after_directory_swap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def swap_storage(
+        project_root: Path,
+        storage_name: str,
+        outside: Path,
+        original_open: Callable[..., int],
+    ) -> int:
+        fd = original_open(project_root, storage_name, create=True)
+        storage = project_root / ".phlo" / "workflow-wizard" / storage_name
+        backup = storage.with_name(f"{storage_name}-safe")
+        storage.rename(backup)
+        storage.symlink_to(outside, target_is_directory=True)
+        return fd
+
+    proposal_root = tmp_path / "issuance"
+    proposal_root.mkdir()
+    proposal_outside = tmp_path / "proposal-outside"
+    proposal_outside.mkdir()
+    original_open = wizard._open_state_storage_fd
+
+    def swap_proposals(project_root: Path, storage_name: str, *, create: bool) -> int:
+        if storage_name == "proposals":
+            return swap_storage(project_root, storage_name, proposal_outside, original_open)
+        return original_open(project_root, storage_name, create=create)
+
+    monkeypatch.setattr(wizard, "_open_state_storage_fd", swap_proposals)
+    proposal = wizard.build_workflow_proposal(
+        proposal_root,
+        wizard.ObservatoryWorkflowProposalRequest(
+            workflow_name="customer_health",
+            domain="customers",
+            graph=wizard.ObservatoryWorkflowGraph(
+                nodes=[
+                    wizard.ObservatoryWorkflowGraphNode(
+                        id="source",
+                        contribution_id="dlt.rest-api-source",
+                        stage="source",
+                        values={"table_name": "orders"},
+                    )
+                ]
+            ),
+        ),
+    )
+    proposal_files = list(
+        (proposal_root / ".phlo" / "workflow-wizard" / "proposals-safe").glob("*.json")
+    )
+    assert proposal_files
+    assert not list(proposal_outside.iterdir())
+    assert proposal["proposal_id"] in proposal_files[0].name
+
+    applied_root = tmp_path / "applied-record"
+    applied_dir = applied_root / ".phlo" / "workflow-wizard" / "applied"
+    applied_dir.mkdir(parents=True)
+    applied_outside = tmp_path / "applied-outside"
+    applied_outside.mkdir()
+    swapped = False
+
+    def swap_applied(project_root: Path, storage_name: str, *, create: bool) -> int:
+        nonlocal swapped
+        fd = original_open(project_root, storage_name, create=create)
+        if storage_name == "applied" and not swapped:
+            swapped = True
+            storage = project_root / ".phlo" / "workflow-wizard" / storage_name
+            backup = storage.with_name("applied-safe")
+            storage.rename(backup)
+            storage.symlink_to(applied_outside, target_is_directory=True)
+        return fd
+
+    monkeypatch.setattr(wizard, "_open_state_storage_fd", swap_applied)
+    wizard._write_state_json(applied_root, "applied", "claim.json", {"status": "applying"})
+
+    assert (applied_root / ".phlo" / "workflow-wizard" / "applied-safe" / "claim.json").exists()
+    assert not list(applied_outside.iterdir())
 
 
 def test_workflow_wizard_escapes_caller_values_in_generated_python(tmp_path: Path) -> None:

--- a/packages/phlo-api/tests/test_observatory_workflow_wizard.py
+++ b/packages/phlo-api/tests/test_observatory_workflow_wizard.py
@@ -1,16 +1,31 @@
 from __future__ import annotations
 
+import json
 from importlib import import_module
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from phlo.capabilities import WorkflowFilePreview, WorkflowProposal
 from phlo_api.main import app
 from phlo_api.observatory_api import observatory
+from phlo_api.observatory_api import observatory_workflow_wizard as wizard
 
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _workflow_project_write_auth(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"operator","scopes":["project:write"]}}',
+    )
+    client.headers.update({"Authorization": "Bearer project-token"})
+    yield
+    client.headers.pop("Authorization", None)
 
 
 def _can_load_workflow_plugin(module_name: str) -> bool:
@@ -49,6 +64,40 @@ def test_workflow_wizard_proposal_requires_graph_nodes() -> None:
 
     assert response.status_code == 422
     assert response.json()["detail"]["graph"] == ["Add at least one workflow node."]
+
+
+def test_workflow_wizard_proposal_requires_project_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = {
+        "workflow_name": "customer_health",
+        "domain": "customers",
+        "graph": {
+            "nodes": [
+                {
+                    "id": "source",
+                    "contribution_id": "dlt.rest-api-source",
+                    "stage": "source",
+                    "values": {"table_name": "orders"},
+                }
+            ],
+            "edges": [],
+        },
+    }
+    client.headers.pop("Authorization", None)
+    anonymous = client.post("/api/observatory/workflow-wizard/proposals", json=request)
+    assert anonymous.status_code == 401
+
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"viewer-token":{"subject":"viewer","scopes":["project:read"]}}',
+    )
+    viewer = client.post(
+        "/api/observatory/workflow-wizard/proposals",
+        json=request,
+        headers={"Authorization": "Bearer viewer-token"},
+    )
+    assert viewer.status_code == 403
 
 
 def test_workflow_wizard_builds_dlt_dbt_graph_proposal(
@@ -254,6 +303,10 @@ def test_workflow_wizard_apply_fails_on_conflict(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"operator","scopes":["project:write"]}}',
+    )
     existing = tmp_path / "workflows" / "ingestion" / "customers"
     existing.mkdir(parents=True)
     (existing / "orders.py").write_text("# existing\n", encoding="utf-8")
@@ -285,7 +338,8 @@ def test_workflow_wizard_apply_fails_on_conflict(
     assert proposal["actions"][0]["enabled"] is False
     apply_response = client.post(
         "/api/observatory/workflow-wizard/actions",
-        json={"action_id": proposal["actions"][0]["id"], "proposal": proposal},
+        json={"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]},
+        headers={"Authorization": "Bearer project-token"},
     )
 
     assert apply_response.status_code == 409
@@ -297,6 +351,10 @@ def test_workflow_wizard_apply_records_operation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"operator","scopes":["project:write"]}}',
+    )
     observatory._clear_read_model_cache()
     proposal_response = client.post(
         "/api/observatory/workflow-wizard/proposals",
@@ -324,7 +382,8 @@ def test_workflow_wizard_apply_records_operation(
 
     apply_response = client.post(
         "/api/observatory/workflow-wizard/actions",
-        json={"action_id": proposal["actions"][0]["id"], "proposal": proposal},
+        json={"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]},
+        headers={"Authorization": "Bearer project-token"},
     )
 
     assert apply_response.status_code == 200
@@ -340,6 +399,10 @@ def test_workflow_wizard_conflict_records_failed_operation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"operator","scopes":["project:write"]}}',
+    )
     observatory._clear_read_model_cache()
     existing = tmp_path / "workflows" / "ingestion" / "customers"
     existing.mkdir(parents=True)
@@ -370,7 +433,8 @@ def test_workflow_wizard_conflict_records_failed_operation(
 
     apply_response = client.post(
         "/api/observatory/workflow-wizard/actions",
-        json={"action_id": proposal["actions"][0]["id"], "proposal": proposal},
+        json={"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]},
+        headers={"Authorization": "Bearer project-token"},
     )
 
     assert apply_response.status_code == 409
@@ -378,3 +442,311 @@ def test_workflow_wizard_conflict_records_failed_operation(
     assert operations[0]["kind"] == "workflow.apply"
     assert operations[0]["status"] == "failed"
     assert "File conflicts" in operations[0]["health"]["message"]
+
+
+def test_workflow_wizard_apply_requires_project_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    proposal = client.post(
+        "/api/observatory/workflow-wizard/proposals",
+        json={
+            "workflow_name": "customer_health",
+            "domain": "customers",
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "source",
+                        "contribution_id": "dlt.rest-api-source",
+                        "stage": "source",
+                        "values": {"table_name": "orders"},
+                    }
+                ],
+                "edges": [],
+            },
+        },
+    ).json()
+    body = {"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]}
+
+    client.headers.pop("Authorization", None)
+    anonymous = client.post("/api/observatory/workflow-wizard/actions", json=body)
+    assert anonymous.status_code == 401
+
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"viewer-token":{"subject":"viewer","scopes":["project:read"]}}',
+    )
+    viewer = client.post(
+        "/api/observatory/workflow-wizard/actions",
+        json=body,
+        headers={"Authorization": "Bearer viewer-token"},
+    )
+    assert viewer.status_code == 403
+    assert not (tmp_path / "workflows").exists()
+
+
+def test_workflow_wizard_apply_rejects_tampered_proposal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"operator","scopes":["project:write"]}}',
+    )
+    response = client.post(
+        "/api/observatory/workflow-wizard/proposals",
+        json={
+            "workflow_name": "customer_health",
+            "domain": "customers",
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "source",
+                        "contribution_id": "dlt.rest-api-source",
+                        "stage": "source",
+                        "values": {"table_name": "orders"},
+                    }
+                ],
+                "edges": [],
+            },
+        },
+    )
+    proposal = response.json()
+    stored_path = (
+        tmp_path / ".phlo" / "workflow-wizard" / "proposals" / f"{proposal['proposal_id']}.json"
+    )
+    stored = json.loads(stored_path.read_text(encoding="utf-8"))
+    stored["proposal"]["files"][0]["path"] = str(tmp_path.parent / "sentinel.py")
+    stored_path.write_text(json.dumps(stored), encoding="utf-8")
+
+    applied = client.post(
+        "/api/observatory/workflow-wizard/actions",
+        json={"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]},
+        headers={"Authorization": "Bearer project-token"},
+    )
+
+    assert applied.status_code == 409
+    assert not (tmp_path.parent / "sentinel.py").exists()
+    assert not (tmp_path / "workflows").exists()
+
+
+def test_workflow_wizard_apply_is_idempotent_for_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"operator","scopes":["project:write"]}}',
+    )
+    proposal = client.post(
+        "/api/observatory/workflow-wizard/proposals",
+        json={
+            "workflow_name": "customer_health",
+            "domain": "customers",
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "source",
+                        "contribution_id": "dlt.rest-api-source",
+                        "stage": "source",
+                        "values": {"table_name": "orders"},
+                    }
+                ],
+                "edges": [],
+            },
+        },
+    ).json()
+    body = {"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]}
+    headers = {"Authorization": "Bearer project-token"}
+
+    first = client.post("/api/observatory/workflow-wizard/actions", json=body, headers=headers)
+    second = client.post("/api/observatory/workflow-wizard/actions", json=body, headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json() == first.json()
+
+
+def test_workflow_wizard_replay_detects_changed_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setenv(
+        "PHLO_API_TOKENS",
+        '{"project-token":{"subject":"operator","scopes":["project:write"]}}',
+    )
+    proposal = client.post(
+        "/api/observatory/workflow-wizard/proposals",
+        json={
+            "workflow_name": "customer_health",
+            "domain": "customers",
+            "graph": {
+                "nodes": [
+                    {
+                        "id": "source",
+                        "contribution_id": "dlt.rest-api-source",
+                        "stage": "source",
+                        "values": {"table_name": "orders"},
+                    }
+                ],
+                "edges": [],
+            },
+        },
+    ).json()
+    body = {"action_id": proposal["actions"][0]["id"], "proposal_id": proposal["proposal_id"]}
+    headers = {"Authorization": "Bearer project-token"}
+    first = client.post("/api/observatory/workflow-wizard/actions", json=body, headers=headers)
+    changed = tmp_path / first.json()["files"][0]
+    changed.unlink()
+
+    replay = client.post("/api/observatory/workflow-wizard/actions", json=body, headers=headers)
+
+    assert first.status_code == 200
+    assert replay.status_code == 409
+    assert "changed after completion" in replay.json()["detail"]
+
+
+def test_workflow_wizard_rejects_absolute_traversal_and_symlink_paths(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-workflow-sentinel.py"
+    cases = [
+        "/tmp/absolute.py",
+        "workflows/../outside.py",
+        "workflows/../../outside.py",
+    ]
+    for path in cases:
+        with pytest.raises(HTTPException) as error:
+            wizard._validated_workflow_targets(
+                tmp_path,
+                WorkflowProposal(
+                    workflow_name="unsafe",
+                    domain="unsafe",
+                    files=[WorkflowFilePreview(path=path, content="x")],
+                ),
+            )
+        assert error.value.status_code == 400
+
+    outside.mkdir(exist_ok=True)
+    workflow_root = tmp_path / "workflows"
+    workflow_root.mkdir()
+    (workflow_root / "escape").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(HTTPException) as error:
+        wizard._validated_workflow_targets(
+            tmp_path,
+            WorkflowProposal(
+                workflow_name="unsafe",
+                domain="unsafe",
+                files=[WorkflowFilePreview(path="workflows/escape/file.py", content="x")],
+            ),
+        )
+    assert error.value.status_code == 400
+
+
+def test_workflow_wizard_integrity_key_is_stable_across_calls(tmp_path: Path) -> None:
+    first = wizard._workflow_integrity_key(tmp_path)
+    second = wizard._workflow_integrity_key(tmp_path)
+
+    assert first == second
+
+
+def test_workflow_wizard_apply_retries_after_completion_record_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    proposal = wizard.build_workflow_proposal(
+        tmp_path,
+        wizard.ObservatoryWorkflowProposalRequest(
+            workflow_name="customer_health",
+            domain="customers",
+            graph=wizard.ObservatoryWorkflowGraph(
+                nodes=[
+                    wizard.ObservatoryWorkflowGraphNode(
+                        id="source",
+                        contribution_id="dlt.rest-api-source",
+                        stage="source",
+                        values={"table_name": "orders"},
+                    )
+                ]
+            ),
+        ),
+    )
+    request = wizard.ObservatoryWorkflowActionRequest(
+        action_id=proposal["actions"][0]["id"],
+        proposal_id=proposal["proposal_id"],
+    )
+    original_write = wizard._write_json_atomically
+    failed = False
+
+    def fail_completion(path: Path, payload: dict[str, object]) -> None:
+        nonlocal failed
+        if path.parent.name == "applied" and payload.get("status") == "succeeded" and not failed:
+            failed = True
+            raise OSError("simulated completion-record failure")
+        original_write(path, payload)
+
+    monkeypatch.setattr(wizard, "_write_json_atomically", fail_completion)
+    with pytest.raises(OSError):
+        wizard.apply_workflow_action(tmp_path, request)
+
+    monkeypatch.setattr(wizard, "_write_json_atomically", original_write)
+    result = wizard.apply_workflow_action(tmp_path, request)
+
+    assert result.status == "succeeded"
+    assert len(result.files) == len(proposal["files"])
+
+
+def test_workflow_wizard_integrity_key_rejects_symlink(tmp_path: Path) -> None:
+    state_dir = tmp_path / ".phlo" / "workflow-wizard"
+    state_dir.mkdir(parents=True)
+    outside = tmp_path / "outside.key"
+    outside.write_bytes(b"attacker-controlled")
+    (state_dir / "integrity.key").symlink_to(outside)
+
+    with pytest.raises(HTTPException) as error:
+        wizard._workflow_integrity_key(tmp_path)
+
+    assert error.value.status_code == 503
+
+
+def test_workflow_wizard_state_directory_rejects_symlink(tmp_path: Path) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    outside = tmp_path / "outside-state"
+    outside.mkdir()
+    (phlo_dir / "workflow-wizard").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(HTTPException) as error:
+        wizard._proposal_state_dir(tmp_path)
+
+    assert error.value.status_code == 503
+
+
+def test_workflow_wizard_escapes_caller_values_in_generated_python(tmp_path: Path) -> None:
+    marker = tmp_path / "injected-marker"
+    payload = f'" or __import__("os").system("touch {marker}") or "'
+    proposal = wizard.build_workflow_proposal(
+        tmp_path,
+        wizard.ObservatoryWorkflowProposalRequest(
+            workflow_name="customer_health",
+            domain="customers",
+            graph=wizard.ObservatoryWorkflowGraph(
+                nodes=[
+                    wizard.ObservatoryWorkflowGraphNode(
+                        id="source",
+                        contribution_id="sling.replication-source",
+                        stage="source",
+                        values={
+                            "table_name": "orders",
+                            "source_stream": payload,
+                            "source_name": payload,
+                            "schedule": payload,
+                        },
+                    )
+                ]
+            ),
+        ),
+    )
+
+    generated = next(
+        item["content"] for item in proposal["files"] if item["path"].endswith("_sling.py")
+    )
+    compile(generated, "generated_sling.py", "exec")
+    assert not marker.exists()

--- a/packages/phlo-api/tests/test_observatory_workflow_wizard.py
+++ b/packages/phlo-api/tests/test_observatory_workflow_wizard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from collections.abc import Callable
 from importlib import import_module
 from pathlib import Path
@@ -591,6 +592,65 @@ def test_workflow_wizard_rejects_target_directory_swap_before_safe_open(
     assert not (
         tmp_path / ".phlo" / "workflow-wizard" / "applied" / f"{proposal['proposal_id']}.json"
     ).exists()
+
+
+def test_workflow_wizard_publish_does_not_replace_competing_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workflows = tmp_path / "workflows"
+    workflows.mkdir()
+    original_link = wizard.os.link
+    injected: set[str] = set()
+
+    def inject_competing_destination(
+        source: str,
+        destination: str,
+        *,
+        src_dir_fd: int | None = None,
+        dst_dir_fd: int | None = None,
+        follow_symlinks: bool = True,
+    ) -> None:
+        if destination not in injected:
+            injected.add(destination)
+            assert dst_dir_fd is not None
+            descriptor = wizard.os.open(
+                destination,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o600,
+                dir_fd=dst_dir_fd,
+            )
+            try:
+                wizard.os.write(descriptor, b"competing content")
+            finally:
+                wizard.os.close(descriptor)
+        original_link(
+            source,
+            destination,
+            src_dir_fd=src_dir_fd,
+            dst_dir_fd=dst_dir_fd,
+            follow_symlinks=follow_symlinks,
+        )
+
+    monkeypatch.setattr(wizard.os, "link", inject_competing_destination)
+    fail_preview = WorkflowFilePreview(path="workflows/race-fail.py", content="generated")
+    with pytest.raises(HTTPException) as error:
+        wizard._apply_workflow_file(
+            tmp_path,
+            fail_preview,
+            conflict_policy="fail-on-conflict",
+        )
+
+    skip_preview = WorkflowFilePreview(path="workflows/race-skip.py", content="generated")
+    outcome = wizard._apply_workflow_file(
+        tmp_path,
+        skip_preview,
+        conflict_policy="skip-if-exists",
+    )
+
+    assert error.value.status_code == 409
+    assert outcome == "skipped"
+    assert (workflows / "race-fail.py").read_text(encoding="utf-8") == "competing content"
+    assert (workflows / "race-skip.py").read_text(encoding="utf-8") == "competing content"
 
 
 def test_workflow_wizard_apply_rejects_tampered_proposal(

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.test.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.test.ts
@@ -99,7 +99,7 @@ describe('observatory dataset resources', () => {
     expect(result).toEqual({ data: actionResult, error: null })
     expect(apiPost).toHaveBeenCalledWith(
       '/api/observatory/workflow-wizard/actions',
-      { action_id: 'apply', proposal },
+      { action_id: 'apply', proposal_id: proposal.proposal_id },
       12000,
     )
   })
@@ -118,7 +118,10 @@ describe('observatory dataset resources', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       'https://api.example.test/api/observatory/workflow-wizard/actions',
       expect.objectContaining({
-        body: JSON.stringify({ action_id: 'apply', proposal }),
+        body: JSON.stringify({
+          action_id: 'apply',
+          proposal_id: proposal.proposal_id,
+        }),
         method: 'POST',
       }),
     )
@@ -146,6 +149,7 @@ function workflowProposal() {
     selected_contributions: [],
     warnings: [],
     workflow_name: 'Revenue refresh',
+    proposal_id: 'proposal_1234567890',
   }
 }
 

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.ts
@@ -921,7 +921,7 @@ export async function runObservatoryWorkflowAction({
   data: { actionId: string; proposal: ObservatoryWorkflowProposal }
 }): Promise<ObservatoryResourceResult<ObservatoryWorkflowActionResult>> {
   try {
-    const body = { action_id: actionId, proposal }
+    const body = { action_id: actionId, proposal_id: proposal.proposal_id }
     const result =
       browserApiBase() !== null
         ? await browserApiPost<ObservatoryWorkflowActionResult>(

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/types.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/types.ts
@@ -4,7 +4,11 @@ export type ObservatoryMetadata = Record<string, NonNullable<unknown>>
 type ObservatoryRecord = Record<string, NonNullable<unknown>>
 
 export type ObservatoryServiceStatus =
-  'running' | 'stopped' | 'unhealthy' | 'starting' | 'unknown'
+  | 'running'
+  | 'stopped'
+  | 'unhealthy'
+  | 'starting'
+  | 'unknown'
 
 interface ObservatoryHealth {
   state: ObservatoryHealthState
@@ -150,7 +154,11 @@ export interface ObservatoryDataset {
 }
 
 export type ObservatoryControlStatus =
-  'pass' | 'fail' | 'warning' | 'unknown' | 'not_applicable'
+  | 'pass'
+  | 'fail'
+  | 'warning'
+  | 'unknown'
+  | 'not_applicable'
 
 export interface ObservatoryControlEvidence {
   kind: string
@@ -414,7 +422,12 @@ export interface ObservatoryOperationDetail {
 }
 
 type ObservatoryRunStatus =
-  'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'unknown'
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled'
+  | 'unknown'
 
 export interface ObservatoryRun {
   id: string

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/types.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/types.ts
@@ -4,11 +4,7 @@ export type ObservatoryMetadata = Record<string, NonNullable<unknown>>
 type ObservatoryRecord = Record<string, NonNullable<unknown>>
 
 export type ObservatoryServiceStatus =
-  | 'running'
-  | 'stopped'
-  | 'unhealthy'
-  | 'starting'
-  | 'unknown'
+  'running' | 'stopped' | 'unhealthy' | 'starting' | 'unknown'
 
 interface ObservatoryHealth {
   state: ObservatoryHealthState
@@ -112,6 +108,7 @@ export interface ObservatoryWorkflowApplyAction {
 }
 
 export interface ObservatoryWorkflowProposal {
+  proposal_id: string
   workflow_name: string
   domain: string
   selected_contributions: Array<string>
@@ -153,11 +150,7 @@ export interface ObservatoryDataset {
 }
 
 export type ObservatoryControlStatus =
-  | 'pass'
-  | 'fail'
-  | 'warning'
-  | 'unknown'
-  | 'not_applicable'
+  'pass' | 'fail' | 'warning' | 'unknown' | 'not_applicable'
 
 export interface ObservatoryControlEvidence {
   kind: string
@@ -421,12 +414,7 @@ export interface ObservatoryOperationDetail {
 }
 
 type ObservatoryRunStatus =
-  | 'queued'
-  | 'running'
-  | 'succeeded'
-  | 'failed'
-  | 'cancelled'
-  | 'unknown'
+  'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'unknown'
 
 export interface ObservatoryRun {
   id: string


### PR DESCRIPTION
## Summary

- Require authenticated `project:write` for proposal issuance and application, and rate-limit both operations by principal.
- Persist server-owned proposals by opaque ID, bind each signed record to its issuing principal, and derive apply files/actions only from that record.
- Restrict generated files to the explicitly allowed `workflows/` and `tests/` roots, rejecting absolute paths, `..`, unsupported extensions, and symlink escapes.
- Anchor proposal/applied records, integrity key, lock, target reads, conflict checks, replay verification, and no-replace atomic writes to `O_DIRECTORY|O_NOFOLLOW` directory descriptors.
- Add locked claim/progress records so concurrent or interrupted applies can resume safely; completed replays verify the files still match.
- Escape caller-provided values in generated Python literals and update the Observatory client to send only `proposal_id` plus `action_id`.
- Publish generated workflow files with a fixed server-derived `0644` mode while keeping proposal, applied-record, lock, and integrity-key state private at `0600`.

## Risk and security implications

Before this change, anonymous callers could submit caller-authored paths and content to write outside the project, including absolute and traversal paths, and could alter actions or permissions in the apply payload. The fix authenticates both proposal issuance and application, binds application to the issuing principal, removes client proposal content from the apply contract, verifies server-owned records, rejects unsafe roots and symlinks, and prevents state and target directory swaps from redirecting reads or writes.

The change adds project-local `.phlo/workflow-wizard` state and a per-project integrity key. State directories and key files are opened as non-followed regular directory/file descriptors and written with fsynced, descriptor-relative atomic primitives. The wizard still intentionally generates workflow source from authorized user selections; generated Python values are escaped so selections cannot break out of their intended literals. Repository templates use normal readable file semantics, and no same-UID/container guarantee exists, so generated workflow outputs use a fixed server-derived `0644` mode; callers cannot supply permissions.

## Roadmap acceptance criteria

- SEC-001/SEC-002 routes require authenticated project-write capability for both proposal issuance and application.
- Proposals are server-produced, opaque to clients beyond `proposal_id`, signed with issuer binding, and rejected when tampered, replayed by another principal, or structurally invalid.
- Caller-authored paths, actions, permissions, and proposal contents are not authoritative for file effects.
- Absolute paths, `..` traversal, symlink roots/children, state-directory swaps, target-directory swaps, and competing destination creation cannot redirect or clobber workflow writes outside the project.
- Apply is locked, claim-based, atomic per file, resumable after failure, and idempotent for unchanged replays; published workflow output mode is fixed at `0644`.
- Anonymous, viewer, traversal, absolute-path, symlink, tampered-proposal, cross-principal, replay/conflict, target-TOCTOU, state-TOCTOU, and valid authorized cases are covered.

## Tests and gates

- `uv run pytest -q packages/phlo-api/tests/test_observatory_api.py packages/phlo-api/tests/test_observatory_workflow_wizard.py` — 112 passed, including the generated-file mode assertion.
- `npm test -- --run src/observatory/api/resources.test.ts` — 5 passed.
- Observatory package Prettier check, ESLint, and TypeScript typecheck — passed.
- `uv run ruff check .`, `uv run ruff format --check .`, and `git diff --check` — passed.
- `uv run ty check packages/phlo-api/src packages/phlo-observatory/src` — exits successfully; repository configuration reports its existing warning diagnostics.
- `SKIP=prettier-observatory prek run` — passed all other staged hooks; the package-local Observatory Prettier check passed separately.
- Independent bypass review exercised auth, forged IDs/actions, path traversal/absolute/symlink cases, state/key handling, concurrent applies, crash/retry behavior, state-directory swaps, target-directory swaps, competing destination creation, and cross-principal application; findings were fixed and re-tested.

Do not merge this PR.

