### PR TITLE
feat(release): add native Windows PowerShell golden path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,31 @@ jobs:
       - name: Run release artifact golden path
         run: python3 scripts/release_golden_path.py
 
+  windows-release-contract:
+    name: windows / release golden path contract
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        with:
+          python-version: "3.11"
+
+      - name: Install focused Python test dependency
+        shell: pwsh
+        run: python -m pip install --disable-pip-version-check pytest
+
+      - name: Run focused Python harness tests
+        shell: pwsh
+        run: python -m pytest tests/scripts/test_release_golden_path.py --tb=short
+
+      - name: Run PowerShell launcher contract tests
+        shell: pwsh
+        run: ./tests/scripts/test_release_golden_path.ps1
+
   python-package-tests:
     name: python / package tests (${{ matrix.group }})
     runs-on: ubuntu-latest
@@ -422,6 +447,7 @@ jobs:
       - python-core-tests
       - quickstart-smoke
       - release-golden-path
+      - windows-release-contract
       - python-package-tests
       - frontend
     steps:
@@ -433,6 +459,7 @@ jobs:
           PYTHON_CORE_TESTS: ${{ needs.python-core-tests.result }}
           QUICKSTART_SMOKE: ${{ needs.quickstart-smoke.result }}
           RELEASE_GOLDEN_PATH: ${{ needs.release-golden-path.result }}
+          WINDOWS_RELEASE_CONTRACT: ${{ needs.windows-release-contract.result }}
           PYTHON_PACKAGE_TESTS: ${{ needs.python-package-tests.result }}
           FRONTEND: ${{ needs.frontend.result }}
         run: |
@@ -448,6 +475,7 @@ jobs:
             echo "| python / core tests | ${PYTHON_CORE_TESTS} |"
             echo "| python / quickstart smoke | ${QUICKSTART_SMOKE} |"
             echo "| python / release golden path | ${RELEASE_GOLDEN_PATH} |"
+            echo "| windows / release golden path contract | ${WINDOWS_RELEASE_CONTRACT} |"
             echo "| python / package tests | ${PYTHON_PACKAGE_TESTS} |"
             echo "| frontend / observatory | ${FRONTEND} |"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -458,6 +486,7 @@ jobs:
             "${PYTHON_CORE_TESTS}" \
             "${QUICKSTART_SMOKE}" \
             "${RELEASE_GOLDEN_PATH}" \
+            "${WINDOWS_RELEASE_CONTRACT}" \
             "${PYTHON_PACKAGE_TESTS}" \
             "${FRONTEND}"; do
             if [ "${result}" != "success" ]; then

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -95,6 +95,27 @@ Troubleshooting tips:
 - If file watching or installs feel slow, move the project from `/mnt/c/...` into the WSL filesystem.
 - If ports are busy on Windows, edit the `env:` ports in `phlo.yaml`, then rerun `phlo services init`.
 
+## Native Windows with Docker Desktop
+
+WSL is optional for the release artifact golden path. Install Python 3.11, [uv](https://docs.astral.sh/uv/getting-started/installation/), and Docker Desktop, switch Docker Desktop to Linux containers, then run the launcher from a native PowerShell prompt at the repository root:
+
+```powershell
+.\scripts\release_golden_path.ps1 `
+  -Partition 2025-01-15 `
+  -ProjectDir "$PWD\.phlo-release-golden-path"
+```
+
+The launcher finds Python 3.11 through `py -3.11` or `PATH`, then delegates to the existing artifact-backed `scripts/release_golden_path.py` harness. Use `-WhatIf` to print the exact command without starting Docker:
+
+```powershell
+.\scripts\release_golden_path.ps1 `
+  -Partition 2025-01-15 `
+  -ProjectDir "$PWD\.phlo-release-golden-path" `
+  -WhatIf
+```
+
+This lane requires Docker Desktop to be running with Linux containers; it does not configure Docker Desktop or require WSL.
+
 ## Quick Install
 
 ```bash

--- a/scripts/release_golden_path.ps1
+++ b/scripts/release_golden_path.ps1
@@ -1,0 +1,74 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [string]$Partition = "2025-01-15",
+    [string]$ProjectDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Find-Python311 {
+    $candidates = @(
+        @{ Name = "py"; PrefixArguments = @("-3.11") },
+        @{ Name = "python"; PrefixArguments = @() },
+        @{ Name = "python3"; PrefixArguments = @() }
+    )
+    $checked = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($candidate in $candidates) {
+        $command = Get-Command $candidate.Name -CommandType Application -ErrorAction SilentlyContinue
+        if ($null -eq $command) {
+            continue
+        }
+
+        $prefixArguments = [string[]]$candidate.PrefixArguments
+        $version = & $command.Source @prefixArguments --version 2>$null
+        if ($LASTEXITCODE -eq 0 -and ($version -match "Python 3\.11\.")) {
+            return @{
+                Executable = $command.Source
+                PrefixArguments = $prefixArguments
+            }
+        }
+        $checked.Add($candidate.Name)
+    }
+
+    $checkedText = if ($checked.Count -eq 0) { "none" } else { $checked -join ", " }
+    throw "Python 3.11 was not found. Install Python 3.11 and make py -3.11 or python available on PATH. Checked: $checkedText."
+}
+
+function Quote-CommandPart([string]$Part) {
+    return '"' + ($Part -replace '"', '\"') + '"'
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$scriptPath = Join-Path $PSScriptRoot "release_golden_path.py"
+$python = Find-Python311
+$arguments = [System.Collections.Generic.List[string]]::new()
+$arguments.AddRange([string[]]$python.PrefixArguments)
+$arguments.Add($scriptPath)
+$arguments.Add("--repo-root")
+$arguments.Add($repoRoot)
+$arguments.Add("--partition")
+$arguments.Add($Partition)
+if ($ProjectDir) {
+    $arguments.Add("--project-dir")
+    $arguments.Add([System.IO.Path]::GetFullPath($ProjectDir))
+}
+
+$displayParts = @((Quote-CommandPart $python.Executable)) + @(
+    $arguments | ForEach-Object { Quote-CommandPart $_ }
+)
+$displayCommand = $displayParts -join " "
+Write-Output "release golden path command: $displayCommand"
+
+if ($PSCmdlet.ShouldProcess($displayCommand, "Run release artifact golden path")) {
+    Push-Location $repoRoot
+    try {
+        & $python.Executable @arguments
+        $exitCode = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    exit $exitCode
+}

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -35,12 +35,44 @@ class RunConfig:
     partition: str = PARTITION
 
     @property
+    def operator_python(self) -> Path:
+        return venv_executable(self.operator_env, "python")
+
+    @property
     def operator_bin(self) -> Path:
-        return self.operator_env / "bin" / "phlo"
+        return venv_executable(self.operator_env, "phlo")
+
+    @property
+    def project_env(self) -> Path:
+        return self.project_dir / ".venv"
+
+    @property
+    def project_python(self) -> Path:
+        return venv_executable(self.project_env, "python")
 
     @property
     def compose_file(self) -> Path:
         return self.project_dir / ".phlo" / "docker-compose.yml"
+
+
+def venv_executable(environment: Path, executable: str) -> Path:
+    """Return a virtualenv executable path for the current platform."""
+    if os.name == "nt":
+        candidates = (
+            environment / "Scripts" / f"{executable}.exe",
+            environment / "Scripts" / executable,
+            environment / "bin" / executable,
+        )
+    else:
+        candidates = (
+            environment / "bin" / executable,
+            environment / "Scripts" / f"{executable}.exe",
+            environment / "Scripts" / executable,
+        )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
 
 
 def command(*parts: str) -> list[str]:
@@ -124,7 +156,7 @@ def install_operator(config: RunConfig) -> None:
             "pip",
             "install",
             "--python",
-            str(config.operator_env / "bin" / "python"),
+            str(config.operator_python),
             "--no-index",
             "--no-deps",
             "--find-links",
@@ -139,7 +171,7 @@ def install_operator(config: RunConfig) -> None:
             "pip",
             "install",
             "--python",
-            str(config.operator_env / "bin" / "python"),
+            str(config.operator_python),
             "--find-links",
             str(config.wheelhouse),
             "phlo[core-services]",
@@ -150,7 +182,7 @@ def install_operator(config: RunConfig) -> None:
     )
     force_local_install(
         config,
-        config.operator_env / "bin" / "python",
+        config.operator_python,
         "phlo",
         "phlo-dlt",
         "phlo-pandera",
@@ -183,15 +215,14 @@ def align_project_name(config: RunConfig) -> None:
 
 
 def install_project_dependencies(config: RunConfig) -> None:
-    project_env = config.project_dir / ".venv"
-    run(command("uv", "venv", str(project_env), "--python", "3.11"), cwd=config.project_dir)
+    run(command("uv", "venv", str(config.project_env), "--python", "3.11"), cwd=config.project_dir)
     run(
         command(
             "uv",
             "pip",
             "install",
             "--python",
-            str(project_env / "bin" / "python"),
+            str(config.project_python),
             "--find-links",
             str(config.wheelhouse),
             "phlo-dlt",
@@ -201,7 +232,7 @@ def install_project_dependencies(config: RunConfig) -> None:
     )
     force_local_install(
         config,
-        project_env / "bin" / "python",
+        config.project_python,
         "phlo-dlt",
         "phlo-pandera",
     )

--- a/tests/scripts/test_release_golden_path.ps1
+++ b/tests/scripts/test_release_golden_path.ps1
@@ -1,0 +1,64 @@
+$ErrorActionPreference = "Stop"
+
+function Assert-Contains([string]$Value, [string]$Expected) {
+    if (-not $Value.Contains($Expected)) {
+        throw "Expected output to contain '$Expected', got: $Value"
+    }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$launcher = Join-Path $repoRoot "scripts/release_golden_path.ps1"
+$pwsh = Join-Path $PSHOME "pwsh.exe"
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("phlo-release-golden-path-" + [Guid]::NewGuid())
+$whatIfProject = Join-Path $tempRoot "what-if-project"
+$fakeBin = Join-Path $tempRoot "fake-bin"
+$emptyBin = Join-Path $tempRoot "empty-bin"
+$originalPath = $env:Path
+
+New-Item -ItemType Directory -Path $fakeBin, $emptyBin | Out-Null
+
+try {
+    $env:Path = $originalPath
+    $whatIfOutput = & $pwsh -NoProfile -File $launcher `
+        -Partition "2025-02-03" -ProjectDir $whatIfProject -WhatIf 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        throw "WhatIf invocation failed with exit code $LASTEXITCODE. Output: $whatIfOutput"
+    }
+    Assert-Contains $whatIfOutput "release golden path command:"
+    Assert-Contains $whatIfOutput "release_golden_path.py"
+    Assert-Contains $whatIfOutput "--partition"
+    Assert-Contains $whatIfOutput "2025-02-03"
+    Assert-Contains $whatIfOutput "--project-dir"
+    Assert-Contains $whatIfOutput $whatIfProject
+
+    $fakePython = Join-Path $fakeBin "py.cmd"
+    Set-Content -Path $fakePython -Encoding ascii -Value @(
+        "@echo off"
+        'if "%1"=="-3.11" if "%2"=="--version" ('
+        "  echo Python 3.11.9"
+        "  exit /b 0"
+        ")"
+        "exit /b 23"
+    )
+    $env:Path = $fakeBin
+    $preservedOutput = & $pwsh -NoProfile -File $launcher `
+        -Partition "2025-02-03" -ProjectDir (Join-Path $tempRoot "exit-project") 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 23) {
+        throw "Launcher did not preserve the Python exit code. Expected 23, got $LASTEXITCODE. Output: $preservedOutput"
+    }
+    Assert-Contains $preservedOutput "--partition"
+
+    $env:Path = $emptyBin
+    $missingOutput = & $pwsh -NoProfile -File $launcher -WhatIf 2>&1 | Out-String
+    if ($LASTEXITCODE -eq 0) {
+        throw "Launcher accepted a missing Python 3.11 interpreter. Output: $missingOutput"
+    }
+    Assert-Contains $missingOutput "Python 3.11 was not found"
+    Assert-Contains $missingOutput "py -3.11"
+}
+finally {
+    $env:Path = $originalPath
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Output "PowerShell release golden-path contract checks passed"

--- a/tests/scripts/test_release_golden_path.ps1
+++ b/tests/scripts/test_release_golden_path.ps1
@@ -62,3 +62,4 @@ finally {
 }
 
 Write-Output "PowerShell release golden-path contract checks passed"
+exit 0

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -53,6 +53,40 @@ def test_project_names_are_unique() -> None:
     assert first != second
 
 
+def test_virtualenv_executables_use_windows_scripts_directory(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    operator_scripts = config.operator_env / "Scripts"
+    project_scripts = config.project_env / "Scripts"
+    operator_scripts.mkdir(parents=True)
+    project_scripts.mkdir(parents=True)
+    operator_python = operator_scripts / "python.exe"
+    operator_bin = operator_scripts / "phlo.exe"
+    project_python = project_scripts / "python.exe"
+    for executable in (operator_python, operator_bin, project_python):
+        executable.touch()
+
+    monkeypatch.setattr(release_golden_path.os, "name", "nt")
+
+    assert config.operator_python == operator_python
+    assert config.operator_bin == operator_bin
+    assert config.project_python == project_python
+
+
+def test_virtualenv_executables_use_unix_bin_directory(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    operator_bin = config.operator_env / "bin" / "phlo"
+    project_python = config.project_env / "bin" / "python"
+    operator_bin.parent.mkdir(parents=True)
+    project_python.parent.mkdir(parents=True)
+    operator_bin.touch()
+    project_python.touch()
+
+    monkeypatch.setattr(release_golden_path.os, "name", "posix")
+
+    assert config.operator_bin == operator_bin
+    assert config.project_python == project_python
+
+
 def test_operator_install_uses_wheelhouse_and_not_editable_source(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

- add a native Windows PowerShell launcher that discovers Python 3.11, supports `-WhatIf`, delegates to the existing Python release golden-path harness, and preserves the delegated exit code
- resolve virtual-environment executables from `Scripts` on Windows and `bin` on Unix
- add focused Python and PowerShell contracts, a `windows-latest` CI lane, and native Docker Desktop installation guidance

## Validation

- `uv run --locked pytest tests/scripts/test_release_golden_path.py --tb=short` — 16 passed
- `uv run --locked ruff check scripts/release_golden_path.py tests/scripts/test_release_golden_path.py` — passed
- `uv run --locked ruff format --check scripts/release_golden_path.py tests/scripts/test_release_golden_path.py` — passed
- workflow YAML parse, `make actionlint`, and `make zizmor` — passed
- the Luna-medium blocking review reported no findings

PowerShell execution was not available on this macOS host, so the Windows launcher contract is validated by the `windows-latest` CI lane. This validates the Windows launcher and contracts; QA-001 remains the full Linux runtime acceptance. No merge or auto-merge is requested.