### PR TITLE
feat(maintenance): add guarded snapshot expiry

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/iceberg_maintenance.py
+++ b/packages/phlo-dagster/src/phlo_dagster/iceberg_maintenance.py
@@ -2,16 +2,16 @@
 
 This module provides scheduled and on-demand maintenance operations for
 Apache Iceberg tables through Dagster jobs and ops. It handles retention
-planning, explicit execution refusal, and table statistics collection.
+planning, guarded snapshot-expiry execution, and table statistics collection.
 
 Maintenance Operations:
-    - expire_table_snapshots: Plan snapshot expiry; v1 destructive execution is refused
+    - expire_table_snapshots: Plan snapshot expiry and execute it with an explicit confirmation token
     - cleanup_orphan_files: Discover unreferenced files; v1 destructive execution is refused
     - collect_table_stats: Gather table metadata for monitoring and policy evaluation
 
 Jobs Provided:
     - iceberg_maintenance_job: Runs all maintenance operations
-    - expire_snapshots_job: Snapshot-expiry planning only
+    - expire_snapshots_job: Plan-first snapshot expiry
     - orphan_cleanup_job: Orphan-file discovery only
     - table_stats_job: Statistics collection only
 
@@ -19,8 +19,8 @@ Schedule:
     Default schedule runs full maintenance daily at 2 AM UTC (stopped by default).
 
 Safety Features:
-    - Planning mode by default; retention execution is refused on the blessed Trino boundary
-    - Explicit execution-refusal warnings in logs
+    - Planning mode by default; snapshot expiry requires a plan token and ref-aware executor
+    - Orphan cleanup remains planning-only
     - Table allowlist for targeted maintenance
     - Error collection and reporting without failing entire job
 
@@ -55,6 +55,7 @@ from typing import Any, cast
 import dagster as dg
 
 from phlo.capabilities import (
+    MaintenanceExecutor,
     MaintenanceRetentionStore,
     resolve_capability,
 )
@@ -84,6 +85,21 @@ def _load_maintenance_retention_store() -> MaintenanceRetentionStore:
             "Resolved table_store:iceberg does not implement the retention maintenance contract."
         )
     return store
+
+
+def _load_snapshot_expiry_executor() -> MaintenanceExecutor:
+    """Resolve the neutral ref-aware executor only for destructive expiry."""
+    resolution = resolve_capability("maintenance_executor")
+    if resolution is None:
+        raise RuntimeError(
+            "Snapshot expiry requires exactly one configured maintenance_executor capability."
+        )
+    executor = resolution.provider
+    if not isinstance(executor, MaintenanceExecutor):
+        raise RuntimeError(
+            "Resolved maintenance executor does not implement the snapshot-expiry contract."
+        )
+    return executor
 
 
 def _confirmation_token_for_table(config: MaintenanceConfig, table_name: str) -> str | None:
@@ -130,6 +146,8 @@ def _run_retention_resource_operation(
     if config.dry_run:
         return plan
     before_revision = cast(int | str | None, plan.get("before_revision"))
+    if operation == "expire_snapshots":
+        common["executor"] = _load_snapshot_expiry_executor()
     return method(
         **common,
         dry_run=False,
@@ -143,7 +161,7 @@ def expire_table_snapshots(
     context: dg.OpExecutionContext,
     config: MaintenanceConfig,
 ) -> dict[str, Any]:
-    """Plan snapshot expiry, refusing destructive execution on the v1 boundary.
+    """Plan snapshot expiry and execute only with guarded, non-atomic evidence.
 
     Args:
         context: Dagster operation execution context.
@@ -516,7 +534,7 @@ def collect_table_stats(
     ),
 )
 def iceberg_maintenance_job():
-    """Plan retention operations without deletion, then collect table statistics.
+    """Plan retention operations, then collect table statistics.
 
     Args:
         None
@@ -534,10 +552,10 @@ def iceberg_maintenance_job():
 
 
 @dg.job(
-    description="Plan Iceberg snapshot expiry; destructive execution is refused",
+    description="Plan Iceberg snapshot expiry; execution requires an explicit plan token",
 )
 def expire_snapshots_job():
-    """Job that only plans snapshot expiry and refuses deletion.
+    """Job that plans snapshot expiry and accepts guarded execution requests.
 
     Args:
         None

--- a/packages/phlo-dagster/src/phlo_dagster/iceberg_maintenance_utils.py
+++ b/packages/phlo-dagster/src/phlo_dagster/iceberg_maintenance_utils.py
@@ -10,9 +10,9 @@ Configuration:
     - snapshot_retention_days: Age threshold for snapshot expiration
     - snapshot_retain_last: Minimum snapshots to preserve
     - orphan_retention_days: Age threshold for orphan file deletion
-    - dry_run: Plan-only mode; current retention execution is refused on the blessed provider boundary
-    - catalog, confirmation_token, confirmation_tokens: Plan-binding fields reserved for a future safe adapter
-    - max_affected_objects, max_affected_bytes: Finite limits validated against the plan before any future execution
+    - dry_run: Plan-only mode; snapshot execution requires an explicit plan token and executor
+    - catalog, confirmation_token, confirmation_tokens: Plan-binding fields for guarded snapshot expiry
+    - max_affected_objects, max_affected_bytes: Finite limits revalidated before provider submission
     - ref: Nessie branch reference (default: main)
     - table_allowlist: Optional restriction to specific tables
 
@@ -94,7 +94,7 @@ class MaintenanceConfig(dg.Config):
         snapshot_retention_days: Snapshot age threshold for expiration in days.
         snapshot_retain_last: Minimum number of snapshots to retain.
         orphan_retention_days: Orphan file age threshold for deletion in days.
-        dry_run: If ``True``, return a plan; current retention execution is refused on the blessed provider boundary.
+        dry_run: If ``True``, return a plan; snapshot execution is guarded and orphan cleanup is refused.
         catalog: Provider catalog used in plan evidence and future adapter validation.
         confirmation_token: Exact token returned by the dry-run plan.
         confirmation_tokens: Optional per-table confirmation tokens for multi-table execution.
@@ -227,6 +227,7 @@ def emit_maintenance_metrics(
     tables_processed: int,
     errors: int,
     snapshots_deleted: int | None = None,
+    total_candidate_snapshots: int | None = None,
     orphan_files: int | None = None,
     candidate_orphan_files: int | None = None,
     deleted_orphan_files: int | None = None,
@@ -242,6 +243,7 @@ def emit_maintenance_metrics(
         tables_processed: Number of tables processed.
         errors: Number of errors observed.
         snapshots_deleted: Optional number of deleted snapshots.
+        total_candidate_snapshots: Optional number of snapshot candidates planned.
         orphan_files: Optional number of orphan files processed.
         total_records: Optional total records affected.
         total_size_mb: Optional total data size affected in MB.

--- a/packages/phlo-dagster/tests/test_maintenance_capability_boundary.py
+++ b/packages/phlo-dagster/tests/test_maintenance_capability_boundary.py
@@ -13,6 +13,7 @@ class FakeMaintenanceRetentionStore:
 
     def __init__(self) -> None:
         self.expected_snapshot_id: int | str | None = None
+        self.executor: object | None = None
 
     def _plan(self) -> dict[str, object]:
         return {
@@ -54,6 +55,18 @@ class FakeMaintenanceRetentionStore:
                 "planned": plan,
             }
         self.expected_snapshot_id = kwargs.get("expected_snapshot_id")
+        self.executor = kwargs.get("executor")
+        if operation == "expire_snapshots" and self.executor is not None:
+            return {
+                "status": "succeeded",
+                "accepted": True,
+                "executed": True,
+                "before_revision": 41,
+                "after_revision": 42,
+                "plan_token": "fake-plan-token",
+                "planned": plan,
+                "affected": {"observed_snapshot_count_reduction": 1},
+            }
         return {
             "status": "blocked",
             "accepted": False,
@@ -68,6 +81,20 @@ class FakeMaintenanceRetentionStore:
             },
             "retry_safe": False,
         }
+
+
+class FakeSnapshotExpiryExecutor:
+    """Structural fake for the declared, neutral executor contract."""
+
+    def for_ref(self, ref: str):
+        assert ref == "main"
+        return self
+
+    def compact_table(self, **_: object) -> dict[str, object]:
+        return {}
+
+    def expire_snapshots_table(self, **_: object) -> dict[str, object]:
+        return {}
 
 
 def test_maintenance_source_does_not_import_concrete_provider_modules() -> None:
@@ -116,6 +143,11 @@ def test_orphan_execute_uses_plan_result_and_refuses_without_executor(monkeypatc
     monkeypatch.setattr(iceberg_maintenance, "resolve_capability", resolve)
     monkeypatch.setattr(iceberg_maintenance, "resolve_namespaces", lambda config: ["raw"])
     monkeypatch.setattr(iceberg_maintenance, "list_tables", lambda namespace, ref: ["raw.events"])
+    monkeypatch.setattr(
+        iceberg_maintenance,
+        "finish_maintenance_op",
+        MagicMock(return_value={"status": "success"}),
+    )
     config = MaintenanceConfig(
         namespace="raw",
         ref="main",
@@ -172,3 +204,33 @@ def test_snapshot_expiry_completion_telemetry_includes_candidate_count(monkeypat
 
     assert finish.call_args.kwargs["total_candidate_snapshots"] == 1
     assert result["total_candidate_snapshots"] == 1
+
+
+def test_snapshot_expiry_execute_resolves_and_passes_neutral_executor(monkeypatch) -> None:
+    store = FakeMaintenanceRetentionStore()
+    executor = FakeSnapshotExpiryExecutor()
+    resolutions: list[tuple[str, str | None]] = []
+
+    def resolve(capability_type: str, name: str | None = None):
+        resolutions.append((capability_type, name))
+        return MagicMock(provider=store if capability_type == "table_store" else executor)
+
+    monkeypatch.setattr(iceberg_maintenance, "resolve_capability", resolve)
+    monkeypatch.setattr(iceberg_maintenance, "resolve_namespaces", lambda config: ["raw"])
+    monkeypatch.setattr(iceberg_maintenance, "list_tables", lambda namespace, ref: ["raw.events"])
+    context = MagicMock(run_id="run-1", job_name="maintenance")
+
+    result = iceberg_maintenance.expire_table_snapshots.compute_fn.decorated_fn(
+        context,
+        MaintenanceConfig(
+            namespace="raw",
+            ref="main",
+            dry_run=False,
+            catalog="iceberg",
+            confirmation_token="fake-plan-token",
+        ),
+    )
+
+    assert resolutions == [("table_store", "iceberg"), ("maintenance_executor", None)]
+    assert store.executor is executor
+    assert result["total_snapshots_deleted"] == 0

--- a/packages/phlo-iceberg/src/phlo_iceberg/resource.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/resource.py
@@ -287,6 +287,16 @@ def _safe_table_state(
         return unavailable_table_state(phase=phase, error_type=type(exc).__name__)
 
 
+def _retention_state_evidence(plan: dict[str, Any]) -> dict[str, object]:
+    """Extract table-state evidence without implying an exact expiry set."""
+    return {
+        "snapshot_id": plan.get("before_snapshot_id"),
+        "snapshot_count": plan.get("snapshot_count"),
+        "file_count": plan.get("file_count"),
+        "total_size_bytes": plan.get("total_size_bytes"),
+    }
+
+
 @dataclass
 class IcebergResource:
     """Resource wrapper for Iceberg REST catalog operations.
@@ -1299,9 +1309,10 @@ class IcebergResource:
             "unavailable_fields": [*unavailable_fields, "provider_version"],
             "max_affected_objects": max_affected_objects,
             "max_affected_bytes": max_affected_bytes,
-            "snapshot_guard": "fresh_table_metadata_only",
+            "snapshot_guard": "provider_preflight_non_atomic",
             "trino_boundary": "pending",
-            "execution_support": "unsupported_without_bound_deletion_set",
+            "execution_support": "guarded_non_atomic_threshold_execution",
+            "retain_last_guarantee": "provider_unsupported_not_enforced",
             "observed_at_ms": int(datetime.now(UTC).timestamp() * 1000),
         }
         plan["plan_token"] = _maintenance_plan_token(plan)
@@ -1468,12 +1479,9 @@ class IcebergResource:
         max_affected_objects: int | None,
         max_affected_bytes: int | None,
         operation_id: str | None,
+        executor: MaintenanceExecutor | None = None,
     ) -> dict[str, object]:
-        """Validate an execute request and return a blocked result.
-
-        The v1 provider boundary has no operation that can bind the complete
-        planned deletion surface, so this method deliberately never submits SQL.
-        """
+        """Revalidate a retention plan before a guarded provider submission."""
         plan = cast(dict[str, Any], plan)
         plan_token = str(plan["plan_token"])
 
@@ -1541,20 +1549,212 @@ class IcebergResource:
                 "concurrent_change_detected",
                 "The table changed after planning; obtain a fresh dry-run.",
             )
-        return self._retention_blocked(
-            operation=operation,
+        if operation != "expire_snapshots":
+            return self._retention_blocked(
+                operation=operation,
+                table_name=table_name,
+                ref=ref,
+                dry_run=False,
+                plan={**plan, "trino_boundary": "not_invoked"},
+                code="bounded_execution_unsupported",
+                message=(
+                    "The Trino retention procedure accepts only a threshold and cannot bind "
+                    "the provider deletion surface to this exact candidate and byte plan."
+                ),
+                operation_id=operation_id,
+                retry_safe=False,
+            )
+        if not plan.get("candidate_snapshots"):
+            return MaintenanceOperationResult(
+                operation=operation,
+                table_name=table_name,
+                ref=ref,
+                dry_run=False,
+                status=MaintenanceOperationState.NOOP,
+                accepted=True,
+                executed=False,
+                before_revision=expected,
+                planned={**plan, "trino_boundary": "not_invoked"},
+                evidence={"before": _retention_state_evidence(plan)},
+                operation_id=operation_id,
+                plan_token=plan_token,
+                retry_safe=True,
+            ).to_dict()
+        if executor is None:
+            return block(
+                "maintenance_executor_required",
+                "Snapshot expiry execute mode requires a ref-aware maintenance executor.",
+            )
+        return self._execute_snapshot_expiry(
+            table_name=table_name,
+            ref=ref,
+            plan=plan,
+            expected_snapshot_id=expected,
+            executor=executor,
+            operation_id=operation_id,
+        )
+
+    def _execute_snapshot_expiry(
+        self,
+        *,
+        table_name: str,
+        ref: str,
+        plan: dict[str, Any],
+        expected_snapshot_id: int,
+        executor: MaintenanceExecutor,
+        operation_id: str | None,
+    ) -> dict[str, object]:
+        """Submit threshold expiry and report its deliberately non-atomic evidence."""
+        before = _retention_state_evidence(plan)
+        try:
+            provider_result = executor.for_ref(ref).expire_snapshots_table(
+                table_name=table_name,
+                ref=ref,
+                expected_revision=expected_snapshot_id,
+                retention_hours=int(plan["retention_hours"]),
+                retain_last=int(plan["retain_last"]),
+                operation_id=operation_id,
+            )
+        except MaintenancePreconditionError as exc:
+            return self._retention_blocked(
+                operation="expire_snapshots",
+                table_name=table_name,
+                ref=ref,
+                dry_run=False,
+                plan={**plan, "trino_boundary": "not_invoked"},
+                code="provider_precondition_failed",
+                message=str(exc) or type(exc).__name__,
+                operation_id=operation_id,
+            )
+        except MaintenanceExecutionError as exc:
+            preflight_failed = exc.phase is MaintenanceExecutionPhase.PREFLIGHT
+            return MaintenanceOperationResult(
+                operation="expire_snapshots",
+                table_name=table_name,
+                ref=ref,
+                dry_run=False,
+                status=MaintenanceOperationState.FAILED,
+                accepted=not preflight_failed,
+                executed=not preflight_failed,
+                before_revision=expected_snapshot_id,
+                planned={
+                    **plan,
+                    "trino_boundary": "not_invoked" if preflight_failed else "submitted",
+                },
+                evidence={"before": before},
+                failure={
+                    **_compaction_failure(
+                        exc.cause,
+                        code=(
+                            "failed_before_submission"
+                            if preflight_failed
+                            else "outcome_unknown_after_submission"
+                        ),
+                        retryable=preflight_failed,
+                    ),
+                    "phase": exc.phase.value,
+                    "outcome": "not_submitted" if preflight_failed else "unknown",
+                },
+                operation_id=operation_id,
+                plan_token=str(plan["plan_token"]),
+                retry_safe=preflight_failed,
+            ).to_dict()
+        except Exception as exc:  # noqa: BLE001 - provider may have committed before the error surfaced
+            return MaintenanceOperationResult(
+                operation="expire_snapshots",
+                table_name=table_name,
+                ref=ref,
+                dry_run=False,
+                status=MaintenanceOperationState.FAILED,
+                accepted=True,
+                executed=True,
+                before_revision=expected_snapshot_id,
+                planned={**plan, "trino_boundary": "submitted"},
+                evidence={"before": before},
+                failure=_compaction_failure(
+                    exc,
+                    code="outcome_unknown_after_submission",
+                    retryable=False,
+                ),
+                operation_id=operation_id,
+                plan_token=str(plan["plan_token"]),
+                retry_safe=False,
+            ).to_dict()
+
+        try:
+            after_plan, _ = self._retention_metadata(
+                table_name=table_name,
+                ref=ref,
+                retention_hours=int(plan["retention_hours"]),
+                retain_last=int(plan["retain_last"]),
+                operation="expire_snapshots",
+                catalog=cast(str | None, plan.get("catalog")),
+                max_affected_objects=cast(int | None, plan.get("max_affected_objects")),
+                max_affected_bytes=cast(int | None, plan.get("max_affected_bytes")),
+            )
+        except Exception as exc:  # noqa: BLE001 - provider submission already returned
+            return MaintenanceOperationResult(
+                operation="expire_snapshots",
+                table_name=table_name,
+                ref=ref,
+                dry_run=False,
+                status=MaintenanceOperationState.FAILED,
+                accepted=True,
+                executed=True,
+                before_revision=expected_snapshot_id,
+                planned={**plan, "trino_boundary": "submitted"},
+                evidence={"before": before},
+                failure=_compaction_failure(
+                    exc,
+                    code="outcome_unknown_after_submission",
+                    retryable=False,
+                ),
+                operation_id=operation_id,
+                plan_token=str(plan["plan_token"]),
+                retry_safe=False,
+            ).to_dict()
+
+        after = _retention_state_evidence(after_plan)
+        return MaintenanceOperationResult(
+            operation="expire_snapshots",
             table_name=table_name,
             ref=ref,
             dry_run=False,
-            plan={**plan, "trino_boundary": "not_invoked"},
-            code="bounded_execution_unsupported",
-            message=(
-                "The Trino retention procedure accepts only a threshold and cannot bind "
-                "the provider deletion surface to this exact candidate and byte plan."
-            ),
+            status=MaintenanceOperationState.SUCCEEDED,
+            accepted=True,
+            executed=True,
+            before_revision=expected_snapshot_id,
+            after_revision=after_plan.get("before_snapshot_id"),
+            planned={
+                **plan,
+                "trino_boundary": "executed",
+                "execution_guarantee": "non_atomic_threshold_submission",
+                "retain_last_guarantee": "provider_unsupported_not_enforced",
+            },
+            affected={
+                "planned_candidate_snapshots": len(plan["candidate_snapshots"]),
+                "observed_snapshot_count_reduction": max(
+                    0,
+                    int(before.get("snapshot_count") or 0) - int(after.get("snapshot_count") or 0),
+                ),
+                "exact_deleted_snapshot_set": "unavailable",
+                "provider_deletion_surface": "threshold_not_bound_to_plan",
+            },
+            evidence={
+                "provider": {
+                    "catalog": provider_result.get("catalog"),
+                    "ref": provider_result.get("ref", ref),
+                    "sql": provider_result.get("sql"),
+                    "preflight": provider_result.get("preflight"),
+                    "retain_last": provider_result.get("retain_last"),
+                },
+                "before": before,
+                "after": after,
+            },
             operation_id=operation_id,
+            plan_token=str(plan["plan_token"]),
             retry_safe=False,
-        )
+        ).to_dict()
 
     def expire_snapshots(
         self,
@@ -1571,6 +1771,7 @@ class IcebergResource:
         max_affected_objects: int | None = None,
         max_affected_bytes: int | None = None,
         operation_id: str | None = None,
+        executor: MaintenanceExecutor | None = None,
     ) -> dict[str, object]:
         """Plan or execute guarded provider-neutral snapshot expiry."""
         branch = override_ref or self.ref
@@ -1651,6 +1852,7 @@ class IcebergResource:
             max_affected_objects=max_affected_objects,
             max_affected_bytes=max_affected_bytes,
             operation_id=operation_id,
+            executor=executor,
         )
 
     def cleanup_orphan_files(

--- a/packages/phlo-iceberg/tests/test_retention_contract.py
+++ b/packages/phlo-iceberg/tests/test_retention_contract.py
@@ -8,6 +8,7 @@ import pytest
 from pyarrow.fs import FileType
 
 from phlo.capabilities import MaintenanceRetentionStore
+from phlo.capabilities import MaintenanceExecutionError, MaintenanceExecutionPhase
 import phlo_iceberg.resource as resource_module
 from phlo_iceberg.resource import (
     SAFE_MIN_RETENTION_HOURS,
@@ -207,7 +208,26 @@ def _plan(
     return result
 
 
-def test_real_snapshot_planner_protects_defaults_refs_and_executes_no_deletion(
+class _FakeSnapshotExpiryExecutor:
+    def __init__(self, result: dict[str, object] | Exception) -> None:
+        self.result = result
+        self.calls: list[dict[str, object]] = []
+
+    def for_ref(self, ref: str) -> "_FakeSnapshotExpiryExecutor":
+        assert ref == "main"
+        return self
+
+    def compact_table(self, **_: object) -> dict[str, object]:
+        raise AssertionError("snapshot expiry must not invoke compaction")
+
+    def expire_snapshots_table(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(kwargs)
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def test_real_snapshot_planner_requires_executor_for_execute(
     monkeypatch,
 ) -> None:
     resource, _ = _real_planner_resource(monkeypatch)
@@ -231,6 +251,7 @@ def test_real_snapshot_planner_protects_defaults_refs_and_executes_no_deletion(
     assert plan["affected_objects"] == 1
     assert plan["affected_bytes"] == 10
     assert plan["affected_objects_scope"] == "candidate_snapshots_only"
+    assert plan["retain_last_guarantee"] == "provider_unsupported_not_enforced"
 
     refused = resource.expire_snapshots(
         table_name="raw.events",
@@ -245,7 +266,7 @@ def test_real_snapshot_planner_protects_defaults_refs_and_executes_no_deletion(
     assert refused["status"] == "blocked"
     assert refused["accepted"] is False
     assert refused["executed"] is False
-    assert refused["failure"]["code"] == "bounded_execution_unsupported"
+    assert refused["failure"]["code"] == "maintenance_executor_required"
     assert refused["planned"]["trino_boundary"] == "not_invoked"
 
 
@@ -343,10 +364,133 @@ def test_snapshot_execute_blocks_when_provider_surface_exceeds_plan(monkeypatch)
     )
 
     assert result["status"] == "blocked"
-    assert result["failure"]["code"] == "bounded_execution_unsupported"
-    assert result["failure"]["retryable"] is False
-    assert result["retry_safe"] is False
+    assert result["failure"]["code"] == "maintenance_executor_required"
+    assert result["failure"]["retryable"] is True
+    assert result["retry_safe"] is True
     assert result["planned"]["trino_boundary"] == "not_invoked"
+
+
+def test_snapshot_execute_revalidates_plan_and_reports_non_atomic_evidence(monkeypatch) -> None:
+    resource = IcebergResource(ref="main")
+    before = _plan(candidates=[39])
+    before["snapshot_count"] = 8
+    before["file_count"] = 3
+    before["total_size_bytes"] = 110
+    before["plan_token"] = _maintenance_plan_token(before)
+    after = _plan()
+    after.update({"before_snapshot_id": 42, "snapshot_count": 7, "file_count": 2})
+    after["plan_token"] = _maintenance_plan_token(after)
+    plans = iter([before, dict(before), after])
+    monkeypatch.setattr(resource, "_retention_metadata", lambda **_: (next(plans), object()))
+    executor = _FakeSnapshotExpiryExecutor(
+        {
+            "catalog": "iceberg",
+            "ref": "main",
+            "sql": (
+                'ALTER TABLE "raw"."events" EXECUTE expire_snapshots(retention_threshold => \'168h\')'
+            ),
+            "preflight": {"snapshot_id": 41},
+            "retain_last": {
+                "requested": 5,
+                "enforced": False,
+                "reason": "trino_expire_snapshots_supports_retention_threshold_only",
+            },
+        }
+    )
+
+    planned = resource.expire_snapshots(table_name="raw.events", catalog="iceberg", dry_run=True)
+    result = resource.expire_snapshots(
+        table_name="raw.events",
+        catalog="iceberg",
+        dry_run=False,
+        expected_snapshot_id=41,
+        confirmation_token=planned["plan_token"],
+        max_affected_objects=10,
+        max_affected_bytes=1000,
+        executor=executor,
+    )
+
+    assert result["status"] == "succeeded"
+    assert executor.calls == [
+        {
+            "table_name": "raw.events",
+            "ref": "main",
+            "expected_revision": 41,
+            "retention_hours": 168,
+            "retain_last": 5,
+            "operation_id": None,
+        }
+    ]
+    assert result["planned"]["execution_guarantee"] == "non_atomic_threshold_submission"
+    assert result["planned"]["retain_last_guarantee"] == "provider_unsupported_not_enforced"
+    assert result["affected"]["exact_deleted_snapshot_set"] == "unavailable"
+    assert result["affected"]["observed_snapshot_count_reduction"] == 1
+    assert result["evidence"]["provider"]["preflight"] == {"snapshot_id": 41}
+    assert result["evidence"]["provider"]["retain_last"]["enforced"] is False
+    assert result["evidence"]["before"]["file_count"] == 3
+    assert result["evidence"]["after"]["file_count"] == 2
+
+
+def test_snapshot_execute_refuses_a_stale_plan_without_provider_submission(monkeypatch) -> None:
+    resource = IcebergResource(ref="main")
+    planned = _plan(candidates=[39])
+    planned["plan_token"] = _maintenance_plan_token(planned)
+    revalidated = dict(planned)
+    revalidated["before_snapshot_id"] = 42
+    revalidated["plan_token"] = _maintenance_plan_token(revalidated)
+    plans = iter([planned, revalidated])
+    monkeypatch.setattr(resource, "_retention_metadata", lambda **_: (next(plans), object()))
+    executor = _FakeSnapshotExpiryExecutor({})
+
+    dry_run = resource.expire_snapshots(table_name="raw.events", catalog="iceberg", dry_run=True)
+    result = resource.expire_snapshots(
+        table_name="raw.events",
+        catalog="iceberg",
+        dry_run=False,
+        expected_snapshot_id=41,
+        confirmation_token=dry_run["plan_token"],
+        max_affected_objects=10,
+        max_affected_bytes=1000,
+        executor=executor,
+    )
+
+    assert result["failure"]["code"] == "plan_token_invalid"
+    assert result["planned"]["before_snapshot_id"] == 42
+    assert result["planned"]["candidate_snapshots"]
+    assert executor.calls == []
+
+
+def test_snapshot_execute_retains_plan_on_preflight_and_submission_failures(monkeypatch) -> None:
+    resource = IcebergResource(ref="main")
+    plan = _plan(candidates=[39])
+    plan["plan_token"] = _maintenance_plan_token(plan)
+    monkeypatch.setattr(resource, "_retention_metadata", lambda **_: (plan, object()))
+
+    def execute_with(error: MaintenanceExecutionError) -> dict[str, object]:
+        return resource.expire_snapshots(
+            table_name="raw.events",
+            catalog="iceberg",
+            dry_run=False,
+            expected_snapshot_id=41,
+            confirmation_token=plan["plan_token"],
+            max_affected_objects=10,
+            max_affected_bytes=1000,
+            executor=_FakeSnapshotExpiryExecutor(error),
+        )
+
+    before_submit = execute_with(
+        MaintenanceExecutionError(MaintenanceExecutionPhase.PREFLIGHT, TimeoutError("timeout"))
+    )
+    after_submit = execute_with(
+        MaintenanceExecutionError(MaintenanceExecutionPhase.SUBMISSION, ConnectionError("reset"))
+    )
+
+    assert before_submit["failure"]["code"] == "failed_before_submission"
+    assert before_submit["executed"] is False
+    assert before_submit["planned"]["candidate_snapshots"]
+    assert after_submit["failure"]["code"] == "outcome_unknown_after_submission"
+    assert after_submit["executed"] is True
+    assert after_submit["planned"]["candidate_snapshots"]
 
 
 def test_retention_floor_cannot_be_weakened() -> None:

--- a/packages/phlo-trino/src/phlo_trino/resource.py
+++ b/packages/phlo-trino/src/phlo_trino/resource.py
@@ -285,6 +285,88 @@ class TrinoResource:
             "rows": rows,
         }
 
+    def expire_snapshots_table(
+        self,
+        *,
+        table_name: str,
+        ref: str,
+        expected_revision: str | int | None,
+        retention_hours: int,
+        retain_last: int,
+        operation_id: str | None = None,
+    ) -> dict[str, object]:
+        """Submit guarded, non-atomic Iceberg snapshot expiry through Trino.
+
+        The history read protects the selected catalog reference immediately
+        before submission, but Trino's threshold procedure cannot bind an exact
+        deletion set, serialize concurrent work on other Nessie references, or
+        enforce the caller's retain-last count.
+        """
+        parts = table_name.split(".")
+        if len(parts) != 2 or any(not _MAINTENANCE_IDENTIFIER.fullmatch(part) for part in parts):
+            raise MaintenancePreconditionError(
+                "Snapshot expiry table_name must be a namespace.table identifier containing only "
+                "letters, numbers, and underscores."
+            )
+        if retention_hours <= 0 or retain_last < 1:
+            raise MaintenancePreconditionError(
+                "Snapshot expiry requires positive retention_hours and retain_last."
+            )
+        requested_ref = ref or "main"
+        effective_ref = self._resolved_ref() or "main"
+        if effective_ref != requested_ref:
+            raise MaintenancePreconditionError(
+                f"Trino executor is configured for ref {effective_ref!r}, "
+                f"but snapshot expiry requested {requested_ref!r}"
+            )
+        history_relation = ".".join(
+            quote_identifier(part) for part in (*parts[:-1], f"{parts[-1]}$history")
+        )
+        try:
+            snapshot_rows = self.execute(
+                f"SELECT snapshot_id FROM {history_relation} "
+                "WHERE is_current_ancestor ORDER BY made_current_at DESC LIMIT 1"
+            )
+        except Exception as exc:  # noqa: BLE001 - no mutation was submitted
+            raise MaintenanceExecutionError(MaintenanceExecutionPhase.PREFLIGHT, exc) from exc
+        current_snapshot_id = int(snapshot_rows[0][0]) if snapshot_rows else None
+        if expected_revision != current_snapshot_id:
+            raise MaintenancePreconditionError(
+                "Iceberg snapshot changed before snapshot expiry: "
+                f"expected {expected_revision!r}, current {current_snapshot_id!r}"
+            )
+        relation = ".".join(quote_identifier(part) for part in parts)
+        sql = (
+            f"ALTER TABLE {relation} EXECUTE expire_snapshots("
+            f"retention_threshold => '{retention_hours}h')"
+        )
+        logger.info(
+            "trino_iceberg_snapshot_expiry_requested",
+            table_name=table_name,
+            ref=effective_ref,
+            catalog=self._resolved_catalog(),
+            retention_hours=retention_hours,
+            retain_last=retain_last,
+            operation_id=operation_id,
+        )
+        try:
+            rows = self.execute(sql)
+        except Exception as exc:  # noqa: BLE001 - DDL submission outcome is ambiguous
+            raise MaintenanceExecutionError(MaintenanceExecutionPhase.SUBMISSION, exc) from exc
+        return {
+            "table_name": table_name,
+            "ref": effective_ref,
+            "catalog": self._resolved_catalog(),
+            "sql": sql,
+            "preflight": {"snapshot_id": current_snapshot_id},
+            "retain_last": {
+                "requested": retain_last,
+                "enforced": False,
+                "reason": "trino_expire_snapshots_supports_retention_threshold_only",
+            },
+            "rows": rows,
+        }
+
     def read_dataframe(
         self,
         query: str | LogicalRelation,

--- a/packages/phlo-trino/tests/test_resource_maintenance.py
+++ b/packages/phlo-trino/tests/test_resource_maintenance.py
@@ -81,6 +81,48 @@ def test_compaction_submission_failure_is_outcome_unknown() -> None:
     assert execute.call_count == 2
 
 
+def test_snapshot_expiry_checks_snapshot_and_submits_threshold_on_selected_ref() -> None:
+    resource, execute = _resource(ref="dev")
+
+    result = resource.expire_snapshots_table(
+        table_name="raw.events",
+        ref="dev",
+        expected_revision=41,
+        retention_hours=168,
+        retain_last=5,
+        operation_id="run-41",
+    )
+
+    assert result["ref"] == "dev"
+    assert result["catalog"] == "iceberg_dev"
+    assert result["preflight"] == {"snapshot_id": 41}
+    assert result["retain_last"] == {
+        "requested": 5,
+        "enforced": False,
+        "reason": "trino_expire_snapshots_supports_retention_threshold_only",
+    }
+    assert execute.call_args_list[1].args[0] == (
+        'ALTER TABLE "raw"."events" EXECUTE expire_snapshots(retention_threshold => \'168h\')'
+    )
+
+
+def test_snapshot_expiry_preflight_failure_never_submits() -> None:
+    resource, execute = _resource(ref="main")
+    execute.side_effect = RuntimeError("connection refused")
+
+    with pytest.raises(MaintenanceExecutionError) as raised:
+        resource.expire_snapshots_table(
+            table_name="raw.events",
+            ref="main",
+            expected_revision=41,
+            retention_hours=168,
+            retain_last=5,
+        )
+
+    assert raised.value.phase is MaintenanceExecutionPhase.PREFLIGHT
+    assert execute.call_count == 1
+
+
 def test_compaction_rejects_unsafe_identifier() -> None:
     resource = TrinoResource(ref="main")
 

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -315,6 +315,24 @@ class MaintenanceExecutor(Protocol):
         """Compact one table on the explicitly selected ref."""
         ...
 
+    def expire_snapshots_table(
+        self,
+        *,
+        table_name: str,
+        ref: str,
+        expected_revision: str | int | None,
+        retention_hours: int,
+        retain_last: int,
+        operation_id: str | None = None,
+    ) -> Any:
+        """Expire snapshots through the provider's selected reference.
+
+        The executor must preflight the supplied revision before submitting its
+        provider-specific statement. This is an optimistic, non-atomic guard;
+        it does not bind an exact deletion set or serialize other references.
+        """
+        ...
+
 
 @runtime_checkable
 class MaintenanceRetentionStore(Protocol):
@@ -334,6 +352,7 @@ class MaintenanceRetentionStore(Protocol):
         max_affected_objects: int | None = None,
         max_affected_bytes: int | None = None,
         operation_id: str | None = None,
+        executor: MaintenanceExecutor | None = None,
     ) -> dict[str, object]:
         """Plan or execute guarded snapshot expiration."""
         ...

--- a/tests/plugins/test_capabilities_runtime.py
+++ b/tests/plugins/test_capabilities_runtime.py
@@ -81,7 +81,44 @@ def test_maintenance_executor_protocol_is_provider_neutral() -> None:
                 "operation_id": operation_id,
             }
 
-    assert isinstance(DeltaLikeMaintenanceExecutor(), MaintenanceExecutor)
+        def expire_snapshots_table(
+            self,
+            *,
+            table_name: str,
+            ref: str,
+            expected_revision: str | int | None,
+            retention_hours: int,
+            retain_last: int,
+            operation_id: str | None = None,
+        ) -> dict[str, object]:
+            return {
+                "provider": "delta",
+                "table_name": table_name,
+                "ref": ref,
+                "expected_revision": expected_revision,
+                "retention_hours": retention_hours,
+                "retain_last": retain_last,
+                "operation_id": operation_id,
+            }
+
+    executor = DeltaLikeMaintenanceExecutor()
+    assert isinstance(executor, MaintenanceExecutor)
+    assert executor.expire_snapshots_table(
+        table_name="raw.events",
+        ref="main",
+        expected_revision=41,
+        retention_hours=168,
+        retain_last=5,
+        operation_id="op-1",
+    ) == {
+        "provider": "delta",
+        "table_name": "raw.events",
+        "ref": "main",
+        "expected_revision": 41,
+        "retention_hours": 168,
+        "retain_last": 5,
+        "operation_id": "op-1",
+    }
 
 
 def test_maintenance_operation_result_uses_neutral_revision_keys() -> None:


### PR DESCRIPTION
Adds guarded, threshold-only Iceberg snapshot expiry through the neutral maintenance capability.

The execution path revalidates the signed plan, selected ref, table snapshot, retention floor, and limits before Trino submits `expire_snapshots`. Requested `retain_last` remains explicit evidence but is marked unenforced because this provider operation only supports a retention threshold. Orphan cleanup remains fail-closed.

Evidence:
- 35 focused retention, Trino executor, and Dagster capability-boundary tests passed.
- Affected-package suite: 458 passed, 1 skipped, 107 deselected.
- Ruff check, format check, and `git diff --check` passed.
- A disposable real-Trino smoke reached submission, then correctly reported the stack GC-disabled rejection as post-submission outcome unknown; the test table was cleaned up.

Limitations are deliberate: no atomic snapshot fence, exact deletion-set claim, cross-ref serialization, or implied `retain_last` guarantee.