### PR TITLE
fix(compose): preserve host ownership for Dagster mounts

### DIFF
--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -231,6 +231,12 @@ class ComposeGenerator:
                 continue
             config[key] = value
 
+        if service.name in {"dagster", "dagster-daemon"}:
+            if os.name == "nt":
+                config.pop("user", None)
+            else:
+                config["user"] = f"{os.getuid()}:{os.getgid()}"
+
         # Dependencies
         if service.depends_on:
             depends_config: dict[str, dict[str, str]] = {}

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from phlo.cli.commands.services.utils import detect_phlo_source_path
 from phlo.cli.infrastructure.selection import select_services_to_install
+from phlo.plugins.compose import generator as generator_module
 from phlo.plugins.compose.env import generate_env, generate_env_local
 from phlo.plugins.compose.generator import ComposeGenerator
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
@@ -101,6 +102,64 @@ def test_compose_generator_injects_phlo_dev_mounts(tmp_path) -> None:
 
     assert "/opt/phlo-dev:rw" in compose
     assert "PHLO_DEV_MODE" in compose
+
+
+@pytest.mark.parametrize("service_name", ["dagster", "dagster-daemon"])
+def test_compose_generator_sets_host_user_for_project_writing_services(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, service_name: str
+) -> None:
+    monkeypatch.setattr(generator_module.os, "getuid", lambda: 1234)
+    monkeypatch.setattr(generator_module.os, "getgid", lambda: 2345)
+
+    service = ServiceDefinition(
+        name=service_name,
+        description=service_name,
+        category="orchestration",
+        default=True,
+        compose={"user": "root"},
+    )
+    unrelated = ServiceDefinition(
+        name="trino",
+        description="trino",
+        category="query",
+        default=True,
+        compose={"user": "root"},
+    )
+
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+    data = yaml.safe_load(
+        generator.generate_compose(
+            services=[service, unrelated],
+            output_dir=tmp_path,
+        )
+    )
+
+    assert data["services"][service_name]["user"] == "1234:2345"
+    assert data["services"]["trino"]["user"] == "root"
+
+
+def test_compose_generator_omits_project_writing_user_on_windows(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setattr(generator_module.os, "name", "nt")
+
+    service = ServiceDefinition(
+        name="dagster",
+        description="dagster",
+        category="orchestration",
+        default=True,
+        compose={"user": "root"},
+    )
+
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+    data = yaml.safe_load(
+        generator.generate_compose(
+            services=[service],
+            output_dir=tmp_path,
+        )
+    )
+
+    assert "user" not in data["services"]["dagster"]
 
 
 def test_compose_generator_passthrough_compose_keys(tmp_path) -> None:

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -108,8 +108,9 @@ def test_compose_generator_injects_phlo_dev_mounts(tmp_path) -> None:
 def test_compose_generator_sets_host_user_for_project_writing_services(
     monkeypatch: pytest.MonkeyPatch, tmp_path, service_name: str
 ) -> None:
-    monkeypatch.setattr(generator_module.os, "getuid", lambda: 1234)
-    monkeypatch.setattr(generator_module.os, "getgid", lambda: 2345)
+    monkeypatch.setattr(generator_module.os, "name", "posix")
+    monkeypatch.setattr(generator_module.os, "getuid", lambda: 1234, raising=False)
+    monkeypatch.setattr(generator_module.os, "getgid", lambda: 2345, raising=False)
 
     service = ServiceDefinition(
         name=service_name,


### PR DESCRIPTION
## Summary
- generated Compose runs only dagster and dagster-daemon as the POSIX generating host UID:GID, preserving ownership of files written through their project mount
- generated Compose omits the user setting on Windows and leaves unrelated services untouched
- makes the POSIX generation test run natively on Windows while still asserting the simulated POSIX branch

## Evidence
- Head: c9d3ed1ca1e15ffa44667259981e40f6e2426483
- 20 focused Compose-generation tests passed
- Ruff check, Ruff format check, and git diff check passed
- Independent Luna-medium review approved the ownership-policy delta
- CodeRabbit Windows-test finding was addressed in c9d3ed1
- Local Docker Desktop bind-mount ownership probe was inconclusive: this host rejected writes from the numeric host identity and left no resources. Linux CI through the QA golden-path consumer remains the required runtime proof.

## Scope
This is the ownership prerequisite only; it does not add configuration, images, cleanup workarounds, or PowerShell behavior.