### PR TITLE
feat(observability): add authenticated run reports

### DIFF
--- a/packages/phlo-api/src/phlo_api/main.py
+++ b/packages/phlo-api/src/phlo_api/main.py
@@ -70,6 +70,7 @@ _ROUTERS = [
     ("phlo_api.api.observability", "/api/observability"),
     ("phlo_api.observatory_api.loki", "/api/loki"),
     ("phlo_api.observatory_api.observatory", "/api/observatory"),
+    ("phlo_api.observatory_api.run_report", "/api/observatory"),
 ]
 
 _OBSERVATORY_ROUTERS_NO_PREFIX: list[str] = []

--- a/packages/phlo-api/src/phlo_api/observatory_api/run_report.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/run_report.py
@@ -1,0 +1,26 @@
+"""Authenticated durable run-report endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Path
+
+from phlo.run_evidence.report import RunReport, RunReportNotFound, build_run_report
+from phlo.run_evidence.store import default_run_evidence_store
+
+router = APIRouter(tags=["observatory"])
+
+
+@router.get(
+    "/projects/{project_id}/runs/{run_id}/attempts/{attempt}/report",
+    response_model=RunReport,
+)
+def get_observatory_run_report(
+    project_id: str,
+    run_id: str,
+    attempt: int = Path(..., ge=1),
+) -> RunReport:
+    """Return the durable evidence projection for one exact run attempt."""
+    try:
+        return build_run_report(default_run_evidence_store(), project_id, run_id, attempt)
+    except RunReportNotFound as exc:
+        raise HTTPException(status_code=404, detail={"error": "run_not_found"}) from exc

--- a/packages/phlo-api/src/phlo_api/security_manifest.py
+++ b/packages/phlo-api/src/phlo_api/security_manifest.py
@@ -265,6 +265,12 @@ HTTP_ROUTE_DECLARATIONS: tuple[OperationSpec, ...] = (
         resource_keys=("run_id",),
     ),
     *_specs(
+        ("get_observatory_run_report",),
+        action=CanonicalAction.RUN_READ.value,
+        resource_type="run",
+        resource_keys=("project_id", "run_id", "attempt"),
+    ),
+    *_specs(
         ("post_observatory_run_retry", "post_observatory_run_cancel"),
         action=CanonicalAction.RUN_MANAGE.value,
         resource_type="run",

--- a/packages/phlo-api/tests/test_observatory_api.py
+++ b/packages/phlo-api/tests/test_observatory_api.py
@@ -15,6 +15,7 @@ from phlo.capabilities.registry import CapabilityRegistry
 from phlo.capabilities.specs import CatalogSpec
 from phlo_api.main import app
 from security_test_support import authenticated_client
+from phlo.run_evidence import PipelineRun, RunEvent, RunStage, SQLiteRunEvidenceStore
 from phlo_api.observatory_api import observatory
 from phlo_api.observatory_api import observatory_services
 from phlo_api.observatory_api.observatory import (
@@ -61,6 +62,78 @@ _PROVIDER_URL_SETTING_NAMES = (
     "trinourl",
     "nessieurl",
 )
+
+
+def test_authenticated_run_report_isolated_by_attempt_and_path_identity(
+    monkeypatch, tmp_path
+) -> None:
+    database = tmp_path / "run-evidence.sqlite"
+    store = SQLiteRunEvidenceStore(database)
+    store.append_pipeline_run(PipelineRun(project_id="project", run_id="run", attempt=2))
+    for attempt in (1, 2):
+        store.append_stage(
+            RunStage(
+                project_id="project",
+                run_id="run",
+                stage_id=f"stage-{attempt}",
+                stage_type="ingest",
+                attempt=attempt,
+            )
+        )
+        store.append_event(
+            RunEvent(
+                project_id="project",
+                run_id="run",
+                event_id=f"event-{attempt}",
+                event_type="run.terminal",
+                producer="test",
+                payload={"status": "success"},
+                attempt=attempt,
+            )
+        )
+    monkeypatch.setenv("PHLO_RUN_EVIDENCE_SQLITE_PATH", str(database))
+
+    response = authenticated_client("viewer").get(
+        "/api/observatory/projects/project/runs/run/attempts/1/report"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["attempt"] == 1
+    assert [stage["stage_id"] for stage in response.json()["stages"]] == ["stage-1"]
+
+    assert (
+        TestClient(app)
+        .get("/api/observatory/projects/project/runs/run/attempts/1/report")
+        .status_code
+        == 401
+    )
+    for path in (
+        "/api/observatory/projects/other/runs/run/attempts/1/report",
+        "/api/observatory/projects/project/runs/other/attempts/1/report",
+        "/api/observatory/projects/project/runs/run/attempts/3/report",
+    ):
+        assert authenticated_client("viewer").get(path).status_code == 404
+
+    class _DenyBackend:
+        def explain_decision(self, *_args, **_kwargs):  # noqa: ANN002, ANN003
+            from phlo.capabilities.interfaces import AuthorizationDecision
+
+            return AuthorizationDecision(
+                allowed=False,
+                reason_code="default_deny",
+                policy_id=None,
+                explanation="denied by test",
+            )
+
+    monkeypatch.setattr(
+        "phlo_api.security_manifest.get_authorization_backend", lambda: _DenyBackend()
+    )
+    assert (
+        authenticated_client("viewer")
+        .get("/api/observatory/projects/project/runs/run/attempts/1/report")
+        .status_code
+        == 403
+    )
 
 
 class _FakeOrchestratorOperations:

--- a/packages/phlo-api/tests/test_security_manifest.py
+++ b/packages/phlo-api/tests/test_security_manifest.py
@@ -86,6 +86,12 @@ def test_read_surfaces_use_their_specific_canonical_actions() -> None:
     assert HTTP_ROUTE_MANIFEST["get_observatory_settings"].action == "settings.read"
     assert HTTP_ROUTE_MANIFEST["get_observatory_dataset_workflow_config"].action == "settings.read"
     assert HTTP_ROUTE_MANIFEST["get_observatory_search"].action == "admin.read"
+    assert HTTP_ROUTE_MANIFEST["get_observatory_run_report"].action == "run.read"
+    assert HTTP_ROUTE_MANIFEST["get_observatory_run_report"].resource_keys == (
+        "project_id",
+        "run_id",
+        "attempt",
+    )
     assert HTTP_ROUTE_MANIFEST["get_observatory_row_journey"].resource_keys == (
         "table_id",
         "row_id",

--- a/src/phlo/run_evidence/__init__.py
+++ b/src/phlo/run_evidence/__init__.py
@@ -29,6 +29,12 @@ from phlo.run_evidence.reconciliation import (
     RunReconciler,
     normalize_status,
 )
+from phlo.run_evidence.report import (
+    RunReport,
+    RunReportNotFound,
+    RunReportStore,
+    build_run_report,
+)
 from phlo.run_evidence.store import (
     IdempotencyConflict,
     PostgresRunEvidenceStore,
@@ -52,6 +58,10 @@ __all__ = [
     "RunObservation",
     "RunReconciler",
     "normalize_status",
+    "RunReportNotFound",
+    "RunReportStore",
+    "RunReport",
+    "build_run_report",
     "IdempotencyConflict",
     "PipelineRun",
     "PostgresRunEvidenceStore",

--- a/src/phlo/run_evidence/report.py
+++ b/src/phlo/run_evidence/report.py
@@ -1,0 +1,465 @@
+"""Attempt-scoped, provider-neutral run report projection."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from phlo.run_evidence.reconciliation import TERMINAL_STATUSES, normalize_status
+from phlo.run_evidence.redaction import redact_payload
+
+Scalar = str | int | float | bool | None
+_SAFE_CATALOG_METADATA = frozenset(
+    {
+        "branch",
+        "ref",
+        "nessie_ref",
+        "nessie_hash",
+        "wap",
+        "operation",
+        "source_hash",
+        "target_hash",
+        "merge_outcome",
+        "snapshot_before",
+        "snapshot_after",
+    }
+)
+
+
+class RunReportStore(Protocol):
+    """Read capability required to project one consistent attempt snapshot."""
+
+    def read_run_attempt(self, project_id: str, run_id: str, attempt: int) -> dict[str, Any]: ...
+
+
+class RunReportNotFound(LookupError):
+    """No durable evidence exists for the requested project/run/attempt."""
+
+
+@dataclass(frozen=True)
+class ReportGap:
+    field: str
+    status: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ReportEvent:
+    event_id: str
+    producer: str
+    event_type: str
+    observed_at: str | None
+    sequence: int | None
+    payload_checksum: str | None
+
+
+@dataclass(frozen=True)
+class ReportStage:
+    stage_id: str
+    stage_type: str
+    provider: str | None
+    tool: str | None
+    asset: str | None
+    status: str
+    started_at: str | None
+    finished_at: str | None
+    error_fingerprint: str | None
+
+
+@dataclass(frozen=True)
+class ReportResource:
+    resource_id: str
+    resource_kind: str
+    role: str
+    normalized_identity: str | None
+    uri: str | None
+    table_name: str | None
+    catalog: str | None
+    ref_name: str | None
+    schema_hash: str | None
+    record_count: int | None
+    byte_count: int | None
+    staged_objects: tuple[dict[str, Scalar], ...]
+    snapshot_before: str | None
+    snapshot_after: str | None
+
+
+@dataclass(frozen=True)
+class ReportLineage:
+    lineage_edge_id: str
+    source: str
+    target: str
+    origin: str
+    derivation: str
+
+
+@dataclass(frozen=True)
+class ReportQuality:
+    quality_result_id: str
+    check_id: str
+    asset: str | None
+    stage_id: str | None
+    severity: str | None
+    blocking: bool
+    passed: bool
+    evaluated_count: int | None
+    failed_count: int | None
+    failure_artifact_id: str | None
+
+
+@dataclass(frozen=True)
+class ReportCatalogChange:
+    catalog_change_id: str
+    catalog_ref: str | None
+    content_key: str | None
+    operation: str
+    source_hash: str | None
+    target_hash: str | None
+    commit_hash: str | None
+    merge_outcome: str | None
+    snapshot_before: str | None
+    snapshot_after: str | None
+    metadata: dict[str, Scalar]
+
+
+@dataclass(frozen=True)
+class ReportArtifact:
+    artifact_id: str
+    artifact_kind: str
+    uri: str | None
+    content_type: str | None
+    checksum: str | None
+    expires_at: str | None
+    legal_hold: bool
+    status: str
+
+
+@dataclass(frozen=True)
+class ReportRunHeader:
+    project_id: str
+    run_id: str
+    pipeline_name: str | None
+    provider_run_id: str | None
+    attempt: int
+    status: str
+    started_at: str | None
+    finished_at: str | None
+    failure_summary: str | None
+    evidence_completeness: str
+
+
+@dataclass(frozen=True)
+class ReportLifecycle:
+    run: ReportRunHeader | None
+    events: tuple[ReportEvent, ...]
+
+
+@dataclass(frozen=True)
+class TerminalOutcome:
+    status: str
+    source: str
+    evidence_id: str
+    observed_at: str | None
+
+
+@dataclass(frozen=True)
+class RunReport:
+    schema_version: int
+    project_id: str
+    run_id: str
+    attempt: int
+    lifecycle: ReportLifecycle
+    stages: tuple[ReportStage, ...]
+    inputs: tuple[ReportResource, ...]
+    staging: tuple[ReportResource, ...]
+    outputs: tuple[ReportResource, ...]
+    lineage: tuple[ReportLineage, ...]
+    transformations: tuple[ReportStage, ...]
+    quality: tuple[ReportQuality, ...]
+    iceberg_snapshots: tuple[ReportResource, ...]
+    catalog_changes: tuple[ReportCatalogChange, ...]
+    artifacts: tuple[ReportArtifact, ...]
+    terminal_outcome: TerminalOutcome | None
+    gaps: tuple[ReportGap, ...]
+
+
+def _scalar(value: Any) -> Scalar:
+    return value if value is None or isinstance(value, (str, int, float, bool)) else None
+
+
+def _safe_text(value: Any) -> str | None:
+    redacted = redact_payload(value)
+    return redacted if isinstance(redacted, str) else None
+
+
+def _safe_staged_objects(value: Any) -> tuple[dict[str, Scalar], ...]:
+    if not isinstance(value, list):
+        return ()
+    safe: list[dict[str, Scalar]] = []
+    for item in value:
+        if isinstance(item, str):
+            safe.append({"identity": _safe_text(item)})
+        elif isinstance(item, dict) and isinstance(item.get("identity"), str):
+            safe.append(
+                {
+                    key: _safe_text(item[key]) if key == "identity" else _scalar(item[key])
+                    for key in ("identity", "checksum", "byte_count", "record_count")
+                    if key in item
+                }
+            )
+    return tuple(safe)
+
+
+def _safe_metadata(value: Any) -> dict[str, Scalar]:
+    if not isinstance(value, dict):
+        return {}
+    safe: dict[str, Scalar] = {}
+    for key in _SAFE_CATALOG_METADATA:
+        if key not in value:
+            continue
+        redacted = redact_payload(value[key])
+        scalar = _scalar(redacted)
+        if scalar is not None:
+            safe[key] = scalar
+    return safe
+
+
+def _fingerprint(value: Any) -> str | None:
+    if value is None:
+        return None
+    return hashlib.sha256(str(value).encode("utf-8")).hexdigest()
+
+
+def _run_header(row: dict[str, Any] | None) -> ReportRunHeader | None:
+    if row is None:
+        return None
+    return ReportRunHeader(
+        project_id=str(row["project_id"]),
+        run_id=str(row["run_id"]),
+        pipeline_name=row.get("pipeline_name"),
+        provider_run_id=row.get("provider_run_id"),
+        attempt=int(row["attempt"]),
+        status=str(row["status"]),
+        started_at=row.get("started_at"),
+        finished_at=row.get("finished_at"),
+        failure_summary=_safe_text(row.get("failure_summary")),
+        evidence_completeness=str(row["evidence_completeness"]),
+    )
+
+
+def _event(row: dict[str, Any]) -> ReportEvent:
+    return ReportEvent(
+        event_id=str(row["event_id"]),
+        producer=str(row["producer"]),
+        event_type=str(row["event_type"]),
+        observed_at=row.get("observed_at"),
+        sequence=row.get("sequence"),
+        payload_checksum=row.get("payload_checksum"),
+    )
+
+
+def _stage(row: dict[str, Any]) -> ReportStage:
+    return ReportStage(
+        stage_id=str(row["stage_id"]),
+        stage_type=str(row["stage_type"]),
+        provider=row.get("provider"),
+        tool=row.get("tool"),
+        asset=row.get("asset"),
+        status=str(row["status"]),
+        started_at=row.get("started_at"),
+        finished_at=row.get("finished_at"),
+        error_fingerprint=_fingerprint(row.get("error")),
+    )
+
+
+def _resource(row: dict[str, Any]) -> ReportResource:
+    return ReportResource(
+        resource_id=str(row["resource_id"]),
+        resource_kind=str(row["resource_kind"]),
+        role=str(row["role"]),
+        normalized_identity=row.get("normalized_identity"),
+        uri=_safe_text(row.get("uri")),
+        table_name=row.get("table_name"),
+        catalog=row.get("catalog"),
+        ref_name=row.get("ref_name"),
+        schema_hash=row.get("schema_hash"),
+        record_count=row.get("record_count"),
+        byte_count=row.get("byte_count"),
+        staged_objects=_safe_staged_objects(row.get("staged_objects")),
+        snapshot_before=row.get("snapshot_before"),
+        snapshot_after=row.get("snapshot_after"),
+    )
+
+
+def _terminal_outcome(
+    events: list[dict[str, Any]], decisions: list[dict[str, Any]]
+) -> tuple[TerminalOutcome | None, str | None]:
+    candidates: list[tuple[str, str, str, str | None]] = []
+    invalid = False
+    for event in events:
+        if event.get("event_type") not in {"run.terminal", "pipeline.terminal"}:
+            continue
+        payload = event.get("payload")
+        status = (
+            normalize_status(payload.get("status") or payload.get("run_status"))
+            if isinstance(payload, dict)
+            else None
+        )
+        if status not in TERMINAL_STATUSES:
+            invalid = True
+            continue
+        candidates.append(
+            (
+                status,
+                "lifecycle_event",
+                f"{event['producer']}:{event['event_id']}",
+                event.get("observed_at"),
+            )
+        )
+    for decision in decisions:
+        status = normalize_status(decision.get("status"))
+        if status in TERMINAL_STATUSES:
+            candidates.append(
+                (status, "reconciliation", str(decision["decision_id"]), decision.get("decided_at"))
+            )
+    statuses = {candidate[0] for candidate in candidates}
+    if invalid:
+        return None, "invalid_terminal_status"
+    if len(statuses) > 1:
+        return None, "conflicting_terminal_statuses"
+    if not candidates:
+        return None, "terminal_evidence_not_stored"
+    status, source, evidence_id, observed_at = candidates[0]
+    return TerminalOutcome(status, source, evidence_id, observed_at), None
+
+
+def build_run_report(
+    store: RunReportStore, project_id: str, run_id: str, attempt: int
+) -> RunReport:
+    """Build a safe typed report from exactly one store read snapshot."""
+    if isinstance(attempt, bool) or not isinstance(attempt, int) or attempt <= 0:
+        raise ValueError("attempt must be a positive integer")
+    snapshot = store.read_run_attempt(project_id, run_id, attempt)
+    rows = {key: value or [] for key, value in snapshot.items() if key != "run"}
+    run_row = snapshot.get("run")
+    if run_row is None and not any(rows.values()):
+        raise RunReportNotFound(f"run report {project_id}/{run_id}/{attempt} was not found")
+
+    stages = tuple(_stage(row) for row in rows["stages"])
+    resources = tuple(_resource(row) for row in rows["resources"])
+    groups = {
+        "inputs": tuple(item for item in resources if item.role.lower() in {"input", "inputs"}),
+        "staging": tuple(item for item in resources if item.role.lower() in {"staged", "staging"}),
+        "outputs": tuple(item for item in resources if item.role.lower() in {"output", "outputs"}),
+    }
+    terminal, terminal_gap = _terminal_outcome(rows["events"], rows["reconciliation"])
+    gaps: list[ReportGap] = []
+    if run_row is None:
+        gaps.append(ReportGap("lifecycle.run", "unavailable", "no_attempt_scoped_run_record"))
+    for field in (
+        "stages",
+        "inputs",
+        "staging",
+        "outputs",
+        "lineage",
+        "quality",
+        "catalog_changes",
+        "artifacts",
+    ):
+        if not rows[field] if field not in groups else not groups[field]:
+            gaps.append(ReportGap(field, "unavailable", "no_attempt_scoped_evidence"))
+    if not rows["resources"] or not any(
+        row.get("snapshot_before") or row.get("snapshot_after") for row in rows["resources"]
+    ):
+        gaps.append(ReportGap("iceberg_snapshots", "unavailable", "no_attempt_scoped_evidence"))
+    if not any(stage.stage_type.lower() in {"transform", "transformation"} for stage in stages):
+        gaps.append(ReportGap("transformations", "unavailable", "no_attempt_scoped_evidence"))
+    if terminal is None:
+        gaps.append(
+            ReportGap(
+                "terminal_outcome", "unavailable", terminal_gap or "terminal_evidence_not_stored"
+            )
+        )
+    if not rows["reconciliation"]:
+        gaps.append(
+            ReportGap("historical_fields", "unavailable", "attempt_reconciliation_not_proven")
+        )
+
+    return RunReport(
+        schema_version=1,
+        project_id=project_id,
+        run_id=run_id,
+        attempt=attempt,
+        lifecycle=ReportLifecycle(
+            _run_header(run_row), tuple(_event(row) for row in rows["events"])
+        ),
+        stages=stages,
+        inputs=groups["inputs"],
+        staging=groups["staging"],
+        outputs=groups["outputs"],
+        lineage=tuple(
+            ReportLineage(
+                str(row["lineage_edge_id"]),
+                str(row["source"]),
+                str(row["target"]),
+                str(row["origin"]),
+                str(row["derivation"]),
+            )
+            for row in rows["lineage"]
+        ),
+        transformations=tuple(
+            stage for stage in stages if stage.stage_type.lower() in {"transform", "transformation"}
+        ),
+        quality=tuple(
+            ReportQuality(
+                str(row["quality_result_id"]),
+                str(row["check_id"]),
+                row.get("asset"),
+                row.get("stage_id"),
+                row.get("severity"),
+                bool(row["blocking"]),
+                bool(row["passed"]),
+                row.get("evaluated_count"),
+                row.get("failed_count"),
+                row.get("failure_artifact_id"),
+            )
+            for row in rows["quality"]
+        ),
+        iceberg_snapshots=tuple(
+            resource
+            for resource in resources
+            if resource.snapshot_before or resource.snapshot_after
+        ),
+        catalog_changes=tuple(
+            ReportCatalogChange(
+                str(row["catalog_change_id"]),
+                row.get("catalog_ref"),
+                row.get("content_key"),
+                str(row["operation"]),
+                row.get("source_hash"),
+                row.get("target_hash"),
+                row.get("commit_hash"),
+                row.get("merge_outcome"),
+                row.get("snapshot_before"),
+                row.get("snapshot_after"),
+                _safe_metadata(row.get("metadata")),
+            )
+            for row in rows["catalog_changes"]
+        ),
+        artifacts=tuple(
+            ReportArtifact(
+                str(row["artifact_id"]),
+                str(row["artifact_kind"]),
+                _safe_text(row.get("uri")),
+                row.get("content_type"),
+                row.get("checksum"),
+                row.get("expires_at"),
+                bool(row["legal_hold"]),
+                str(row["status"]),
+            )
+            for row in rows["artifacts"]
+        ),
+        terminal_outcome=terminal,
+        gaps=tuple(gaps),
+    )

--- a/src/phlo/run_evidence/store.py
+++ b/src/phlo/run_evidence/store.py
@@ -38,6 +38,18 @@ from phlo.run_evidence.reconciliation import (
 )
 from phlo.run_evidence.redaction import canonical_json, payload_checksum, redact_payload
 
+_REPORT_ORDER_BY = {
+    "pipeline_run": "attempt",
+    "run_event": "sequence IS NULL, sequence, observed_at, event_id, producer",
+    "run_stage": "started_at IS NULL, started_at, stage_id",
+    "run_resource": "role, normalized_identity, resource_id",
+    "run_lineage_edge": "source, target, lineage_edge_id",
+    "run_quality_result": "check_id, quality_result_id",
+    "run_catalog_change": "catalog_ref, operation, catalog_change_id",
+    "run_artifact": "artifact_kind, artifact_id",
+    "run_reconciliation_decision": "decided_at, decision_id",
+}
+
 
 class IdempotencyConflict(ValueError):
     """A producer reused an event identity with different content."""
@@ -166,6 +178,28 @@ class _SqlRunEvidenceStore:
             finally:
                 cursor.close()
                 self._close_connection(connection)
+
+    @contextmanager
+    def _read_transaction(self) -> Iterator[tuple[Any, Any]]:
+        """Open one consistent read snapshot for a report projection."""
+        self._ensure_schema()
+        with self._lock:
+            connection = self._connect()
+            cursor = connection.cursor()
+            try:
+                if self.placeholder == "?":
+                    cursor.execute("BEGIN")
+                else:
+                    cursor.execute("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+                yield connection, cursor
+            finally:
+                try:
+                    connection.rollback()
+                finally:
+                    try:
+                        cursor.close()
+                    finally:
+                        self._close_connection(connection)
 
     def _ensure_schema(self) -> None:
         if self._initialized:
@@ -620,7 +654,7 @@ class _SqlRunEvidenceStore:
             cursor.execute(
                 f"SELECT * FROM {self._table('run_reconciliation_decision')} "
                 f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder} "
-                "ORDER BY decided_at, id",
+                f"ORDER BY {_REPORT_ORDER_BY['run_reconciliation_decision']}",
                 (project_id, run_id),
             )
             return [
@@ -628,27 +662,99 @@ class _SqlRunEvidenceStore:
                 for row in cursor.fetchall()
             ]
 
-    def get_run(self, project_id: str, run_id: str) -> dict[str, Any] | None:
+    def read_run_attempt(
+        self, project_id: str, run_id: str, attempt: int
+    ) -> dict[str, list[dict[str, Any]] | dict[str, Any] | None]:
+        """Read every report family from one transaction snapshot."""
+        attempt = _positive_attempt(attempt)
+        with self._read_transaction() as (_, cursor):
+            run = self._select_snapshot_rows(
+                cursor, "pipeline_run", project_id, run_id, attempt, "attempt"
+            )
+            result: dict[str, list[dict[str, Any]] | dict[str, Any] | None] = {
+                "run": run[0] if run else None
+            }
+            for family, table in (
+                ("events", "run_event"),
+                ("stages", "run_stage"),
+                ("resources", "run_resource"),
+                ("lineage", "run_lineage_edge"),
+                ("quality", "run_quality_result"),
+                ("catalog_changes", "run_catalog_change"),
+                ("artifacts", "run_artifact"),
+            ):
+                result[family] = self._select_snapshot_rows(
+                    cursor, table, project_id, run_id, attempt, _REPORT_ORDER_BY[table]
+                )
+            result["reconciliation"] = self._select_snapshot_rows(
+                cursor,
+                "run_reconciliation_decision",
+                project_id,
+                run_id,
+                attempt,
+                _REPORT_ORDER_BY["run_reconciliation_decision"],
+            )
+            return result
+
+    def _select_snapshot_rows(
+        self,
+        cursor: Any,
+        table: str,
+        project_id: str,
+        run_id: str,
+        attempt: int,
+        order_by: str,
+    ) -> list[dict[str, Any]]:
+        cursor.execute(
+            f"SELECT * FROM {self._table(table)} "
+            f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder} "
+            f"AND attempt = {self.placeholder} ORDER BY {order_by}",
+            (project_id, run_id, attempt),
+        )
+        return [self._row_dict(cursor, row, table=table) for row in cursor.fetchall()]
+
+    def get_run(
+        self, project_id: str, run_id: str, *, attempt: int | None = None
+    ) -> dict[str, Any] | None:
         with self._transaction() as (_, cursor):
+            where = f"project_id = {self.placeholder} AND run_id = {self.placeholder}"
+            params: tuple[Any, ...] = (project_id, run_id)
+            if attempt is not None:
+                attempt = _positive_attempt(attempt)
+                where += f" AND attempt = {self.placeholder}"
+                params += (attempt,)
             cursor.execute(
-                f"SELECT * FROM {self._table('pipeline_run')} "
-                f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder}",
-                (project_id, run_id),
+                f"SELECT * FROM {self._table('pipeline_run')} WHERE {where}",
+                params,
             )
             row = cursor.fetchone()
             if row is None:
                 return None
             return self._row_dict(cursor, row, table="pipeline_run")
 
-    def list_events(self, project_id: str, run_id: str) -> list[dict[str, Any]]:
+    def list_events(
+        self, project_id: str, run_id: str, *, attempt: int | None = None
+    ) -> list[dict[str, Any]]:
         with self._transaction() as (_, cursor):
+            where = f"project_id = {self.placeholder} AND run_id = {self.placeholder}"
+            params: tuple[Any, ...] = (project_id, run_id)
+            if attempt is not None:
+                attempt = _positive_attempt(attempt)
+                where += f" AND attempt = {self.placeholder}"
+                params += (attempt,)
             cursor.execute(
                 f"SELECT * FROM {self._table('run_event')} "
-                f"WHERE project_id = {self.placeholder} AND run_id = {self.placeholder} "
-                "ORDER BY observed_at, id",
-                (project_id, run_id),
+                f"WHERE {where} "
+                f"ORDER BY {_REPORT_ORDER_BY['run_event']}",
+                params,
             )
             return [self._row_dict(cursor, row, table="run_event") for row in cursor.fetchall()]
+
+    def list_stages(
+        self, project_id: str, run_id: str, *, attempt: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Return stages in deterministic execution order for one attempt."""
+        return self._list_attempt_records("run_stage", project_id, run_id, attempt=attempt)
 
     def count_events(self, project_id: str, run_id: str) -> int:
         with self._transaction() as (_, cursor):
@@ -685,7 +791,13 @@ class _SqlRunEvidenceStore:
         return self._list_attempt_records("run_lineage_edge", project_id, run_id, attempt=attempt)
 
     def _list_attempt_records(
-        self, table: str, project_id: str, run_id: str, *, attempt: int | None
+        self,
+        table: str,
+        project_id: str,
+        run_id: str,
+        *,
+        attempt: int | None,
+        order_by: str | None = None,
     ) -> list[dict[str, Any]]:
         if attempt is not None:
             attempt = _positive_attempt(attempt)
@@ -694,9 +806,10 @@ class _SqlRunEvidenceStore:
         if attempt is not None:
             where += f" AND attempt = {self.placeholder}"
             params += (attempt,)
+        order_by = order_by or _REPORT_ORDER_BY.get(table, "record_checksum")
         with self._transaction() as (_, cursor):
             cursor.execute(
-                f"SELECT * FROM {self._table(table)} WHERE {where} ORDER BY record_checksum",
+                f"SELECT * FROM {self._table(table)} WHERE {where} ORDER BY {order_by}",
                 params,
             )
             return [self._row_dict(cursor, row, table=table) for row in cursor.fetchall()]

--- a/tests/observability/test_run_evidence.py
+++ b/tests/observability/test_run_evidence.py
@@ -51,6 +51,7 @@ from phlo.run_evidence import (
 from phlo.run_evidence.emit import emit_observation
 from phlo.run_evidence.hooks import CoreRunEvidenceHookProvider
 from phlo.run_evidence.redaction import canonical_json, payload_checksum
+from phlo.run_evidence.report import build_run_report
 from phlo.run_evidence.store import _catalog_checksum_payload, _resource_checksum_payload
 
 
@@ -96,6 +97,115 @@ def _make_sqlite_v2_store(path: Path) -> SQLiteRunEvidenceStore:
     store._connection.commit()
     store._initialized = True
     return store
+
+
+def test_run_report_is_attempt_scoped_and_marks_unproven_history_unavailable() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    store.append_pipeline_run(PipelineRun(project_id="project", run_id="run", attempt=2))
+    for attempt in (1, 2):
+        started = datetime(2026, 1, attempt, tzinfo=UTC)
+        store.append_stage(
+            RunStage(
+                project_id="project",
+                run_id="run",
+                stage_id=f"stage-{attempt}",
+                stage_type="transform",
+                attempt=attempt,
+                started_at=started,
+            )
+        )
+        store.append_resource(
+            RunResource(
+                project_id="project",
+                run_id="run",
+                resource_id=f"input-{attempt}",
+                role="input",
+                attempt=attempt,
+            )
+        )
+        store.append_event(
+            RunEvent(
+                project_id="project",
+                run_id="run",
+                event_id=f"terminal-{attempt}",
+                event_type="run.terminal",
+                producer="test",
+                payload={"status": "success", "attempt": attempt},
+                sequence=2,
+                attempt=attempt,
+            )
+        )
+
+    report = build_run_report(store, "project", "run", 1)
+
+    assert report.attempt == 1
+    assert [stage.stage_id for stage in report.stages] == ["stage-1"]
+    assert [event.event_id for event in report.lifecycle.events] == ["terminal-1"]
+    assert report.lifecycle.events[0].producer == "test"
+    assert [resource.resource_id for resource in report.inputs] == ["input-1"]
+    assert report.terminal_outcome is not None
+    assert report.terminal_outcome.status == "success"
+    assert any(gap.field == "historical_fields" for gap in report.gaps)
+
+
+def test_run_report_orders_cross_producer_events_and_redacts_legacy_locations() -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    store.append_pipeline_run(
+        PipelineRun(
+            project_id="project",
+            run_id="run",
+            attempt=1,
+            failure_summary="password=secret",
+        )
+    )
+    observed_at = datetime(2026, 1, 1, tzinfo=UTC)
+    for producer in ("zeta", "alpha"):
+        store.append_event(
+            RunEvent(
+                project_id="project",
+                run_id="run",
+                event_id="shared",
+                event_type="stage.finished",
+                producer=producer,
+                payload={},
+                observed_at=observed_at,
+                sequence=1,
+                attempt=1,
+            )
+        )
+    store.append_resource(
+        RunResource(
+            project_id="project",
+            run_id="run",
+            resource_id="staged",
+            role="staged",
+            attempt=1,
+            uri="s3://access_token=secret/data",
+            staged_objects=[{"identity": "s3://client_secret=secret/staged", "checksum": "abc"}],
+        )
+    )
+    store.append_artifact(
+        RunArtifact(
+            project_id="project",
+            run_id="run",
+            artifact_id="report",
+            artifact_kind="report",
+            attempt=1,
+            uri="https://example.test/report?token=secret",
+        )
+    )
+
+    rows = store.read_run_attempt("project", "run", 1)
+    assert [event["producer"] for event in rows["events"]] == ["alpha", "zeta"]
+    report = build_run_report(store, "project", "run", 1)
+    assert [event.producer for event in report.lifecycle.events] == ["alpha", "zeta"]
+    assert report.lifecycle.run is not None
+    assert report.lifecycle.run.failure_summary == "password=<redacted>"
+    assert report.staging[0].staged_objects == (
+        {"identity": "s3://client_secret=<redacted>/staged", "checksum": "abc"},
+    )
+    assert report.staging[0].uri == "s3://access_token=<redacted>/data"
+    assert report.artifacts[0].uri == "https://example.test/report?token=<redacted>"
 
 
 def _insert_v2_fixture_rows(store: object) -> dict[str, object]:


### PR DESCRIPTION
## Outcome

Adds an authenticated, attempt-scoped run report endpoint at GET /api/observatory/projects/{project_id}/runs/{run_id}/attempts/{attempt}/report. The response is a stable typed contract covering lifecycle, ordered stages, inputs/staging/outputs, lineage, quality, Iceberg snapshot evidence, Nessie/WAP catalog changes, artifacts, terminal outcome when supported, and explicit evidence gaps.

Authorization uses the canonical run.read capability against the exact project/run/attempt path identity. Report assembly reads one consistent database snapshot, orders every evidence family deterministically, rejects conflicting or invalid terminal claims, and projects legacy rows through an allowlisted and redacted boundary. Event producer identity is retained in the public contract, provider failure summaries are redacted, and transaction cleanup remains safe when rollback fails.

## Boundaries

Core exposes a provider-neutral report/store capability; phlo-api owns routing and authorization. No provider package imports or schema migration are introduced. This does not add the Observatory UI, run search/listing, retention execution, or deployment/recovery behavior.

## Evidence

Exact SHA: 3c12bd2c720359f9e7dcd3eea26a7451283a1678

- PYTHONPATH=src:packages/phlo-api/src /Users/garethprice/Developer/phlo/.venv/bin/python -m pytest tests/observability/test_run_evidence.py packages/phlo-api/tests/test_observatory_api.py packages/phlo-api/tests/test_security_manifest.py -q: 189 passed, 2 skipped
- Ruff check: passed
- Ruff format --check: passed
- git diff --check: passed
- pre-commit hooks on the exact committed state: passed

CodeRabbit findings were addressed with regression coverage for producer identity, failure-summary redaction, rollback-safe cleanup, and shared report ordering constants.