### PR TITLE
feat(observatory): add authenticated run report view

### DIFF
--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.test.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.test.ts
@@ -1,7 +1,65 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+type ServerFnBuilderMock = {
+  middleware: (middlewares: Array<RequestMiddleware>) => ServerFnBuilderMock
+  inputValidator: <TInputValidator>(
+    inputValidator: TInputValidator,
+  ) => ServerFnBuilderMock
+  handler: <THandler>(handler: THandler) => THandler
+}
+
+type RequestMiddleware = (options: {
+  next: (options?: { context?: Record<string, unknown> }) => unknown
+  request: Request
+}) => unknown
+
+type ServerFnOptions = {
+  data: unknown
+  headers?: HeadersInit
+}
+
 const apiGet = vi.fn()
 const apiPost = vi.fn()
+
+vi.mock('@tanstack/react-start', () => ({
+  createMiddleware: () => ({
+    server: <THandler>(handler: THandler): THandler => handler,
+  }),
+  createServerFn: () => {
+    const middlewares: Array<RequestMiddleware> = []
+    const builder: ServerFnBuilderMock = {
+      middleware: (registered) => {
+        middlewares.push(...registered)
+        return builder
+      },
+      inputValidator: () => builder,
+      handler: (handler) =>
+        ((options: ServerFnOptions) => {
+          const invokeHandler = handler as unknown as (context: {
+            context: Record<string, unknown>
+            data: unknown
+          }) => unknown
+          let context: Record<string, unknown> = {}
+          const invokeMiddleware = (index: number): unknown => {
+            if (index === middlewares.length) {
+              return invokeHandler({ context, data: options.data })
+            }
+            return middlewares[index]({
+              request: new Request('https://observatory.example.test', {
+                headers: options.headers,
+              }),
+              next: (nextOptions = {}) => {
+                context = { ...context, ...nextOptions.context }
+                return invokeMiddleware(index + 1)
+              },
+            })
+          }
+          return invokeMiddleware(0)
+        }) as unknown as typeof handler,
+    }
+    return builder
+  },
+}))
 
 vi.mock('@/server/phlo-api', () => ({
   apiGet,
@@ -51,6 +109,106 @@ describe('observatory dataset resources', () => {
       8000,
     )
   })
+
+  it('forwards the signed-in operator bearer credential to the run report API', async () => {
+    apiGet.mockResolvedValue({
+      schema_version: 1,
+      project_id: 'finance',
+      run_id: 'daily-orders',
+      attempt: 2,
+      lifecycle: { run: null, events: [] },
+      stages: [],
+      inputs: [],
+      staging: [],
+      outputs: [],
+      lineage: [],
+      transformations: [],
+      quality: [],
+      iceberg_snapshots: [],
+      catalog_changes: [],
+      artifacts: [],
+      terminal_outcome: null,
+      gaps: [],
+    })
+
+    const { getObservatoryRunReport } = await import('./resources')
+    const result = await getObservatoryRunReport({
+      data: { projectId: 'finance', runId: 'daily-orders', attempt: '2' },
+      headers: {
+        authorization: 'Bearer operator-token',
+        'x-unrelated-header': 'must-not-reach-phlo-api',
+      },
+    })
+
+    expect(result).toMatchObject({
+      data: { attempt: 2 },
+      error: null,
+    })
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/observatory/projects/finance/runs/daily-orders/attempts/2/report',
+      undefined,
+      8000,
+      'Bearer operator-token',
+    )
+  })
+
+  it('does not forward non-Bearer or unrelated request headers', async () => {
+    apiGet.mockResolvedValue({
+      schema_version: 1,
+      project_id: 'finance',
+      run_id: 'daily-orders',
+      attempt: 2,
+      lifecycle: { run: null, events: [] },
+      stages: [],
+      inputs: [],
+      staging: [],
+      outputs: [],
+      lineage: [],
+      transformations: [],
+      quality: [],
+      iceberg_snapshots: [],
+      catalog_changes: [],
+      artifacts: [],
+      terminal_outcome: null,
+      gaps: [],
+    })
+
+    const { getObservatoryRunReport } = await import('./resources')
+    await getObservatoryRunReport({
+      data: { projectId: 'finance', runId: 'daily-orders', attempt: 2 },
+      headers: {
+        authorization: 'Basic should-not-forward',
+        'x-unrelated-header': 'must-not-reach-phlo-api',
+      },
+    })
+
+    expect(apiGet).toHaveBeenCalledWith(
+      '/api/observatory/projects/finance/runs/daily-orders/attempts/2/report',
+      undefined,
+      8000,
+      undefined,
+    )
+  })
+
+  it.each([401, 403])(
+    'classifies report %i failures without changing the API contract',
+    async (status) => {
+      apiGet.mockRejectedValue(new Error(`phlo-api error: ${status} Forbidden`))
+
+      const { getObservatoryRunReport } = await import('./resources')
+      const result = await getObservatoryRunReport({
+        data: { projectId: 'finance', runId: 'daily-orders', attempt: 2 },
+        headers: { authorization: 'Bearer operator-token' },
+      })
+
+      expect(result).toEqual({
+        data: null,
+        error:
+          'Access denied: this account cannot read the requested run report.',
+        errorCode: 'access_denied',
+      })
+    },
+  )
 
   it('creates workflow proposals through the server API during SSR', async () => {
     const proposal = workflowProposal()

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.test.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.test.ts
@@ -27,12 +27,16 @@ vi.mock('@tanstack/react-start', () => ({
   }),
   createServerFn: () => {
     const middlewares: Array<RequestMiddleware> = []
+    let validateInput = (input: unknown): unknown => input
     const builder: ServerFnBuilderMock = {
       middleware: (registered) => {
         middlewares.push(...registered)
         return builder
       },
-      inputValidator: () => builder,
+      inputValidator: (validator) => {
+        validateInput = validator as (input: unknown) => unknown
+        return builder
+      },
       handler: (handler) =>
         ((options: ServerFnOptions) => {
           const invokeHandler = handler as unknown as (context: {
@@ -42,7 +46,10 @@ vi.mock('@tanstack/react-start', () => ({
           let context: Record<string, unknown> = {}
           const invokeMiddleware = (index: number): unknown => {
             if (index === middlewares.length) {
-              return invokeHandler({ context, data: options.data })
+              return invokeHandler({
+                context,
+                data: validateInput(options.data),
+              })
             }
             return middlewares[index]({
               request: new Request('https://observatory.example.test', {
@@ -209,6 +216,58 @@ describe('observatory dataset resources', () => {
       })
     },
   )
+
+  it.each([
+    null,
+    'finance/daily-orders/2',
+    [],
+    { attempt: 2, projectId: 1, runId: 'daily-orders' },
+    { attempt: 2, projectId: 'finance', runId: null },
+    { attempt: '1e2', projectId: 'finance', runId: 'daily-orders' },
+    {
+      attempt: Number.MAX_SAFE_INTEGER + 1,
+      projectId: 'finance',
+      runId: 'daily-orders',
+    },
+    {
+      attempt: '9007199254740992',
+      projectId: 'finance',
+      runId: 'daily-orders',
+    },
+    { attempt: 0, projectId: 'finance', runId: 'daily-orders' },
+    { attempt: -1, projectId: 'finance', runId: 'daily-orders' },
+  ])(
+    'rejects invalid run report input %o before calling the API',
+    async (data) => {
+      const { getObservatoryRunReport } = await import('./resources')
+      const result = await getObservatoryRunReport({ data })
+
+      expect(result).toEqual({
+        data: null,
+        error:
+          'Enter a project, run, and positive attempt number to open a report.',
+        errorCode: 'invalid_request',
+      })
+      expect(apiGet).not.toHaveBeenCalled()
+    },
+  )
+
+  it('does not expose unexpected upstream failure details', async () => {
+    apiGet.mockRejectedValue(
+      new Error('phlo-api error: 500 internal token=secret'),
+    )
+
+    const { getObservatoryRunReport } = await import('./resources')
+    const result = await getObservatoryRunReport({
+      data: { projectId: 'finance', runId: 'daily-orders', attempt: 2 },
+    })
+
+    expect(result).toEqual({
+      data: null,
+      error: 'The run report request failed. Please try again.',
+      errorCode: 'request_failed',
+    })
+  })
 
   it('creates workflow proposals through the server API during SSR', async () => {
     const proposal = workflowProposal()

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.ts
@@ -378,74 +378,100 @@ export function getObservatoryRunRecords() {
 }
 
 export type ObservatoryRunReportErrorCode =
-  'access_denied' | 'not_found' | 'request_failed' | 'invalid_request'
+  | 'access_denied'
+  | 'not_found'
+  | 'request_failed'
+  | 'invalid_request'
 
 export type ObservatoryRunReportResult =
   ObservatoryResourceResult<ObservatoryRunReport> & {
     errorCode?: ObservatoryRunReportErrorCode
   }
 
+type ObservatoryRunReportInput = {
+  attempt: number
+  projectId: string
+  runId: string
+}
+
+function parseObservatoryRunReportInput(
+  input: unknown,
+): ObservatoryRunReportInput | null {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null
+
+  const { attempt, projectId, runId } = input as Record<string, unknown>
+  if (
+    typeof projectId !== 'string' ||
+    !projectId.trim() ||
+    typeof runId !== 'string' ||
+    !runId.trim()
+  ) {
+    return null
+  }
+
+  const parsedAttempt =
+    typeof attempt === 'number'
+      ? attempt
+      : typeof attempt === 'string' && /^[1-9]\d*$/.test(attempt)
+        ? Number(attempt)
+        : Number.NaN
+  if (!Number.isSafeInteger(parsedAttempt) || parsedAttempt < 1) return null
+
+  return { attempt: parsedAttempt, projectId, runId }
+}
+
 export const getObservatoryRunReport = createServerFn()
   .middleware([observatoryReportAuthorization])
-  .inputValidator(
-    (input: { projectId: string; runId: string; attempt: string | number }) =>
-      input,
-  )
-  .handler(
-    async ({
-      data: { projectId, runId, attempt: rawAttempt },
-      context,
-    }): Promise<ObservatoryRunReportResult> => {
-      const attempt =
-        typeof rawAttempt === 'number' ? rawAttempt : Number(rawAttempt)
-      if (
-        !projectId.trim() ||
-        !runId.trim() ||
-        !Number.isInteger(attempt) ||
-        attempt < 1
-      ) {
+  .inputValidator(parseObservatoryRunReportInput)
+  .handler(async ({ data, context }): Promise<ObservatoryRunReportResult> => {
+    if (!data) {
+      return {
+        data: null,
+        error:
+          'Enter a project, run, and positive attempt number to open a report.',
+        errorCode: 'invalid_request',
+      }
+    }
+
+    const { attempt, projectId, runId } = data
+
+    try {
+      const data = await apiGet<ObservatoryRunReport>(
+        `${Observatory_API_PREFIX}/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}/attempts/${attempt}/report`,
+        undefined,
+        8000,
+        context.authorization,
+      )
+      return { data, error: null }
+    } catch (error) {
+      const status = Number(
+        error instanceof Error
+          ? error.message.match(/^phlo-api error: (401|403|404)\b/)?.[1]
+          : undefined,
+      )
+      if (status === 401 || status === 403) {
         return {
           data: null,
           error:
-            'Enter a project, run, and positive attempt number to open a report.',
-          errorCode: 'invalid_request',
+            'Access denied: this account cannot read the requested run report.',
+          errorCode: 'access_denied',
         }
       }
-
-      try {
-        const data = await apiGet<ObservatoryRunReport>(
-          `${Observatory_API_PREFIX}/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}/attempts/${attempt}/report`,
-          undefined,
-          8000,
-          context.authorization,
-        )
-        return { data, error: null }
-      } catch (error) {
-        const message =
-          error instanceof Error
-            ? error.message
-            : 'Lakehouse API is unavailable'
-        const status = Number(message.match(/\b([45]\d{2})\b/)?.[1])
-        if (status === 401 || status === 403) {
-          return {
-            data: null,
-            error:
-              'Access denied: this account cannot read the requested run report.',
-            errorCode: 'access_denied',
-          }
+      if (status === 404) {
+        return {
+          data: null,
+          error:
+            'No report was found for the requested project, run, and attempt.',
+          errorCode: 'not_found',
         }
-        if (status === 404) {
-          return {
-            data: null,
-            error:
-              'No report was found for the requested project, run, and attempt.',
-            errorCode: 'not_found',
-          }
-        }
-        return { data: null, error: message, errorCode: 'request_failed' }
       }
-    },
-  )
+      return {
+        data: null,
+        error: 'The run report request failed. Please try again.',
+        errorCode: 'request_failed',
+      }
+    }
+  })
 
 export function getObservatoryStorageItems() {
   return getRawCollection<ObservatorySurfaceItem>('storage')

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/resources.ts
@@ -1,4 +1,4 @@
-import { createServerFn } from '@tanstack/react-start'
+import { createMiddleware, createServerFn } from '@tanstack/react-start'
 
 import type {
   ObservatoryActionResult,
@@ -28,6 +28,7 @@ import type {
   ObservatoryResourceResult,
   ObservatoryRowJourney,
   ObservatoryRun,
+  ObservatoryRunReport,
   ObservatoryRuntimeSettings,
   ObservatorySavedQuery,
   ObservatorySearchResult,
@@ -44,6 +45,21 @@ import type {
 import { apiGet, apiPost } from '@/server/phlo-api'
 
 const Observatory_API_PREFIX = '/api/observatory'
+
+function bearerAuthorization(value: string | null): string | undefined {
+  if (value === null) return undefined
+  return /^Bearer\s+\S+$/i.test(value) ? value : undefined
+}
+
+const observatoryReportAuthorization = createMiddleware({
+  type: 'request',
+}).server(({ next, request }) =>
+  next({
+    context: {
+      authorization: bearerAuthorization(request.headers.get('authorization')),
+    },
+  }),
+)
 
 declare global {
   interface Window {
@@ -360,6 +376,76 @@ export async function getObservatoryOperationDetailDirect({
 export function getObservatoryRunRecords() {
   return getRawCollection<ObservatoryRun>('runs')
 }
+
+export type ObservatoryRunReportErrorCode =
+  'access_denied' | 'not_found' | 'request_failed' | 'invalid_request'
+
+export type ObservatoryRunReportResult =
+  ObservatoryResourceResult<ObservatoryRunReport> & {
+    errorCode?: ObservatoryRunReportErrorCode
+  }
+
+export const getObservatoryRunReport = createServerFn()
+  .middleware([observatoryReportAuthorization])
+  .inputValidator(
+    (input: { projectId: string; runId: string; attempt: string | number }) =>
+      input,
+  )
+  .handler(
+    async ({
+      data: { projectId, runId, attempt: rawAttempt },
+      context,
+    }): Promise<ObservatoryRunReportResult> => {
+      const attempt =
+        typeof rawAttempt === 'number' ? rawAttempt : Number(rawAttempt)
+      if (
+        !projectId.trim() ||
+        !runId.trim() ||
+        !Number.isInteger(attempt) ||
+        attempt < 1
+      ) {
+        return {
+          data: null,
+          error:
+            'Enter a project, run, and positive attempt number to open a report.',
+          errorCode: 'invalid_request',
+        }
+      }
+
+      try {
+        const data = await apiGet<ObservatoryRunReport>(
+          `${Observatory_API_PREFIX}/projects/${encodeURIComponent(projectId)}/runs/${encodeURIComponent(runId)}/attempts/${attempt}/report`,
+          undefined,
+          8000,
+          context.authorization,
+        )
+        return { data, error: null }
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Lakehouse API is unavailable'
+        const status = Number(message.match(/\b([45]\d{2})\b/)?.[1])
+        if (status === 401 || status === 403) {
+          return {
+            data: null,
+            error:
+              'Access denied: this account cannot read the requested run report.',
+            errorCode: 'access_denied',
+          }
+        }
+        if (status === 404) {
+          return {
+            data: null,
+            error:
+              'No report was found for the requested project, run, and attempt.',
+            errorCode: 'not_found',
+          }
+        }
+        return { data: null, error: message, errorCode: 'request_failed' }
+      }
+    },
+  )
 
 export function getObservatoryStorageItems() {
   return getRawCollection<ObservatorySurfaceItem>('storage')

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/types.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/types.ts
@@ -4,7 +4,11 @@ export type ObservatoryMetadata = Record<string, NonNullable<unknown>>
 type ObservatoryRecord = Record<string, NonNullable<unknown>>
 
 export type ObservatoryServiceStatus =
-  'running' | 'stopped' | 'unhealthy' | 'starting' | 'unknown'
+  | 'running'
+  | 'stopped'
+  | 'unhealthy'
+  | 'starting'
+  | 'unknown'
 
 interface ObservatoryHealth {
   state: ObservatoryHealthState
@@ -150,7 +154,11 @@ export interface ObservatoryDataset {
 }
 
 export type ObservatoryControlStatus =
-  'pass' | 'fail' | 'warning' | 'unknown' | 'not_applicable'
+  | 'pass'
+  | 'fail'
+  | 'warning'
+  | 'unknown'
+  | 'not_applicable'
 
 export interface ObservatoryControlEvidence {
   kind: string
@@ -414,7 +422,12 @@ export interface ObservatoryOperationDetail {
 }
 
 type ObservatoryRunStatus =
-  'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'unknown'
+  | 'queued'
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'cancelled'
+  | 'unknown'
 
 export interface ObservatoryRun {
   id: string

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/types.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/api/types.ts
@@ -4,11 +4,7 @@ export type ObservatoryMetadata = Record<string, NonNullable<unknown>>
 type ObservatoryRecord = Record<string, NonNullable<unknown>>
 
 export type ObservatoryServiceStatus =
-  | 'running'
-  | 'stopped'
-  | 'unhealthy'
-  | 'starting'
-  | 'unknown'
+  'running' | 'stopped' | 'unhealthy' | 'starting' | 'unknown'
 
 interface ObservatoryHealth {
   state: ObservatoryHealthState
@@ -154,11 +150,7 @@ export interface ObservatoryDataset {
 }
 
 export type ObservatoryControlStatus =
-  | 'pass'
-  | 'fail'
-  | 'warning'
-  | 'unknown'
-  | 'not_applicable'
+  'pass' | 'fail' | 'warning' | 'unknown' | 'not_applicable'
 
 export interface ObservatoryControlEvidence {
   kind: string
@@ -422,12 +414,7 @@ export interface ObservatoryOperationDetail {
 }
 
 type ObservatoryRunStatus =
-  | 'queued'
-  | 'running'
-  | 'succeeded'
-  | 'failed'
-  | 'cancelled'
-  | 'unknown'
+  'queued' | 'running' | 'succeeded' | 'failed' | 'cancelled' | 'unknown'
 
 export interface ObservatoryRun {
   id: string
@@ -440,6 +427,141 @@ export interface ObservatoryRun {
   checks: Array<ObservatoryResourceRef>
   logs: Array<ObservatoryResourceRef>
   metadata: ObservatoryMetadata
+}
+
+export interface ObservatoryReportGap {
+  field: string
+  status: string
+  reason: string
+}
+
+export interface ObservatoryReportEvent {
+  event_id: string
+  producer: string
+  event_type: string
+  observed_at?: string | null
+  sequence?: number | null
+  payload_checksum?: string | null
+}
+
+export interface ObservatoryReportStage {
+  stage_id: string
+  stage_type: string
+  provider?: string | null
+  tool?: string | null
+  asset?: string | null
+  status: string
+  started_at?: string | null
+  finished_at?: string | null
+  error_fingerprint?: string | null
+}
+
+export interface ObservatoryReportResource {
+  resource_id: string
+  resource_kind: string
+  role: string
+  normalized_identity?: string | null
+  uri?: string | null
+  table_name?: string | null
+  catalog?: string | null
+  ref_name?: string | null
+  schema_hash?: string | null
+  record_count?: number | null
+  byte_count?: number | null
+  staged_objects: Array<Record<string, string | number | boolean | null>>
+  snapshot_before?: string | null
+  snapshot_after?: string | null
+}
+
+export interface ObservatoryReportLineage {
+  lineage_edge_id: string
+  source: string
+  target: string
+  origin: string
+  derivation: string
+}
+
+export interface ObservatoryReportQuality {
+  quality_result_id: string
+  check_id: string
+  asset?: string | null
+  stage_id?: string | null
+  severity?: string | null
+  blocking: boolean
+  passed: boolean
+  evaluated_count?: number | null
+  failed_count?: number | null
+  failure_artifact_id?: string | null
+}
+
+export interface ObservatoryReportCatalogChange {
+  catalog_change_id: string
+  catalog_ref?: string | null
+  content_key?: string | null
+  operation: string
+  source_hash?: string | null
+  target_hash?: string | null
+  commit_hash?: string | null
+  merge_outcome?: string | null
+  snapshot_before?: string | null
+  snapshot_after?: string | null
+  metadata: Record<string, string | number | boolean | null>
+}
+
+export interface ObservatoryReportArtifact {
+  artifact_id: string
+  artifact_kind: string
+  uri?: string | null
+  content_type?: string | null
+  checksum?: string | null
+  expires_at?: string | null
+  legal_hold: boolean
+  status: string
+}
+
+export interface ObservatoryReportRun {
+  project_id: string
+  run_id: string
+  pipeline_name?: string | null
+  provider_run_id?: string | null
+  attempt: number
+  status: string
+  started_at?: string | null
+  finished_at?: string | null
+  failure_summary?: string | null
+  evidence_completeness: string
+}
+
+export interface ObservatoryReportLifecycle {
+  run?: ObservatoryReportRun | null
+  events: Array<ObservatoryReportEvent>
+}
+
+export interface ObservatoryReportTerminalOutcome {
+  status: string
+  source: string
+  evidence_id: string
+  observed_at?: string | null
+}
+
+export interface ObservatoryRunReport {
+  schema_version: number
+  project_id: string
+  run_id: string
+  attempt: number
+  lifecycle: ObservatoryReportLifecycle
+  stages: Array<ObservatoryReportStage>
+  inputs: Array<ObservatoryReportResource>
+  staging: Array<ObservatoryReportResource>
+  outputs: Array<ObservatoryReportResource>
+  lineage: Array<ObservatoryReportLineage>
+  transformations: Array<ObservatoryReportStage>
+  quality: Array<ObservatoryReportQuality>
+  iceberg_snapshots: Array<ObservatoryReportResource>
+  catalog_changes: Array<ObservatoryReportCatalogChange>
+  artifacts: Array<ObservatoryReportArtifact>
+  terminal_outcome?: ObservatoryReportTerminalOutcome | null
+  gaps: Array<ObservatoryReportGap>
 }
 
 export interface ObservatoryAsset {

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.test.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.test.tsx
@@ -95,6 +95,35 @@ describe('RunReportView', () => {
       screen.getByText('failure-artifact · report · available'),
     ).toBeTruthy()
   })
+
+  it.each([
+    [
+      'transformation-only evidence',
+      () => ({
+        ...emptyReport(),
+        transformations: [populatedReport().stages[0]],
+      }),
+      'Transformations',
+    ],
+    [
+      'Iceberg-only evidence',
+      () => ({
+        ...emptyReport(),
+        iceberg_snapshots: [resource('output', 'orders_gold')],
+      }),
+      'Iceberg snapshots',
+    ],
+  ])('renders %s instead of the empty state', (_, report, evidenceLabel) => {
+    render(
+      <RunReportView
+        request={request}
+        result={{ data: report(), error: null }}
+      />,
+    )
+
+    expect(screen.queryByText('No attempt-scoped evidence recorded')).toBeNull()
+    expect(screen.getByText(evidenceLabel)).toBeTruthy()
+  })
 })
 
 function emptyReport(): ObservatoryRunReport {

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.test.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.test.tsx
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { ObservatoryRunReport } from '@/observatory/api/types'
+import { RunReportView } from './RunReportView'
+
+const request = { projectId: 'finance', runId: 'daily-orders', attempt: '2' }
+
+describe('RunReportView', () => {
+  afterEach(cleanup)
+
+  it('renders loading, empty, denied, not-found, and generic error states', () => {
+    const { rerender } = render(
+      <RunReportView request={request} result={null} />,
+    )
+    expect(screen.getByText('Loading run report')).toBeTruthy()
+
+    rerender(
+      <RunReportView
+        request={request}
+        result={{
+          data: null,
+          error: 'No evidence',
+          errorCode: 'not_found',
+        }}
+      />,
+    )
+    expect(screen.getByText('Run report not found')).toBeTruthy()
+
+    rerender(
+      <RunReportView
+        request={request}
+        result={{
+          data: null,
+          error: 'Access denied',
+          errorCode: 'access_denied',
+        }}
+      />,
+    )
+    expect(screen.getByRole('heading', { name: 'Access denied' })).toBeTruthy()
+
+    rerender(
+      <RunReportView
+        request={request}
+        result={{
+          data: null,
+          error: 'Network failed',
+          errorCode: 'request_failed',
+        }}
+      />,
+    )
+    expect(screen.getByText('Run report unavailable')).toBeTruthy()
+
+    rerender(
+      <RunReportView
+        request={request}
+        result={{
+          data: emptyReport(),
+          error: null,
+        }}
+      />,
+    )
+    expect(screen.getByText('No attempt-scoped evidence recorded')).toBeTruthy()
+    expect(screen.getByText('no_attempt_scoped_evidence')).toBeTruthy()
+  })
+
+  it('renders every evidence area and preserves explicit unknowns and gaps', () => {
+    render(
+      <RunReportView
+        request={request}
+        result={{ data: populatedReport(), error: null }}
+      />,
+    )
+
+    for (const label of [
+      'Lifecycle',
+      'Stages and transformations',
+      'Inputs, staging, and outputs',
+      'Lineage',
+      'Quality',
+      'Catalog / Nessie evidence',
+      'Artifacts',
+      'Outcome and gaps',
+      'Explicit gaps',
+    ]) {
+      expect(screen.getByText(label)).toBeTruthy()
+    }
+    expect(screen.getByText('terminal')).toBeTruthy()
+    expect(screen.getByText('historical_fields · unavailable')).toBeTruthy()
+    expect(screen.getByText('event.started · dagster')).toBeTruthy()
+    expect(screen.getByText('orders_raw → orders_gold')).toBeTruthy()
+    expect(
+      screen.getByText('failure-artifact · report · available'),
+    ).toBeTruthy()
+  })
+})
+
+function emptyReport(): ObservatoryRunReport {
+  return {
+    ...populatedReport(),
+    lifecycle: { run: null, events: [] },
+    stages: [],
+    inputs: [],
+    staging: [],
+    outputs: [],
+    lineage: [],
+    transformations: [],
+    quality: [],
+    iceberg_snapshots: [],
+    catalog_changes: [],
+    artifacts: [],
+    terminal_outcome: null,
+    gaps: [
+      {
+        field: 'stages',
+        status: 'unavailable',
+        reason: 'no_attempt_scoped_evidence',
+      },
+    ],
+  }
+}
+
+function populatedReport(): ObservatoryRunReport {
+  return {
+    schema_version: 1,
+    project_id: 'finance',
+    run_id: 'daily-orders',
+    attempt: 2,
+    lifecycle: {
+      run: {
+        project_id: 'finance',
+        run_id: 'daily-orders',
+        pipeline_name: 'orders',
+        provider_run_id: 'dagster-42',
+        attempt: 2,
+        status: 'failed',
+        started_at: '2026-07-15T10:00:00Z',
+        finished_at: '2026-07-15T10:02:00Z',
+        failure_summary: 'quality check failed',
+        evidence_completeness: 'partial',
+      },
+      events: [
+        {
+          event_id: 'event-1',
+          producer: 'dagster',
+          event_type: 'event.started',
+          observed_at: '2026-07-15T10:00:00Z',
+          sequence: 1,
+          payload_checksum: 'checksum',
+        },
+      ],
+    },
+    stages: [
+      {
+        stage_id: 'load',
+        stage_type: 'transform',
+        provider: 'dbt',
+        tool: 'dbt',
+        asset: 'orders_gold',
+        status: 'failed',
+        started_at: '2026-07-15T10:00:00Z',
+        finished_at: '2026-07-15T10:02:00Z',
+        error_fingerprint: 'error-1',
+      },
+    ],
+    inputs: [resource('input', 'orders_raw')],
+    staging: [resource('staged', 'orders_stage')],
+    outputs: [resource('output', 'orders_gold')],
+    lineage: [
+      {
+        lineage_edge_id: 'edge-1',
+        source: 'orders_raw',
+        target: 'orders_gold',
+        origin: 'observed',
+        derivation: 'transform',
+      },
+    ],
+    transformations: [],
+    quality: [
+      {
+        quality_result_id: 'quality-1',
+        check_id: 'orders_not_null',
+        asset: 'orders_gold',
+        stage_id: 'load',
+        severity: 'error',
+        blocking: true,
+        passed: false,
+        evaluated_count: 100,
+        failed_count: 2,
+        failure_artifact_id: 'failure-artifact',
+      },
+    ],
+    iceberg_snapshots: [resource('output', 'orders_gold')],
+    catalog_changes: [
+      {
+        catalog_change_id: 'nessie-1',
+        catalog_ref: 'main',
+        content_key: 'orders_gold',
+        operation: 'commit',
+        source_hash: 'before',
+        target_hash: 'after',
+        commit_hash: 'commit-1',
+        merge_outcome: 'accepted',
+        snapshot_before: 'snap-1',
+        snapshot_after: 'snap-2',
+        metadata: { ref: 'main' },
+      },
+    ],
+    artifacts: [
+      {
+        artifact_id: 'failure-artifact',
+        artifact_kind: 'report',
+        uri: 's3://reports/failure.json',
+        content_type: 'application/json',
+        checksum: 'checksum',
+        expires_at: null,
+        legal_hold: false,
+        status: 'available',
+      },
+    ],
+    terminal_outcome: {
+      status: 'failed',
+      source: 'event-1',
+      evidence_id: 'terminal',
+      observed_at: '2026-07-15T10:02:00Z',
+    },
+    gaps: [
+      {
+        field: 'historical_fields',
+        status: 'unavailable',
+        reason: 'attempt_reconciliation_not_proven',
+      },
+    ],
+  }
+}
+
+function resource(role: string, resourceId: string) {
+  return {
+    resource_id: resourceId,
+    resource_kind: 'table',
+    role,
+    normalized_identity: resourceId,
+    uri: `s3://warehouse/${resourceId}`,
+    table_name: resourceId,
+    catalog: 'lakehouse',
+    ref_name: 'main',
+    schema_hash: 'schema-1',
+    record_count: 100,
+    byte_count: 1024,
+    staged_objects: [],
+    snapshot_before: 'snap-1',
+    snapshot_after: 'snap-2',
+  }
+}

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.test.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.test.tsx
@@ -3,8 +3,8 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import type { ObservatoryRunReport } from '@/observatory/api/types'
 import { RunReportView } from './RunReportView'
+import type { ObservatoryRunReport } from '@/observatory/api/types'
 
 const request = { projectId: 'finance', runId: 'daily-orders', attempt: '2' }
 

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.tsx
@@ -87,7 +87,9 @@ function ReportContent({ report }: { report: ObservatoryRunReport }) {
     report.staging.length === 0 &&
     report.outputs.length === 0 &&
     report.lineage.length === 0 &&
+    report.transformations.length === 0 &&
     report.quality.length === 0 &&
+    report.iceberg_snapshots.length === 0 &&
     report.catalog_changes.length === 0 &&
     report.artifacts.length === 0 &&
     !report.terminal_outcome

--- a/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/observatory/components/RunReportView.tsx
@@ -1,0 +1,477 @@
+import type {
+  ObservatoryReportArtifact,
+  ObservatoryReportCatalogChange,
+  ObservatoryReportQuality,
+  ObservatoryReportResource,
+  ObservatoryReportStage,
+  ObservatoryRunReport,
+} from '@/observatory/api/types'
+import type {
+  ObservatoryRunReportErrorCode,
+  ObservatoryRunReportResult,
+} from '@/observatory/api/resources'
+import type { ReactNode } from 'react'
+import { ObservatoryPage } from '@/observatory/components/ObservatoryPage'
+
+export interface RunReportRequest {
+  projectId: string
+  runId: string
+  attempt: string
+}
+
+export function RunReportView({
+  request,
+  result,
+}: {
+  request: RunReportRequest
+  result: ObservatoryRunReportResult | null
+}) {
+  const report = result?.data
+  return (
+    <ObservatoryPage
+      action={
+        <span className="phlo-observatory-pill">Attempt {request.attempt}</span>
+      }
+      description={`Attempt-scoped evidence for ${request.projectId} / ${request.runId}.`}
+      kicker="Run report"
+      title="Run report"
+    >
+      {!result ? (
+        <ReportState
+          title="Loading run report"
+          detail="Reading the exact attempt-scoped evidence snapshot."
+        />
+      ) : result.error ? (
+        <ReportState
+          detail={result.error}
+          title={errorTitle(result.errorCode)}
+        />
+      ) : report ? (
+        <ReportContent report={report} />
+      ) : (
+        <ReportState
+          detail="The API returned no report payload for this attempt."
+          title="No report evidence"
+        />
+      )}
+    </ObservatoryPage>
+  )
+}
+
+function ReportState({ title, detail }: { title: string; detail: string }) {
+  return (
+    <section
+      aria-busy={title.startsWith('Loading')}
+      className="phlo-observatory-empty-state"
+    >
+      <h2>{title}</h2>
+      <p>{detail}</p>
+    </section>
+  )
+}
+
+function errorTitle(code?: ObservatoryRunReportErrorCode) {
+  if (code === 'access_denied') return 'Access denied'
+  if (code === 'not_found') return 'Run report not found'
+  if (code === 'invalid_request') return 'Run report details are incomplete'
+  return 'Run report unavailable'
+}
+
+function ReportContent({ report }: { report: ObservatoryRunReport }) {
+  const run = report.lifecycle.run
+  const empty =
+    !run &&
+    report.lifecycle.events.length === 0 &&
+    report.stages.length === 0 &&
+    report.inputs.length === 0 &&
+    report.staging.length === 0 &&
+    report.outputs.length === 0 &&
+    report.lineage.length === 0 &&
+    report.quality.length === 0 &&
+    report.catalog_changes.length === 0 &&
+    report.artifacts.length === 0 &&
+    !report.terminal_outcome
+
+  if (empty) {
+    return (
+      <section className="phlo-observatory-command">
+        <div className="phlo-observatory-command-primary phlo-observatory-panel">
+          <ReportState
+            title="No attempt-scoped evidence recorded"
+            detail="This report contains no lifecycle or evidence records for the requested attempt."
+          />
+          <Gaps gaps={report.gaps} />
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="phlo-observatory-command phlo-observatory-surface-grid">
+      <div className="phlo-observatory-command-primary">
+        <Summary report={report} />
+        <ReportSection title="Lifecycle">
+          {run ? (
+            <RunFacts run={run} />
+          ) : (
+            <MissingEvidence text="No run header was recorded." />
+          )}
+          <EventList events={report.lifecycle.events} />
+        </ReportSection>
+        <ReportSection title="Stages and transformations">
+          <StageList stages={report.stages} />
+          {report.transformations.length > 0 && (
+            <div className="phlo-observatory-detail-list">
+              <div className="phlo-observatory-inspector-label">
+                Transformations
+              </div>
+              <StageList stages={report.transformations} />
+            </div>
+          )}
+        </ReportSection>
+        <ReportSection title="Inputs, staging, and outputs">
+          <ResourceGroup label="Inputs" resources={report.inputs} />
+          <ResourceGroup label="Staging" resources={report.staging} />
+          <ResourceGroup label="Outputs" resources={report.outputs} />
+        </ReportSection>
+        <ReportSection title="Lineage">
+          {report.lineage.length ? (
+            <div className="phlo-observatory-detail-list">
+              {report.lineage.map((edge) => (
+                <div
+                  className="phlo-observatory-mini-row"
+                  key={edge.lineage_edge_id}
+                >
+                  <span>
+                    {edge.source} → {edge.target}
+                  </span>
+                  <small>
+                    {edge.origin} · {edge.derivation}
+                  </small>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <MissingEvidence text="No lineage evidence was recorded." />
+          )}
+        </ReportSection>
+        <ReportSection title="Quality">
+          {report.quality.length ? (
+            <QualityList quality={report.quality} />
+          ) : (
+            <MissingEvidence text="No quality evidence was recorded." />
+          )}
+        </ReportSection>
+        <ReportSection title="Catalog / Nessie evidence">
+          <CatalogChanges changes={report.catalog_changes} />
+          <ResourceGroup
+            label="Iceberg snapshots"
+            resources={report.iceberg_snapshots}
+          />
+        </ReportSection>
+        <ReportSection title="Artifacts">
+          {report.artifacts.length ? (
+            <ArtifactList artifacts={report.artifacts} />
+          ) : (
+            <MissingEvidence text="No artifacts were recorded." />
+          )}
+        </ReportSection>
+      </div>
+      <aside className="phlo-observatory-inspector">
+        <div className="phlo-observatory-inspector-label">Outcome and gaps</div>
+        <TerminalOutcome report={report} />
+        <Gaps gaps={report.gaps} />
+      </aside>
+    </section>
+  )
+}
+
+function Summary({ report }: { report: ObservatoryRunReport }) {
+  return (
+    <div className="phlo-observatory-command-strip">
+      <Metric label="Project" value={report.project_id} />
+      <Metric label="Run" value={report.run_id} />
+      <Metric label="Attempt" value={report.attempt} />
+      <Metric label="Schema" value={report.schema_version} />
+    </div>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="phlo-observatory-command-metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  )
+}
+
+function ReportSection({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="phlo-observatory-panel">
+      <div className="phlo-observatory-browser-toolbar">
+        <span>{title}</span>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function RunFacts({
+  run,
+}: {
+  run: NonNullable<ObservatoryRunReport['lifecycle']['run']>
+}) {
+  return (
+    <dl className="phlo-observatory-facts">
+      <Fact label="Pipeline" value={run.pipeline_name} />
+      <Fact label="Provider run" value={run.provider_run_id} />
+      <Fact label="Status" value={run.status} />
+      <Fact label="Started" value={run.started_at} />
+      <Fact label="Finished" value={run.finished_at} />
+      <Fact label="Evidence completeness" value={run.evidence_completeness} />
+      <Fact label="Failure summary" value={run.failure_summary} />
+    </dl>
+  )
+}
+
+function EventList({
+  events,
+}: {
+  events: ObservatoryRunReport['lifecycle']['events']
+}) {
+  return events.length ? (
+    <div className="phlo-observatory-detail-list">
+      {events.map((event) => (
+        <div className="phlo-observatory-mini-row" key={event.event_id}>
+          <span>
+            {event.event_type} · {event.producer}
+          </span>
+          <small>
+            {event.observed_at ?? 'not timestamped'} · sequence{' '}
+            {display(event.sequence)}
+          </small>
+        </div>
+      ))}
+    </div>
+  ) : (
+    <MissingEvidence text="No lifecycle events were recorded." />
+  )
+}
+
+function StageList({ stages }: { stages: Array<ObservatoryReportStage> }) {
+  return stages.length ? (
+    <div className="phlo-observatory-detail-list">
+      {stages.map((stage) => (
+        <div className="phlo-observatory-mini-row" key={stage.stage_id}>
+          <span>
+            {stage.stage_id} · {stage.stage_type} · {stage.status}
+          </span>
+          <small>
+            {stage.provider ?? 'provider not reported'} ·{' '}
+            {stage.asset ?? 'asset not reported'} ·{' '}
+            {stage.error_fingerprint ?? 'no error fingerprint'}
+          </small>
+        </div>
+      ))}
+    </div>
+  ) : (
+    <MissingEvidence text="No stage evidence was recorded." />
+  )
+}
+
+function ResourceGroup({
+  label,
+  resources,
+}: {
+  label: string
+  resources: Array<ObservatoryReportResource>
+}) {
+  return (
+    <div className="phlo-observatory-detail-list">
+      <div className="phlo-observatory-inspector-label">{label}</div>
+      {resources.length ? (
+        resources.map((resource) => (
+          <ResourceRow key={resource.resource_id} resource={resource} />
+        ))
+      ) : (
+        <MissingEvidence
+          text={`No ${label.toLowerCase()} evidence was recorded.`}
+        />
+      )}
+    </div>
+  )
+}
+
+function ResourceRow({ resource }: { resource: ObservatoryReportResource }) {
+  return (
+    <div className="phlo-observatory-mini-row">
+      <span>
+        {resource.resource_id} · {resource.resource_kind}
+      </span>
+      <small>
+        {resource.table_name ??
+          resource.normalized_identity ??
+          resource.uri ??
+          'identity not reported'}{' '}
+        · {resource.record_count ?? 'records not reported'} records ·{' '}
+        {resource.byte_count ?? 'bytes not reported'} bytes · snapshots{' '}
+        {display(resource.snapshot_before)} → {display(resource.snapshot_after)}
+      </small>
+    </div>
+  )
+}
+
+function QualityList({
+  quality,
+}: {
+  quality: Array<ObservatoryReportQuality>
+}) {
+  return (
+    <div className="phlo-observatory-detail-list">
+      {quality.map((check) => (
+        <div
+          className="phlo-observatory-mini-row"
+          key={check.quality_result_id}
+        >
+          <span>
+            {check.check_id} · {check.passed ? 'passed' : 'failed'}
+            {check.blocking ? ' · blocking' : ''}
+          </span>
+          <small>
+            {check.asset ?? 'asset not reported'} · severity{' '}
+            {display(check.severity)} · evaluated{' '}
+            {display(check.evaluated_count)} · failed{' '}
+            {display(check.failed_count)}
+          </small>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function CatalogChanges({
+  changes,
+}: {
+  changes: Array<ObservatoryReportCatalogChange>
+}) {
+  return changes.length ? (
+    <div className="phlo-observatory-detail-list">
+      {changes.map((change) => (
+        <div
+          className="phlo-observatory-mini-row"
+          key={change.catalog_change_id}
+        >
+          <span>
+            {change.catalog_change_id} · {change.operation}
+          </span>
+          <small>
+            {change.catalog_ref ?? 'catalog not reported'} · ref{' '}
+            {display(change.content_key)} · commit {display(change.commit_hash)}{' '}
+            · outcome {display(change.merge_outcome)} · snapshots{' '}
+            {display(change.snapshot_before)} → {display(change.snapshot_after)}
+          </small>
+        </div>
+      ))}
+    </div>
+  ) : (
+    <MissingEvidence text="No catalog or Nessie changes were recorded." />
+  )
+}
+
+function ArtifactList({
+  artifacts,
+}: {
+  artifacts: Array<ObservatoryReportArtifact>
+}) {
+  return (
+    <div className="phlo-observatory-detail-list">
+      {artifacts.map((artifact) => (
+        <div className="phlo-observatory-mini-row" key={artifact.artifact_id}>
+          <span>
+            {artifact.artifact_id} · {artifact.artifact_kind} ·{' '}
+            {artifact.status}
+          </span>
+          <small>
+            {artifact.uri ?? 'URI not reported'} ·{' '}
+            {artifact.content_type ?? 'content type not reported'} · checksum{' '}
+            {display(artifact.checksum)} · legal hold{' '}
+            {String(artifact.legal_hold)}
+          </small>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function TerminalOutcome({ report }: { report: ObservatoryRunReport }) {
+  const outcome = report.terminal_outcome
+  return (
+    <div className="phlo-observatory-detail-list">
+      {outcome ? (
+        <>
+          <Fact label="Status" value={outcome.status} />
+          <Fact label="Source" value={outcome.source} />
+          <Fact label="Evidence" value={outcome.evidence_id} />
+          <Fact label="Observed" value={outcome.observed_at} />
+        </>
+      ) : (
+        <MissingEvidence text="No terminal outcome was recorded; the result remains unknown." />
+      )}
+    </div>
+  )
+}
+
+function Gaps({ gaps }: { gaps: ObservatoryRunReport['gaps'] }) {
+  return (
+    <div className="phlo-observatory-detail-list">
+      <div className="phlo-observatory-inspector-label">Explicit gaps</div>
+      {gaps.length ? (
+        gaps.map((gap) => (
+          <div
+            className="phlo-observatory-mini-row"
+            key={`${gap.field}:${gap.reason}`}
+          >
+            <span>
+              {gap.field} · {gap.status}
+            </span>
+            <small>{gap.reason}</small>
+          </div>
+        ))
+      ) : (
+        <MissingEvidence text="No explicit gaps were returned." />
+      )}
+    </div>
+  )
+}
+
+function Fact({
+  label,
+  value,
+}: {
+  label: string
+  value?: string | number | null
+}) {
+  return (
+    <div>
+      <dt>{label}</dt>
+      <dd>{display(value)}</dd>
+    </div>
+  )
+}
+
+function MissingEvidence({ text }: { text: string }) {
+  return <p className="phlo-observatory-panel-footer">{text}</p>
+}
+
+function display(value: unknown) {
+  return value === null || value === undefined || value === ''
+    ? 'not reported'
+    : String(value)
+}

--- a/packages/phlo-observatory/src/phlo_observatory/src/routeTree.gen.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routeTree.gen.ts
@@ -38,6 +38,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as WorkflowsNewRouteImport } from './routes/workflows/new'
 import { Route as ExtensionsExtensionIdRouteImport } from './routes/extensions/$extensionId'
 import { Route as DatasetsDatasetIdRouteImport } from './routes/datasets.$datasetId'
+import { Route as RunsProjectIdRunIdAttemptsAttemptReportRouteImport } from './routes/runs.$projectId.$runId.attempts.$attempt.report'
 
 const WorkspaceRoute = WorkspaceRouteImport.update({
   id: '/workspace',
@@ -184,6 +185,12 @@ const DatasetsDatasetIdRoute = DatasetsDatasetIdRouteImport.update({
   path: '/$datasetId',
   getParentRoute: () => DatasetsRoute,
 } as any)
+const RunsProjectIdRunIdAttemptsAttemptReportRoute =
+  RunsProjectIdRunIdAttemptsAttemptReportRouteImport.update({
+    id: '/$projectId/$runId/attempts/$attempt/report',
+    path: '/$projectId/$runId/attempts/$attempt/report',
+    getParentRoute: () => RunsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -205,7 +212,7 @@ export interface FileRoutesByFullPath {
   '/queries': typeof QueriesRoute
   '/query-history': typeof QueryHistoryRoute
   '/recents': typeof RecentsRoute
-  '/runs': typeof RunsRoute
+  '/runs': typeof RunsRouteWithChildren
   '/search': typeof SearchRoute
   '/services': typeof ServicesRoute
   '/settings': typeof SettingsRoute
@@ -215,6 +222,7 @@ export interface FileRoutesByFullPath {
   '/datasets/$datasetId': typeof DatasetsDatasetIdRoute
   '/extensions/$extensionId': typeof ExtensionsExtensionIdRoute
   '/workflows/new': typeof WorkflowsNewRoute
+  '/runs/$projectId/$runId/attempts/$attempt/report': typeof RunsProjectIdRunIdAttemptsAttemptReportRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -236,7 +244,7 @@ export interface FileRoutesByTo {
   '/queries': typeof QueriesRoute
   '/query-history': typeof QueryHistoryRoute
   '/recents': typeof RecentsRoute
-  '/runs': typeof RunsRoute
+  '/runs': typeof RunsRouteWithChildren
   '/search': typeof SearchRoute
   '/services': typeof ServicesRoute
   '/settings': typeof SettingsRoute
@@ -246,6 +254,7 @@ export interface FileRoutesByTo {
   '/datasets/$datasetId': typeof DatasetsDatasetIdRoute
   '/extensions/$extensionId': typeof ExtensionsExtensionIdRoute
   '/workflows/new': typeof WorkflowsNewRoute
+  '/runs/$projectId/$runId/attempts/$attempt/report': typeof RunsProjectIdRunIdAttemptsAttemptReportRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -268,7 +277,7 @@ export interface FileRoutesById {
   '/queries': typeof QueriesRoute
   '/query-history': typeof QueryHistoryRoute
   '/recents': typeof RecentsRoute
-  '/runs': typeof RunsRoute
+  '/runs': typeof RunsRouteWithChildren
   '/search': typeof SearchRoute
   '/services': typeof ServicesRoute
   '/settings': typeof SettingsRoute
@@ -278,6 +287,7 @@ export interface FileRoutesById {
   '/datasets/$datasetId': typeof DatasetsDatasetIdRoute
   '/extensions/$extensionId': typeof ExtensionsExtensionIdRoute
   '/workflows/new': typeof WorkflowsNewRoute
+  '/runs/$projectId/$runId/attempts/$attempt/report': typeof RunsProjectIdRunIdAttemptsAttemptReportRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -311,6 +321,7 @@ export interface FileRouteTypes {
     | '/datasets/$datasetId'
     | '/extensions/$extensionId'
     | '/workflows/new'
+    | '/runs/$projectId/$runId/attempts/$attempt/report'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -342,6 +353,7 @@ export interface FileRouteTypes {
     | '/datasets/$datasetId'
     | '/extensions/$extensionId'
     | '/workflows/new'
+    | '/runs/$projectId/$runId/attempts/$attempt/report'
   id:
     | '__root__'
     | '/'
@@ -373,6 +385,7 @@ export interface FileRouteTypes {
     | '/datasets/$datasetId'
     | '/extensions/$extensionId'
     | '/workflows/new'
+    | '/runs/$projectId/$runId/attempts/$attempt/report'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -395,7 +408,7 @@ export interface RootRouteChildren {
   QueriesRoute: typeof QueriesRoute
   QueryHistoryRoute: typeof QueryHistoryRoute
   RecentsRoute: typeof RecentsRoute
-  RunsRoute: typeof RunsRoute
+  RunsRoute: typeof RunsRouteWithChildren
   SearchRoute: typeof SearchRoute
   ServicesRoute: typeof ServicesRoute
   SettingsRoute: typeof SettingsRoute
@@ -610,6 +623,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DatasetsDatasetIdRouteImport
       parentRoute: typeof DatasetsRoute
     }
+    '/runs/$projectId/$runId/attempts/$attempt/report': {
+      id: '/runs/$projectId/$runId/attempts/$attempt/report'
+      path: '/$projectId/$runId/attempts/$attempt/report'
+      fullPath: '/runs/$projectId/$runId/attempts/$attempt/report'
+      preLoaderRoute: typeof RunsProjectIdRunIdAttemptsAttemptReportRouteImport
+      parentRoute: typeof RunsRoute
+    }
   }
 }
 
@@ -637,6 +657,17 @@ const ExtensionsRouteWithChildren = ExtensionsRoute._addFileChildren(
   ExtensionsRouteChildren,
 )
 
+interface RunsRouteChildren {
+  RunsProjectIdRunIdAttemptsAttemptReportRoute: typeof RunsProjectIdRunIdAttemptsAttemptReportRoute
+}
+
+const RunsRouteChildren: RunsRouteChildren = {
+  RunsProjectIdRunIdAttemptsAttemptReportRoute:
+    RunsProjectIdRunIdAttemptsAttemptReportRoute,
+}
+
+const RunsRouteWithChildren = RunsRoute._addFileChildren(RunsRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   SplatRoute: SplatRoute,
@@ -657,7 +688,7 @@ const rootRouteChildren: RootRouteChildren = {
   QueriesRoute: QueriesRoute,
   QueryHistoryRoute: QueryHistoryRoute,
   RecentsRoute: RecentsRoute,
-  RunsRoute: RunsRoute,
+  RunsRoute: RunsRouteWithChildren,
   SearchRoute: SearchRoute,
   ServicesRoute: ServicesRoute,
   SettingsRoute: SettingsRoute,

--- a/packages/phlo-observatory/src/phlo_observatory/src/routes/runs.$projectId.$runId.attempts.$attempt.report.tsx
+++ b/packages/phlo-observatory/src/phlo_observatory/src/routes/runs.$projectId.$runId.attempts.$attempt.report.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { getObservatoryRunReport } from '@/observatory/api/resources'
+import { RunReportView } from '@/observatory/components/RunReportView'
+
+export const Route = createFileRoute(
+  '/runs/$projectId/$runId/attempts/$attempt/report',
+)({
+  loader: ({ params }) =>
+    getObservatoryRunReport({
+      data: {
+        projectId: params.projectId,
+        runId: params.runId,
+        attempt: params.attempt,
+      },
+    }),
+  pendingComponent: RunReportPending,
+  component: RunReportRoute,
+})
+
+function RunReportRoute() {
+  const params = Route.useParams()
+  return <RunReportView request={params} result={Route.useLoaderData()} />
+}
+
+function RunReportPending() {
+  const params = Route.useParams()
+  return <RunReportView request={params} result={null} />
+}

--- a/packages/phlo-observatory/src/phlo_observatory/src/server/phlo-api.ts
+++ b/packages/phlo-observatory/src/phlo_observatory/src/server/phlo-api.ts
@@ -10,6 +10,7 @@ const PHLO_API_URL = process.env.PHLO_API_URL || 'http://localhost:4000'
 type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE'
 
 interface RequestOptions {
+  authorization?: string
   method?: HttpMethod
   params?: Record<string, string | number | boolean | undefined>
   body?: unknown
@@ -23,7 +24,13 @@ async function request<T>(
   endpoint: string,
   options: RequestOptions = {},
 ): Promise<T> {
-  const { method = 'GET', params, body, timeoutMs = 30000 } = options
+  const {
+    authorization,
+    method = 'GET',
+    params,
+    body,
+    timeoutMs = 30000,
+  } = options
 
   const url = new URL(`${PHLO_API_URL}${endpoint}`)
   if (params) {
@@ -34,10 +41,14 @@ async function request<T>(
     }
   }
 
+  const headers = new Headers()
+  const hasHeaders = Boolean(authorization) || body !== undefined
+  if (authorization) headers.set('Authorization', authorization)
+  if (body !== undefined) headers.set('Content-Type', 'application/json')
+
   const response = await fetch(url.toString(), {
     method,
-    headers:
-      body !== undefined ? { 'Content-Type': 'application/json' } : undefined,
+    headers: hasHeaders ? headers : undefined,
     body: body !== undefined ? JSON.stringify(body) : undefined,
     signal: AbortSignal.timeout(timeoutMs),
   })
@@ -57,8 +68,9 @@ export async function apiGet<T>(
   endpoint: string,
   params?: Record<string, string | number | boolean | undefined>,
   timeoutMs = 30000,
+  authorization?: string,
 ): Promise<T> {
-  return request<T>(endpoint, { params, timeoutMs })
+  return request<T>(endpoint, { authorization, params, timeoutMs })
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an authenticated deep-linkable Observatory run-report view at `/runs/{projectId}/{runId}/attempts/{attempt}/report`. The view renders lifecycle, stages, inputs, outputs, lineage, transformations, quality decisions, Iceberg/catalog evidence, artifacts, terminal outcome, and explicit gaps returned by the existing Run Report API.

The server-side report request forwards only a syntactically valid Bearer credential to the protected API. It does not forward cookies or arbitrary request headers; 401 and 403 render as access denied.

## Verification

- `npm test -- src/observatory/components/RunReportView.test.tsx src/observatory/api/resources.test.ts` — 11 passed
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- Observatory Prettier pre-commit hook