### PR TITLE
fix(compose): restrict Dagster host user to Linux

### DIFF
--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -5,6 +5,7 @@ Generates docker-compose.yml and .env/.env.local files from service definitions.
 """
 
 import os
+import platform
 import shutil
 from pathlib import Path
 from typing import Any
@@ -232,10 +233,10 @@ class ComposeGenerator:
             config[key] = value
 
         if service.name in {"dagster", "dagster-daemon"}:
-            if os.name == "nt":
-                config.pop("user", None)
-            else:
+            if platform.system() == "Linux":
                 config["user"] = f"{os.getuid()}:{os.getgid()}"
+            else:
+                config.pop("user", None)
 
         # Dependencies
         if service.depends_on:

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -105,10 +105,18 @@ def test_compose_generator_injects_phlo_dev_mounts(tmp_path) -> None:
 
 
 @pytest.mark.parametrize("service_name", ["dagster", "dagster-daemon"])
+@pytest.mark.parametrize(
+    ("host_platform", "expected_user"),
+    [("Linux", "1234:2345"), ("Darwin", None), ("Windows", None)],
+)
 def test_compose_generator_sets_host_user_for_project_writing_services(
-    monkeypatch: pytest.MonkeyPatch, tmp_path, service_name: str
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    service_name: str,
+    host_platform: str,
+    expected_user: str | None,
 ) -> None:
-    monkeypatch.setattr(generator_module.os, "name", "posix")
+    monkeypatch.setattr(generator_module.platform, "system", lambda: host_platform)
     monkeypatch.setattr(generator_module.os, "getuid", lambda: 1234, raising=False)
     monkeypatch.setattr(generator_module.os, "getgid", lambda: 2345, raising=False)
 
@@ -135,32 +143,8 @@ def test_compose_generator_sets_host_user_for_project_writing_services(
         )
     )
 
-    assert data["services"][service_name]["user"] == "1234:2345"
+    assert data["services"][service_name].get("user") == expected_user
     assert data["services"]["trino"]["user"] == "root"
-
-
-def test_compose_generator_omits_project_writing_user_on_windows(
-    monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
-    monkeypatch.setattr(generator_module.os, "name", "nt")
-
-    service = ServiceDefinition(
-        name="dagster",
-        description="dagster",
-        category="orchestration",
-        default=True,
-        compose={"user": "root"},
-    )
-
-    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
-    data = yaml.safe_load(
-        generator.generate_compose(
-            services=[service],
-            output_dir=tmp_path,
-        )
-    )
-
-    assert "user" not in data["services"]["dagster"]
 
 
 def test_compose_generator_passthrough_compose_keys(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- Restrict generated Dagster numeric `user: UID:GID` settings to Linux hosts.
- Preserve Docker Desktop defaults by omitting the setting on macOS and Windows.
- Keep unrelated service ownership settings unchanged.

## Evidence

- `uv run pytest tests/cli/test_cli_services_init.py -k "compose or service"` — 7 passed.
- Ruff check and format check passed for the changed files.
- `git diff --check origin/main...b65b17d0d4bfff1f22337bdcd6a8866883d2c728` passed.
- One bounded independent Luna-medium review approved the exact two-file diff.

No Docker run was needed for this configuration-only correction; the preceding local Docker Desktop probe established why macOS must retain the default container user.
