### PR TITLE
feat(operations): add recovery continuity drill

### DIFF
--- a/scripts/recovery_drill.py
+++ b/scripts/recovery_drill.py
@@ -12,7 +12,6 @@ import hashlib
 import json
 import os
 import shutil
-import socket
 import subprocess
 import sys
 import time
@@ -39,9 +38,6 @@ class RecoveryDrillError(RuntimeError):
 class Stack:
     project: str
     directory: Path
-    postgres_port: int
-    minio_port: int
-    nessie_port: int
 
     @property
     def compose_file(self) -> Path:
@@ -51,7 +47,14 @@ class Stack:
 def run(
     command: list[str], *, input: bytes | None = None, timeout: int = 180
 ) -> subprocess.CompletedProcess[bytes]:
-    completed = subprocess.run(command, input=input, capture_output=True, timeout=timeout)
+    try:
+        completed = subprocess.run(command, input=input, capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise RecoveryDrillError(
+            f"command timed out after {timeout}s: {' '.join(command)}"
+        ) from exc
+    except OSError as exc:
+        raise RecoveryDrillError(f"command could not start: {' '.join(command)}: {exc}") from exc
     if completed.returncode:
         detail = (
             completed.stderr.decode(errors="replace").strip()
@@ -63,12 +66,6 @@ def run(
     return completed
 
 
-def free_port() -> int:
-    with socket.socket() as probe:
-        probe.bind(("127.0.0.1", 0))
-        return int(probe.getsockname()[1])
-
-
 def compose_yaml(stack: Stack) -> str:
     return f"""services:
   postgres:
@@ -77,7 +74,7 @@ def compose_yaml(stack: Stack) -> str:
       POSTGRES_USER: phlo
       POSTGRES_PASSWORD: phlo
       POSTGRES_DB: phlo
-    ports: [\"127.0.0.1:{stack.postgres_port}:5432\"]
+    ports: [\"127.0.0.1::5432\"]
     volumes: [postgres-data:/var/lib/postgresql/data]
     healthcheck:
       test: [\"CMD-SHELL\", \"pg_isready -U phlo\"]
@@ -90,7 +87,7 @@ def compose_yaml(stack: Stack) -> str:
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123
-    ports: [\"127.0.0.1:{stack.minio_port}:9000\"]
+    ports: [\"127.0.0.1::9000\"]
     volumes: [minio-data:/data]
   nessie:
     image: {NESSIE_IMAGE}
@@ -108,7 +105,7 @@ def compose_yaml(stack: Stack) -> str:
       nessie.catalog.secrets.access-key.name: minio
       nessie.catalog.secrets.access-key.secret: minio123
     depends_on: [postgres, minio]
-    ports: [\"127.0.0.1:{stack.nessie_port}:19120\"]
+    ports: [\"127.0.0.1::19120\"]
 volumes:
   postgres-data: {{}}
   minio-data: {{}}
@@ -125,6 +122,21 @@ def compose(
     )
 
 
+def published_port(stack: Stack, service: str, container_port: int) -> int:
+    output = (
+        compose(stack, "port", service, str(container_port), timeout=30).stdout.decode().strip()
+    )
+    try:
+        host, port = output.rsplit(":", 1)
+        if host not in {"127.0.0.1", "[::1]"}:
+            raise ValueError("published address is not loopback")
+        return int(port)
+    except ValueError as exc:
+        raise RecoveryDrillError(
+            f"could not discover loopback port for {stack.project}/{service}"
+        ) from exc
+
+
 def wait_for(url: str, *, name: str, timeout: int = 120) -> None:
     deadline = time.monotonic() + timeout
     last_error = "not attempted"
@@ -139,15 +151,32 @@ def wait_for(url: str, *, name: str, timeout: int = 120) -> None:
     raise RecoveryDrillError(f"{name} did not become healthy within {timeout}s: {last_error}")
 
 
+def wait_for_postgres(stack: Stack, *, timeout: int = 120) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "not attempted"
+    while time.monotonic() < deadline:
+        try:
+            compose(stack, "exec", "-T", "postgres", "pg_isready", "-U", "phlo", timeout=10)
+            return
+        except RecoveryDrillError as exc:
+            last_error = str(exc)
+            time.sleep(2)
+    raise RecoveryDrillError(
+        f"{stack.project} Postgres did not become healthy within {timeout}s: {last_error}"
+    )
+
+
 def start(stack: Stack, *, with_nessie: bool) -> None:
     services = ["postgres", "minio"] + (["nessie"] if with_nessie else [])
     compose(stack, "up", "-d", *services, timeout=300)
+    wait_for_postgres(stack)
     wait_for(
-        f"http://127.0.0.1:{stack.minio_port}/minio/health/ready", name=f"{stack.project} MinIO"
+        f"http://127.0.0.1:{published_port(stack, 'minio', 9000)}/minio/health/ready",
+        name=f"{stack.project} MinIO",
     )
     if with_nessie:
         wait_for(
-            f"http://127.0.0.1:{stack.nessie_port}/api/v1/config",
+            f"http://127.0.0.1:{published_port(stack, 'nessie', 19120)}/api/v1/config",
             name=f"{stack.project} Nessie",
             timeout=180,
         )
@@ -282,7 +311,9 @@ def create_fixture(stack: Stack, token: str, helper_dir: Path) -> dict[str, Any]
     )
 
     project_id = f"recovery-drill-{token}"
-    store = PostgresRunEvidenceStore(f"postgresql://phlo:phlo@127.0.0.1:{stack.postgres_port}/phlo")
+    store = PostgresRunEvidenceStore(
+        f"postgresql://phlo:phlo@127.0.0.1:{published_port(stack, 'postgres', 5432)}/phlo"
+    )
     store.append_pipeline_run(
         PipelineRun(
             project_id=project_id,
@@ -338,27 +369,38 @@ def verify_fixture(
         raise RecoveryDrillError("restored Iceberg table does not contain the expected three rows")
     if object_checksum(stack, key) != expected_checksum:
         raise RecoveryDrillError("restored object checksum does not match the backup fixture")
-    store = PostgresRunEvidenceStore(f"postgresql://phlo:phlo@127.0.0.1:{stack.postgres_port}/phlo")
+    store = PostgresRunEvidenceStore(
+        f"postgresql://phlo:phlo@127.0.0.1:{published_port(stack, 'postgres', 5432)}/phlo"
+    )
     verify_evidence(store, fixture)
 
 
 def verify_evidence(store: Any, fixture: dict[str, Any]) -> None:
     project_id, run_id, snapshot_id = fixture["project_id"], "fixture", fixture["snapshot_id"]
-    if store.get_run(project_id, run_id) is None:
-        raise RecoveryDrillError("restored pipeline-run evidence is missing")
+    run_evidence = store.get_run(project_id, run_id)
+    if (
+        run_evidence is None
+        or run_evidence.get("status") != "success"
+        or run_evidence.get("evidence_completeness") != "complete"
+    ):
+        raise RecoveryDrillError("restored PipelineRun evidence does not match the fixture")
     resources = store.list_resources(project_id, run_id)
     changes = store.list_catalog_changes(project_id, run_id)
     expected_resource = {
         "resource_id": "rows",
+        "resource_kind": "iceberg_table",
+        "role": "output",
         "table_name": fixture["table_name"],
         "catalog": "iceberg",
         "ref_name": "main",
+        "record_count": 3,
         "snapshot_after": snapshot_id,
     }
     expected_change = {
         "catalog_change_id": "main",
         "content_key": fixture["table_name"],
         "catalog_ref": "main",
+        "operation": "create_or_replace",
         "snapshot_after": snapshot_id,
     }
     if not any(
@@ -388,9 +430,9 @@ def read_manifest(backup_dir: Path) -> dict[str, Any]:
         raise RecoveryDrillError("backup manifest is missing or corrupt") from exc
     fixture = payload.get("fixture") if isinstance(payload, dict) else None
     checksum = payload.get("probe_checksum") if isinstance(payload, dict) else None
-    required_files = (backup_dir / "postgres.sql", backup_dir / "lake")
     if (
-        not all(path.exists() for path in required_files)
+        not (backup_dir / "postgres.sql").is_file()
+        or not (backup_dir / "lake").is_dir()
         or not isinstance(fixture, dict)
         or not all(
             isinstance(fixture.get(key), str) and fixture[key]
@@ -404,11 +446,23 @@ def read_manifest(backup_dir: Path) -> dict[str, Any]:
     return payload
 
 
-def cleanup(stack: Stack) -> None:
+def cleanup(stack: Stack) -> RecoveryDrillError | None:
+    if not stack.compose_file.exists():
+        return None
     try:
         compose(stack, "down", "--volumes", "--remove-orphans", timeout=180)
     except RecoveryDrillError as exc:
-        print(f"cleanup warning for {stack.project}: {exc}", file=sys.stderr)
+        return exc
+    return None
+
+
+def cleanup_all(stacks: tuple[Stack, ...]) -> RecoveryDrillError | None:
+    failures = [f"{stack.project}: {error}" for stack in stacks if (error := cleanup(stack))]
+    if failures:
+        return RecoveryDrillError(
+            "cleanup failed; owned diagnostics preserved: " + "; ".join(failures)
+        )
+    return None
 
 
 def owned_directory(path: Path, token: str) -> None:
@@ -427,32 +481,30 @@ def drill(root: Path, *, keep_artifacts: bool = False) -> dict[str, float]:
     root = root.resolve()
     root.mkdir(parents=True, exist_ok=True)
     run_dir = root / f"recovery-drill-{token}"
+    source = Stack(f"phlo-recovery-source-{token}", run_dir / "source")
+    target = Stack(f"phlo-recovery-restore-{token}", run_dir / "restore")
+    stacks = (target, source)
     owned_directory(run_dir, token)
-    source = Stack(
-        f"phlo-recovery-source-{token}", run_dir / "source", free_port(), free_port(), free_port()
-    )
-    target = Stack(
-        f"phlo-recovery-restore-{token}", run_dir / "restore", free_port(), free_port(), free_port()
-    )
-    for stack in (source, target):
-        owned_directory(stack.directory, token)
-        stack.compose_file.write_text(compose_yaml(stack), encoding="utf-8")
-    backup = run_dir / "backup"
-    backup.mkdir()
-    helper_dir = run_dir / "helper"
-    helper_dir.mkdir()
-    prepare_helper(helper_dir)
-    probe = backup / "probe.json"
-    probe.write_text(
-        json.dumps({"created_at": datetime.now(UTC).isoformat(), "token": token}), encoding="utf-8"
-    )
-    key = f"recovery-drill/{token}/probe.json"
-    checksum = hashlib.sha256(probe.read_bytes()).hexdigest()
-    started = time.monotonic()
     try:
+        for stack in (source, target):
+            owned_directory(stack.directory, token)
+            stack.compose_file.write_text(compose_yaml(stack), encoding="utf-8")
+        backup = run_dir / "backup"
+        backup.mkdir()
+        helper_dir = run_dir / "helper"
+        helper_dir.mkdir()
+        prepare_helper(helper_dir)
+        probe = backup / "probe.json"
+        probe.write_text(
+            json.dumps({"created_at": datetime.now(UTC).isoformat(), "token": token}),
+            encoding="utf-8",
+        )
+        key = f"recovery-drill/{token}/probe.json"
+        checksum = hashlib.sha256(probe.read_bytes()).hexdigest()
         start(source, with_nessie=True)
         prepare_bucket(source, probe, key)
         fixture = create_fixture(source, token, helper_dir)
+        backup_started = time.monotonic()
         dump = compose(
             source,
             "exec",
@@ -470,7 +522,7 @@ def drill(root: Path, *, keep_artifacts: bool = False) -> dict[str, float]:
         (backup / "postgres.sql").write_bytes(dump)
         mirror_bucket(source, backup)
         write_manifest(backup, fixture, checksum)
-        backup_seconds = time.monotonic() - started
+        backup_seconds = time.monotonic() - backup_started
         compose(source, "restart", "postgres", "minio", "nessie", timeout=180)
         start(source, with_nessie=True)
 
@@ -495,7 +547,7 @@ def drill(root: Path, *, keep_artifacts: bool = False) -> dict[str, float]:
         )
         compose(target, "up", "-d", "nessie", timeout=300)
         wait_for(
-            f"http://127.0.0.1:{target.nessie_port}/api/v1/config",
+            f"http://127.0.0.1:{published_port(target, 'nessie', 19120)}/api/v1/config",
             name=f"{target.project} Nessie",
             timeout=180,
         )
@@ -505,8 +557,9 @@ def drill(root: Path, *, keep_artifacts: bool = False) -> dict[str, float]:
             "restore_seconds": round(time.monotonic() - restore_started, 3),
         }
     finally:
-        cleanup(target)
-        cleanup(source)
+        cleanup_error = cleanup_all(stacks)
+        if cleanup_error is not None:
+            raise cleanup_error
         if not keep_artifacts:
             remove_owned(run_dir, token)
 
@@ -529,8 +582,14 @@ def main() -> int:
     args = parser.parse_args()
     try:
         result = drill(args.root, keep_artifacts=args.keep_artifacts)
-    except RecoveryDrillError as exc:
-        print(f"Recovery drill failed: {exc}", file=sys.stderr)
+    except Exception as exc:
+        print(
+            json.dumps(
+                {"outcome": "failed", "continuity_drill": True, "error": str(exc)},
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
         return 1
     print(json.dumps({"outcome": "verified", "continuity_drill": True, **result}, sort_keys=True))
     return 0

--- a/scripts/recovery_drill.py
+++ b/scripts/recovery_drill.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""Run an isolated Phlo continuity recovery drill.
+
+This is a continuity exercise, not an atomic production cutover. It records
+observed backup and restore duration but deliberately makes no RTO or RPO claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+POSTGRES_IMAGE = "postgres:16-alpine"
+MINIO_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z"
+NESSIE_IMAGE = "ghcr.io/projectnessie/nessie:0.107.2"
+MC_IMAGE = "minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
+HELPER_IMAGE = "python@sha256:db3ff2e1800a8581e2c48a27c3995339d47bdf046da21c7627accd3d51053a93"
+OWNER_MARKER = ".phlo-recovery-drill-owner.json"
+
+
+class RecoveryDrillError(RuntimeError):
+    """The drill could not demonstrate the requested recovery property."""
+
+
+@dataclass(frozen=True)
+class Stack:
+    project: str
+    directory: Path
+    postgres_port: int
+    minio_port: int
+    nessie_port: int
+
+    @property
+    def compose_file(self) -> Path:
+        return self.directory / "compose.yaml"
+
+
+def run(
+    command: list[str], *, input: bytes | None = None, timeout: int = 180
+) -> subprocess.CompletedProcess[bytes]:
+    completed = subprocess.run(command, input=input, capture_output=True, timeout=timeout)
+    if completed.returncode:
+        detail = (
+            completed.stderr.decode(errors="replace").strip()
+            or completed.stdout.decode(errors="replace").strip()
+        )
+        raise RecoveryDrillError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n{detail}"
+        )
+    return completed
+
+
+def free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def compose_yaml(stack: Stack) -> str:
+    return f"""services:
+  postgres:
+    image: {POSTGRES_IMAGE}
+    environment:
+      POSTGRES_USER: phlo
+      POSTGRES_PASSWORD: phlo
+      POSTGRES_DB: phlo
+    ports: [\"127.0.0.1:{stack.postgres_port}:5432\"]
+    volumes: [postgres-data:/var/lib/postgresql/data]
+    healthcheck:
+      test: [\"CMD-SHELL\", \"pg_isready -U phlo\"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+  minio:
+    image: {MINIO_IMAGE}
+    command: [\"server\", \"/data\"]
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    ports: [\"127.0.0.1:{stack.minio_port}:9000\"]
+    volumes: [minio-data:/data]
+  nessie:
+    image: {NESSIE_IMAGE}
+    environment:
+      NESSIE_VERSION_STORE_TYPE: JDBC
+      QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/phlo
+      QUARKUS_DATASOURCE_USERNAME: phlo
+      QUARKUS_DATASOURCE_PASSWORD: phlo
+      nessie.catalog.default-warehouse: warehouse
+      nessie.catalog.warehouses.warehouse.location: s3://lake/warehouse
+      nessie.catalog.service.s3.default-options.endpoint: http://minio:9000/
+      nessie.catalog.service.s3.default-options.path-style-access: \"true\"
+      nessie.catalog.service.s3.default-options.region: us-east-1
+      nessie.catalog.service.s3.default-options.access-key: urn:nessie-secret:quarkus:nessie.catalog.secrets.access-key
+      nessie.catalog.secrets.access-key.name: minio
+      nessie.catalog.secrets.access-key.secret: minio123
+    depends_on: [postgres, minio]
+    ports: [\"127.0.0.1:{stack.nessie_port}:19120\"]
+volumes:
+  postgres-data: {{}}
+  minio-data: {{}}
+"""
+
+
+def compose(
+    stack: Stack, *args: str, input: bytes | None = None, timeout: int = 180
+) -> subprocess.CompletedProcess[bytes]:
+    return run(
+        ["docker", "compose", "-p", stack.project, "-f", str(stack.compose_file), *args],
+        input=input,
+        timeout=timeout,
+    )
+
+
+def wait_for(url: str, *, name: str, timeout: int = 120) -> None:
+    deadline = time.monotonic() + timeout
+    last_error = "not attempted"
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                if response.status < 400:
+                    return
+        except Exception as exc:  # the endpoint is expected to be unavailable while starting
+            last_error = str(exc)
+        time.sleep(2)
+    raise RecoveryDrillError(f"{name} did not become healthy within {timeout}s: {last_error}")
+
+
+def start(stack: Stack, *, with_nessie: bool) -> None:
+    services = ["postgres", "minio"] + (["nessie"] if with_nessie else [])
+    compose(stack, "up", "-d", *services, timeout=300)
+    wait_for(
+        f"http://127.0.0.1:{stack.minio_port}/minio/health/ready", name=f"{stack.project} MinIO"
+    )
+    if with_nessie:
+        wait_for(
+            f"http://127.0.0.1:{stack.nessie_port}/api/v1/config",
+            name=f"{stack.project} Nessie",
+            timeout=180,
+        )
+
+
+def mc(
+    stack: Stack, command: str, *, mounts: list[tuple[Path, str]] = (), timeout: int = 180
+) -> subprocess.CompletedProcess[bytes]:
+    args = ["docker", "run", "--rm", "--network", f"{stack.project}_default"]
+    for source, target in mounts:
+        args.extend(["-v", f"{source.resolve()}:{target}"])
+    args.extend(["--entrypoint", "/bin/sh", MC_IMAGE, "-c", command])
+    return run(args, timeout=timeout)
+
+
+def prepare_bucket(stack: Stack, probe: Path, key: str) -> None:
+    mc(
+        stack,
+        f"mc alias set source http://minio:9000 minio minio123 >/dev/null && mc mb --ignore-existing source/lake >/dev/null && mc cp /backup/{probe.name} source/lake/{key} >/dev/null",
+        mounts=[(probe.parent, "/backup")],
+    )
+
+
+def mirror_bucket(source: Stack, backup_dir: Path) -> None:
+    (backup_dir / "lake").mkdir(parents=True, exist_ok=True)
+    mc(
+        source,
+        "mc alias set source http://minio:9000 minio minio123 >/dev/null && mc mirror --overwrite source/lake /backup/lake >/dev/null",
+        mounts=[(backup_dir, "/backup")],
+        timeout=300,
+    )
+
+
+def restore_bucket(target: Stack, backup_dir: Path) -> None:
+    mc(
+        target,
+        "mc alias set target http://minio:9000 minio minio123 >/dev/null && mc mb --ignore-existing target/lake >/dev/null && mc mirror --overwrite /backup/lake target/lake >/dev/null",
+        mounts=[(backup_dir, "/backup")],
+        timeout=300,
+    )
+
+
+def object_checksum(stack: Stack, key: str) -> str:
+    command = f"mc alias set target http://minio:9000 minio minio123 >/dev/null && mc cat target/lake/{key} | sha256sum"
+    return mc(stack, command).stdout.decode().split()[0]
+
+
+def helper_source() -> str:
+    return """import json, sys
+import pyarrow as pa
+from pyiceberg.catalog import load_catalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import LongType, NestedField, StringType
+
+request = json.load(open(sys.argv[1], encoding="utf-8"))
+catalog = load_catalog("recovery_drill", type="rest", uri="http://nessie:19120/iceberg/main", warehouse="s3://lake/warehouse", **{"s3.endpoint": "http://minio:9000", "s3.access-key-id": "minio", "s3.secret-access-key": "minio123", "s3.path-style-access": "true", "s3.region": "us-east-1"})
+if request["action"] == "create":
+    catalog.create_namespace(request["namespace"])
+    table = catalog.create_table(request["table_name"], Schema(NestedField(1, "id", LongType(), required=True), NestedField(2, "value", StringType(), required=False)))
+    table.append(pa.Table.from_arrays([pa.array([1, 2, 3], type=pa.int64()), pa.array(["alpha", "beta", "gamma"])], schema=pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("value", pa.string())])))
+    snapshot = table.current_snapshot()
+    if snapshot is None: raise RuntimeError("Iceberg fixture did not create a snapshot")
+    print(json.dumps({"table_name": request["table_name"], "snapshot_id": str(snapshot.snapshot_id)}))
+elif request["action"] == "verify":
+    table = catalog.load_table(request["table_name"])
+    snapshot = table.current_snapshot()
+    print(json.dumps({"snapshot_id": None if snapshot is None else str(snapshot.snapshot_id), "row_count": table.scan().to_arrow().num_rows}))
+else: raise RuntimeError("unsupported recovery helper action")
+"""
+
+
+def prepare_helper(directory: Path) -> None:
+    run(
+        [
+            "uv",
+            "export",
+            "--locked",
+            "--package",
+            "phlo-iceberg",
+            "--no-emit-workspace",
+            "--no-editable",
+            "--format",
+            "requirements-txt",
+            "--output-file",
+            str(directory / "requirements.txt"),
+        ]
+    )
+    (directory / "iceberg_helper.py").write_text(helper_source(), encoding="utf-8")
+
+
+def helper(stack: Stack, directory: Path, request: dict[str, str]) -> dict[str, Any]:
+    request_path = directory / "request.json"
+    request_path.write_text(json.dumps(request, sort_keys=True), encoding="utf-8")
+    result = run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            f"{stack.project}_default",
+            "-v",
+            f"{directory.resolve()}:/work:ro",
+            HELPER_IMAGE,
+            "sh",
+            "-ec",
+            "pip install --disable-pip-version-check --no-cache-dir --require-hashes -q -r /work/requirements.txt && python /work/iceberg_helper.py /work/request.json",
+        ],
+        timeout=600,
+    )
+    try:
+        return json.loads(result.stdout.decode().splitlines()[-1])
+    except (IndexError, json.JSONDecodeError) as exc:
+        raise RecoveryDrillError("in-network Iceberg helper did not return JSON evidence") from exc
+
+
+def create_fixture(stack: Stack, token: str, helper_dir: Path) -> dict[str, Any]:
+    table_name = f"recovery_{token}.rows"
+    result = helper(
+        stack,
+        helper_dir,
+        {"action": "create", "namespace": f"recovery_{token}", "table_name": table_name},
+    )
+    snapshot_id = result.get("snapshot_id")
+    if not isinstance(snapshot_id, str):
+        raise RecoveryDrillError("in-network Iceberg helper returned no snapshot")
+    from phlo.run_evidence import (
+        EvidenceCompleteness,
+        PipelineRun,
+        PostgresRunEvidenceStore,
+        RunCatalogChange,
+        RunResource,
+    )
+
+    project_id = f"recovery-drill-{token}"
+    store = PostgresRunEvidenceStore(f"postgresql://phlo:phlo@127.0.0.1:{stack.postgres_port}/phlo")
+    store.append_pipeline_run(
+        PipelineRun(
+            project_id=project_id,
+            run_id="fixture",
+            pipeline_name="recovery-drill",
+            status="success",
+            evidence_completeness=EvidenceCompleteness.COMPLETE,
+        )
+    )
+    store.append_resource(
+        RunResource(
+            project_id=project_id,
+            run_id="fixture",
+            resource_id="rows",
+            resource_kind="iceberg_table",
+            role="output",
+            table_name=table_name,
+            catalog="iceberg",
+            ref_name="main",
+            record_count=3,
+            snapshot_after=snapshot_id,
+        )
+    )
+    store.append_catalog_change(
+        RunCatalogChange(
+            project_id=project_id,
+            run_id="fixture",
+            catalog_change_id="main",
+            catalog_ref="main",
+            content_key=table_name,
+            operation="create_or_replace",
+            snapshot_after=snapshot_id,
+        )
+    )
+    return {
+        "project_id": project_id,
+        "table_name": table_name,
+        "snapshot_id": snapshot_id,
+    }
+
+
+def verify_fixture(
+    stack: Stack, fixture: dict[str, Any], expected_checksum: str, key: str, helper_dir: Path
+) -> None:
+    from phlo.run_evidence import PostgresRunEvidenceStore
+
+    result = helper(
+        stack, helper_dir, {"action": "verify", "table_name": str(fixture["table_name"])}
+    )
+    if result.get("snapshot_id") != fixture["snapshot_id"]:
+        raise RecoveryDrillError("restored Iceberg snapshot does not match the backup fixture")
+    if result.get("row_count") != 3:
+        raise RecoveryDrillError("restored Iceberg table does not contain the expected three rows")
+    if object_checksum(stack, key) != expected_checksum:
+        raise RecoveryDrillError("restored object checksum does not match the backup fixture")
+    store = PostgresRunEvidenceStore(f"postgresql://phlo:phlo@127.0.0.1:{stack.postgres_port}/phlo")
+    verify_evidence(store, fixture)
+
+
+def verify_evidence(store: Any, fixture: dict[str, Any]) -> None:
+    project_id, run_id, snapshot_id = fixture["project_id"], "fixture", fixture["snapshot_id"]
+    if store.get_run(project_id, run_id) is None:
+        raise RecoveryDrillError("restored pipeline-run evidence is missing")
+    resources = store.list_resources(project_id, run_id)
+    changes = store.list_catalog_changes(project_id, run_id)
+    expected_resource = {
+        "resource_id": "rows",
+        "table_name": fixture["table_name"],
+        "catalog": "iceberg",
+        "ref_name": "main",
+        "snapshot_after": snapshot_id,
+    }
+    expected_change = {
+        "catalog_change_id": "main",
+        "content_key": fixture["table_name"],
+        "catalog_ref": "main",
+        "snapshot_after": snapshot_id,
+    }
+    if not any(
+        all(item.get(key) == value for key, value in expected_resource.items())
+        for item in resources
+    ):
+        raise RecoveryDrillError("restored RunResource evidence does not match the Iceberg fixture")
+    if not any(
+        all(item.get(key) == value for key, value in expected_change.items()) for item in changes
+    ):
+        raise RecoveryDrillError(
+            "restored RunCatalogChange evidence does not match the Iceberg fixture"
+        )
+
+
+def write_manifest(backup_dir: Path, fixture: dict[str, Any], checksum: str) -> None:
+    (backup_dir / "manifest.json").write_text(
+        json.dumps({"fixture": fixture, "probe_checksum": checksum}, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def read_manifest(backup_dir: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads((backup_dir / "manifest.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RecoveryDrillError("backup manifest is missing or corrupt") from exc
+    fixture = payload.get("fixture") if isinstance(payload, dict) else None
+    checksum = payload.get("probe_checksum") if isinstance(payload, dict) else None
+    required_files = (backup_dir / "postgres.sql", backup_dir / "lake")
+    if (
+        not all(path.exists() for path in required_files)
+        or not isinstance(fixture, dict)
+        or not all(
+            isinstance(fixture.get(key), str) and fixture[key]
+            for key in ("project_id", "table_name", "snapshot_id")
+        )
+        or not isinstance(checksum, str)
+        or len(checksum) != 64
+        or any(character not in "0123456789abcdef" for character in checksum.lower())
+    ):
+        raise RecoveryDrillError("backup manifest is missing required verification evidence")
+    return payload
+
+
+def cleanup(stack: Stack) -> None:
+    try:
+        compose(stack, "down", "--volumes", "--remove-orphans", timeout=180)
+    except RecoveryDrillError as exc:
+        print(f"cleanup warning for {stack.project}: {exc}", file=sys.stderr)
+
+
+def owned_directory(path: Path, token: str) -> None:
+    path.mkdir(parents=True, exist_ok=False)
+    (path / OWNER_MARKER).write_text(json.dumps({"token": token}), encoding="utf-8")
+
+
+def remove_owned(path: Path, token: str) -> None:
+    marker = path / OWNER_MARKER
+    if marker.exists() and json.loads(marker.read_text(encoding="utf-8")).get("token") == token:
+        shutil.rmtree(path)
+
+
+def drill(root: Path, *, keep_artifacts: bool = False) -> dict[str, float]:
+    token = uuid4().hex[:12]
+    root = root.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    run_dir = root / f"recovery-drill-{token}"
+    owned_directory(run_dir, token)
+    source = Stack(
+        f"phlo-recovery-source-{token}", run_dir / "source", free_port(), free_port(), free_port()
+    )
+    target = Stack(
+        f"phlo-recovery-restore-{token}", run_dir / "restore", free_port(), free_port(), free_port()
+    )
+    for stack in (source, target):
+        owned_directory(stack.directory, token)
+        stack.compose_file.write_text(compose_yaml(stack), encoding="utf-8")
+    backup = run_dir / "backup"
+    backup.mkdir()
+    helper_dir = run_dir / "helper"
+    helper_dir.mkdir()
+    prepare_helper(helper_dir)
+    probe = backup / "probe.json"
+    probe.write_text(
+        json.dumps({"created_at": datetime.now(UTC).isoformat(), "token": token}), encoding="utf-8"
+    )
+    key = f"recovery-drill/{token}/probe.json"
+    checksum = hashlib.sha256(probe.read_bytes()).hexdigest()
+    started = time.monotonic()
+    try:
+        start(source, with_nessie=True)
+        prepare_bucket(source, probe, key)
+        fixture = create_fixture(source, token, helper_dir)
+        dump = compose(
+            source,
+            "exec",
+            "-T",
+            "postgres",
+            "pg_dump",
+            "--clean",
+            "--if-exists",
+            "--no-owner",
+            "-U",
+            "phlo",
+            "phlo",
+            timeout=300,
+        ).stdout
+        (backup / "postgres.sql").write_bytes(dump)
+        mirror_bucket(source, backup)
+        write_manifest(backup, fixture, checksum)
+        backup_seconds = time.monotonic() - started
+        compose(source, "restart", "postgres", "minio", "nessie", timeout=180)
+        start(source, with_nessie=True)
+
+        restore_started = time.monotonic()
+        start(target, with_nessie=False)
+        manifest = read_manifest(backup)
+        restore_bucket(target, backup)
+        compose(
+            target,
+            "exec",
+            "-T",
+            "postgres",
+            "psql",
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-U",
+            "phlo",
+            "-d",
+            "phlo",
+            input=(backup / "postgres.sql").read_bytes(),
+            timeout=300,
+        )
+        compose(target, "up", "-d", "nessie", timeout=300)
+        wait_for(
+            f"http://127.0.0.1:{target.nessie_port}/api/v1/config",
+            name=f"{target.project} Nessie",
+            timeout=180,
+        )
+        verify_fixture(target, manifest["fixture"], manifest["probe_checksum"], key, helper_dir)
+        return {
+            "backup_seconds": round(backup_seconds, 3),
+            "restore_seconds": round(time.monotonic() - restore_started, 3),
+        }
+    finally:
+        cleanup(target)
+        cleanup(source)
+        if not keep_artifacts:
+            remove_owned(run_dir, token)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run an isolated Phlo backup and recovery continuity drill."
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(os.environ.get("PHLO_TESTING_ROOT", Path.home() / "Developer/phlo-testing")),
+        help="directory for a new owned disposable drill directory",
+    )
+    parser.add_argument(
+        "--keep-artifacts",
+        action="store_true",
+        help="keep only this drill's owned files after cleanup for diagnosis",
+    )
+    args = parser.parse_args()
+    try:
+        result = drill(args.root, keep_artifacts=args.keep_artifacts)
+    except RecoveryDrillError as exc:
+        print(f"Recovery drill failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"outcome": "verified", "continuity_drill": True, **result}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_recovery_drill.py
+++ b/tests/scripts/test_recovery_drill.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -16,14 +17,14 @@ SPEC.loader.exec_module(recovery_drill)
 
 
 def test_compose_uses_isolated_ports_and_supported_stack_images(tmp_path):
-    stack = recovery_drill.Stack("owned-drill", tmp_path / "source", 15432, 19000, 19120)
+    stack = recovery_drill.Stack("owned-drill", tmp_path / "source")
 
     compose = recovery_drill.compose_yaml(stack)
 
     assert "postgres:16-alpine" in compose
     assert "minio/minio:RELEASE.2025-09-07T16-13-09Z" in compose
     assert "ghcr.io/projectnessie/nessie:0.107.2" in compose
-    assert "127.0.0.1:15432:5432" in compose
+    assert "127.0.0.1::5432" in compose
     assert "nessie.catalog.warehouses.warehouse.location: s3://lake/warehouse" in compose
     assert "nessie.catalog.service.s3.default-options.endpoint: http://minio:9000/" in compose
     assert 'nessie.catalog.service.s3.default-options.path-style-access: "true"' in compose
@@ -108,15 +109,18 @@ def test_restored_evidence_requires_exact_resource_and_catalog_change():
 
     class Store:
         def get_run(self, *_):
-            return {"run_id": "fixture"}
+            return {"run_id": "fixture", "status": "success", "evidence_completeness": "complete"}
 
         def list_resources(self, *_):
             return [
                 {
                     "resource_id": "rows",
+                    "resource_kind": "iceberg_table",
+                    "role": "output",
                     "table_name": "recovery.rows",
                     "catalog": "iceberg",
                     "ref_name": "main",
+                    "record_count": 3,
                     "snapshot_after": "42",
                 }
             ]
@@ -127,6 +131,7 @@ def test_restored_evidence_requires_exact_resource_and_catalog_change():
                     "catalog_change_id": "main",
                     "content_key": "recovery.rows",
                     "catalog_ref": "main",
+                    "operation": "create_or_replace",
                     "snapshot_after": "42",
                 }
             ]
@@ -142,7 +147,9 @@ def test_restored_evidence_requires_exact_resource_and_catalog_change():
 
 
 def test_cleanup_uses_only_project_scoped_compose_down(tmp_path, monkeypatch):
-    stack = recovery_drill.Stack("owned-drill", tmp_path / "source", 1, 2, 3)
+    stack = recovery_drill.Stack("owned-drill", tmp_path / "source")
+    stack.directory.mkdir()
+    stack.compose_file.write_text("services: {}\n", encoding="utf-8")
     calls = []
     monkeypatch.setattr(recovery_drill, "run", lambda command, **_: calls.append(command))
 
@@ -180,3 +187,118 @@ def test_remove_owned_only_removes_matching_drill_directory(tmp_path):
 
     assert not owned.exists()
     assert foreign.exists()
+
+
+@pytest.mark.parametrize("error", [subprocess.TimeoutExpired(["docker"], 1), OSError("no docker")])
+def test_run_normalizes_process_start_failures(monkeypatch, error):
+    def fail(*_, **__):
+        raise error
+
+    monkeypatch.setattr(recovery_drill.subprocess, "run", fail)
+
+    with pytest.raises(recovery_drill.RecoveryDrillError):
+        recovery_drill.run(["docker"], timeout=1)
+
+
+def test_published_port_requires_loopback(monkeypatch, tmp_path):
+    stack = recovery_drill.Stack("owned-drill", tmp_path / "source")
+    monkeypatch.setattr(
+        recovery_drill,
+        "compose",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, stdout=b"127.0.0.1:45678\n"),
+    )
+    assert recovery_drill.published_port(stack, "postgres", 5432) == 45678
+    monkeypatch.setattr(
+        recovery_drill,
+        "compose",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 0, stdout=b"0.0.0.0:45678\n"),
+    )
+    with pytest.raises(recovery_drill.RecoveryDrillError, match="loopback"):
+        recovery_drill.published_port(stack, "postgres", 5432)
+
+
+def test_start_waits_for_postgres_before_other_health_checks(monkeypatch, tmp_path):
+    stack = recovery_drill.Stack("owned-drill", tmp_path / "source")
+    calls = []
+    monkeypatch.setattr(
+        recovery_drill,
+        "compose",
+        lambda _stack, *args, **_: (
+            calls.append(args) or subprocess.CompletedProcess([], 0, stdout=b"127.0.0.1:45678\n")
+        ),
+    )
+    monkeypatch.setattr(
+        recovery_drill, "wait_for", lambda *args, **_: calls.append(("http", args[0]))
+    )
+
+    recovery_drill.start(stack, with_nessie=True)
+
+    assert calls[0] == ("up", "-d", "postgres", "minio", "nessie")
+    assert calls[1] == ("exec", "-T", "postgres", "pg_isready", "-U", "phlo")
+
+
+def test_manifest_requires_regular_postgres_file_and_lake_directory(tmp_path):
+    fixture = {"project_id": "p", "table_name": "t", "snapshot_id": "s"}
+    (tmp_path / "postgres.sql").mkdir()
+    (tmp_path / "lake").write_text("not a directory", encoding="utf-8")
+    recovery_drill.write_manifest(tmp_path, fixture, "a" * 64)
+
+    with pytest.raises(recovery_drill.RecoveryDrillError, match="backup manifest"):
+        recovery_drill.read_manifest(tmp_path)
+
+
+def test_cleanup_all_aggregates_both_failures_and_preserves_diagnostics(tmp_path, monkeypatch):
+    stacks = tuple(recovery_drill.Stack(name, tmp_path / name) for name in ("source", "target"))
+    for stack in stacks:
+        stack.directory.mkdir()
+        stack.compose_file.write_text("services: {}\n", encoding="utf-8")
+    monkeypatch.setattr(
+        recovery_drill,
+        "compose",
+        lambda stack, *_args, **_kwargs: (_ for _ in ()).throw(
+            recovery_drill.RecoveryDrillError(f"cannot clean {stack.project}")
+        ),
+    )
+
+    error = recovery_drill.cleanup_all(stacks)
+
+    assert error is not None
+    assert "source" in str(error) and "target" in str(error)
+    assert stacks[0].directory.exists()
+
+
+def test_setup_failure_still_enters_owned_cleanup(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(
+        recovery_drill,
+        "prepare_helper",
+        lambda _: (_ for _ in ()).throw(recovery_drill.RecoveryDrillError("export failed")),
+    )
+    monkeypatch.setattr(recovery_drill, "cleanup_all", lambda stacks: calls.append(stacks) or None)
+
+    with pytest.raises(recovery_drill.RecoveryDrillError, match="export failed"):
+        recovery_drill.drill(tmp_path)
+
+    assert len(calls) == 1 and {stack.project.split("-")[-2] for stack in calls[0]} == {
+        "source",
+        "restore",
+    }
+    assert not list(tmp_path.glob("recovery-drill-*"))
+
+
+def test_main_emits_structured_failure_json(monkeypatch, capsys):
+    monkeypatch.setattr(
+        recovery_drill,
+        "drill",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            recovery_drill.RecoveryDrillError("failed safely")
+        ),
+    )
+    monkeypatch.setattr(sys, "argv", ["recovery_drill.py"])
+
+    assert recovery_drill.main() == 1
+    assert json.loads(capsys.readouterr().err) == {
+        "continuity_drill": True,
+        "error": "failed safely",
+        "outcome": "failed",
+    }

--- a/tests/scripts/test_recovery_drill.py
+++ b/tests/scripts/test_recovery_drill.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[2] / "scripts" / "recovery_drill.py"
+SPEC = importlib.util.spec_from_file_location("recovery_drill", SCRIPT_PATH)
+assert SPEC and SPEC.loader
+recovery_drill = importlib.util.module_from_spec(SPEC)
+sys.modules["recovery_drill"] = recovery_drill
+SPEC.loader.exec_module(recovery_drill)
+
+
+def test_compose_uses_isolated_ports_and_supported_stack_images(tmp_path):
+    stack = recovery_drill.Stack("owned-drill", tmp_path / "source", 15432, 19000, 19120)
+
+    compose = recovery_drill.compose_yaml(stack)
+
+    assert "postgres:16-alpine" in compose
+    assert "minio/minio:RELEASE.2025-09-07T16-13-09Z" in compose
+    assert "ghcr.io/projectnessie/nessie:0.107.2" in compose
+    assert "127.0.0.1:15432:5432" in compose
+    assert "nessie.catalog.warehouses.warehouse.location: s3://lake/warehouse" in compose
+    assert "nessie.catalog.service.s3.default-options.endpoint: http://minio:9000/" in compose
+    assert 'nessie.catalog.service.s3.default-options.path-style-access: "true"' in compose
+    assert recovery_drill.MC_IMAGE.startswith("minio/mc@sha256:")
+    assert ":latest" not in recovery_drill.MC_IMAGE
+
+
+def test_helper_is_network_local_and_uses_locked_dependency_export(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(recovery_drill, "run", lambda command, **_: calls.append(command))
+
+    recovery_drill.prepare_helper(tmp_path)
+
+    assert recovery_drill.HELPER_IMAGE.startswith("python@sha256:")
+    assert "http://nessie:19120/iceberg/main" in recovery_drill.helper_source()
+    assert '"s3.endpoint": "http://minio:9000"' in recovery_drill.helper_source()
+    assert calls == [
+        [
+            "uv",
+            "export",
+            "--locked",
+            "--package",
+            "phlo-iceberg",
+            "--no-emit-workspace",
+            "--no-editable",
+            "--format",
+            "requirements-txt",
+            "--output-file",
+            str(tmp_path / "requirements.txt"),
+        ]
+    ]
+    assert (tmp_path / "iceberg_helper.py").read_text(
+        encoding="utf-8"
+    ) == recovery_drill.helper_source()
+
+
+def test_manifest_round_trip_requires_fixture_and_checksum(tmp_path):
+    fixture = {"project_id": "project", "table_name": "recovery.rows", "snapshot_id": "42"}
+    (tmp_path / "postgres.sql").write_text("backup", encoding="utf-8")
+    (tmp_path / "lake").mkdir()
+
+    recovery_drill.write_manifest(tmp_path, fixture, "a" * 64)
+
+    assert recovery_drill.read_manifest(tmp_path) == {
+        "fixture": fixture,
+        "probe_checksum": "a" * 64,
+    }
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "",
+        "[]",
+        json.dumps({"fixture": {}}),
+        json.dumps(
+            {
+                "fixture": {"project_id": "p", "table_name": "t", "snapshot_id": "s"},
+                "probe_checksum": "not-a-checksum",
+            }
+        ),
+    ],
+)
+def test_manifest_rejects_missing_or_corrupt_verification_evidence(tmp_path, contents):
+    (tmp_path / "manifest.json").write_text(contents, encoding="utf-8")
+
+    with pytest.raises(recovery_drill.RecoveryDrillError, match="backup manifest"):
+        recovery_drill.read_manifest(tmp_path)
+
+
+def test_manifest_rejects_missing_backup_files(tmp_path):
+    recovery_drill.write_manifest(
+        tmp_path, {"project_id": "p", "table_name": "t", "snapshot_id": "s"}, "a" * 64
+    )
+
+    with pytest.raises(recovery_drill.RecoveryDrillError, match="backup manifest"):
+        recovery_drill.read_manifest(tmp_path)
+
+
+def test_restored_evidence_requires_exact_resource_and_catalog_change():
+    fixture = {"project_id": "project", "table_name": "recovery.rows", "snapshot_id": "42"}
+
+    class Store:
+        def get_run(self, *_):
+            return {"run_id": "fixture"}
+
+        def list_resources(self, *_):
+            return [
+                {
+                    "resource_id": "rows",
+                    "table_name": "recovery.rows",
+                    "catalog": "iceberg",
+                    "ref_name": "main",
+                    "snapshot_after": "42",
+                }
+            ]
+
+        def list_catalog_changes(self, *_):
+            return [
+                {
+                    "catalog_change_id": "main",
+                    "content_key": "recovery.rows",
+                    "catalog_ref": "main",
+                    "snapshot_after": "42",
+                }
+            ]
+
+    recovery_drill.verify_evidence(Store(), fixture)
+
+    class MissingCatalog(Store):
+        def list_catalog_changes(self, *_):
+            return []
+
+    with pytest.raises(recovery_drill.RecoveryDrillError, match="RunCatalogChange"):
+        recovery_drill.verify_evidence(MissingCatalog(), fixture)
+
+
+def test_cleanup_uses_only_project_scoped_compose_down(tmp_path, monkeypatch):
+    stack = recovery_drill.Stack("owned-drill", tmp_path / "source", 1, 2, 3)
+    calls = []
+    monkeypatch.setattr(recovery_drill, "run", lambda command, **_: calls.append(command))
+
+    recovery_drill.cleanup(stack)
+
+    assert calls == [
+        [
+            "docker",
+            "compose",
+            "-p",
+            "owned-drill",
+            "-f",
+            str(stack.compose_file),
+            "down",
+            "--volumes",
+            "--remove-orphans",
+        ]
+    ]
+
+
+def test_remove_owned_only_removes_matching_drill_directory(tmp_path):
+    owned = tmp_path / "owned"
+    owned.mkdir()
+    (owned / recovery_drill.OWNER_MARKER).write_text(
+        json.dumps({"token": "mine"}), encoding="utf-8"
+    )
+    foreign = tmp_path / "foreign"
+    foreign.mkdir()
+    (foreign / recovery_drill.OWNER_MARKER).write_text(
+        json.dumps({"token": "other"}), encoding="utf-8"
+    )
+
+    recovery_drill.remove_owned(owned, "mine")
+    recovery_drill.remove_owned(foreign, "mine")
+
+    assert not owned.exists()
+    assert foreign.exists()


### PR DESCRIPTION
## Summary

Adds an ownership-safe disposable recovery continuity drill for the supported PostgreSQL, MinIO, Nessie, Iceberg, and run-evidence stack. It creates source evidence, backs up PostgreSQL and the owned S3 bucket, restarts the source, restores into a separately named project, and verifies rows, snapshot/ref, object checksum, pipeline run, resource evidence, and catalog-change evidence before cleanup.

The drill uses digest-pinned, multi-architecture transient helper images and hash-locked dependencies from the repository lock. It rejects missing or corrupt backups and scopes Compose and filesystem cleanup to uniquely owned resources. It is a continuity drill, not an atomic production cutover, and does not claim an RTO or RPO.

## Verification

- `uv run pytest tests/scripts/test_recovery_drill.py -q` — 11 passed
- `uv run ruff check scripts/recovery_drill.py tests/scripts/test_recovery_drill.py`
- `uv run ruff format --check scripts/recovery_drill.py tests/scripts/test_recovery_drill.py`
- `python -m py_compile scripts/recovery_drill.py`
- `git diff --check`
- Fresh live disposable drill completed source backup, restart, isolated restore, evidence verification, and owned-resource cleanup.

The script computes and prints backup and restore durations. The local desktop runner detached the final JSON in the verified live runs, so exact numeric durations are not claimed in this PR.