### PR TITLE
feat(run-evidence): add durable provider-neutral evidence store

### DIFF
--- a/packages/phlo-dbt/src/phlo_dbt/transformer.py
+++ b/packages/phlo-dbt/src/phlo_dbt/transformer.py
@@ -281,6 +281,7 @@ def _emit_dbt_lineage(
             edges=edges,
             asset_keys=target_keys,
             metadata={"source": "dbt", "manifest_path": str(manifest_path)},
+            operation_id=f"manifest:{manifest_path}",
         )
 
 

--- a/packages/phlo-trino/src/phlo_trino/publishing.py
+++ b/packages/phlo-trino/src/phlo_trino/publishing.py
@@ -332,6 +332,9 @@ def _publish_marts(
                 edges=edges,
                 asset_keys=[edge[1] for edge in edges],
                 metadata={"source_system": "trino", "target_system": target_system},
+                operation_id=(
+                    f"publish:{data_source}:{schema}:{','.join(sorted(tables_to_publish))}"
+                ),
             )
         logger.info(
             "trino_publish_completed",

--- a/src/phlo/hooks/bus.py
+++ b/src/phlo/hooks/bus.py
@@ -110,8 +110,10 @@ class HookBus:
             return
         from phlo.hooks.telemetry import CoreTelemetryHookProvider
         from phlo.plugins.discovery import discover_plugins, get_global_registry
+        from phlo.run_evidence.hooks import CoreRunEvidenceHookProvider
 
         self.register_provider(CoreTelemetryHookProvider(), plugin_name="core")
+        self.register_provider(CoreRunEvidenceHookProvider(), plugin_name="core")
         discover_plugins(auto_register=True)
         registry = get_global_registry()
         for plugin in registry.iter_plugins():

--- a/src/phlo/hooks/emitters.py
+++ b/src/phlo/hooks/emitters.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from phlo.hooks.bus import HookBus, get_hook_bus
@@ -67,6 +69,38 @@ class _ContextEmitterBase:
         )
         self._hook_bus.emit(event)
 
+    def _event_id(self, event_type: str, explicit: str | None, *identity_parts: str) -> str:
+        """Return an explicit or deterministic identity for retryable events."""
+        if explicit:
+            return explicit
+        context = asdict(self._context)
+        context.pop("tags", None)
+        context.pop("correlation", None)
+        correlation = asdict(self._context.correlation)
+        correlation = {
+            key: correlation.get(key)
+            for key in (
+                "project_id",
+                "run_id",
+                "attempt",
+                "asset_key",
+                "partition_key",
+                "job_name",
+            )
+        }
+        identity = json.dumps(
+            {
+                "event_type": event_type,
+                "context": context,
+                "correlation": correlation,
+                "identity_parts": identity_parts,
+            },
+            sort_keys=True,
+            default=str,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:32]
+
 
 @dataclass(frozen=True)
 class IngestionEventContext:
@@ -76,18 +110,22 @@ class IngestionEventContext:
     table_name: str
     group_name: str
     partition_key: str | None = None
+    project_id: str | None = None
     run_id: str | None = None
     branch_name: str | None = None
     tags: dict[str, str] = field(default_factory=dict)
     correlation: HookCorrelation = field(default_factory=HookCorrelation)
+    producer: str = "phlo"
 
 
 class IngestionEventEmitter(_ContextEmitterBase):
     """Emit ingestion lifecycle events with a shared context."""
 
-    def emit_start(self, *, status: str = "started") -> None:
+    def emit_start(self, *, status: str = "started", event_id: str | None = None) -> None:
         """Emit an ingestion start event."""
-        self._emit(event_type="ingestion.start", status=status, metrics=None, error=None)
+        self._emit(
+            event_type="ingestion.start", status=status, metrics=None, error=None, event_id=event_id
+        )
 
     def emit_end(
         self,
@@ -95,9 +133,16 @@ class IngestionEventEmitter(_ContextEmitterBase):
         status: str,
         metrics: dict[str, Any] | None = None,
         error: str | None = None,
+        event_id: str | None = None,
     ) -> None:
         """Emit an ingestion end event."""
-        self._emit(event_type="ingestion.end", status=status, metrics=metrics, error=error)
+        self._emit(
+            event_type="ingestion.end",
+            status=status,
+            metrics=metrics,
+            error=error,
+            event_id=event_id,
+        )
 
     def _emit(
         self,
@@ -106,6 +151,7 @@ class IngestionEventEmitter(_ContextEmitterBase):
         status: str | None,
         metrics: dict[str, Any] | None,
         error: str | None,
+        event_id: str | None,
     ) -> None:
         """Emit an ingestion event.
 
@@ -119,6 +165,8 @@ class IngestionEventEmitter(_ContextEmitterBase):
         self._emit_event(
             IngestionEvent(
                 event_type=event_type,
+                event_id=self._event_id(event_type, event_id),
+                producer=self._context.producer,
                 asset_key=self._context.asset_key,
                 table_name=self._context.table_name,
                 group_name=self._context.group_name,
@@ -132,6 +180,7 @@ class IngestionEventEmitter(_ContextEmitterBase):
             ),
             correlation_overrides={
                 "run_id": self._context.run_id,
+                "project_id": self._context.project_id,
                 "asset_key": self._context.asset_key,
                 "partition_key": self._context.partition_key,
             },
@@ -147,18 +196,22 @@ class TransformEventContext:
     target: str | None = None
     partition_key: str | None = None
     asset_key: str | None = None
+    project_id: str | None = None
     run_id: str | None = None
     model_names: list[str] = field(default_factory=list)
     tags: dict[str, str] = field(default_factory=dict)
     correlation: HookCorrelation = field(default_factory=HookCorrelation)
+    producer: str = "phlo"
 
 
 class TransformEventEmitter(_ContextEmitterBase):
     """Emit transform lifecycle events with a shared context."""
 
-    def emit_start(self, *, status: str = "started") -> None:
+    def emit_start(self, *, status: str = "started", event_id: str | None = None) -> None:
         """Emit a transform start event."""
-        self._emit(event_type="transform.start", status=status, metrics=None, error=None)
+        self._emit(
+            event_type="transform.start", status=status, metrics=None, error=None, event_id=event_id
+        )
 
     def emit_end(
         self,
@@ -166,9 +219,16 @@ class TransformEventEmitter(_ContextEmitterBase):
         status: str,
         metrics: dict[str, Any] | None = None,
         error: str | None = None,
+        event_id: str | None = None,
     ) -> None:
         """Emit a transform end event."""
-        self._emit(event_type="transform.end", status=status, metrics=metrics, error=error)
+        self._emit(
+            event_type="transform.end",
+            status=status,
+            metrics=metrics,
+            error=error,
+            event_id=event_id,
+        )
 
     def _emit(
         self,
@@ -177,6 +237,7 @@ class TransformEventEmitter(_ContextEmitterBase):
         status: str | None,
         metrics: dict[str, Any] | None,
         error: str | None,
+        event_id: str | None,
     ) -> None:
         """Emit a transform event.
 
@@ -190,6 +251,8 @@ class TransformEventEmitter(_ContextEmitterBase):
         self._emit_event(
             TransformEvent(
                 event_type=event_type,
+                event_id=self._event_id(event_type, event_id),
+                producer=self._context.producer,
                 tool=self._context.tool,
                 project_dir=self._context.project_dir,
                 target=self._context.target,
@@ -203,6 +266,7 @@ class TransformEventEmitter(_ContextEmitterBase):
             ),
             correlation_overrides={
                 "run_id": self._context.run_id,
+                "project_id": self._context.project_id,
                 "asset_key": self._context.asset_key,
                 "partition_key": self._context.partition_key,
             },
@@ -215,19 +279,23 @@ class PublishEventContext:
 
     asset_key: str | None = None
     run_id: str | None = None
+    project_id: str | None = None
     partition_key: str | None = None
     target_system: str | None = None
     tables: dict[str, str] = field(default_factory=dict)
     tags: dict[str, str] = field(default_factory=dict)
     correlation: HookCorrelation = field(default_factory=HookCorrelation)
+    producer: str = "phlo"
 
 
 class PublishEventEmitter(_ContextEmitterBase):
     """Emit publish lifecycle events with a shared context."""
 
-    def emit_start(self, *, status: str = "started") -> None:
+    def emit_start(self, *, status: str = "started", event_id: str | None = None) -> None:
         """Emit a publish start event."""
-        self._emit(event_type="publish.start", status=status, metrics=None, error=None)
+        self._emit(
+            event_type="publish.start", status=status, metrics=None, error=None, event_id=event_id
+        )
 
     def emit_end(
         self,
@@ -235,9 +303,12 @@ class PublishEventEmitter(_ContextEmitterBase):
         status: str,
         metrics: dict[str, Any] | None = None,
         error: str | None = None,
+        event_id: str | None = None,
     ) -> None:
         """Emit a publish end event."""
-        self._emit(event_type="publish.end", status=status, metrics=metrics, error=error)
+        self._emit(
+            event_type="publish.end", status=status, metrics=metrics, error=error, event_id=event_id
+        )
 
     def _emit(
         self,
@@ -246,6 +317,7 @@ class PublishEventEmitter(_ContextEmitterBase):
         status: str | None,
         metrics: dict[str, Any] | None,
         error: str | None,
+        event_id: str | None,
     ) -> None:
         """Emit a publish event.
 
@@ -259,6 +331,8 @@ class PublishEventEmitter(_ContextEmitterBase):
         self._emit_event(
             PublishEvent(
                 event_type=event_type,
+                event_id=self._event_id(event_type, event_id),
+                producer=self._context.producer,
                 asset_key=self._context.asset_key,
                 target_system=self._context.target_system,
                 tables=self._context.tables.copy(),
@@ -269,6 +343,7 @@ class PublishEventEmitter(_ContextEmitterBase):
             ),
             correlation_overrides={
                 "run_id": self._context.run_id,
+                "project_id": self._context.project_id,
                 "asset_key": self._context.asset_key,
                 "partition_key": self._context.partition_key,
             },
@@ -280,10 +355,12 @@ class QualityResultEventContext:
     """Shared context for quality result event emissions."""
 
     asset_key: str
+    project_id: str | None = None
     run_id: str | None = None
     partition_key: str | None = None
     tags: dict[str, str] = field(default_factory=dict)
     correlation: HookCorrelation = field(default_factory=HookCorrelation)
+    producer: str = "phlo"
 
 
 class QualityResultEventEmitter(_ContextEmitterBase):
@@ -297,11 +374,14 @@ class QualityResultEventEmitter(_ContextEmitterBase):
         severity: str | None = None,
         check_type: str | None = None,
         metadata: dict[str, Any] | None = None,
+        event_id: str | None = None,
     ) -> None:
         """Emit a quality result event."""
         self._emit_event(
             QualityResultEvent(
                 event_type="quality.result",
+                event_id=self._event_id("quality.result", event_id, check_name),
+                producer=self._context.producer,
                 asset_key=self._context.asset_key,
                 check_name=check_name,
                 passed=passed,
@@ -313,6 +393,7 @@ class QualityResultEventEmitter(_ContextEmitterBase):
             ),
             correlation_overrides={
                 "run_id": self._context.run_id,
+                "project_id": self._context.project_id,
                 "asset_key": self._context.asset_key,
                 "partition_key": self._context.partition_key,
                 "check_name": check_name,
@@ -324,8 +405,12 @@ class QualityResultEventEmitter(_ContextEmitterBase):
 class LineageEventContext:
     """Shared context for lineage event emissions."""
 
+    project_id: str | None = None
+    run_id: str | None = None
     tags: dict[str, str] = field(default_factory=dict)
     correlation: HookCorrelation = field(default_factory=HookCorrelation)
+    producer: str = "phlo"
+    operation_id: str | None = None
 
 
 class LineageEventEmitter(_ContextEmitterBase):
@@ -337,16 +422,28 @@ class LineageEventEmitter(_ContextEmitterBase):
         edges: list[tuple[str, str]],
         asset_keys: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
+        event_id: str | None = None,
+        operation_id: str | None = None,
     ) -> None:
         """Emit a lineage edges event."""
+        logical_operation_id = operation_id or self._context.operation_id or event_id
+        if logical_operation_id is None and self._context.correlation.run_id is not None:
+            raise ValueError("lineage event requires operation_id or event_id for retry identity")
+        logical_operation_id = logical_operation_id or "uncorrelated"
         self._emit_event(
             LineageEvent(
                 event_type="lineage.edges",
+                event_id=self._event_id("lineage.edges", event_id, logical_operation_id),
+                producer=self._context.producer,
                 edges=list(edges),
                 asset_keys=list(asset_keys) if asset_keys else [],
                 metadata=metadata or {},
                 tags=self._context.tags.copy(),
             ),
+            correlation_overrides={
+                "project_id": self._context.project_id,
+                "run_id": self._context.run_id,
+            },
         )
 
 

--- a/src/phlo/hooks/emitters.py
+++ b/src/phlo/hooks/emitters.py
@@ -19,6 +19,7 @@ from phlo.hooks.events import (
     ServiceLifecycleEvent,
     TelemetryEvent,
     TransformEvent,
+    normalize_attempt,
 )
 from phlo.logging import get_bound_correlation_context
 
@@ -33,12 +34,18 @@ def _merge_correlation(
     if base is not None:
         for key, value in vars(base).items():
             if value is not None:
-                setattr(correlation, key, str(value))
+                setattr(correlation, key, _normalize_correlation_value(key, value))
     if overrides is not None:
         for key, value in overrides.items():
             if value is not None:
-                setattr(correlation, key, str(value))
+                setattr(correlation, key, _normalize_correlation_value(key, value))
     return correlation
+
+
+def _normalize_correlation_value(key: str, value: Any) -> Any:
+    if key == "attempt":
+        return normalize_attempt(value)
+    return str(value)
 
 
 class _ContextEmitterBase:

--- a/src/phlo/hooks/events.py
+++ b/src/phlo/hooks/events.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
+from uuid import uuid4
 
 EVENT_VERSION = "1.0"
 
@@ -96,7 +97,9 @@ class HookCorrelation:
     trace_id: str | None = None
     span_id: str | None = None
     trace_flags: str | None = None
+    project_id: str | None = None
     run_id: str | None = None
+    attempt: int = 1
     asset_key: str | None = None
     job_name: str | None = None
     partition_key: str | None = None
@@ -137,6 +140,8 @@ class HookEvent:
 
     event_type: str
     version: str = EVENT_VERSION
+    event_id: str = field(default_factory=lambda: str(uuid4()))
+    producer: str = "phlo"
     timestamp: datetime = field(default_factory=_utc_now)
     tags: dict[str, str] = field(default_factory=dict)
     correlation: HookCorrelation = field(default_factory=HookCorrelation)

--- a/src/phlo/hooks/events.py
+++ b/src/phlo/hooks/events.py
@@ -53,6 +53,24 @@ from uuid import uuid4
 EVENT_VERSION = "1.0"
 
 
+def normalize_attempt(value: Any) -> int:
+    """Return a positive integer attempt, accepting numeric strings at boundaries."""
+    if isinstance(value, bool):
+        raise ValueError("attempt must be a positive integer")
+    if isinstance(value, int):
+        attempt = value
+    elif isinstance(value, str) and value.strip():
+        try:
+            attempt = int(value)
+        except ValueError as exc:
+            raise ValueError("attempt must be a positive integer") from exc
+    else:
+        raise ValueError("attempt must be a positive integer")
+    if attempt <= 0:
+        raise ValueError("attempt must be a positive integer")
+    return attempt
+
+
 def _utc_now() -> datetime:
     """Return the current UTC timestamp.
 
@@ -104,6 +122,9 @@ class HookCorrelation:
     job_name: str | None = None
     partition_key: str | None = None
     check_name: str | None = None
+
+    def __post_init__(self) -> None:
+        self.attempt = normalize_attempt(self.attempt)
 
 
 @dataclass(kw_only=True)

--- a/src/phlo/logging.py
+++ b/src/phlo/logging.py
@@ -100,6 +100,7 @@ _CORRELATION_FIELDS = (
     "trace_flags",
     "project_id",
     "run_id",
+    "attempt",
     "asset_key",
     "job_name",
     "partition_key",
@@ -316,10 +317,11 @@ def clear_context() -> None:
 
 def get_bound_correlation_context() -> HookCorrelation:
     """Return the current correlation fields bound in logging contextvars."""
-    values: dict[str, Any] = {
-        field: _coerce_optional_string(structlog.contextvars.get_contextvars().get(field))
-        for field in _CORRELATION_FIELDS
-    }
+    values: dict[str, Any] = {}
+    for field in _CORRELATION_FIELDS:
+        value = _coerce_optional_string(structlog.contextvars.get_contextvars().get(field))
+        if value is not None:
+            values[field] = value
     return HookCorrelation(**values)
 
 

--- a/src/phlo/logging.py
+++ b/src/phlo/logging.py
@@ -98,6 +98,7 @@ _CORRELATION_FIELDS = (
     "trace_id",
     "span_id",
     "trace_flags",
+    "project_id",
     "run_id",
     "asset_key",
     "job_name",
@@ -315,7 +316,7 @@ def clear_context() -> None:
 
 def get_bound_correlation_context() -> HookCorrelation:
     """Return the current correlation fields bound in logging contextvars."""
-    values = {
+    values: dict[str, Any] = {
         field: _coerce_optional_string(structlog.contextvars.get_contextvars().get(field))
         for field in _CORRELATION_FIELDS
     }
@@ -413,7 +414,7 @@ def _record_to_event(record: logging.LogRecord, default_service: str) -> LogEven
         tags.setdefault("service", service)
 
     bound_correlation = get_bound_correlation_context()
-    correlation_values = {
+    correlation_values: dict[str, Any] = {
         field: _pop_value(extra, field) or getattr(bound_correlation, field)
         for field in _CORRELATION_FIELDS
     }

--- a/src/phlo/run_evidence/__init__.py
+++ b/src/phlo/run_evidence/__init__.py
@@ -1,0 +1,39 @@
+"""Durable, provider-neutral pipeline run evidence."""
+
+from phlo.run_evidence.hooks import CoreRunEvidenceHookProvider
+from phlo.run_evidence.models import (
+    RUN_EVIDENCE_SCHEMA_VERSION,
+    EvidenceCompleteness,
+    PipelineRun,
+    RunArtifact,
+    RunCatalogChange,
+    RunEvent,
+    RunLineageEdge,
+    RunQualityResult,
+    RunResource,
+    RunStage,
+)
+from phlo.run_evidence.store import (
+    IdempotencyConflict,
+    PostgresRunEvidenceStore,
+    SQLiteRunEvidenceStore,
+    default_run_evidence_store,
+)
+
+__all__ = [
+    "EvidenceCompleteness",
+    "RUN_EVIDENCE_SCHEMA_VERSION",
+    "CoreRunEvidenceHookProvider",
+    "IdempotencyConflict",
+    "PipelineRun",
+    "PostgresRunEvidenceStore",
+    "RunArtifact",
+    "RunCatalogChange",
+    "RunEvent",
+    "RunLineageEdge",
+    "RunQualityResult",
+    "RunResource",
+    "RunStage",
+    "SQLiteRunEvidenceStore",
+    "default_run_evidence_store",
+]

--- a/src/phlo/run_evidence/hooks.py
+++ b/src/phlo/run_evidence/hooks.py
@@ -162,6 +162,7 @@ def _stage_for_event(event: HookEvent, *, project_id: str, run_id: str) -> RunSt
         tool=getattr(event, "tool", None) or getattr(event, "target_system", None),
         asset=asset,
         status=status,
+        attempt=event.correlation.attempt,
         started_at=event.timestamp,
         finished_at=event.timestamp if status not in {"running", "observed"} else None,
         metrics=getattr(event, "metrics", {}) or {},

--- a/src/phlo/run_evidence/hooks.py
+++ b/src/phlo/run_evidence/hooks.py
@@ -1,0 +1,257 @@
+"""Core hook sink that records correlated lifecycle events."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict
+from typing import Any
+
+from phlo.hooks.events import (
+    HookEvent,
+    IngestionEvent,
+    LineageEvent,
+    PublishEvent,
+    QualityResultEvent,
+    TransformEvent,
+)
+from phlo.plugins.hooks import FailurePolicy, HookFilter, HookRegistration
+from phlo.run_evidence.models import (
+    PipelineRun,
+    RunEvent,
+    RunLineageEdge,
+    RunQualityResult,
+    RunStage,
+)
+from phlo.run_evidence.store import (
+    _SqlRunEvidenceStore,
+    default_run_evidence_store,
+)
+
+_LIFECYCLE_EVENT_TYPES = {
+    "ingestion.start",
+    "ingestion.end",
+    "transform.start",
+    "transform.end",
+    "quality.result",
+    "publish.start",
+    "publish.end",
+    "lineage.edges",
+}
+
+
+def _stable_id(*parts: str) -> str:
+    return hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()[:32]
+
+
+class CoreRunEvidenceHookProvider:
+    """Persist the provider-neutral lifecycle events already emitted by Phlo."""
+
+    def __init__(self, store: _SqlRunEvidenceStore | None = None) -> None:
+        self._store = store
+
+    def get_hooks(self) -> list[HookRegistration]:
+        return [
+            HookRegistration(
+                hook_name="core_run_evidence",
+                handler=self._handle_event,
+                priority=0,
+                filters=HookFilter(event_types=set(_LIFECYCLE_EVENT_TYPES)),
+                failure_policy=FailurePolicy.RAISE,
+            )
+        ]
+
+    def _handle_event(self, event: HookEvent) -> None:
+        project_id, run_id = _event_correlation(event)
+        if run_id is None:
+            # Legacy hook callers can emit uncorrelated events. They cannot be
+            # safely attached to a durable run and are intentionally skipped.
+            return
+        if project_id is None:
+            # A run ID without its project is an incomplete correlation, not a
+            # tenant identity. Keep legacy hook callers operational while
+            # refusing to persist evidence that cannot satisfy the composite
+            # tenant keys in the store.
+            return
+
+        store = self._store or default_run_evidence_store()
+        self._store = store
+        run = PipelineRun(
+            project_id=project_id,
+            run_id=run_id,
+            pipeline_name=event.correlation.job_name,
+            provider_run_id=run_id,
+            partition_key=event.correlation.partition_key,
+            trace_id=event.correlation.trace_id,
+            status=_run_status(event),
+            attempt=event.correlation.attempt,
+        )
+        stage = _stage_for_event(event, project_id=project_id, run_id=run_id)
+        quality_result = _quality_for_event(
+            event, project_id=project_id, run_id=run_id, stage=stage
+        )
+        lineage_edges = _lineage_for_event(event, project_id=project_id, run_id=run_id)
+        store.append_event(
+            RunEvent(
+                project_id=project_id,
+                run_id=run_id,
+                event_id=event.event_id,
+                event_type=event.event_type,
+                producer=event.producer,
+                schema_version=event.version,
+                observed_at=event.timestamp,
+                payload=_event_payload(event),
+                stage_id=stage.stage_id if stage else None,
+            ),
+            run=run,
+            stage=stage,
+            quality_result=quality_result,
+            lineage_edges=tuple(lineage_edges),
+        )
+
+
+def _event_correlation(event: HookEvent) -> tuple[str | None, str | None]:
+    project_id = event.correlation.project_id
+    run_id = event.correlation.run_id or getattr(event, "run_id", None)
+    event_run_id = getattr(event, "run_id", None)
+    if event_run_id is not None and event.correlation.run_id not in (None, event_run_id):
+        raise ValueError("event run_id and correlation.run_id do not match")
+    return project_id, run_id
+
+
+def _event_payload(event: HookEvent) -> dict[str, Any]:
+    """Keep envelope identity/time in columns so retries hash logical content."""
+    payload = asdict(event)
+    payload.pop("event_id", None)
+    payload.pop("timestamp", None)
+    correlation = payload.get("correlation")
+    if isinstance(correlation, dict):
+        payload["correlation"] = {
+            key: correlation.get(key)
+            for key in (
+                "project_id",
+                "run_id",
+                "attempt",
+                "asset_key",
+                "job_name",
+                "partition_key",
+                "check_name",
+            )
+        }
+    return payload
+
+
+def _stage_for_event(event: HookEvent, *, project_id: str, run_id: str) -> RunStage | None:
+    stage_type = _stage_type(event)
+    if stage_type is None:
+        return None
+    asset = getattr(event, "asset_key", None)
+    check_name = getattr(event, "check_name", None)
+    stage_key = check_name or asset or getattr(event.correlation, "job_name", None) or stage_type
+    stage_id = _stable_id(
+        project_id, run_id, str(event.correlation.attempt), stage_type, str(stage_key)
+    )
+    status = getattr(event, "status", None) or "observed"
+    if status in {"started", "start", "running"}:
+        status = "running"
+    return RunStage(
+        project_id=project_id,
+        run_id=run_id,
+        stage_id=stage_id,
+        stage_type=stage_type,
+        provider="hook",
+        tool=getattr(event, "tool", None) or getattr(event, "target_system", None),
+        asset=asset,
+        status=status,
+        started_at=event.timestamp,
+        finished_at=event.timestamp if status not in {"running", "observed"} else None,
+        metrics=getattr(event, "metrics", {}) or {},
+        error=getattr(event, "error", None),
+    )
+
+
+def _quality_for_event(
+    event: HookEvent,
+    *,
+    project_id: str,
+    run_id: str,
+    stage: RunStage | None,
+) -> RunQualityResult | None:
+    if not isinstance(event, QualityResultEvent):
+        return None
+    metadata = event.metadata or {}
+    return RunQualityResult(
+        project_id=project_id,
+        run_id=run_id,
+        quality_result_id=_stable_id(
+            project_id, run_id, str(event.correlation.attempt), "quality", event.check_name
+        ),
+        check_id=event.check_name,
+        asset=event.asset_key,
+        stage_id=stage.stage_id if stage else None,
+        severity=event.severity,
+        blocking=event.severity in {"error", "critical"},
+        passed=event.passed,
+        evaluated_count=_as_int(metadata.get("evaluated_count", metadata.get("total_rows"))),
+        failed_count=_as_int(metadata.get("failed_count", metadata.get("failed_rows"))),
+        metadata=metadata,
+    )
+
+
+def _lineage_for_event(
+    event: HookEvent,
+    *,
+    project_id: str,
+    run_id: str,
+) -> list[RunLineageEdge]:
+    if not isinstance(event, LineageEvent):
+        return []
+    metadata = event.metadata or {}
+    return [
+        RunLineageEdge(
+            project_id=project_id,
+            run_id=run_id,
+            lineage_edge_id=_stable_id(project_id, run_id, event.event_id, str(index)),
+            source=source,
+            target=target,
+            column_mapping=metadata.get("column_mapping", {}),
+            origin=str(metadata.get("origin", "observed")),
+            derivation=str(metadata.get("derivation", "exact")),
+            confidence=_as_float(metadata.get("confidence")),
+        )
+        for index, (source, target) in enumerate(event.edges)
+    ]
+
+
+def _stage_type(event: HookEvent) -> str | None:
+    if isinstance(event, IngestionEvent):
+        return "ingest"
+    if isinstance(event, TransformEvent):
+        return "transform"
+    if isinstance(event, QualityResultEvent):
+        return "check"
+    if isinstance(event, PublishEvent):
+        return "publish"
+    if isinstance(event, LineageEvent):
+        return "lineage"
+    return None
+
+
+def _run_status(event: HookEvent) -> str:
+    status = getattr(event, "status", None)
+    if status in {"success", "failed", "error", "cancelled", "canceled", "skipped"}:
+        return str(status)
+    return "running"
+
+
+def _as_int(value: Any) -> int | None:
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_float(value: Any) -> float | None:
+    try:
+        return float(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None

--- a/src/phlo/run_evidence/models.py
+++ b/src/phlo/run_evidence/models.py
@@ -1,0 +1,176 @@
+"""Provider-neutral models for durable pipeline run evidence."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+RUN_EVIDENCE_SCHEMA_VERSION = 1
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class EvidenceCompleteness(StrEnum):
+    """Evidence availability, kept separate from the run outcome."""
+
+    COMPLETE = "complete"
+    INCOMPLETE = "incomplete"
+    MISSING = "missing"
+    EXPIRED = "expired"
+    REDACTED = "redacted"
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineRun:
+    """Authoritative project-scoped record for one pipeline execution."""
+
+    project_id: str
+    run_id: str
+    pipeline_name: str | None = None
+    provider_run_id: str | None = None
+    trigger: str | None = None
+    initiator: str | None = None
+    effective_identity: str | None = None
+    partition_key: str | None = None
+    code_version: str | None = None
+    config_version: str | None = None
+    attempt: int = 1
+    trace_id: str | None = None
+    status: str = "running"
+    started_at: datetime = field(default_factory=_now)
+    finished_at: datetime | None = None
+    failure_summary: str | None = None
+    evidence_completeness: EvidenceCompleteness = EvidenceCompleteness.INCOMPLETE
+
+
+@dataclass(frozen=True, slots=True)
+class RunEvent:
+    """Immutable lifecycle event with producer-scoped idempotency identity."""
+
+    project_id: str
+    run_id: str
+    event_id: str
+    event_type: str
+    producer: str
+    payload: dict[str, Any]
+    stage_id: str | None = None
+    schema_version: str = "1.0"
+    observed_at: datetime = field(default_factory=_now)
+    sequence: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunStage:
+    """Observed lifecycle stage within a pipeline run."""
+
+    project_id: str
+    run_id: str
+    stage_id: str
+    stage_type: str = "unknown"
+    provider: str | None = None
+    tool: str | None = None
+    asset: str | None = None
+    attempt: int = 1
+    status: str = "unknown"
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    metrics: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunResource:
+    """Input, staged, or output resource observed by a run."""
+
+    project_id: str
+    run_id: str
+    resource_id: str
+    resource_kind: str = "unknown"
+    role: str = "unknown"
+    normalized_identity: str | None = None
+    uri: str | None = None
+    table_name: str | None = None
+    catalog: str | None = None
+    ref_name: str | None = None
+    schema_hash: str | None = None
+    watermark: str | None = None
+    record_count: int | None = None
+    byte_count: int | None = None
+    staged_objects: list[str] = field(default_factory=list)
+    snapshot_before: str | None = None
+    snapshot_after: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunLineageEdge:
+    """Historical lineage edge observed or declared for one run."""
+
+    project_id: str
+    run_id: str
+    source: str
+    target: str
+    lineage_edge_id: str
+    column_mapping: dict[str, Any] = field(default_factory=dict)
+    origin: str = "observed"
+    derivation: str = "exact"
+    confidence: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RunQualityResult:
+    """One quality result correlated to its run and optional stage."""
+
+    project_id: str
+    run_id: str
+    quality_result_id: str
+    check_id: str
+    asset: str | None = None
+    stage_id: str | None = None
+    severity: str | None = None
+    blocking: bool = False
+    passed: bool = False
+    evaluated_count: int | None = None
+    failed_count: int | None = None
+    failure_artifact_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RunCatalogChange:
+    """Catalog/WAP change associated with a run."""
+
+    project_id: str
+    run_id: str
+    catalog_change_id: str
+    operation: str
+    catalog_ref: str | None = None
+    content_key: str | None = None
+    source_hash: str | None = None
+    target_hash: str | None = None
+    commit_hash: str | None = None
+    commit_message: str | None = None
+    merge_outcome: str | None = None
+    snapshot_before: str | None = None
+    snapshot_after: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RunArtifact:
+    """Durable identity for an artifact even after its content expires."""
+
+    project_id: str
+    run_id: str
+    artifact_id: str
+    artifact_kind: str
+    uri: str | None = None
+    content_type: str | None = None
+    checksum: str | None = None
+    retention_class: str | None = None
+    expires_at: datetime | None = None
+    legal_hold: bool = False
+    status: EvidenceCompleteness = EvidenceCompleteness.COMPLETE

--- a/src/phlo/run_evidence/redaction.py
+++ b/src/phlo/run_evidence/redaction.py
@@ -1,0 +1,54 @@
+"""Redaction and canonical serialization for stored run evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any
+
+from phlo.exceptions import redact_sensitive_text
+from phlo.helpers._common import is_sensitive_key
+
+_TEXT_SECRET_PATTERN = re.compile(
+    r"(?i)\b(password|passwd|token|secret|api[_-]?key|access[_-]?token)\s*[:=]\s*([^&\s/]+)"
+)
+
+
+def redact_payload(value: Any, *, key: str | None = None) -> Any:
+    """Deep-redact sensitive keys and credential-bearing strings."""
+    if key is not None and is_sensitive_key(key):
+        return "<redacted>" if value not in (None, "") else value
+    if isinstance(value, Mapping):
+        return {str(k): redact_payload(v, key=str(k)) for k, v in value.items()}
+    if isinstance(value, list):
+        return [redact_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_payload(item) for item in value]
+    if isinstance(value, str):
+        return _TEXT_SECRET_PATTERN.sub(r"\1=<redacted>", redact_sensitive_text(value))
+    return value
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    return str(value)
+
+
+def canonical_json(value: Any) -> str:
+    """Return stable JSON used for checksums and compatibility tests."""
+    return json.dumps(
+        redact_payload(value),
+        default=_json_default,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+def payload_checksum(value: Any) -> str:
+    """Return a full SHA-256 checksum of the redacted canonical payload."""
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()

--- a/src/phlo/run_evidence/store.py
+++ b/src/phlo/run_evidence/store.py
@@ -1,0 +1,732 @@
+"""Transactional stores for the run-evidence contract."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from phlo.run_evidence.models import (
+    EvidenceCompleteness,
+    PipelineRun,
+    RunArtifact,
+    RunCatalogChange,
+    RunEvent,
+    RunLineageEdge,
+    RunQualityResult,
+    RunResource,
+    RunStage,
+)
+from phlo.run_evidence.redaction import canonical_json, payload_checksum, redact_payload
+
+
+class IdempotencyConflict(ValueError):
+    """A producer reused an event identity with different content."""
+
+
+def _timestamp(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _json(value: Any) -> str:
+    return canonical_json(value)
+
+
+def _text(value: str | None) -> str | None:
+    redacted = redact_payload(value)
+    return redacted if isinstance(redacted, str) or redacted is None else str(redacted)
+
+
+class _SqlRunEvidenceStore:
+    """Shared SQL implementation; subclasses provide transaction connections."""
+
+    placeholder = "?"
+    table_prefix = ""
+
+    def __init__(self) -> None:
+        self._initialized = False
+        self._lock = threading.RLock()
+
+    def _connect(self) -> Any:
+        raise NotImplementedError
+
+    def _close_connection(self, connection: Any) -> None:
+        connection.close()
+
+    def _table(self, name: str) -> str:
+        return f"{self.table_prefix}{name}"
+
+    @contextmanager
+    def _transaction(self) -> Iterator[tuple[Any, Any]]:
+        self._ensure_schema()
+        with self._lock:
+            connection = self._connect()
+            cursor = connection.cursor()
+            try:
+                if self.placeholder == "?":
+                    cursor.execute("BEGIN IMMEDIATE")
+                yield connection, cursor
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+            finally:
+                cursor.close()
+                self._close_connection(connection)
+
+    def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        with self._lock:
+            if self._initialized:
+                return
+            self._initialize_schema()
+            self._initialized = True
+
+    def _initialize_schema(self) -> None:
+        raise NotImplementedError
+
+    def append_pipeline_run(self, run: PipelineRun) -> None:
+        with self._transaction() as (_, cursor):
+            self._upsert_run(cursor, run)
+
+    def append_event(
+        self,
+        event: RunEvent,
+        *,
+        run: PipelineRun | None = None,
+        stage: RunStage | None = None,
+        quality_result: RunQualityResult | None = None,
+        lineage_edges: tuple[RunLineageEdge, ...] = (),
+    ) -> bool:
+        """Append one event and optional derived records in one transaction."""
+        with self._transaction() as (_, cursor):
+            cursor.execute(
+                f"SELECT 1 FROM {self._table('run_event')} "
+                f"WHERE project_id = {self.placeholder} AND producer = {self.placeholder} "
+                f"AND event_id = {self.placeholder}",
+                (event.project_id, event.producer, event.event_id),
+            )
+            event_exists = cursor.fetchone() is not None
+            if run is not None and not event_exists:
+                self._upsert_run(cursor, run)
+            inserted = self._insert_event(cursor, event)
+            if inserted:
+                if stage is not None:
+                    self._insert_stage(cursor, stage)
+                if quality_result is not None:
+                    self._insert_quality(cursor, quality_result)
+                for edge in lineage_edges:
+                    self._insert_lineage(cursor, edge)
+            return inserted
+
+    def append_stage(self, stage: RunStage) -> None:
+        with self._transaction() as (_, cursor):
+            self._insert_stage(cursor, stage)
+
+    def append_resource(self, resource: RunResource) -> None:
+        with self._transaction() as (_, cursor):
+            self._insert_resource(cursor, resource)
+
+    def append_lineage_edge(self, edge: RunLineageEdge) -> None:
+        with self._transaction() as (_, cursor):
+            self._insert_lineage(cursor, edge)
+
+    def append_quality_result(self, result: RunQualityResult) -> None:
+        with self._transaction() as (_, cursor):
+            self._insert_quality(cursor, result)
+
+    def append_catalog_change(self, change: RunCatalogChange) -> None:
+        with self._transaction() as (_, cursor):
+            self._insert_catalog_change(cursor, change)
+
+    def append_artifact(self, artifact: RunArtifact) -> None:
+        with self._transaction() as (_, cursor):
+            self._insert_artifact(cursor, artifact)
+
+    def update_run(
+        self,
+        project_id: str,
+        run_id: str,
+        *,
+        status: str | None = None,
+        finished_at: datetime | None = None,
+        failure_summary: str | None = None,
+        evidence_completeness: EvidenceCompleteness | None = None,
+    ) -> None:
+        """Update terminal run state without changing its identity or history."""
+        fields: list[str] = []
+        values: list[Any] = []
+        if status is not None:
+            fields.append("status = " + self.placeholder)
+            values.append(status)
+        if finished_at is not None:
+            fields.append("finished_at = " + self.placeholder)
+            values.append(_timestamp(finished_at))
+        if failure_summary is not None:
+            fields.append("failure_summary = " + self.placeholder)
+            values.append(_text(failure_summary))
+        if evidence_completeness is not None:
+            fields.append("evidence_completeness = " + self.placeholder)
+            values.append(evidence_completeness.value)
+        if not fields:
+            return
+        fields.append("updated_at = " + self.placeholder)
+        values.append(_timestamp(datetime.now(UTC)))
+        values.extend([project_id, run_id])
+        with self._transaction() as (_, cursor):
+            cursor.execute(
+                f"UPDATE {self._table('pipeline_run')} SET {', '.join(fields)} "
+                f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder}",
+                tuple(values),
+            )
+
+    def get_run(self, project_id: str, run_id: str) -> dict[str, Any] | None:
+        with self._transaction() as (_, cursor):
+            cursor.execute(
+                f"SELECT * FROM {self._table('pipeline_run')} "
+                f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder}",
+                (project_id, run_id),
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return self._row_dict(cursor, row)
+
+    def list_events(self, project_id: str, run_id: str) -> list[dict[str, Any]]:
+        with self._transaction() as (_, cursor):
+            cursor.execute(
+                f"SELECT * FROM {self._table('run_event')} "
+                f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder} "
+                "ORDER BY observed_at, id",
+                (project_id, run_id),
+            )
+            return [self._row_dict(cursor, row) for row in cursor.fetchall()]
+
+    def count_events(self, project_id: str, run_id: str) -> int:
+        with self._transaction() as (_, cursor):
+            cursor.execute(
+                f"SELECT COUNT(*) FROM {self._table('run_event')} "
+                f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder}",
+                (project_id, run_id),
+            )
+            return int(cursor.fetchone()[0])
+
+    def _upsert_run(self, cursor: Any, run: PipelineRun) -> None:
+        cursor.execute(
+            f"SELECT project_id FROM {self._table('pipeline_run')} "
+            f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder}",
+            (run.project_id, run.run_id),
+        )
+        columns = (
+            "run_id, project_id, pipeline_name, provider_run_id, trigger, initiator, "
+            "effective_identity, partition_key, code_version, config_version, attempt, "
+            "trace_id, status, started_at, finished_at, failure_summary, evidence_completeness"
+        )
+        values = (
+            run.run_id,
+            run.project_id,
+            _text(run.pipeline_name),
+            _text(run.provider_run_id),
+            _text(run.trigger),
+            _text(run.initiator),
+            _text(run.effective_identity),
+            _text(run.partition_key),
+            _text(run.code_version),
+            _text(run.config_version),
+            run.attempt,
+            _text(run.trace_id),
+            _text(run.status),
+            _timestamp(run.started_at),
+            _timestamp(run.finished_at),
+            _text(run.failure_summary),
+            run.evidence_completeness.value,
+        )
+        updates = ", ".join(
+            [
+                f"{field} = EXCLUDED.{field}"
+                for field in (
+                    "pipeline_name",
+                    "provider_run_id",
+                    "trigger",
+                    "initiator",
+                    "effective_identity",
+                    "partition_key",
+                    "code_version",
+                    "config_version",
+                    "attempt",
+                    "trace_id",
+                )
+            ]
+            + [
+                "status = CASE WHEN existing_run.status IN "
+                "('success', 'failed', 'error', 'cancelled', 'canceled') "
+                "AND EXCLUDED.status = 'running' THEN existing_run.status ELSE EXCLUDED.status END",
+                "finished_at = COALESCE(EXCLUDED.finished_at, existing_run.finished_at)",
+                "failure_summary = COALESCE(EXCLUDED.failure_summary, existing_run.failure_summary)",
+                "evidence_completeness = CASE WHEN existing_run.evidence_completeness IN "
+                "('complete', 'expired', 'redacted') AND EXCLUDED.evidence_completeness = 'incomplete' "
+                "THEN existing_run.evidence_completeness ELSE EXCLUDED.evidence_completeness END",
+            ]
+        )
+        cursor.execute(
+            f"INSERT INTO {self._table('pipeline_run')} AS existing_run ({columns}) VALUES "
+            f"({', '.join([self.placeholder] * len(values))}) "
+            f"ON CONFLICT (project_id, run_id) DO UPDATE SET {updates}, "
+            "updated_at = CURRENT_TIMESTAMP",
+            values,
+        )
+
+    def _insert_event(self, cursor: Any, event: RunEvent) -> bool:
+        self._require_id("event_id", event.event_id)
+        self._require_id("producer", event.producer)
+        redacted = redact_payload(event.payload)
+        checksum = payload_checksum(redacted)
+        values = (
+            event.project_id,
+            event.run_id,
+            event.stage_id,
+            event.event_id,
+            event.event_type,
+            event.schema_version,
+            event.producer,
+            _timestamp(event.observed_at),
+            event.sequence,
+            _json(redacted),
+            checksum,
+        )
+        cursor.execute(
+            f"INSERT INTO {self._table('run_event')} "
+            "(project_id, run_id, stage_id, event_id, event_type, schema_version, producer, "
+            "observed_at, sequence, payload, payload_checksum) VALUES ("
+            + ", ".join([self.placeholder] * len(values))
+            + ") ON CONFLICT (project_id, producer, event_id) DO NOTHING",
+            values,
+        )
+        inserted = cursor.rowcount == 1
+        cursor.execute(
+            f"SELECT project_id, run_id, payload_checksum FROM {self._table('run_event')} "
+            f"WHERE project_id = {self.placeholder} AND producer = {self.placeholder} "
+            f"AND event_id = {self.placeholder}",
+            (event.project_id, event.producer, event.event_id),
+        )
+        existing = cursor.fetchone()
+        if existing is None:
+            raise RuntimeError("event insert did not return a durable record")
+        if existing[0] != event.project_id or existing[1] != event.run_id:
+            raise IdempotencyConflict(
+                f"event {event.producer}/{event.event_id} is correlated to another run"
+            )
+        if existing[2] != checksum:
+            raise IdempotencyConflict(
+                f"event {event.producer}/{event.event_id} was replayed with different payload"
+            )
+        return inserted
+
+    def _insert_stage(self, cursor: Any, stage: RunStage) -> None:
+        self._require_id("stage_id", stage.stage_id)
+        immutable_checksum = payload_checksum(
+            {
+                "stage_id": stage.stage_id,
+                "project_id": stage.project_id,
+                "run_id": stage.run_id,
+                "stage_type": stage.stage_type,
+                "provider": stage.provider,
+                "tool": stage.tool,
+                "asset": stage.asset,
+                "attempt": stage.attempt,
+            }
+        )
+        values = (
+            stage.stage_id,
+            stage.project_id,
+            stage.run_id,
+            stage.stage_type,
+            _text(stage.provider),
+            _text(stage.tool),
+            _text(stage.asset),
+            stage.attempt,
+            stage.status,
+            _timestamp(stage.started_at),
+            _timestamp(stage.finished_at),
+            _json(stage.metrics),
+            _text(stage.error),
+            immutable_checksum,
+        )
+        cursor.execute(
+            f"INSERT INTO {self._table('run_stage')} "
+            "(stage_id, project_id, run_id, stage_type, provider, tool, asset, attempt, status, "
+            "started_at, finished_at, metrics, error, record_checksum) VALUES ("
+            + ", ".join([self.placeholder] * len(values))
+            + ") ON CONFLICT (project_id, stage_id) DO NOTHING",
+            values,
+        )
+        if cursor.rowcount == 1:
+            return
+        cursor.execute(
+            f"SELECT run_id, record_checksum FROM {self._table('run_stage')} "
+            f"WHERE project_id = {self.placeholder} AND stage_id = {self.placeholder}",
+            (stage.project_id, stage.stage_id),
+        )
+        existing = cursor.fetchone()
+        if existing is None or existing[0] != stage.run_id or existing[1] != immutable_checksum:
+            raise IdempotencyConflict(
+                f"stage {stage.project_id}/{stage.stage_id} was replayed differently"
+            )
+        p = self.placeholder
+        cursor.execute(
+            f"UPDATE {self._table('run_stage')} SET status = CASE "
+            f"WHEN status IN ('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
+            f"AND {p} IN ('running', 'observed') THEN status ELSE {p} END, "
+            f"finished_at = COALESCE(finished_at, {p}), metrics = {p}, error = COALESCE({p}, error) "
+            f"WHERE project_id = {p} AND stage_id = {p}",
+            (
+                stage.status,
+                stage.status,
+                _timestamp(stage.finished_at),
+                _json(stage.metrics),
+                _text(stage.error),
+                stage.project_id,
+                stage.stage_id,
+            ),
+        )
+
+    def _insert_resource(self, cursor: Any, resource: RunResource) -> None:
+        self._require_id("resource_id", resource.resource_id)
+        record_checksum = payload_checksum(
+            {key: value for key, value in asdict(resource).items() if key != "resource_id"}
+        )
+        values = (
+            resource.resource_id,
+            resource.project_id,
+            resource.run_id,
+            resource.resource_kind,
+            resource.role,
+            _text(resource.normalized_identity),
+            _text(resource.uri),
+            _text(resource.table_name),
+            _text(resource.catalog),
+            _text(resource.ref_name),
+            _text(resource.schema_hash),
+            _text(resource.watermark),
+            resource.record_count,
+            resource.byte_count,
+            _json(resource.staged_objects),
+            _text(resource.snapshot_before),
+            _text(resource.snapshot_after),
+            record_checksum,
+        )
+        cursor.execute(
+            f"INSERT INTO {self._table('run_resource')} "
+            "(resource_id, project_id, run_id, resource_kind, role, normalized_identity, uri, "
+            "table_name, catalog, ref_name, schema_hash, watermark, record_count, byte_count, "
+            "staged_objects, snapshot_before, snapshot_after, record_checksum) VALUES ("
+            + ", ".join([self.placeholder] * len(values))
+            + ") ON CONFLICT (project_id, resource_id) DO NOTHING",
+            values,
+        )
+        if cursor.rowcount != 1:
+            self._confirm_immutable(
+                cursor,
+                table="run_resource",
+                id_column="resource_id",
+                project_id=resource.project_id,
+                record_id=resource.resource_id,
+                run_id=resource.run_id,
+                checksum=record_checksum,
+            )
+
+    def _insert_lineage(self, cursor: Any, edge: RunLineageEdge) -> None:
+        self._require_id("lineage_edge_id", edge.lineage_edge_id)
+        record_checksum = payload_checksum(
+            {key: value for key, value in asdict(edge).items() if key != "lineage_edge_id"}
+        )
+        values = (
+            edge.lineage_edge_id,
+            edge.project_id,
+            edge.run_id,
+            _text(edge.source),
+            _text(edge.target),
+            _json(edge.column_mapping),
+            _text(edge.origin),
+            _text(edge.derivation),
+            edge.confidence,
+            record_checksum,
+        )
+        cursor.execute(
+            f"INSERT INTO {self._table('run_lineage_edge')} "
+            "(lineage_edge_id, project_id, run_id, source, target, column_mapping, origin, "
+            "derivation, confidence, record_checksum) VALUES ("
+            + ", ".join([self.placeholder] * len(values))
+            + ") ON CONFLICT (project_id, lineage_edge_id) DO NOTHING",
+            values,
+        )
+        if cursor.rowcount != 1:
+            self._confirm_immutable(
+                cursor,
+                table="run_lineage_edge",
+                id_column="lineage_edge_id",
+                project_id=edge.project_id,
+                record_id=edge.lineage_edge_id,
+                run_id=edge.run_id,
+                checksum=record_checksum,
+            )
+
+    def _insert_quality(self, cursor: Any, result: RunQualityResult) -> None:
+        self._require_id("quality_result_id", result.quality_result_id)
+        record_checksum = payload_checksum(
+            {key: value for key, value in asdict(result).items() if key != "quality_result_id"}
+        )
+        values = (
+            result.quality_result_id,
+            result.project_id,
+            result.run_id,
+            result.stage_id,
+            _text(result.check_id),
+            _text(result.asset),
+            _text(result.severity),
+            int(result.blocking),
+            int(result.passed),
+            result.evaluated_count,
+            result.failed_count,
+            _text(result.failure_artifact_id),
+            _json(result.metadata),
+            record_checksum,
+        )
+        cursor.execute(
+            f"INSERT INTO {self._table('run_quality_result')} "
+            "(quality_result_id, project_id, run_id, stage_id, check_id, asset, severity, blocking, "
+            "passed, evaluated_count, failed_count, failure_artifact_id, metadata, record_checksum) VALUES ("
+            + ", ".join([self.placeholder] * len(values))
+            + ") ON CONFLICT (project_id, quality_result_id) DO NOTHING",
+            values,
+        )
+        if cursor.rowcount != 1:
+            self._confirm_immutable(
+                cursor,
+                table="run_quality_result",
+                id_column="quality_result_id",
+                project_id=result.project_id,
+                record_id=result.quality_result_id,
+                run_id=result.run_id,
+                checksum=record_checksum,
+            )
+
+    def _insert_catalog_change(self, cursor: Any, change: RunCatalogChange) -> None:
+        self._require_id("catalog_change_id", change.catalog_change_id)
+        record_checksum = payload_checksum(
+            {key: value for key, value in asdict(change).items() if key != "catalog_change_id"}
+        )
+        values = (
+            change.catalog_change_id,
+            change.project_id,
+            change.run_id,
+            _text(change.catalog_ref),
+            _text(change.content_key),
+            _text(change.operation),
+            _text(change.source_hash),
+            _text(change.target_hash),
+            _text(change.commit_hash),
+            _text(change.commit_message),
+            _text(change.merge_outcome),
+            _text(change.snapshot_before),
+            _text(change.snapshot_after),
+            _json(change.metadata),
+            record_checksum,
+        )
+        cursor.execute(
+            f"INSERT INTO {self._table('run_catalog_change')} "
+            "(catalog_change_id, project_id, run_id, catalog_ref, content_key, operation, "
+            "source_hash, target_hash, commit_hash, commit_message, merge_outcome, snapshot_before, "
+            "snapshot_after, metadata, record_checksum) VALUES ("
+            + ", ".join([self.placeholder] * len(values))
+            + ") ON CONFLICT (project_id, catalog_change_id) DO NOTHING",
+            values,
+        )
+        if cursor.rowcount != 1:
+            self._confirm_immutable(
+                cursor,
+                table="run_catalog_change",
+                id_column="catalog_change_id",
+                project_id=change.project_id,
+                record_id=change.catalog_change_id,
+                run_id=change.run_id,
+                checksum=record_checksum,
+            )
+
+    def _insert_artifact(self, cursor: Any, artifact: RunArtifact) -> None:
+        self._require_id("artifact_id", artifact.artifact_id)
+        record_checksum = payload_checksum(
+            {key: value for key, value in asdict(artifact).items() if key != "artifact_id"}
+        )
+        values = (
+            artifact.artifact_id,
+            artifact.project_id,
+            artifact.run_id,
+            _text(artifact.artifact_kind),
+            _text(artifact.uri),
+            _text(artifact.content_type),
+            _text(artifact.checksum),
+            _text(artifact.retention_class),
+            _timestamp(artifact.expires_at),
+            int(artifact.legal_hold),
+            artifact.status.value,
+            record_checksum,
+        )
+        cursor.execute(
+            f"INSERT INTO {self._table('run_artifact')} "
+            "(artifact_id, project_id, run_id, artifact_kind, uri, content_type, checksum, "
+            "retention_class, expires_at, legal_hold, status, record_checksum) VALUES ("
+            + ", ".join([self.placeholder] * len(values))
+            + ") ON CONFLICT (project_id, artifact_id) DO NOTHING",
+            values,
+        )
+        if cursor.rowcount != 1:
+            self._confirm_immutable(
+                cursor,
+                table="run_artifact",
+                id_column="artifact_id",
+                project_id=artifact.project_id,
+                record_id=artifact.artifact_id,
+                run_id=artifact.run_id,
+                checksum=record_checksum,
+            )
+
+    @staticmethod
+    def _row_dict(cursor: Any, row: Any) -> dict[str, Any]:
+        if hasattr(row, "keys"):
+            return dict(row)
+        columns = [description[0] for description in cursor.description]
+        return dict(zip(columns, row, strict=True))
+
+    @staticmethod
+    def _require_id(name: str, value: str) -> None:
+        if not value or not value.strip():
+            raise ValueError(f"{name} must be a stable non-empty identifier")
+
+    def _confirm_immutable(
+        self,
+        cursor: Any,
+        *,
+        table: str,
+        id_column: str,
+        project_id: str,
+        record_id: str,
+        run_id: str,
+        checksum: str,
+    ) -> None:
+        cursor.execute(
+            f"SELECT run_id, record_checksum FROM {self._table(table)} "
+            f"WHERE project_id = {self.placeholder} AND {id_column} = {self.placeholder}",
+            (project_id, record_id),
+        )
+        existing = cursor.fetchone()
+        if existing is None or existing[0] != run_id or existing[1] != checksum:
+            raise IdempotencyConflict(
+                f"{table} {project_id}/{record_id} was replayed with different evidence"
+            )
+
+
+class SQLiteRunEvidenceStore(_SqlRunEvidenceStore):
+    """Local SQLite fallback for single-process development and tests."""
+
+    placeholder = "?"
+
+    def __init__(self, path: str | Path = ":memory:") -> None:
+        super().__init__()
+        self.path = str(path)
+        if self.path != ":memory:":
+            Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(self.path, check_same_thread=False)
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA foreign_keys = ON")
+        self._connection.execute("PRAGMA busy_timeout = 5000")
+        if self.path != ":memory:":
+            self._connection.execute("PRAGMA journal_mode = WAL")
+
+    def _connect(self) -> sqlite3.Connection:
+        return self._connection
+
+    def _close_connection(self, connection: sqlite3.Connection) -> None:
+        del connection
+
+    def _initialize_schema(self) -> None:
+        sql_path = Path(__file__).parent.parent / "sql" / "002_create_run_evidence.sql"
+        sql = sql_path.read_text(encoding="utf-8")
+        replacements = {
+            "CREATE SCHEMA IF NOT EXISTS phlo;": "",
+            "phlo.": "",
+            "BIGSERIAL": "INTEGER",
+            "TIMESTAMPTZ": "TEXT",
+            "JSONB": "TEXT",
+            "DOUBLE PRECISION": "REAL",
+            "BOOLEAN": "INTEGER",
+            "DEFAULT NOW()": "DEFAULT CURRENT_TIMESTAMP",
+            "DEFAULT '{}'::jsonb": "DEFAULT '{}'",
+            "DEFAULT '[]'::jsonb": "DEFAULT '[]'",
+            "INSERT INTO run_evidence_schema_version(version) VALUES (1)\nON CONFLICT (version) DO NOTHING;": "INSERT OR IGNORE INTO run_evidence_schema_version(version) VALUES (1);",
+        }
+        for old, new in replacements.items():
+            sql = sql.replace(old, new)
+        sql = "\n".join(
+            line for line in sql.splitlines() if not line.strip().startswith("COMMENT ON")
+        )
+        self._connection.executescript(sql)
+        self._connection.commit()
+
+
+class PostgresRunEvidenceStore(_SqlRunEvidenceStore):
+    """Production PostgreSQL adapter using the runtime psycopg2 dependency."""
+
+    placeholder = "%s"
+    table_prefix = "phlo."
+
+    def __init__(self, dsn: str, *, connection_factory: Any | None = None) -> None:
+        super().__init__()
+        self.dsn = dsn
+        self._connection_factory = connection_factory
+
+    def _connect(self) -> Any:
+        if self._connection_factory is not None:
+            return self._connection_factory()
+        try:
+            import psycopg2
+        except ImportError as exc:
+            raise RuntimeError(
+                "PostgresRunEvidenceStore requires the runtime extra: install phlo[runtime]."
+            ) from exc
+        return psycopg2.connect(self.dsn)
+
+    def _initialize_schema(self) -> None:
+        sql_path = Path(__file__).parent.parent / "sql" / "002_create_run_evidence.sql"
+        connection = self._connect()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(sql_path.read_text(encoding="utf-8"))
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+
+def default_run_evidence_store() -> SQLiteRunEvidenceStore | PostgresRunEvidenceStore:
+    """Resolve the production DSN or durable local path from environment."""
+    dsn = os.environ.get("PHLO_RUN_EVIDENCE_DB_URL")
+    if dsn:
+        return PostgresRunEvidenceStore(dsn)
+    environment = os.environ.get("PHLO_ENVIRONMENT", "dev").lower()
+    if environment in {"prod", "production", "staging", "regulated"}:
+        raise RuntimeError(
+            "Run evidence requires PHLO_RUN_EVIDENCE_DB_URL in production, staging, "
+            "and regulated environments; SQLite is local-only."
+        )
+    path = os.environ.get("PHLO_RUN_EVIDENCE_SQLITE_PATH", ".phlo/run-evidence.sqlite")
+    return SQLiteRunEvidenceStore(path)

--- a/src/phlo/run_evidence/store.py
+++ b/src/phlo/run_evidence/store.py
@@ -250,20 +250,32 @@ class _SqlRunEvidenceStore:
         )
         updates = ", ".join(
             [
-                f"{field} = EXCLUDED.{field}"
+                f"{field} = COALESCE(existing_run.{field}, EXCLUDED.{field})"
                 for field in (
                     "pipeline_name",
                     "provider_run_id",
                     "trigger",
                     "initiator",
-                    "effective_identity",
                     "partition_key",
-                    "code_version",
-                    "config_version",
-                    "trace_id",
                 )
             ]
             + [
+                # provider_run_id identifies the logical provider run, while
+                # these fields describe the latest execution attempt. A
+                # same-attempt replay only fills a missing value so late
+                # lower-attempt evidence cannot rewrite current provenance.
+                "effective_identity = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.effective_identity WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.effective_identity ELSE COALESCE(existing_run.effective_identity, EXCLUDED.effective_identity) END",
+                "code_version = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.code_version WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.code_version ELSE COALESCE(existing_run.code_version, EXCLUDED.code_version) END",
+                "config_version = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.config_version WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.config_version ELSE COALESCE(existing_run.config_version, EXCLUDED.config_version) END",
+                "started_at = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.started_at WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.started_at ELSE COALESCE(existing_run.started_at, EXCLUDED.started_at) END",
                 "attempt = CASE WHEN existing_run.attempt > EXCLUDED.attempt "
                 "THEN existing_run.attempt ELSE EXCLUDED.attempt END",
                 "status = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
@@ -271,9 +283,26 @@ class _SqlRunEvidenceStore:
                 "THEN existing_run.status WHEN existing_run.status IN "
                 "('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
                 "THEN existing_run.status ELSE EXCLUDED.status END",
-                "finished_at = COALESCE(EXCLUDED.finished_at, existing_run.finished_at)",
-                "failure_summary = COALESCE(EXCLUDED.failure_summary, existing_run.failure_summary)",
-                "evidence_completeness = CASE WHEN existing_run.evidence_completeness IN "
+                "trace_id = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.trace_id WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.trace_id ELSE COALESCE(existing_run.trace_id, EXCLUDED.trace_id) END",
+                "finished_at = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.finished_at WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.finished_at WHEN existing_run.status IN "
+                "('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
+                "THEN COALESCE(existing_run.finished_at, EXCLUDED.finished_at) "
+                "ELSE COALESCE(EXCLUDED.finished_at, existing_run.finished_at) END",
+                "failure_summary = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.failure_summary WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.failure_summary WHEN existing_run.status IN "
+                "('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
+                "THEN COALESCE(existing_run.failure_summary, EXCLUDED.failure_summary) "
+                "ELSE COALESCE(EXCLUDED.failure_summary, existing_run.failure_summary) END",
+                "evidence_completeness = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.evidence_completeness WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.evidence_completeness WHEN existing_run.status IN "
+                "('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
+                "THEN existing_run.evidence_completeness WHEN existing_run.evidence_completeness IN "
                 "('complete', 'expired', 'redacted') AND EXCLUDED.evidence_completeness = 'incomplete' "
                 "THEN existing_run.evidence_completeness ELSE EXCLUDED.evidence_completeness END",
             ]
@@ -387,14 +416,22 @@ class _SqlRunEvidenceStore:
         cursor.execute(
             f"UPDATE {self._table('run_stage')} SET status = CASE "
             f"WHEN status IN ('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
-            f"AND {p} IN ('running', 'observed') THEN status ELSE {p} END, "
-            f"finished_at = COALESCE(finished_at, {p}), metrics = {p}, error = COALESCE({p}, error) "
+            f"THEN status ELSE {p} END, "
+            f"finished_at = CASE WHEN status IN "
+            f"('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
+            f"THEN COALESCE(finished_at, {p}) ELSE COALESCE({p}, finished_at) END, "
+            f"metrics = CASE WHEN status IN "
+            f"('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
+            f"THEN metrics ELSE {p} END, error = CASE WHEN status IN "
+            f"('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
+            f"THEN COALESCE(error, {p}) ELSE COALESCE({p}, error) END "
             f"WHERE project_id = {p} AND run_id = {p} AND stage_id = {p}",
             (
                 stage.status,
-                stage.status,
+                _timestamp(stage.finished_at),
                 _timestamp(stage.finished_at),
                 _json(stage.metrics),
+                _text(stage.error),
                 _text(stage.error),
                 stage.project_id,
                 stage.run_id,

--- a/src/phlo/run_evidence/store.py
+++ b/src/phlo/run_evidence/store.py
@@ -260,14 +260,17 @@ class _SqlRunEvidenceStore:
                     "partition_key",
                     "code_version",
                     "config_version",
-                    "attempt",
                     "trace_id",
                 )
             ]
             + [
-                "status = CASE WHEN existing_run.status IN "
-                "('success', 'failed', 'error', 'cancelled', 'canceled') "
-                "AND EXCLUDED.status = 'running' THEN existing_run.status ELSE EXCLUDED.status END",
+                "attempt = CASE WHEN existing_run.attempt > EXCLUDED.attempt "
+                "THEN existing_run.attempt ELSE EXCLUDED.attempt END",
+                "status = CASE WHEN EXCLUDED.attempt > existing_run.attempt "
+                "THEN EXCLUDED.status WHEN EXCLUDED.attempt < existing_run.attempt "
+                "THEN existing_run.status WHEN existing_run.status IN "
+                "('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
+                "THEN existing_run.status ELSE EXCLUDED.status END",
                 "finished_at = COALESCE(EXCLUDED.finished_at, existing_run.finished_at)",
                 "failure_summary = COALESCE(EXCLUDED.failure_summary, existing_run.failure_summary)",
                 "evidence_completeness = CASE WHEN existing_run.evidence_completeness IN "
@@ -364,15 +367,16 @@ class _SqlRunEvidenceStore:
             "(stage_id, project_id, run_id, stage_type, provider, tool, asset, attempt, status, "
             "started_at, finished_at, metrics, error, record_checksum) VALUES ("
             + ", ".join([self.placeholder] * len(values))
-            + ") ON CONFLICT (project_id, stage_id) DO NOTHING",
+            + ") ON CONFLICT (project_id, run_id, stage_id) DO NOTHING",
             values,
         )
         if cursor.rowcount == 1:
             return
         cursor.execute(
             f"SELECT run_id, record_checksum FROM {self._table('run_stage')} "
-            f"WHERE project_id = {self.placeholder} AND stage_id = {self.placeholder}",
-            (stage.project_id, stage.stage_id),
+            f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder} "
+            f"AND stage_id = {self.placeholder}",
+            (stage.project_id, stage.run_id, stage.stage_id),
         )
         existing = cursor.fetchone()
         if existing is None or existing[0] != stage.run_id or existing[1] != immutable_checksum:
@@ -385,7 +389,7 @@ class _SqlRunEvidenceStore:
             f"WHEN status IN ('success', 'failed', 'error', 'cancelled', 'canceled', 'skipped') "
             f"AND {p} IN ('running', 'observed') THEN status ELSE {p} END, "
             f"finished_at = COALESCE(finished_at, {p}), metrics = {p}, error = COALESCE({p}, error) "
-            f"WHERE project_id = {p} AND stage_id = {p}",
+            f"WHERE project_id = {p} AND run_id = {p} AND stage_id = {p}",
             (
                 stage.status,
                 stage.status,
@@ -393,6 +397,7 @@ class _SqlRunEvidenceStore:
                 _json(stage.metrics),
                 _text(stage.error),
                 stage.project_id,
+                stage.run_id,
                 stage.stage_id,
             ),
         )
@@ -428,7 +433,7 @@ class _SqlRunEvidenceStore:
             "table_name, catalog, ref_name, schema_hash, watermark, record_count, byte_count, "
             "staged_objects, snapshot_before, snapshot_after, record_checksum) VALUES ("
             + ", ".join([self.placeholder] * len(values))
-            + ") ON CONFLICT (project_id, resource_id) DO NOTHING",
+            + ") ON CONFLICT (project_id, run_id, resource_id) DO NOTHING",
             values,
         )
         if cursor.rowcount != 1:
@@ -464,7 +469,7 @@ class _SqlRunEvidenceStore:
             "(lineage_edge_id, project_id, run_id, source, target, column_mapping, origin, "
             "derivation, confidence, record_checksum) VALUES ("
             + ", ".join([self.placeholder] * len(values))
-            + ") ON CONFLICT (project_id, lineage_edge_id) DO NOTHING",
+            + ") ON CONFLICT (project_id, run_id, lineage_edge_id) DO NOTHING",
             values,
         )
         if cursor.rowcount != 1:
@@ -491,8 +496,8 @@ class _SqlRunEvidenceStore:
             _text(result.check_id),
             _text(result.asset),
             _text(result.severity),
-            int(result.blocking),
-            int(result.passed),
+            result.blocking,
+            result.passed,
             result.evaluated_count,
             result.failed_count,
             _text(result.failure_artifact_id),
@@ -504,7 +509,7 @@ class _SqlRunEvidenceStore:
             "(quality_result_id, project_id, run_id, stage_id, check_id, asset, severity, blocking, "
             "passed, evaluated_count, failed_count, failure_artifact_id, metadata, record_checksum) VALUES ("
             + ", ".join([self.placeholder] * len(values))
-            + ") ON CONFLICT (project_id, quality_result_id) DO NOTHING",
+            + ") ON CONFLICT (project_id, run_id, quality_result_id) DO NOTHING",
             values,
         )
         if cursor.rowcount != 1:
@@ -546,7 +551,7 @@ class _SqlRunEvidenceStore:
             "source_hash, target_hash, commit_hash, commit_message, merge_outcome, snapshot_before, "
             "snapshot_after, metadata, record_checksum) VALUES ("
             + ", ".join([self.placeholder] * len(values))
-            + ") ON CONFLICT (project_id, catalog_change_id) DO NOTHING",
+            + ") ON CONFLICT (project_id, run_id, catalog_change_id) DO NOTHING",
             values,
         )
         if cursor.rowcount != 1:
@@ -575,7 +580,7 @@ class _SqlRunEvidenceStore:
             _text(artifact.checksum),
             _text(artifact.retention_class),
             _timestamp(artifact.expires_at),
-            int(artifact.legal_hold),
+            artifact.legal_hold,
             artifact.status.value,
             record_checksum,
         )
@@ -584,7 +589,7 @@ class _SqlRunEvidenceStore:
             "(artifact_id, project_id, run_id, artifact_kind, uri, content_type, checksum, "
             "retention_class, expires_at, legal_hold, status, record_checksum) VALUES ("
             + ", ".join([self.placeholder] * len(values))
-            + ") ON CONFLICT (project_id, artifact_id) DO NOTHING",
+            + ") ON CONFLICT (project_id, run_id, artifact_id) DO NOTHING",
             values,
         )
         if cursor.rowcount != 1:
@@ -623,8 +628,9 @@ class _SqlRunEvidenceStore:
     ) -> None:
         cursor.execute(
             f"SELECT run_id, record_checksum FROM {self._table(table)} "
-            f"WHERE project_id = {self.placeholder} AND {id_column} = {self.placeholder}",
-            (project_id, record_id),
+            f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder} "
+            f"AND {id_column} = {self.placeholder}",
+            (project_id, run_id, record_id),
         )
         existing = cursor.fetchone()
         if existing is None or existing[0] != run_id or existing[1] != checksum:

--- a/src/phlo/sql/002_create_run_evidence.sql
+++ b/src/phlo/sql/002_create_run_evidence.sql
@@ -64,8 +64,7 @@ CREATE TABLE IF NOT EXISTS phlo.run_stage (
     metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
     error TEXT,
     record_checksum TEXT NOT NULL,
-    PRIMARY KEY (project_id, stage_id),
-    UNIQUE (project_id, run_id, stage_id),
+    PRIMARY KEY (project_id, run_id, stage_id),
     FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
 );
 
@@ -88,7 +87,7 @@ CREATE TABLE IF NOT EXISTS phlo.run_resource (
     snapshot_before TEXT,
     snapshot_after TEXT,
     record_checksum TEXT NOT NULL,
-    PRIMARY KEY (project_id, resource_id),
+    PRIMARY KEY (project_id, run_id, resource_id),
     FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
 );
 
@@ -103,7 +102,7 @@ CREATE TABLE IF NOT EXISTS phlo.run_lineage_edge (
     derivation TEXT NOT NULL,
     confidence DOUBLE PRECISION,
     record_checksum TEXT NOT NULL,
-    PRIMARY KEY (project_id, lineage_edge_id),
+    PRIMARY KEY (project_id, run_id, lineage_edge_id),
     FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
 );
 
@@ -123,7 +122,7 @@ CREATE TABLE IF NOT EXISTS phlo.run_catalog_change (
     snapshot_after TEXT,
     metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
     record_checksum TEXT NOT NULL,
-    PRIMARY KEY (project_id, catalog_change_id),
+    PRIMARY KEY (project_id, run_id, catalog_change_id),
     FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
 );
 
@@ -140,8 +139,7 @@ CREATE TABLE IF NOT EXISTS phlo.run_artifact (
     legal_hold BOOLEAN NOT NULL DEFAULT FALSE,
     status TEXT NOT NULL CHECK (status IN ('complete', 'incomplete', 'missing', 'expired', 'redacted')),
     record_checksum TEXT NOT NULL,
-    PRIMARY KEY (project_id, artifact_id),
-    UNIQUE (project_id, run_id, artifact_id),
+    PRIMARY KEY (project_id, run_id, artifact_id),
     FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
 );
 
@@ -160,7 +158,7 @@ CREATE TABLE IF NOT EXISTS phlo.run_quality_result (
     failure_artifact_id TEXT,
     metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
     record_checksum TEXT NOT NULL,
-    PRIMARY KEY (project_id, quality_result_id),
+    PRIMARY KEY (project_id, run_id, quality_result_id),
     FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id),
     FOREIGN KEY (project_id, run_id, stage_id)
         REFERENCES phlo.run_stage(project_id, run_id, stage_id)

--- a/src/phlo/sql/002_create_run_evidence.sql
+++ b/src/phlo/sql/002_create_run_evidence.sql
@@ -1,0 +1,191 @@
+-- Run-evidence schema version 1. PostgreSQL is the production dialect.
+CREATE SCHEMA IF NOT EXISTS phlo;
+
+CREATE TABLE IF NOT EXISTS phlo.run_evidence_schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS phlo.pipeline_run (
+    project_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    pipeline_name TEXT,
+    provider_run_id TEXT,
+    trigger TEXT,
+    initiator TEXT,
+    effective_identity TEXT,
+    partition_key TEXT,
+    code_version TEXT,
+    config_version TEXT,
+    attempt INTEGER NOT NULL DEFAULT 1 CHECK (attempt > 0),
+    trace_id TEXT,
+    status TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL,
+    finished_at TIMESTAMPTZ,
+    failure_summary TEXT,
+    evidence_completeness TEXT NOT NULL CHECK (
+        evidence_completeness IN ('complete', 'incomplete', 'missing', 'expired', 'redacted')
+    ),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (project_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS phlo.run_event (
+    id BIGSERIAL PRIMARY KEY,
+    project_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    stage_id TEXT,
+    event_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    schema_version TEXT NOT NULL,
+    producer TEXT NOT NULL,
+    observed_at TIMESTAMPTZ NOT NULL,
+    sequence BIGINT,
+    payload JSONB NOT NULL,
+    payload_checksum TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (project_id, producer, event_id),
+    FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS phlo.run_stage (
+    project_id TEXT NOT NULL,
+    stage_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    stage_type TEXT NOT NULL,
+    provider TEXT,
+    tool TEXT,
+    asset TEXT,
+    attempt INTEGER NOT NULL DEFAULT 1 CHECK (attempt > 0),
+    status TEXT NOT NULL,
+    started_at TIMESTAMPTZ,
+    finished_at TIMESTAMPTZ,
+    metrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+    error TEXT,
+    record_checksum TEXT NOT NULL,
+    PRIMARY KEY (project_id, stage_id),
+    UNIQUE (project_id, run_id, stage_id),
+    FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS phlo.run_resource (
+    project_id TEXT NOT NULL,
+    resource_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    resource_kind TEXT NOT NULL,
+    role TEXT NOT NULL,
+    normalized_identity TEXT,
+    uri TEXT,
+    table_name TEXT,
+    catalog TEXT,
+    ref_name TEXT,
+    schema_hash TEXT,
+    watermark TEXT,
+    record_count BIGINT,
+    byte_count BIGINT,
+    staged_objects JSONB NOT NULL DEFAULT '[]'::jsonb,
+    snapshot_before TEXT,
+    snapshot_after TEXT,
+    record_checksum TEXT NOT NULL,
+    PRIMARY KEY (project_id, resource_id),
+    FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS phlo.run_lineage_edge (
+    project_id TEXT NOT NULL,
+    lineage_edge_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    source TEXT NOT NULL,
+    target TEXT NOT NULL,
+    column_mapping JSONB NOT NULL DEFAULT '{}'::jsonb,
+    origin TEXT NOT NULL,
+    derivation TEXT NOT NULL,
+    confidence DOUBLE PRECISION,
+    record_checksum TEXT NOT NULL,
+    PRIMARY KEY (project_id, lineage_edge_id),
+    FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS phlo.run_catalog_change (
+    project_id TEXT NOT NULL,
+    catalog_change_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    catalog_ref TEXT,
+    content_key TEXT,
+    operation TEXT NOT NULL,
+    source_hash TEXT,
+    target_hash TEXT,
+    commit_hash TEXT,
+    commit_message TEXT,
+    merge_outcome TEXT,
+    snapshot_before TEXT,
+    snapshot_after TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    record_checksum TEXT NOT NULL,
+    PRIMARY KEY (project_id, catalog_change_id),
+    FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS phlo.run_artifact (
+    project_id TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    artifact_kind TEXT NOT NULL,
+    uri TEXT,
+    content_type TEXT,
+    checksum TEXT,
+    retention_class TEXT,
+    expires_at TIMESTAMPTZ,
+    legal_hold BOOLEAN NOT NULL DEFAULT FALSE,
+    status TEXT NOT NULL CHECK (status IN ('complete', 'incomplete', 'missing', 'expired', 'redacted')),
+    record_checksum TEXT NOT NULL,
+    PRIMARY KEY (project_id, artifact_id),
+    UNIQUE (project_id, run_id, artifact_id),
+    FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS phlo.run_quality_result (
+    project_id TEXT NOT NULL,
+    quality_result_id TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    stage_id TEXT,
+    check_id TEXT NOT NULL,
+    asset TEXT,
+    severity TEXT,
+    blocking BOOLEAN NOT NULL DEFAULT FALSE,
+    passed BOOLEAN NOT NULL,
+    evaluated_count BIGINT,
+    failed_count BIGINT,
+    failure_artifact_id TEXT,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    record_checksum TEXT NOT NULL,
+    PRIMARY KEY (project_id, quality_result_id),
+    FOREIGN KEY (project_id, run_id) REFERENCES phlo.pipeline_run(project_id, run_id),
+    FOREIGN KEY (project_id, run_id, stage_id)
+        REFERENCES phlo.run_stage(project_id, run_id, stage_id)
+        DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (project_id, run_id, failure_artifact_id)
+        REFERENCES phlo.run_artifact(project_id, run_id, artifact_id)
+        DEFERRABLE INITIALLY DEFERRED
+);
+
+INSERT INTO phlo.run_evidence_schema_version(version) VALUES (1)
+ON CONFLICT (version) DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_run_project_started
+    ON phlo.pipeline_run(project_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_run_event_project_run_observed
+    ON phlo.run_event(project_id, run_id, observed_at);
+CREATE INDEX IF NOT EXISTS idx_run_stage_project_run
+    ON phlo.run_stage(project_id, run_id);
+CREATE INDEX IF NOT EXISTS idx_run_resource_project_run
+    ON phlo.run_resource(project_id, run_id);
+CREATE INDEX IF NOT EXISTS idx_run_lineage_project_run
+    ON phlo.run_lineage_edge(project_id, run_id);
+CREATE INDEX IF NOT EXISTS idx_run_quality_project_run
+    ON phlo.run_quality_result(project_id, run_id);
+CREATE INDEX IF NOT EXISTS idx_run_catalog_project_run
+    ON phlo.run_catalog_change(project_id, run_id);
+CREATE INDEX IF NOT EXISTS idx_run_artifact_project_run
+    ON phlo.run_artifact(project_id, run_id);

--- a/tests/observability/test_hook_emitters.py
+++ b/tests/observability/test_hook_emitters.py
@@ -24,6 +24,7 @@ from phlo.hooks.emitters import (
     TransformEventContext,
     TransformEventEmitter,
 )
+from phlo.hooks.events import HookCorrelation
 from phlo.logging import bind_context, clear_context
 from tests.helpers import RecordingBus
 
@@ -56,6 +57,27 @@ def test_ingestion_emitter_merges_bound_correlation_context() -> None:
     assert event.correlation.job_name == "daily_orders"
     assert event.correlation.trace_id == "abc123"
     assert event.correlation.span_id == "def456"
+
+
+def test_emitter_preserves_integer_attempt_after_correlation_merge() -> None:
+    bus = RecordingBus()
+    emitter = IngestionEventEmitter(
+        IngestionEventContext(
+            asset_key="silver.orders",
+            table_name="orders",
+            group_name="sales",
+            correlation=HookCorrelation(run_id="run-123", attempt=2),
+        ),
+        hook_bus=bus,
+    )
+
+    emitter.emit_start()
+
+    assert bus.events[0].correlation.attempt == 2
+    assert isinstance(bus.events[0].correlation.attempt, int)
+    assert HookCorrelation(attempt="2").attempt == 2
+    with pytest.raises(ValueError, match="positive integer"):
+        HookCorrelation(attempt=0)
 
 
 def test_transform_emitter_merges_bound_correlation_context() -> None:

--- a/tests/observability/test_run_evidence.py
+++ b/tests/observability/test_run_evidence.py
@@ -226,6 +226,122 @@ def test_child_ids_are_project_scoped_and_cross_run_quality_refs_fail() -> None:
         )
 
 
+def test_same_project_child_ids_are_scoped_to_each_run() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    for run_id in ("one", "two"):
+        store.append_pipeline_run(PipelineRun(project_id="project", run_id=run_id))
+
+    store.append_stage(
+        RunStage(project_id="project", run_id="one", stage_id="same", stage_type="ingest")
+    )
+    store.append_stage(
+        RunStage(project_id="project", run_id="two", stage_id="same", stage_type="ingest")
+    )
+    store.append_resource(
+        RunResource(project_id="project", run_id="one", resource_id="same", uri="one")
+    )
+    store.append_resource(
+        RunResource(project_id="project", run_id="two", resource_id="same", uri="two")
+    )
+    store.append_lineage_edge(
+        RunLineageEdge(
+            project_id="project", run_id="one", lineage_edge_id="same", source="a", target="b"
+        )
+    )
+    store.append_lineage_edge(
+        RunLineageEdge(
+            project_id="project", run_id="two", lineage_edge_id="same", source="a", target="c"
+        )
+    )
+    store.append_quality_result(
+        RunQualityResult(
+            project_id="project", run_id="one", quality_result_id="same", check_id="one"
+        )
+    )
+    store.append_quality_result(
+        RunQualityResult(
+            project_id="project", run_id="two", quality_result_id="same", check_id="two"
+        )
+    )
+    store.append_catalog_change(
+        RunCatalogChange(
+            project_id="project", run_id="one", catalog_change_id="same", operation="commit"
+        )
+    )
+    store.append_catalog_change(
+        RunCatalogChange(
+            project_id="project", run_id="two", catalog_change_id="same", operation="merge"
+        )
+    )
+    store.append_artifact(
+        RunArtifact(project_id="project", run_id="one", artifact_id="same", artifact_kind="log")
+    )
+    store.append_artifact(
+        RunArtifact(
+            project_id="project", run_id="two", artifact_id="same", artifact_kind="manifest"
+        )
+    )
+
+    with store._transaction() as (_, cursor):
+        for table in (
+            "run_stage",
+            "run_resource",
+            "run_lineage_edge",
+            "run_quality_result",
+            "run_catalog_change",
+            "run_artifact",
+        ):
+            cursor.execute(f"SELECT COUNT(*) FROM {table} WHERE project_id = ?", ("project",))
+            assert cursor.fetchone()[0] == 2, table
+
+
+def test_child_primary_keys_include_project_and_run() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    expected = {
+        "run_stage": ["project_id", "run_id", "stage_id"],
+        "run_resource": ["project_id", "run_id", "resource_id"],
+        "run_lineage_edge": ["project_id", "run_id", "lineage_edge_id"],
+        "run_quality_result": ["project_id", "run_id", "quality_result_id"],
+        "run_catalog_change": ["project_id", "run_id", "catalog_change_id"],
+        "run_artifact": ["project_id", "run_id", "artifact_id"],
+    }
+    with store._transaction() as (_, cursor):
+        for table, columns in expected.items():
+            cursor.execute(f"PRAGMA table_info({table})")
+            primary_key = [
+                row[1] for row in sorted(cursor.fetchall(), key=lambda row: row[5]) if row[5]
+            ]
+            assert primary_key == columns, table
+
+
+def test_run_attempt_and_terminal_status_are_monotonic() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    store.append_pipeline_run(
+        PipelineRun(project_id="project", run_id="run", attempt=1, status="failed")
+    )
+    store.append_pipeline_run(
+        PipelineRun(project_id="project", run_id="run", attempt=2, status="running")
+    )
+    store.append_pipeline_run(
+        PipelineRun(project_id="project", run_id="run", attempt=2, status="success")
+    )
+
+    row = store.get_run("project", "run")
+    assert row["attempt"] == 2
+    assert row["status"] == "success"
+
+    store.append_pipeline_run(
+        PipelineRun(project_id="project", run_id="run", attempt=1, status="failed")
+    )
+    store.append_pipeline_run(
+        PipelineRun(project_id="project", run_id="run", attempt=2, status="failed")
+    )
+
+    row = store.get_run("project", "run")
+    assert row["attempt"] == 2
+    assert row["status"] == "success"
+
+
 def test_previous_event_schema_version_remains_readable() -> None:
     store = _store_with_run()
     assert store.append_event(_event(payload={"value": 1}, event_id="old")) is True

--- a/tests/observability/test_run_evidence.py
+++ b/tests/observability/test_run_evidence.py
@@ -1,0 +1,404 @@
+"""Focused tests for the versioned run-evidence contract and sink."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+
+import pytest
+
+from phlo.hooks.emitters import (
+    IngestionEventContext,
+    IngestionEventEmitter,
+    LineageEventContext,
+    LineageEventEmitter,
+    QualityResultEventContext,
+    QualityResultEventEmitter,
+)
+from phlo.hooks.events import (
+    HookCorrelation,
+    IngestionEvent,
+    LineageEvent,
+    PublishEvent,
+    QualityResultEvent,
+    TransformEvent,
+)
+from phlo.run_evidence import (
+    RUN_EVIDENCE_SCHEMA_VERSION,
+    IdempotencyConflict,
+    PipelineRun,
+    RunArtifact,
+    RunCatalogChange,
+    RunEvent,
+    RunLineageEdge,
+    RunQualityResult,
+    RunResource,
+    RunStage,
+    SQLiteRunEvidenceStore,
+    default_run_evidence_store,
+)
+from phlo.run_evidence.hooks import CoreRunEvidenceHookProvider
+
+
+def _store_with_run(*, project_id: str = "project", run_id: str = "run") -> SQLiteRunEvidenceStore:
+    store = SQLiteRunEvidenceStore(":memory:")
+    store.append_pipeline_run(PipelineRun(project_id=project_id, run_id=run_id))
+    return store
+
+
+def _event(*, payload: dict, event_id: str = "event", producer: str = "producer") -> RunEvent:
+    return RunEvent(
+        project_id="project",
+        run_id="run",
+        event_id=event_id,
+        event_type="ingestion.start",
+        producer=producer,
+        payload=payload,
+    )
+
+
+def test_event_append_is_redacted_checksumed_and_idempotent() -> None:
+    store = _store_with_run()
+    event = _event(payload={"nested": {"token": "secret", "value": 1}})
+
+    assert store.append_event(event) is True
+    replay = replace(event, payload={"nested": {"value": 1, "token": "another-secret"}})
+    assert store.append_event(replay) is False
+
+    row = store.list_events("project", "run")[0]
+    assert "secret" not in row["payload"]
+    assert "<redacted>" in row["payload"]
+    assert row["schema_version"] == "1.0"
+
+
+def test_event_identity_is_scoped_by_project_and_producer() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    store.append_pipeline_run(PipelineRun(project_id="one", run_id="same"))
+    store.append_pipeline_run(PipelineRun(project_id="two", run_id="same"))
+    first = replace(_event(payload={"value": 1}), project_id="one", run_id="same")
+
+    assert store.append_event(first, run=PipelineRun(project_id="one", run_id="same")) is True
+    assert (
+        store.append_event(
+            replace(first, project_id="two", run_id="same"),
+            run=PipelineRun(project_id="two", run_id="same"),
+        )
+        is True
+    )
+    assert store.append_event(replace(first, producer="other")) is True
+
+
+def test_event_payload_conflict_rolls_back_and_preserves_original() -> None:
+    store = _store_with_run()
+    event = _event(payload={"value": 1})
+    store.append_event(event)
+
+    with pytest.raises(IdempotencyConflict):
+        store.append_event(replace(event, payload={"value": 2}))
+
+    assert store.list_events("project", "run")[0]["payload"] == '{"value":1}'
+
+
+def test_event_and_derived_rows_share_one_transaction(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = _store_with_run()
+    stage = RunStage(project_id="project", run_id="run", stage_id="stage", stage_type="ingest")
+
+    def fail_after_event(*_args, **_kwargs) -> None:
+        raise RuntimeError("failpoint")
+
+    monkeypatch.setattr(store, "_insert_stage", fail_after_event)
+    with pytest.raises(RuntimeError, match="failpoint"):
+        store.append_event(_event(payload={"value": 1}), stage=stage)
+
+    assert store.count_events("project", "run") == 0
+    monkeypatch.setattr(store, "_insert_stage", SQLiteRunEvidenceStore._insert_stage.__get__(store))
+    assert store.append_event(_event(payload={"value": 1}), stage=stage) is True
+
+
+@pytest.mark.parametrize(
+    ("family", "first", "different"),
+    [
+        (
+            "stage",
+            RunStage(project_id="project", run_id="run", stage_id="stable", stage_type="ingest"),
+            RunStage(project_id="project", run_id="run", stage_id="stable", stage_type="transform"),
+        ),
+        (
+            "resource",
+            RunResource(project_id="project", run_id="run", resource_id="stable", uri="a"),
+            RunResource(project_id="project", run_id="run", resource_id="stable", uri="b"),
+        ),
+        (
+            "lineage",
+            RunLineageEdge(
+                project_id="project", run_id="run", lineage_edge_id="stable", source="a", target="b"
+            ),
+            RunLineageEdge(
+                project_id="project", run_id="run", lineage_edge_id="stable", source="a", target="c"
+            ),
+        ),
+        (
+            "quality",
+            RunQualityResult(
+                project_id="project",
+                run_id="run",
+                quality_result_id="stable",
+                check_id="check",
+                passed=True,
+            ),
+            RunQualityResult(
+                project_id="project",
+                run_id="run",
+                quality_result_id="stable",
+                check_id="other",
+                passed=True,
+            ),
+        ),
+        (
+            "catalog",
+            RunCatalogChange(
+                project_id="project", run_id="run", catalog_change_id="stable", operation="commit"
+            ),
+            RunCatalogChange(
+                project_id="project", run_id="run", catalog_change_id="stable", operation="merge"
+            ),
+        ),
+        (
+            "artifact",
+            RunArtifact(
+                project_id="project", run_id="run", artifact_id="stable", artifact_kind="log"
+            ),
+            RunArtifact(
+                project_id="project", run_id="run", artifact_id="stable", artifact_kind="manifest"
+            ),
+        ),
+    ],
+)
+def test_normalized_records_are_idempotent_and_conflict_on_content(
+    family, first, different
+) -> None:
+    store = _store_with_run()
+    append = getattr(
+        store,
+        f"append_{'lineage_edge' if family == 'lineage' else 'quality_result' if family == 'quality' else 'catalog_change' if family == 'catalog' else family}",
+    )
+
+    append(first)
+    append(first)
+    with pytest.raises(IdempotencyConflict):
+        append(different)
+
+
+def test_child_ids_are_project_scoped_and_cross_run_quality_refs_fail() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    store.append_pipeline_run(PipelineRun(project_id="project", run_id="one"))
+    store.append_pipeline_run(PipelineRun(project_id="project", run_id="two"))
+    store.append_pipeline_run(PipelineRun(project_id="other", run_id="one"))
+    store.append_stage(
+        RunStage(project_id="project", run_id="one", stage_id="same", stage_type="ingest")
+    )
+    store.append_stage(
+        RunStage(project_id="other", run_id="one", stage_id="same", stage_type="ingest")
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        store.append_quality_result(
+            RunQualityResult(
+                project_id="project",
+                run_id="two",
+                quality_result_id="quality",
+                check_id="check",
+                stage_id="same",
+            )
+        )
+    store.append_artifact(
+        RunArtifact(project_id="project", run_id="one", artifact_id="artifact", artifact_kind="log")
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        store.append_quality_result(
+            RunQualityResult(
+                project_id="project",
+                run_id="two",
+                quality_result_id="quality-artifact",
+                check_id="check",
+                failure_artifact_id="artifact",
+            )
+        )
+
+
+def test_previous_event_schema_version_remains_readable() -> None:
+    store = _store_with_run()
+    assert store.append_event(_event(payload={"value": 1}, event_id="old")) is True
+    store.append_event(
+        replace(_event(payload={"value": 2}, event_id="previous"), schema_version="0.9")
+    )
+    assert store.list_events("project", "run")[-1]["schema_version"] == "0.9"
+
+
+def test_sqlite_migration_is_versioned_and_idempotent() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    store._initialize_schema()
+    store._initialize_schema()
+    with store._transaction() as (_, cursor):
+        cursor.execute("SELECT version FROM run_evidence_schema_version")
+        assert [row[0] for row in cursor.fetchall()] == [RUN_EVIDENCE_SCHEMA_VERSION]
+
+
+def test_core_sink_records_all_correlated_lifecycle_families() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    provider = CoreRunEvidenceHookProvider(store)
+    correlation = HookCorrelation(project_id="project", run_id="run", job_name="job")
+    events = [
+        IngestionEvent(
+            event_type="ingestion.start",
+            asset_key="raw",
+            table_name="raw",
+            group_name="raw",
+            correlation=correlation,
+        ),
+        TransformEvent(
+            event_type="transform.start", tool="dbt", asset_key="model", correlation=correlation
+        ),
+        QualityResultEvent(
+            event_type="quality.result",
+            asset_key="model",
+            check_name="valid",
+            passed=True,
+            correlation=correlation,
+        ),
+        PublishEvent(
+            event_type="publish.end", asset_key="model", status="success", correlation=correlation
+        ),
+        LineageEvent(event_type="lineage.edges", edges=[("raw", "model")], correlation=correlation),
+    ]
+
+    for event in events:
+        provider._handle_event(event)
+
+    assert store.count_events("project", "run") == 5
+    assert store.get_run("project", "run")["evidence_completeness"] == "incomplete"
+
+
+def test_standard_emitter_reconstructs_same_event_identity_for_retry() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    provider = CoreRunEvidenceHookProvider(store)
+    context = IngestionEventContext(
+        asset_key="raw",
+        table_name="raw",
+        group_name="raw",
+        project_id="project",
+        run_id="run",
+    )
+
+    first_bus = type("Bus", (), {"emit": lambda self, event: provider._handle_event(event)})()
+    IngestionEventEmitter(context, hook_bus=first_bus).emit_start()
+    IngestionEventEmitter(context, hook_bus=first_bus).emit_start()
+
+    assert store.count_events("project", "run") == 1
+
+
+def test_production_requires_postgres_run_evidence_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PHLO_ENVIRONMENT", "production")
+    monkeypatch.delenv("PHLO_RUN_EVIDENCE_DB_URL", raising=False)
+    monkeypatch.delenv("PHLO_RUN_EVIDENCE_SQLITE_PATH", raising=False)
+
+    with pytest.raises(RuntimeError, match="requires PHLO_RUN_EVIDENCE_DB_URL"):
+        default_run_evidence_store()
+
+
+def test_incomplete_correlation_is_not_persisted() -> None:
+    provider = CoreRunEvidenceHookProvider(SQLiteRunEvidenceStore(":memory:"))
+    provider._handle_event(
+        IngestionEvent(
+            event_type="ingestion.start",
+            asset_key="raw",
+            table_name="raw",
+            group_name="raw",
+            correlation=HookCorrelation(run_id="run"),
+        )
+    )
+    assert provider._store is not None
+    assert provider._store.get_run("unknown", "run") is None
+
+
+def test_quality_and_lineage_identities_include_logical_operation() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    provider = CoreRunEvidenceHookProvider(store)
+    correlation = HookCorrelation(project_id="project", run_id="run", trace_id="trace-a")
+    quality = QualityResultEventContext(
+        asset_key="model", project_id="project", run_id="run", correlation=correlation
+    )
+    quality_bus = type("Bus", (), {"emit": lambda self, event: provider._handle_event(event)})()
+    QualityResultEventEmitter(quality, hook_bus=quality_bus).emit_result(
+        check_name="nulls", passed=True
+    )
+    QualityResultEventEmitter(quality, hook_bus=quality_bus).emit_result(
+        check_name="uniqueness", passed=True
+    )
+    retry_quality = replace(correlation, trace_id="trace-b")
+    QualityResultEventEmitter(
+        replace(quality, correlation=retry_quality), hook_bus=quality_bus
+    ).emit_result(check_name="nulls", passed=True)
+
+    lineage = LineageEventContext(project_id="project", run_id="run", correlation=correlation)
+    lineage_emitter = LineageEventEmitter(lineage, hook_bus=quality_bus)
+    lineage_emitter.emit_edges(edges=[("a", "b")], operation_id="batch-1")
+    lineage_emitter.emit_edges(edges=[("a", "b")], operation_id="batch-2")
+
+    assert store.count_events("project", "run") == 4
+    assert store.get_run("project", "run")["trace_id"] == "trace-a"
+
+
+def test_correlated_lineage_requires_explicit_operation_identity() -> None:
+    emitter = LineageEventEmitter(
+        LineageEventContext(
+            project_id="project",
+            run_id="run",
+            correlation=HookCorrelation(project_id="project", run_id="run"),
+        ),
+        hook_bus=type("Bus", (), {"emit": lambda self, event: None})(),
+    )
+    with pytest.raises(ValueError, match="operation_id or event_id"):
+        emitter.emit_edges(edges=[("a", "b")])
+
+
+def test_retry_attempts_get_distinct_stage_evidence() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    provider = CoreRunEvidenceHookProvider(store)
+    for attempt in (1, 2):
+        provider._handle_event(
+            IngestionEvent(
+                event_type="ingestion.end",
+                asset_key="raw",
+                table_name="raw",
+                group_name="raw",
+                status="failed" if attempt == 1 else "success",
+                correlation=HookCorrelation(project_id="project", run_id="run", attempt=attempt),
+            )
+        )
+
+    with store._transaction() as (_, cursor):
+        cursor.execute(
+            "SELECT COUNT(*) FROM run_stage WHERE project_id = ? AND run_id = ?", ("project", "run")
+        )
+        assert cursor.fetchone()[0] == 2
+
+
+def test_normalized_resource_payload_is_redacted() -> None:
+    store = _store_with_run()
+    store.append_resource(
+        RunResource(
+            project_id="project",
+            run_id="run",
+            resource_id="resource",
+            uri="postgresql://user:secret@example.test/db",
+            staged_objects=["s3://access_token=secret/object"],
+        )
+    )
+    with store._transaction() as (_, cursor):
+        cursor.execute(
+            "SELECT uri, staged_objects FROM run_resource WHERE resource_id = ?", ("resource",)
+        )
+        uri, staged_objects = cursor.fetchone()
+    assert "secret" not in uri
+    assert "secret" not in staged_objects

--- a/tests/observability/test_run_evidence.py
+++ b/tests/observability/test_run_evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import replace
+from datetime import UTC, datetime
 
 import pytest
 
@@ -25,6 +26,7 @@ from phlo.hooks.events import (
 )
 from phlo.run_evidence import (
     RUN_EVIDENCE_SCHEMA_VERSION,
+    EvidenceCompleteness,
     IdempotencyConflict,
     PipelineRun,
     RunArtifact,
@@ -342,6 +344,126 @@ def test_run_attempt_and_terminal_status_are_monotonic() -> None:
     assert row["status"] == "success"
 
 
+def test_higher_attempt_replaces_summary_and_late_attempt_is_ignored() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    first_finished = datetime(2026, 7, 13, 12, 0, tzinfo=UTC)
+    second_finished = datetime(2026, 7, 13, 12, 1, tzinfo=UTC)
+    late_first_finished = datetime(2026, 7, 13, 12, 2, tzinfo=UTC)
+    first = PipelineRun(
+        project_id="project",
+        run_id="run",
+        attempt=1,
+        trace_id="trace-one",
+        effective_identity="identity-one",
+        code_version="code-one",
+        config_version="config-one",
+        status="failed",
+        finished_at=first_finished,
+        failure_summary="first failure",
+        evidence_completeness=EvidenceCompleteness.COMPLETE,
+    )
+    second_running = replace(
+        first,
+        attempt=2,
+        trace_id="trace-two",
+        effective_identity="identity-two",
+        code_version="code-two",
+        config_version="config-two",
+        status="running",
+        finished_at=None,
+        failure_summary=None,
+        evidence_completeness=EvidenceCompleteness.INCOMPLETE,
+    )
+    store.append_pipeline_run(first)
+    store.append_pipeline_run(second_running)
+
+    row = store.get_run("project", "run")
+    assert (
+        row["attempt"],
+        row["status"],
+        row["trace_id"],
+        row["effective_identity"],
+        row["code_version"],
+        row["config_version"],
+    ) == (2, "running", "trace-two", "identity-two", "code-two", "config-two")
+    assert row["finished_at"] is None
+    assert row["failure_summary"] is None
+    assert row["evidence_completeness"] == EvidenceCompleteness.INCOMPLETE
+
+    store.append_pipeline_run(
+        replace(
+            second_running,
+            status="success",
+            finished_at=second_finished,
+            evidence_completeness=EvidenceCompleteness.COMPLETE,
+        )
+    )
+    store.append_pipeline_run(
+        replace(
+            first,
+            trace_id="late-trace-one",
+            effective_identity="late-identity-one",
+            code_version="late-code-one",
+            config_version="late-config-one",
+            finished_at=late_first_finished,
+            failure_summary="late first failure",
+            evidence_completeness=EvidenceCompleteness.REDACTED,
+        )
+    )
+
+    row = store.get_run("project", "run")
+    assert (
+        row["attempt"],
+        row["status"],
+        row["trace_id"],
+        row["effective_identity"],
+        row["code_version"],
+        row["config_version"],
+    ) == (2, "success", "trace-two", "identity-two", "code-two", "config-two")
+    assert row["finished_at"] == second_finished.isoformat()
+    assert row["failure_summary"] is None
+    assert row["evidence_completeness"] == EvidenceCompleteness.COMPLETE
+
+
+def test_terminal_stage_status_and_metadata_are_sticky() -> None:
+    store = _store_with_run()
+    first_finished = datetime(2026, 7, 13, 12, 0, tzinfo=UTC)
+    later_finished = datetime(2026, 7, 13, 12, 1, tzinfo=UTC)
+    first = RunStage(
+        project_id="project",
+        run_id="run",
+        stage_id="stage",
+        stage_type="ingest",
+        status="failed",
+        finished_at=first_finished,
+        metrics={"rows": 10, "bytes": 100},
+        error="first failure",
+    )
+    store.append_stage(first)
+    store.append_stage(
+        replace(
+            first,
+            status="success",
+            finished_at=later_finished,
+            metrics={"rows": 20},
+            error="late outcome",
+        )
+    )
+    store.append_stage(replace(first, status="running", finished_at=None, metrics={}, error=None))
+
+    with store._transaction() as (_, cursor):
+        cursor.execute(
+            "SELECT status, finished_at, metrics, error FROM run_stage "
+            "WHERE project_id = ? AND run_id = ? AND stage_id = ?",
+            ("project", "run", "stage"),
+        )
+        row = cursor.fetchone()
+    assert row[0] == "failed"
+    assert row[1] == first_finished.isoformat()
+    assert row[2] == '{"bytes":100,"rows":10}'
+    assert row[3] == "first failure"
+
+
 def test_previous_event_schema_version_remains_readable() -> None:
     store = _store_with_run()
     assert store.append_event(_event(payload={"value": 1}, event_id="old")) is True
@@ -495,9 +617,10 @@ def test_retry_attempts_get_distinct_stage_evidence() -> None:
 
     with store._transaction() as (_, cursor):
         cursor.execute(
-            "SELECT COUNT(*) FROM run_stage WHERE project_id = ? AND run_id = ?", ("project", "run")
+            "SELECT attempt FROM run_stage WHERE project_id = ? AND run_id = ? ORDER BY attempt",
+            ("project", "run"),
         )
-        assert cursor.fetchone()[0] == 2
+        assert [row[0] for row in cursor.fetchall()] == [1, 2]
 
 
 def test_normalized_resource_payload_is_redacted() -> None:


### PR DESCRIPTION
## Summary

This PR establishes the versioned provider-neutral RUN-001/RUN-002 evidence contract and durable local store. It adds project-scoped normalized records for pipeline runs, events, stages, resources, lineage edges, quality results, catalog changes, and artifacts, with PostgreSQL production migrations and a durable SQLite development/test adapter.

The append boundary is transactional and replay-safe: producer/event identities and normalized record IDs are scoped by project, canonical redacted payload checksums detect conflicts, derived rows are not mutated by an already-accepted event replay, and same-run foreign keys protect stage and failure-artifact references. Core ingestion, transform, quality, publish, and lineage hooks now persist correlated events when a project and run identity are present.

Standard emitters carry producer and project/run correlation, derive retry-stable event IDs from logical identity fields, include quality check names, and require explicit lineage operation IDs for repeated lineage batches. Trace/span fields and mutable timestamps are excluded from logical event identity and stored event checksums.

## Roadmap acceptance criteria

- RUN-001: versioned provider-neutral run-evidence models and migration for all eight normalized record families, project-scoped tenant keys, explicit evidence-completeness states, and redaction/checksum fields.
- RUN-002: transactional PostgreSQL adapter plus local SQLite fallback with producer/event idempotency, normalized-record replay/conflict semantics, rollback behavior, and core lifecycle hook ingestion.
- Compatibility and migration coverage includes SQLite migration idempotence, `(project_id, run_id, child_id)` primary-key parity, same-project child IDs reused across runs, composite cross-run reference rejection, stable-ID enforcement, crash/rollback behavior, quality and lineage identity collisions, reconstructed retries with changed tracing context, and monotonic attempt/status transitions.
- Provider-specific instrumentation and Observatory projections remain out of scope for this foundation PR.

## Risk

The new core sink uses `FailurePolicy.RAISE` for durable-write failures so a run cannot appear successful while evidence persistence failed. Legacy events with a run ID but no project ID remain operational but are deliberately skipped because they cannot satisfy tenant-scoped storage keys; local/dev correlated events use the configured durable SQLite fallback, while production, staging, and regulated environments require `PHLO_RUN_EVIDENCE_DB_URL`.

## Security implications

Tenant isolation is encoded in composite primary and foreign keys in both PostgreSQL and SQLite, so identical provider IDs cannot cross project boundaries. Stored payloads and normalized text fields are recursively redacted before canonicalization and persistence; checksums are calculated over the redacted representation, and PostgreSQL credentials were used only for the live smoke test and were not printed or committed.

## Tests and validation

- `make lint-python format-python typecheck-python` — passed; the repository's existing type-check warnings remain non-fatal.
- Focused run-evidence, emitter, and hook tests — `42 passed`.
- Focused dbt, dlt, Sling, and Trino compatibility tests — `46 passed`.
- Full non-integration suite — `2639 passed, 2 skipped, 478 deselected`; two unrelated pre-existing configuration-cache tests fail in `packages/phlo-dbt/tests/test_runtime_config.py` and `packages/phlo-nessie/tests/test_cli_catalog.py` when run in the full suite, while each passes in isolation.
- Authorized live PostgreSQL smoke against the test lakehouse on loopback port 10000 — schema creation, composite-key inspection, replay/no-op, checksum conflict, tenant and dependent-FK isolation, retry metadata, stage attempts/terminal metrics, and cleanup passed; test rows were removed and the shared schema was retained.
