### PR TITLE
feat(release): add artifact golden path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,23 @@ jobs:
             exit 1
           fi
 
+  release-golden-path:
+    name: python / release golden path
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          version: "latest"
+
+      - name: Run release artifact golden path
+        run: python3 scripts/release_golden_path.py
+
   python-package-tests:
     name: python / package tests (${{ matrix.group }})
     runs-on: ubuntu-latest
@@ -404,6 +421,7 @@ jobs:
       - python-quality
       - python-core-tests
       - quickstart-smoke
+      - release-golden-path
       - python-package-tests
       - frontend
     steps:
@@ -414,6 +432,7 @@ jobs:
           PYTHON_QUALITY: ${{ needs.python-quality.result }}
           PYTHON_CORE_TESTS: ${{ needs.python-core-tests.result }}
           QUICKSTART_SMOKE: ${{ needs.quickstart-smoke.result }}
+          RELEASE_GOLDEN_PATH: ${{ needs.release-golden-path.result }}
           PYTHON_PACKAGE_TESTS: ${{ needs.python-package-tests.result }}
           FRONTEND: ${{ needs.frontend.result }}
         run: |
@@ -428,6 +447,7 @@ jobs:
             echo "| python / quality | ${PYTHON_QUALITY} |"
             echo "| python / core tests | ${PYTHON_CORE_TESTS} |"
             echo "| python / quickstart smoke | ${QUICKSTART_SMOKE} |"
+            echo "| python / release golden path | ${RELEASE_GOLDEN_PATH} |"
             echo "| python / package tests | ${PYTHON_PACKAGE_TESTS} |"
             echo "| frontend / observatory | ${FRONTEND} |"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -437,6 +457,7 @@ jobs:
             "${PYTHON_QUALITY}" \
             "${PYTHON_CORE_TESTS}" \
             "${QUICKSTART_SMOKE}" \
+            "${RELEASE_GOLDEN_PATH}" \
             "${PYTHON_PACKAGE_TESTS}" \
             "${FRONTEND}"; do
             if [ "${result}" != "success" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Validate workflow YAML
         run: ruby -e 'Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }' -r yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Set up Python
         run: uv python install 3.11
@@ -155,7 +155,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -239,7 +239,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Set up Python
         run: uv python install 3.11
@@ -307,7 +307,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Run release artifact golden path
         run: python3 scripts/release_golden_path.py
@@ -335,7 +335,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Install pymdx
         run: uv tool install "pymdx==${PYMDX_VERSION}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/packages/phlo-dagster/src/phlo_dagster/Dockerfile
+++ b/packages/phlo-dagster/src/phlo_dagster/Dockerfile
@@ -1,8 +1,16 @@
+FROM python:3.12-slim AS phlo-build-context
+
+WORKDIR /opt/phlo-build-context
+
+COPY . .
+RUN mkdir -p /opt/phlo-build-context/wheelhouse
+
 FROM python:3.12-slim
 
 WORKDIR /opt/dagster
 
 ARG PHLO_VERSION=""
+ARG PHLO_WHEELHOUSE=""
 
 # Install system dependencies and uv
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -11,11 +19,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && pip install uv
 
-# Install phlo from PyPI (or specific version if provided)
-RUN if [ -n "$PHLO_VERSION" ]; then \
+# Copy only the artifact directory from the context stage; normal generated builds receive an
+# empty directory and retain the existing PyPI installation path.
+COPY --from=phlo-build-context /opt/phlo-build-context/wheelhouse /opt/phlo-wheelhouse
+
+# Install Phlo from the local wheelhouse when supplied; normal generated stacks retain PyPI behavior.
+RUN \
+    if [ -n "$PHLO_VERSION" ]; then \
+    if [ -n "$PHLO_WHEELHOUSE" ]; then \
+        test -d /opt/phlo-wheelhouse; \
+        uv pip install --system --no-index --no-deps --reinstall --find-links /opt/phlo-wheelhouse "phlo==$PHLO_VERSION"; \
+        uv pip install --system --prerelease explicit --find-links /opt/phlo-wheelhouse "phlo[defaults]==$PHLO_VERSION" dagster-webserver dagster-postgres "psycopg[binary]"; \
+        uv pip install --system --no-index --no-deps --reinstall --find-links /opt/phlo-wheelhouse "phlo==$PHLO_VERSION"; \
+    else \
         uv pip install --system --no-deps --prerelease explicit "phlo==$PHLO_VERSION"; \
         PHLO_PRERELEASE_REQUIREMENTS="$(python -c 'import importlib.metadata as md, re; print(" ".join(req.split(";")[0].strip() for req in (md.metadata("phlo").get_all("Requires-Dist") or []) if "extra == '\''defaults'\''" in req and re.search(r"(a|b|rc|dev)[0-9]+", req)))')"; \
         uv pip install --system --prerelease explicit "phlo[defaults]==$PHLO_VERSION" $PHLO_PRERELEASE_REQUIREMENTS dagster-webserver dagster-postgres "psycopg[binary]"; \
+    fi; \
     else \
         uv pip install --system "phlo[defaults]" dagster-webserver dagster-postgres "psycopg[binary]"; \
     fi

--- a/packages/phlo-dagster/src/phlo_dagster/dagster-daemon.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/dagster-daemon.yaml
@@ -10,6 +10,7 @@ build:
   dockerfile: dagster/Dockerfile
   args:
     PHLO_VERSION: ${PHLO_VERSION:-}
+    PHLO_WHEELHOUSE: ${PHLO_WHEELHOUSE:-}
 
 depends_on:
   - dagster

--- a/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
+++ b/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
@@ -4,6 +4,8 @@
 
 set -e
 
+if [ "$(id -u)" -eq 0 ]; then
+
 # If dev mode is enabled, sync dependencies from mounted pyproject.toml
 if [ "$PHLO_DEV_MODE" = "true" ] && [ -f /opt/phlo-dev/pyproject.toml ]; then
     echo "Dev mode: syncing dependencies from pyproject.toml..."
@@ -87,6 +89,10 @@ try:
 except ImportError:
     pass
 EOF
+
+else
+    echo "Non-root mode: using mounted project directly"
+fi
 
 # Execute Dagster from the mounted project root when available. User workflows
 # often read local files relative to the project (for example data/*.csv), while

--- a/packages/phlo-dagster/src/phlo_dagster/service.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/service.yaml
@@ -14,6 +14,7 @@ build:
   dockerfile: dagster/Dockerfile
   args:
     PHLO_VERSION: ${PHLO_VERSION:-}
+    PHLO_WHEELHOUSE: ${PHLO_WHEELHOUSE:-}
 
 depends_on:
   - postgres

--- a/packages/phlo-dagster/tests/test_runtime_image_contract.py
+++ b/packages/phlo-dagster/tests/test_runtime_image_contract.py
@@ -22,5 +22,12 @@ def test_dagster_runtime_image_installs_prerelease_phlo_with_postgres_driver() -
 def test_dagster_runtime_entrypoint_installs_mounted_project() -> None:
     entrypoint = resources.files("phlo_dagster").joinpath("entrypoint.sh").read_text()
 
+    root_guard = 'if [ "$(id -u)" -eq 0 ]; then'
     assert "if [ -f /app/pyproject.toml ]; then" in entrypoint
     assert "uv pip install --system -e /app" in entrypoint
+    assert root_guard in entrypoint
+    assert entrypoint.index(root_guard) < entrypoint.index("uv pip install --system -e /app")
+    non_root_message = 'echo "Non-root mode: using mounted project directly"'
+    assert non_root_message in entrypoint
+    assert entrypoint.index("uv pip install --system -e /app") < entrypoint.index(non_root_message)
+    assert entrypoint.index("fi\n\n# Execute Dagster") > entrypoint.index(non_root_message)

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -285,22 +285,24 @@ def cleanup(
 ) -> list[Exception]:
     errors: list[Exception] = []
     if config.compose_file.exists():
-        for service in ("dagster", "dagster-daemon"):
-            with contextlib.suppress(Exception):
-                run(
-                    compose_command(
-                        config,
-                        "exec",
-                        "--no-TTY",
-                        "--user",
-                        "root",
-                        service,
-                        "rm",
-                        "-rf",
-                        "/app/.venv",
-                    ),
-                    cwd=config.project_dir,
-                )
+        with contextlib.suppress(Exception):
+            run(compose_command(config, "stop"), cwd=config.project_dir)
+        with contextlib.suppress(Exception):
+            run(
+                compose_command(
+                    config,
+                    "run",
+                    "--rm",
+                    "--no-deps",
+                    "--user",
+                    "root",
+                    "dagster",
+                    "rm",
+                    "-rf",
+                    "/app/.venv",
+                ),
+                cwd=config.project_dir,
+            )
         try:
             run(
                 compose_command(config, "down", "--volumes", "--remove-orphans"),

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -276,14 +276,32 @@ def verify_rows(config: RunConfig) -> None:
         raise RuntimeError(f"raw.events has no rows for partition {config.partition}")
 
 
-def cleanup(config: RunConfig, *, owned_paths: set[Path]) -> None:
+def cleanup(
+    config: RunConfig,
+    *,
+    owned_paths: set[Path],
+    temporary_root: Path | None = None,
+) -> list[Exception]:
+    errors: list[Exception] = []
     if config.compose_file.exists():
-        run(
-            compose_command(config, "down", "--volumes", "--remove-orphans"),
-            cwd=config.project_dir,
-        )
-    for path in sorted(owned_paths, key=lambda candidate: len(candidate.parts), reverse=True):
-        shutil.rmtree(path, ignore_errors=True)
+        try:
+            run(
+                compose_command(config, "down", "--volumes", "--remove-orphans"),
+                cwd=config.project_dir,
+            )
+        except Exception as exc:
+            errors.append(exc)
+    paths = set(owned_paths)
+    if temporary_root:
+        paths.add(temporary_root)
+    for path in sorted(paths, key=lambda candidate: len(candidate.parts), reverse=True):
+        try:
+            shutil.rmtree(path)
+        except FileNotFoundError:
+            pass
+        except Exception as exc:
+            errors.append(exc)
+    return errors
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -301,14 +319,21 @@ def main(argv: list[str] | None = None) -> int:
     temporary_root: Path | None = None
     if args.project_dir:
         project_dir = args.project_dir.resolve()
-        if project_dir.exists():
-            print(f"refusing to use existing project directory: {project_dir}", file=sys.stderr)
+        wheelhouse = project_dir.parent / "wheelhouse"
+        operator_env = project_dir.parent / "operator-env"
+        existing_paths = [path for path in (project_dir, wheelhouse, operator_env) if path.exists()]
+        if existing_paths:
+            print(
+                "refusing to use existing project artifacts: "
+                + ", ".join(str(path) for path in existing_paths),
+                file=sys.stderr,
+            )
             return 2
     else:
         temporary_root = Path(tempfile.mkdtemp(prefix=".phlo-release-golden-path-", dir=repo_root))
         project_dir = temporary_root / f"csv-batch-{os.getpid()}"
-    wheelhouse = project_dir.parent / "wheelhouse"
-    operator_env = project_dir.parent / "operator-env"
+        wheelhouse = project_dir.parent / "wheelhouse"
+        operator_env = project_dir.parent / "operator-env"
     owned_paths = {path for path in (project_dir, wheelhouse, operator_env) if not path.exists()}
     config = RunConfig(
         repo_root=repo_root,
@@ -319,6 +344,8 @@ def main(argv: list[str] | None = None) -> int:
         partition=args.partition,
     )
     project_dir.parent.mkdir(parents=True, exist_ok=True)
+    primary_error: Exception | None = None
+    cleanup_errors: list[Exception] = []
     try:
         build_wheelhouse(config)
         install_operator(config)
@@ -329,18 +356,26 @@ def main(argv: list[str] | None = None) -> int:
         start_stack(config)
         materialize_partition(config)
         verify_rows(config)
-        print("release golden path passed")
-        return 0
-    except (OSError, subprocess.CalledProcessError) as exc:
-        print(f"release golden path failed: {exc}", file=sys.stderr)
-        return 1
+    except Exception as exc:
+        primary_error = exc
     finally:
         if not args.keep_project:
-            cleanup(config, owned_paths=owned_paths)
-            if temporary_root:
-                shutil.rmtree(temporary_root, ignore_errors=True)
+            cleanup_errors = cleanup(
+                config,
+                owned_paths=owned_paths,
+                temporary_root=temporary_root,
+            )
         elif temporary_root:
             print(f"kept project at {project_dir}")
+
+    if primary_error:
+        print(f"release golden path failed: {primary_error}", file=sys.stderr)
+    for error in cleanup_errors:
+        print(f"release golden path cleanup failed: {error}", file=sys.stderr)
+    if primary_error or cleanup_errors:
+        return 1
+    print("release golden path passed")
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import contextlib
 import os
 import shutil
 import socket
@@ -285,24 +284,6 @@ def cleanup(
 ) -> list[Exception]:
     errors: list[Exception] = []
     if config.compose_file.exists():
-        with contextlib.suppress(Exception):
-            run(compose_command(config, "stop"), cwd=config.project_dir)
-        with contextlib.suppress(Exception):
-            run(
-                compose_command(
-                    config,
-                    "run",
-                    "--rm",
-                    "--no-deps",
-                    "--user",
-                    "root",
-                    "dagster",
-                    "rm",
-                    "-rf",
-                    "/app/.venv",
-                ),
-                cwd=config.project_dir,
-            )
         try:
             run(
                 compose_command(config, "down", "--volumes", "--remove-orphans"),

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -6,15 +6,23 @@ from __future__ import annotations
 import argparse
 import os
 import shutil
-import socket
 import subprocess
 import sys
 import tempfile
 import tomllib
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
 PARTITION = "2025-01-15"
+PORT_NAMES = (
+    "POSTGRES_PORT",
+    "MINIO_API_PORT",
+    "MINIO_CONSOLE_PORT",
+    "NESSIE_PORT",
+    "TRINO_PORT",
+    "DAGSTER_PORT",
+)
 
 
 @dataclass(frozen=True)
@@ -55,6 +63,11 @@ def compose_command(config: RunConfig, *parts: str) -> list[str]:
         str(config.project_dir / ".phlo" / ".env.local"),
         *parts,
     )
+
+
+def project_name() -> str:
+    """Return a globally unique Compose project name for one harness run."""
+    return f"phlo-qa001-{uuid.uuid4().hex}"
 
 
 def run(
@@ -194,22 +207,6 @@ def install_project_dependencies(config: RunConfig) -> None:
     )
 
 
-def find_free_port(*, start: int, reserved: set[int]) -> int:
-    """Return a host port that is free for the short-lived Compose stack."""
-    for port in range(start, start + 1000):
-        if port in reserved:
-            continue
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            try:
-                sock.bind(("0.0.0.0", port))
-            except OSError:
-                continue
-        reserved.add(port)
-        return port
-    raise RuntimeError(f"no free host port found in {start}-{start + 999}")
-
-
 def configure_non_dev_compose(config: RunConfig) -> None:
     run(
         command(str(config.operator_bin), "services", "init", "--no-dev", "--force"),
@@ -219,22 +216,10 @@ def configure_non_dev_compose(config: RunConfig) -> None:
     shutil.copytree(config.wheelhouse, destination)
     with (config.repo_root / "pyproject.toml").open("rb") as stream:
         version = tomllib.load(stream)["project"]["version"]
-    reserved: set[int] = set()
-    ports = {
-        name: find_free_port(start=20000, reserved=reserved)
-        for name in (
-            "POSTGRES_PORT",
-            "MINIO_API_PORT",
-            "MINIO_CONSOLE_PORT",
-            "NESSIE_PORT",
-            "TRINO_PORT",
-            "DAGSTER_PORT",
-        )
-    }
     env_local = config.project_dir / ".phlo" / ".env.local"
     with env_local.open("a", encoding="utf-8") as stream:
         stream.write(f"\nPHLO_VERSION={version}\nPHLO_WHEELHOUSE=wheelhouse\n")
-        stream.writelines(f"{name}={port}\n" for name, port in ports.items())
+        stream.writelines(f"{name}=0\n" for name in PORT_NAMES)
 
 
 def start_stack(config: RunConfig) -> None:
@@ -348,7 +333,7 @@ def main(argv: list[str] | None = None) -> int:
         project_dir=project_dir,
         wheelhouse=wheelhouse,
         operator_env=operator_env,
-        project_name=f"phlo-qa001-{os.getpid()}",
+        project_name=project_name(),
         partition=args.partition,
     )
     project_dir.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -238,7 +238,15 @@ def configure_non_dev_compose(config: RunConfig) -> None:
 
 
 def start_stack(config: RunConfig) -> None:
-    run(compose_command(config, "up", "--detach", "--build"), cwd=config.project_dir)
+    try:
+        run(compose_command(config, "up", "--detach", "--build"), cwd=config.project_dir)
+    except subprocess.CalledProcessError:
+        for parts in (("ps",), ("logs", "--no-color", "--timestamps")):
+            try:
+                run(compose_command(config, *parts), cwd=config.project_dir)
+            except Exception as exc:
+                print(f"release golden path diagnostics failed: {exc}", file=sys.stderr)
+        raise
 
 
 def materialize_partition(config: RunConfig) -> None:

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -285,21 +285,22 @@ def cleanup(
 ) -> list[Exception]:
     errors: list[Exception] = []
     if config.compose_file.exists():
-        with contextlib.suppress(Exception):
-            run(
-                compose_command(
-                    config,
-                    "exec",
-                    "--no-TTY",
-                    "--user",
-                    "root",
-                    "dagster",
-                    "rm",
-                    "-rf",
-                    "/app/.venv",
-                ),
-                cwd=config.project_dir,
-            )
+        for service in ("dagster", "dagster-daemon"):
+            with contextlib.suppress(Exception):
+                run(
+                    compose_command(
+                        config,
+                        "exec",
+                        "--no-TTY",
+                        "--user",
+                        "root",
+                        service,
+                        "rm",
+                        "-rf",
+                        "/app/.venv",
+                    ),
+                    cwd=config.project_dir,
+                )
         try:
             run(
                 compose_command(config, "down", "--volumes", "--remove-orphans"),

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import os
 import shutil
 import socket
@@ -284,6 +285,21 @@ def cleanup(
 ) -> list[Exception]:
     errors: list[Exception] = []
     if config.compose_file.exists():
+        with contextlib.suppress(Exception):
+            run(
+                compose_command(
+                    config,
+                    "exec",
+                    "--no-TTY",
+                    "--user",
+                    "root",
+                    "dagster",
+                    "rm",
+                    "-rf",
+                    "/app/.venv",
+                ),
+                cwd=config.project_dir,
+            )
         try:
             run(
                 compose_command(config, "down", "--volumes", "--remove-orphans"),

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Run the Phlo release artifact golden path in an owned temporary project."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+PARTITION = "2025-01-15"
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    repo_root: Path
+    project_dir: Path
+    wheelhouse: Path
+    operator_env: Path
+    project_name: str
+    partition: str = PARTITION
+
+    @property
+    def operator_bin(self) -> Path:
+        return self.operator_env / "bin" / "phlo"
+
+    @property
+    def compose_file(self) -> Path:
+        return self.project_dir / ".phlo" / "docker-compose.yml"
+
+
+def command(*parts: str) -> list[str]:
+    """Return a subprocess command as a list, keeping shell interpolation out."""
+    return list(parts)
+
+
+def compose_command(config: RunConfig, *parts: str) -> list[str]:
+    """Build a project-scoped Docker Compose command."""
+    return command(
+        "docker",
+        "compose",
+        "-p",
+        config.project_name,
+        "--file",
+        str(config.compose_file),
+        "--env-file",
+        str(config.project_dir / ".phlo" / ".env"),
+        "--env-file",
+        str(config.project_dir / ".phlo" / ".env.local"),
+        *parts,
+    )
+
+
+def run(
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    capture_output: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    """Run one command and stream its output."""
+    print(f"+ {' '.join(args)}", flush=True)
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        check=True,
+        capture_output=capture_output,
+        text=True,
+    )
+
+
+def force_local_install(config: RunConfig, python: Path, *packages: str) -> None:
+    run(
+        command(
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(python),
+            "--no-index",
+            "--no-deps",
+            "--reinstall",
+            "--find-links",
+            str(config.wheelhouse),
+            *packages,
+        ),
+        cwd=config.repo_root,
+    )
+
+
+def build_wheelhouse(config: RunConfig) -> None:
+    config.wheelhouse.mkdir(parents=True, exist_ok=True)
+    run(
+        command("uv", "build", "--all-packages", "--wheel", "--out-dir", str(config.wheelhouse)),
+        cwd=config.repo_root,
+    )
+
+
+def install_operator(config: RunConfig) -> None:
+    run(command("uv", "venv", str(config.operator_env), "--python", "3.11"), cwd=config.repo_root)
+    run(
+        command(
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(config.operator_env / "bin" / "python"),
+            "--no-index",
+            "--no-deps",
+            "--find-links",
+            str(config.wheelhouse),
+            "phlo",
+        ),
+        cwd=config.repo_root,
+    )
+    run(
+        command(
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(config.operator_env / "bin" / "python"),
+            "--find-links",
+            str(config.wheelhouse),
+            "phlo[core-services]",
+            "phlo-dlt",
+            "phlo-pandera",
+        ),
+        cwd=config.repo_root,
+    )
+    force_local_install(
+        config,
+        config.operator_env / "bin" / "python",
+        "phlo",
+        "phlo-dlt",
+        "phlo-pandera",
+    )
+
+
+def create_project(config: RunConfig) -> None:
+    run(
+        command(
+            str(config.operator_bin),
+            "init",
+            str(config.project_dir),
+            "--template",
+            "csv-batch",
+        ),
+        cwd=config.repo_root,
+    )
+
+
+def align_project_name(config: RunConfig) -> None:
+    """Make generated CLI project discovery use the owned Compose project name."""
+    config_file = config.project_dir / "phlo.yaml"
+    lines = config_file.read_text(encoding="utf-8").splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if line.startswith("name:"):
+            lines[index] = f"name: {config.project_name}\n"
+            config_file.write_text("".join(lines), encoding="utf-8")
+            return
+    raise RuntimeError(f"generated project config has no name: {config_file}")
+
+
+def install_project_dependencies(config: RunConfig) -> None:
+    project_env = config.project_dir / ".venv"
+    run(command("uv", "venv", str(project_env), "--python", "3.11"), cwd=config.project_dir)
+    run(
+        command(
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(project_env / "bin" / "python"),
+            "--find-links",
+            str(config.wheelhouse),
+            "phlo-dlt",
+            "phlo-pandera",
+        ),
+        cwd=config.project_dir,
+    )
+    force_local_install(
+        config,
+        project_env / "bin" / "python",
+        "phlo-dlt",
+        "phlo-pandera",
+    )
+
+
+def find_free_port(*, start: int, reserved: set[int]) -> int:
+    """Return a host port that is free for the short-lived Compose stack."""
+    for port in range(start, start + 1000):
+        if port in reserved:
+            continue
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("0.0.0.0", port))
+            except OSError:
+                continue
+        reserved.add(port)
+        return port
+    raise RuntimeError(f"no free host port found in {start}-{start + 999}")
+
+
+def configure_non_dev_compose(config: RunConfig) -> None:
+    run(
+        command(str(config.operator_bin), "services", "init", "--no-dev", "--force"),
+        cwd=config.project_dir,
+    )
+    destination = config.project_dir / ".phlo" / "wheelhouse"
+    shutil.copytree(config.wheelhouse, destination)
+    with (config.repo_root / "pyproject.toml").open("rb") as stream:
+        version = tomllib.load(stream)["project"]["version"]
+    reserved: set[int] = set()
+    ports = {
+        name: find_free_port(start=20000, reserved=reserved)
+        for name in (
+            "POSTGRES_PORT",
+            "MINIO_API_PORT",
+            "MINIO_CONSOLE_PORT",
+            "NESSIE_PORT",
+            "TRINO_PORT",
+            "DAGSTER_PORT",
+        )
+    }
+    env_local = config.project_dir / ".phlo" / ".env.local"
+    with env_local.open("a", encoding="utf-8") as stream:
+        stream.write(f"\nPHLO_VERSION={version}\nPHLO_WHEELHOUSE=wheelhouse\n")
+        stream.writelines(f"{name}={port}\n" for name, port in ports.items())
+
+
+def start_stack(config: RunConfig) -> None:
+    run(compose_command(config, "up", "--detach", "--build"), cwd=config.project_dir)
+
+
+def materialize_partition(config: RunConfig) -> None:
+    run(
+        command(
+            str(config.operator_bin),
+            "materialize",
+            "dlt_events",
+            "--partition",
+            config.partition,
+        ),
+        cwd=config.project_dir,
+    )
+
+
+def verify_rows(config: RunConfig) -> None:
+    query = "SELECT count(*) FROM iceberg.raw.events"
+    result = run(
+        compose_command(config, "exec", "--no-TTY", "trino", "trino", "--execute", query),
+        cwd=config.project_dir,
+        capture_output=True,
+    )
+    print(result.stdout, end="")
+    print(result.stderr, end="", file=sys.stderr)
+    try:
+        last_line = result.stdout.strip().splitlines()[-1].strip()
+        if len(last_line) >= 2 and last_line[0] == last_line[-1] and last_line[0] in "'\"":
+            last_line = last_line[1:-1].strip()
+        if not last_line.isdigit():
+            raise ValueError(last_line)
+        count = int(last_line)
+    except (IndexError, ValueError) as exc:
+        raise RuntimeError(f"Trino returned no row count: {result.stdout!r}") from exc
+    if count <= 0:
+        raise RuntimeError(f"raw.events has no rows for partition {config.partition}")
+
+
+def cleanup(config: RunConfig, *, owned_paths: set[Path]) -> None:
+    if config.compose_file.exists():
+        run(
+            compose_command(config, "down", "--volumes", "--remove-orphans"),
+            cwd=config.project_dir,
+        )
+    for path in sorted(owned_paths, key=lambda candidate: len(candidate.parts), reverse=True):
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--project-dir", type=Path)
+    parser.add_argument("--keep-project", action="store_true")
+    parser.add_argument("--partition", default=PARTITION)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    temporary_root: Path | None = None
+    if args.project_dir:
+        project_dir = args.project_dir.resolve()
+        if project_dir.exists():
+            print(f"refusing to use existing project directory: {project_dir}", file=sys.stderr)
+            return 2
+    else:
+        temporary_root = Path(tempfile.mkdtemp(prefix=".phlo-release-golden-path-", dir=repo_root))
+        project_dir = temporary_root / f"csv-batch-{os.getpid()}"
+    wheelhouse = project_dir.parent / "wheelhouse"
+    operator_env = project_dir.parent / "operator-env"
+    owned_paths = {path for path in (project_dir, wheelhouse, operator_env) if not path.exists()}
+    config = RunConfig(
+        repo_root=repo_root,
+        project_dir=project_dir,
+        wheelhouse=wheelhouse,
+        operator_env=operator_env,
+        project_name=f"phlo-qa001-{os.getpid()}",
+        partition=args.partition,
+    )
+    project_dir.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        build_wheelhouse(config)
+        install_operator(config)
+        create_project(config)
+        align_project_name(config)
+        install_project_dependencies(config)
+        configure_non_dev_compose(config)
+        start_stack(config)
+        materialize_partition(config)
+        verify_rows(config)
+        print("release golden path passed")
+        return 0
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print(f"release golden path failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if not args.keep_project:
+            cleanup(config, owned_paths=owned_paths)
+            if temporary_root:
+                shutil.rmtree(temporary_root, ignore_errors=True)
+        elif temporary_root:
+            print(f"kept project at {project_dir}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -235,6 +235,13 @@ class ComposeGenerator:
         if service.name in {"dagster", "dagster-daemon"}:
             if platform.system() == "Linux":
                 config["user"] = f"{os.getuid()}:{os.getgid()}"
+                environment = config.setdefault("environment", {})
+                if isinstance(environment, dict):
+                    environment.setdefault("HOME", "/opt/dagster")
+                elif isinstance(environment, list) and not any(
+                    item.startswith("HOME=") for item in environment if isinstance(item, str)
+                ):
+                    environment.append("HOME=/opt/dagster")
             else:
                 config.pop("user", None)
 

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -106,8 +106,8 @@ def test_compose_generator_injects_phlo_dev_mounts(tmp_path) -> None:
 
 @pytest.mark.parametrize("service_name", ["dagster", "dagster-daemon"])
 @pytest.mark.parametrize(
-    ("host_platform", "expected_user"),
-    [("Linux", "1234:2345"), ("Darwin", None), ("Windows", None)],
+    ("host_platform", "expected_user", "expected_home"),
+    [("Linux", "1234:2345", "/opt/dagster"), ("Darwin", None, None), ("Windows", None, None)],
 )
 def test_compose_generator_sets_host_user_for_project_writing_services(
     monkeypatch: pytest.MonkeyPatch,
@@ -115,6 +115,7 @@ def test_compose_generator_sets_host_user_for_project_writing_services(
     service_name: str,
     host_platform: str,
     expected_user: str | None,
+    expected_home: str | None,
 ) -> None:
     monkeypatch.setattr(generator_module.platform, "system", lambda: host_platform)
     monkeypatch.setattr(generator_module.os, "getuid", lambda: 1234, raising=False)
@@ -144,7 +145,31 @@ def test_compose_generator_sets_host_user_for_project_writing_services(
     )
 
     assert data["services"][service_name].get("user") == expected_user
+    assert data["services"][service_name].get("environment", {}).get("HOME") == expected_home
     assert data["services"]["trino"]["user"] == "root"
+
+
+def test_compose_generator_adds_home_to_list_environment_on_linux(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(generator_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(generator_module.os, "getuid", lambda: 1234, raising=False)
+    monkeypatch.setattr(generator_module.os, "getgid", lambda: 2345, raising=False)
+    service = ServiceDefinition(
+        name="dagster",
+        description="dagster",
+        category="orchestration",
+        default=True,
+        compose={"environment": ["EXISTING=value"]},
+    )
+
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+    data = yaml.safe_load(generator.generate_compose([service], output_dir=tmp_path))
+
+    assert data["services"]["dagster"]["environment"] == [
+        "EXISTING=value",
+        "HOME=/opt/dagster",
+    ]
 
 
 def test_compose_generator_passthrough_compose_keys(tmp_path) -> None:

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -110,6 +110,52 @@ def test_verify_rows_requires_a_positive_count(tmp_path: Path, monkeypatch) -> N
             raise AssertionError(f"invalid raw.events result should fail: {output!r}")
 
 
+def test_start_stack_diagnoses_owned_compose_failure_in_order(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    commands: list[list[str]] = []
+    startup_error = release_golden_path.subprocess.CalledProcessError(1, ["docker", "compose"])
+
+    def fake_run(args, **kwargs):
+        commands.append(args)
+        if args[-3:] == ["up", "--detach", "--build"]:
+            raise startup_error
+        return release_golden_path.subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(release_golden_path, "run", fake_run)
+
+    try:
+        release_golden_path.start_stack(config)
+    except release_golden_path.subprocess.CalledProcessError as exc:
+        assert exc is startup_error
+    else:
+        raise AssertionError("startup failure should be re-raised")
+
+    assert commands == [
+        release_golden_path.compose_command(config, "up", "--detach", "--build"),
+        release_golden_path.compose_command(config, "ps"),
+        release_golden_path.compose_command(config, "logs", "--no-color", "--timestamps"),
+    ]
+
+
+def test_start_stack_diagnostics_do_not_mask_startup_failure(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    startup_error = release_golden_path.subprocess.CalledProcessError(1, ["docker", "compose"])
+
+    def fail_commands(args, **kwargs):
+        if args[-3:] == ["up", "--detach", "--build"]:
+            raise startup_error
+        raise RuntimeError("diagnostic failed")
+
+    monkeypatch.setattr(release_golden_path, "run", fail_commands)
+
+    try:
+        release_golden_path.start_stack(config)
+    except release_golden_path.subprocess.CalledProcessError as exc:
+        assert exc is startup_error
+    else:
+        raise AssertionError("startup failure should be re-raised")
+
+
 def test_align_project_name_binds_cli_lookup_to_owned_compose_project(tmp_path: Path) -> None:
     config = _config(tmp_path)
     config.project_dir.mkdir()

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -139,13 +139,13 @@ def test_cleanup_only_targets_owned_compose_project(tmp_path: Path, monkeypatch)
             "--no-TTY",
             "--user",
             "root",
-            "dagster",
+            service,
             "rm",
             "-rf",
             "/app/.venv",
-        ),
-        release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans"),
-    ]
+        )
+        for service in ("dagster", "dagster-daemon")
+    ] + [release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans")]
     assert not config.project_dir.exists()
 
 

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -66,19 +66,24 @@ def test_operator_install_uses_wheelhouse_and_not_editable_source(
     assert "phlo[core-services]" in commands[-2]
 
 
-def test_existing_project_dir_is_rejected_without_touching_it(tmp_path: Path, monkeypatch) -> None:
-    project = tmp_path / "project"
-    project.mkdir()
-    marker = project / "keep.txt"
-    marker.write_text("caller-owned\n", encoding="utf-8")
+def test_existing_project_or_sibling_is_rejected_without_touching_it(
+    tmp_path: Path, monkeypatch
+) -> None:
     monkeypatch.setattr(
         release_golden_path, "build_wheelhouse", lambda _: (_ for _ in ()).throw(AssertionError)
     )
+    for existing_name in ("project", "wheelhouse", "operator-env"):
+        case = tmp_path / existing_name
+        project = case / "project"
+        existing = project if existing_name == "project" else case / existing_name
+        existing.mkdir(parents=True)
+        marker = existing / "keep.txt"
+        marker.write_text("caller-owned\n", encoding="utf-8")
 
-    assert (
-        release_golden_path.main(["--repo-root", str(tmp_path), "--project-dir", str(project)]) == 2
-    )
-    assert marker.read_text(encoding="utf-8") == "caller-owned\n"
+        assert (
+            release_golden_path.main(["--repo-root", str(case), "--project-dir", str(project)]) == 2
+        )
+        assert marker.read_text(encoding="utf-8") == "caller-owned\n"
 
 
 def test_verify_rows_requires_a_positive_count(tmp_path: Path, monkeypatch) -> None:
@@ -124,12 +129,80 @@ def test_cleanup_only_targets_owned_compose_project(tmp_path: Path, monkeypatch)
     commands: list[list[str]] = []
     monkeypatch.setattr(release_golden_path, "run", lambda args, **_: commands.append(args))
 
-    release_golden_path.cleanup(config, owned_paths={config.project_dir})
+    errors = release_golden_path.cleanup(config, owned_paths={config.project_dir})
 
+    assert errors == []
     assert commands == [
         release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans")
     ]
     assert not config.project_dir.exists()
+
+
+def test_cleanup_removes_owned_paths_when_compose_down_fails(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    config.compose_file.parent.mkdir(parents=True)
+    config.compose_file.write_text("services: {}\n", encoding="utf-8")
+    wheelhouse = tmp_path / "wheelhouse"
+    operator_env = tmp_path / "operator-env"
+    wheelhouse.mkdir()
+    operator_env.mkdir()
+    monkeypatch.setattr(
+        release_golden_path,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("down failed")),
+    )
+
+    errors = release_golden_path.cleanup(
+        config,
+        owned_paths={config.project_dir, wheelhouse, operator_env},
+    )
+
+    assert [str(error) for error in errors] == ["down failed"]
+    assert not config.project_dir.exists()
+    assert not wheelhouse.exists()
+    assert not operator_env.exists()
+
+
+def test_runtime_error_returns_nonzero_without_masking_cleanup_failure(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    project = tmp_path / "project"
+
+    def fail_validation(config: release_golden_path.RunConfig) -> None:
+        config.project_dir.mkdir()
+        config.compose_file.parent.mkdir()
+        config.compose_file.write_text("services: {}\n", encoding="utf-8")
+        raise RuntimeError("validation failed")
+
+    monkeypatch.setattr(release_golden_path, "build_wheelhouse", fail_validation)
+    monkeypatch.setattr(
+        release_golden_path,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("down failed")),
+    )
+
+    result = release_golden_path.main(["--repo-root", str(tmp_path), "--project-dir", str(project)])
+
+    assert result == 1
+    assert not project.exists()
+    stderr = capsys.readouterr().err
+    assert "release golden path failed: validation failed" in stderr
+    assert "release golden path cleanup failed: down failed" in stderr
+
+
+def test_unexpected_exception_still_cleans_owned_paths(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "project"
+
+    def fail_unexpectedly(config: release_golden_path.RunConfig) -> None:
+        config.project_dir.mkdir()
+        raise ValueError("unexpected validation error")
+
+    monkeypatch.setattr(release_golden_path, "build_wheelhouse", fail_unexpectedly)
+
+    result = release_golden_path.main(["--repo-root", str(tmp_path), "--project-dir", str(project)])
+
+    assert result == 1
+    assert not project.exists()
 
 
 def test_dagster_build_receives_a_local_wheelhouse_arg() -> None:

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -1,0 +1,172 @@
+"""Focused tests for the release artifact golden-path harness."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "release_golden_path", REPO_ROOT / "scripts" / "release_golden_path.py"
+)
+assert _spec and _spec.loader
+release_golden_path = importlib.util.module_from_spec(_spec)
+sys.modules["release_golden_path"] = release_golden_path
+_spec.loader.exec_module(release_golden_path)
+
+
+def _config(tmp_path: Path) -> release_golden_path.RunConfig:
+    project = tmp_path / "project"
+    return release_golden_path.RunConfig(
+        repo_root=tmp_path,
+        project_dir=project,
+        wheelhouse=tmp_path / "wheelhouse",
+        operator_env=tmp_path / "operator-env",
+        project_name="phlo-qa001-test",
+    )
+
+
+def test_compose_commands_are_project_scoped(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+
+    assert release_golden_path.compose_command(config, "up", "--detach") == [
+        "docker",
+        "compose",
+        "-p",
+        "phlo-qa001-test",
+        "--file",
+        str(config.compose_file),
+        "--env-file",
+        str(config.project_dir / ".phlo" / ".env"),
+        "--env-file",
+        str(config.project_dir / ".phlo" / ".env.local"),
+        "up",
+        "--detach",
+    ]
+
+
+def test_operator_install_uses_wheelhouse_and_not_editable_source(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(release_golden_path, "run", lambda args, **_: commands.append(args))
+
+    release_golden_path.install_operator(config)
+
+    assert any(command[0:3] == ["uv", "pip", "install"] for command in commands)
+    local_install = commands[-1]
+    assert "--no-index" in local_install
+    assert "--no-deps" in local_install
+    assert "--reinstall" in local_install
+    assert "--find-links" in local_install
+    assert str(config.wheelhouse) in local_install
+    assert "-e" not in local_install
+    assert "." not in local_install
+    assert local_install[-3:] == ["phlo", "phlo-dlt", "phlo-pandera"]
+    assert "phlo[core-services]" in commands[-2]
+
+
+def test_existing_project_dir_is_rejected_without_touching_it(tmp_path: Path, monkeypatch) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    marker = project / "keep.txt"
+    marker.write_text("caller-owned\n", encoding="utf-8")
+    monkeypatch.setattr(
+        release_golden_path, "build_wheelhouse", lambda _: (_ for _ in ()).throw(AssertionError)
+    )
+
+    assert (
+        release_golden_path.main(["--repo-root", str(tmp_path), "--project-dir", str(project)]) == 2
+    )
+    assert marker.read_text(encoding="utf-8") == "caller-owned\n"
+
+
+def test_verify_rows_requires_a_positive_count(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    result = release_golden_path.subprocess.CompletedProcess([], 0, stdout='"2"\n', stderr="")
+    monkeypatch.setattr(release_golden_path, "run", lambda *args, **kwargs: result)
+
+    release_golden_path.verify_rows(config)
+
+    for output, expected in (
+        ("\n", "no row count"),
+        ("0\n", "no rows"),
+        ("oops\n", "no row count"),
+    ):
+        invalid = release_golden_path.subprocess.CompletedProcess([], 0, stdout=output, stderr="")
+        monkeypatch.setattr(
+            release_golden_path, "run", lambda *args, result=invalid, **kwargs: result
+        )
+        try:
+            release_golden_path.verify_rows(config)
+        except RuntimeError as exc:
+            assert expected in str(exc)
+        else:
+            raise AssertionError(f"invalid raw.events result should fail: {output!r}")
+
+
+def test_align_project_name_binds_cli_lookup_to_owned_compose_project(tmp_path: Path) -> None:
+    config = _config(tmp_path)
+    config.project_dir.mkdir()
+    (config.project_dir / "phlo.yaml").write_text("name: csv-batch\ndescription: demo\n")
+
+    release_golden_path.align_project_name(config)
+
+    assert (config.project_dir / "phlo.yaml").read_text().splitlines()[0] == (
+        "name: phlo-qa001-test"
+    )
+
+
+def test_cleanup_only_targets_owned_compose_project(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    config.compose_file.parent.mkdir(parents=True)
+    config.compose_file.write_text("services: {}\n", encoding="utf-8")
+    commands: list[list[str]] = []
+    monkeypatch.setattr(release_golden_path, "run", lambda args, **_: commands.append(args))
+
+    release_golden_path.cleanup(config, owned_paths={config.project_dir})
+
+    assert commands == [
+        release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans")
+    ]
+    assert not config.project_dir.exists()
+
+
+def test_dagster_build_receives_a_local_wheelhouse_arg() -> None:
+    service = Path("packages/phlo-dagster/src/phlo_dagster/service.yaml").read_text()
+    daemon = Path("packages/phlo-dagster/src/phlo_dagster/dagster-daemon.yaml").read_text()
+    dockerfile = Path("packages/phlo-dagster/src/phlo_dagster/Dockerfile").read_text()
+    trino_service = Path("packages/phlo-trino/src/phlo_trino/service.yaml").read_text()
+
+    assert "PHLO_WHEELHOUSE: ${PHLO_WHEELHOUSE:-}" in service
+    assert "PHLO_WHEELHOUSE: ${PHLO_WHEELHOUSE:-}" in daemon
+    assert 'ARG PHLO_WHEELHOUSE=""' in dockerfile
+    assert "FROM python:3.12-slim AS phlo-build-context" in dockerfile
+    assert "COPY . ." in dockerfile
+    assert "RUN mkdir -p /opt/phlo-build-context/wheelhouse" in dockerfile
+    assert (
+        "COPY --from=phlo-build-context /opt/phlo-build-context/wheelhouse /opt/phlo-wheelhouse"
+        in dockerfile
+    )
+    assert "RUN --mount=" not in dockerfile
+    assert "--no-index --no-deps --reinstall --find-links" in dockerfile
+    assert '"phlo==$PHLO_VERSION"' in dockerfile
+    local_reinstall = dockerfile.rindex(
+        "uv pip install --system --no-index --no-deps --reinstall --find-links"
+    )
+    dependency_install = dockerfile.index(
+        "uv pip install --system --prerelease explicit --find-links"
+    )
+    assert local_reinstall > dependency_install
+    assert "- source: jvm.config" in trino_service
+    assert "dest: trino/jvm.config" in trino_service
+
+
+def test_find_free_port_skips_reserved_ports(tmp_path: Path) -> None:
+    del tmp_path
+    reserved = {20000}
+
+    port = release_golden_path.find_free_port(start=20000, reserved=reserved)
+
+    assert port != 20000
+    assert port in reserved

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -133,7 +133,18 @@ def test_cleanup_only_targets_owned_compose_project(tmp_path: Path, monkeypatch)
 
     assert errors == []
     assert commands == [
-        release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans")
+        release_golden_path.compose_command(
+            config,
+            "exec",
+            "--no-TTY",
+            "--user",
+            "root",
+            "dagster",
+            "rm",
+            "-rf",
+            "/app/.venv",
+        ),
+        release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans"),
     ]
     assert not config.project_dir.exists()
 

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -44,6 +44,15 @@ def test_compose_commands_are_project_scoped(tmp_path: Path) -> None:
     ]
 
 
+def test_project_names_are_unique() -> None:
+    first = release_golden_path.project_name()
+    second = release_golden_path.project_name()
+
+    assert first.startswith("phlo-qa001-")
+    assert second.startswith("phlo-qa001-")
+    assert first != second
+
+
 def test_operator_install_uses_wheelhouse_and_not_editable_source(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -252,10 +261,10 @@ def test_unexpected_exception_still_cleans_owned_paths(tmp_path: Path, monkeypat
 
 
 def test_dagster_build_receives_a_local_wheelhouse_arg() -> None:
-    service = Path("packages/phlo-dagster/src/phlo_dagster/service.yaml").read_text()
-    daemon = Path("packages/phlo-dagster/src/phlo_dagster/dagster-daemon.yaml").read_text()
-    dockerfile = Path("packages/phlo-dagster/src/phlo_dagster/Dockerfile").read_text()
-    trino_service = Path("packages/phlo-trino/src/phlo_trino/service.yaml").read_text()
+    service = (REPO_ROOT / "packages/phlo-dagster/src/phlo_dagster/service.yaml").read_text()
+    daemon = (REPO_ROOT / "packages/phlo-dagster/src/phlo_dagster/dagster-daemon.yaml").read_text()
+    dockerfile = (REPO_ROOT / "packages/phlo-dagster/src/phlo_dagster/Dockerfile").read_text()
+    trino_service = (REPO_ROOT / "packages/phlo-trino/src/phlo_trino/service.yaml").read_text()
 
     assert "PHLO_WHEELHOUSE: ${PHLO_WHEELHOUSE:-}" in service
     assert "PHLO_WHEELHOUSE: ${PHLO_WHEELHOUSE:-}" in daemon
@@ -281,11 +290,19 @@ def test_dagster_build_receives_a_local_wheelhouse_arg() -> None:
     assert "dest: trino/jvm.config" in trino_service
 
 
-def test_find_free_port_skips_reserved_ports(tmp_path: Path) -> None:
-    del tmp_path
-    reserved = {20000}
+def test_configure_non_dev_compose_uses_docker_ephemeral_ports(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    config.project_dir.mkdir()
+    config.project_dir.joinpath(".phlo").mkdir()
+    config.project_dir.joinpath(".phlo/.env.local").write_text("", encoding="utf-8")
+    config.wheelhouse.mkdir()
+    config.wheelhouse.joinpath("phlo.whl").write_text("wheel", encoding="utf-8")
+    config.repo_root.joinpath("pyproject.toml").write_text(
+        "[project]\nversion = '1.2.3'\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(release_golden_path, "run", lambda *args, **kwargs: None)
 
-    port = release_golden_path.find_free_port(start=20000, reserved=reserved)
+    release_golden_path.configure_non_dev_compose(config)
 
-    assert port != 20000
-    assert port in reserved
+    env_local = config.project_dir.joinpath(".phlo/.env.local").read_text()
+    assert all(f"{name}=0\n" in env_local for name in release_golden_path.PORT_NAMES)

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -122,7 +122,7 @@ def test_align_project_name_binds_cli_lookup_to_owned_compose_project(tmp_path: 
     )
 
 
-def test_cleanup_only_targets_owned_compose_project(tmp_path: Path, monkeypatch) -> None:
+def test_cleanup_stops_before_scoped_run_and_down(tmp_path: Path, monkeypatch) -> None:
     config = _config(tmp_path)
     config.compose_file.parent.mkdir(parents=True)
     config.compose_file.write_text("services: {}\n", encoding="utf-8")
@@ -135,16 +135,20 @@ def test_cleanup_only_targets_owned_compose_project(tmp_path: Path, monkeypatch)
     assert commands == [
         release_golden_path.compose_command(
             config,
-            "exec",
-            "--no-TTY",
+            "stop",
+        ),
+        release_golden_path.compose_command(
+            config,
+            "run",
+            "--rm",
+            "--no-deps",
             "--user",
             "root",
-            service,
+            "dagster",
             "rm",
             "-rf",
             "/app/.venv",
-        )
-        for service in ("dagster", "dagster-daemon")
+        ),
     ] + [release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans")]
     assert not config.project_dir.exists()
 

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -122,7 +122,7 @@ def test_align_project_name_binds_cli_lookup_to_owned_compose_project(tmp_path: 
     )
 
 
-def test_cleanup_stops_before_scoped_run_and_down(tmp_path: Path, monkeypatch) -> None:
+def test_cleanup_only_tears_down_owned_compose_project(tmp_path: Path, monkeypatch) -> None:
     config = _config(tmp_path)
     config.compose_file.parent.mkdir(parents=True)
     config.compose_file.write_text("services: {}\n", encoding="utf-8")
@@ -133,23 +133,8 @@ def test_cleanup_stops_before_scoped_run_and_down(tmp_path: Path, monkeypatch) -
 
     assert errors == []
     assert commands == [
-        release_golden_path.compose_command(
-            config,
-            "stop",
-        ),
-        release_golden_path.compose_command(
-            config,
-            "run",
-            "--rm",
-            "--no-deps",
-            "--user",
-            "root",
-            "dagster",
-            "rm",
-            "-rf",
-            "/app/.venv",
-        ),
-    ] + [release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans")]
+        release_golden_path.compose_command(config, "down", "--volumes", "--remove-orphans")
+    ]
     assert not config.project_dir.exists()
 
 


### PR DESCRIPTION
## Summary
- adds a release harness that builds local wheels, creates a fresh csv-batch project, installs the operator from that wheelhouse, starts an owned non-dev stack, materializes `dlt_events` for `2025-01-15`, verifies `iceberg.raw.events` has a positive Trino count, and tears down only owned resources
- passes the built wheelhouse into Dagster through the existing generated-Compose build seam; the final image re-installs root `phlo` from the local wheelhouse after index-enabled dependency resolution
- adds the real harness as a required CI lane and includes it in aggregate CI status
- fails safely when a caller-owned artifact path exists, preserves the primary failure while attempting scoped teardown, and removes container-owned virtualenv files from both project-scoped Dagster services before host cleanup
- pins uv in the three required PR workflows after their `latest` resolution failed on a GitHub API 503 before tests began
- adds best-effort `docker compose ps` and timestamped logs when owned stack startup fails, while preserving the original startup error

## Evidence
- Current head: `3f884ef9f7` (`fix(release): add compose startup diagnostics`)
- Changed files in the current follow-up: `scripts/release_golden_path.py`, `tests/scripts/test_release_golden_path.py`
- `uv run pytest -q tests/scripts/test_release_golden_path.py` — 13 passed
- `uv run ruff check scripts/release_golden_path.py tests/scripts/test_release_golden_path.py` — passed
- `uv run ruff format --check scripts/release_golden_path.py tests/scripts/test_release_golden_path.py` — passed
- `git diff --check` — passed
- commit hooks — passed, including Ruff, AST, YAML/TOML/JSON checks, codespell, and security checks
- independent Luna-medium exact-diff review — passed with no blockers
- targeted local Agent CI reached `.github/workflows/ci.yml` and paused at `ci-config` / `Validate workflow YAML` with `ruby: command not found`; this is a Colima nested-Docker tooling blocker, not a source failure, and no publish or integration workflow was run
- prior artifact-backed local acceptance, before this diagnostic-only follow-up, built local wheels, started the stack, materialized `dlt_events`, received Trino count `"2"`, and completed owned cleanup

## Acceptance
The GitHub Actions `release-golden-path` job is the acceptance demonstration for this change. The targeted local Agent CI result above does not claim that GitHub acceptance has passed.

## Scope
This is QA-001 only. It does not publish artifacts or change normal generated-stack behavior when `PHLO_WHEELHOUSE` is unset.