### PR TITLE
feat(services): add secure production compose profile

### DIFF
--- a/src/phlo/cli/commands/services/init.py
+++ b/src/phlo/cli/commands/services/init.py
@@ -24,6 +24,15 @@ from phlo.cli.output import user_error
 from phlo.plugins.compose import ComposeGenerator
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
 
+_PRODUCTION_USERNAME_DEFAULTS = {
+    "POSTGRES_USER": "phlo",
+    "MINIO_ROOT_USER": "minio",
+}
+_PRODUCTION_PASSWORD_DEFAULTS = {
+    "POSTGRES_PASSWORD": "phlo",
+    "MINIO_ROOT_PASSWORD": "minio123",
+}
+
 
 def _expand_selected_services(
     discovery: ServiceDiscovery,
@@ -68,6 +77,40 @@ def _load_existing_project_config(config_file: Path) -> dict:
     return project_config
 
 
+def _validate_production_credentials(
+    env_overrides: dict,
+    existing_local_values: dict[str, str],
+) -> None:
+    """Reject bundled credential values before rendering a production profile."""
+    invalid: list[str] = []
+
+    for variable, default in _PRODUCTION_USERNAME_DEFAULTS.items():
+        value = env_overrides.get(variable)
+        if not isinstance(value, str) or not value.strip() or value.strip() == default:
+            invalid.append(variable)
+
+    supplied_passwords: dict[str, str] = {}
+    for variable, default in _PRODUCTION_PASSWORD_DEFAULTS.items():
+        value = existing_local_values.get(variable, env_overrides.get(variable))
+        if value is None:
+            continue  # generate_env_local creates an independent secret for new deployments.
+        if not isinstance(value, str) or not value.strip() or value.strip() == default:
+            invalid.append(variable)
+        else:
+            supplied_passwords[variable] = value
+
+    if len(set(supplied_passwords.values())) != len(supplied_passwords):
+        invalid.extend(sorted(supplied_passwords))
+
+    if invalid:
+        variables = ", ".join(sorted(set(invalid)))
+        raise click.ClickException(
+            "Production credentials must be non-empty, non-default, and independent: "
+            f"{variables}. Set POSTGRES_USER and MINIO_ROOT_USER under phlo.yaml env:, "
+            "then replace any existing default passwords in .phlo/.env.local."
+        )
+
+
 @click.command("init")
 @click.option("--force", is_flag=True, help="Overwrite existing configuration")
 @click.option("--name", "project_name", help="Project name (default: directory name)")
@@ -92,6 +135,11 @@ def _load_existing_project_config(config_file: Path) -> dict:
     help="Also apply service-specific `dev:` runtime overrides (opt-in)",
 )
 @click.option(
+    "--production",
+    is_flag=True,
+    help="Render the production deployment profile without core host ports.",
+)
+@click.option(
     "--profile",
     "profiles",
     multiple=True,
@@ -105,6 +153,7 @@ def init_cmd(
     no_dev: bool,
     phlo_source: str | None,
     service_dev: bool,
+    production: bool,
     profiles: tuple[str, ...],
 ):
     """Initialize Phlo infrastructure in .phlo/ directory.
@@ -133,6 +182,7 @@ def init_cmd(
         phlo services init --dev --phlo-source ../../src/phlo
         phlo services init --dev --service-dev
         phlo services init --no-dev --force  # Regenerate without dev mode
+        phlo services init --production --no-dev
     """
     phlo_dir = get_phlo_dir()
     config_file = Path.cwd() / PHLO_CONFIG_FILE
@@ -149,10 +199,15 @@ def init_cmd(
     if service_dev and no_dev:
         click.echo("Error: Cannot specify both --service-dev and --no-dev.", err=True)
         sys.exit(1)
+    if production and (dev or service_dev):
+        click.echo("Error: Production cannot be combined with --dev or --service-dev.", err=True)
+        sys.exit(1)
 
     # --no-dev takes precedence
     if no_dev:
         dev = False
+    if production:
+        no_dev = True
 
     # Auto-enable dev mode if we can detect a local Phlo checkout and the user didn't opt out.
     phlo_src_path: str | None = None
@@ -233,6 +288,10 @@ def init_cmd(
         existing_config = _load_existing_project_config(config_file)
     user_overrides = existing_config.get("services", {})
     env_overrides = _get_env_overrides(existing_config)
+    existing_env_local = parse_env_file(phlo_dir / ".env.local")
+    if production:
+        _validate_production_credentials(env_overrides, existing_env_local)
+        env_overrides = {**env_overrides, "PHLO_ENVIRONMENT": "production"}
 
     # Collect inline custom services (those with type: inline)
     inline_services = [
@@ -275,6 +334,7 @@ def init_cmd(
         service_dev_mode=service_dev,
         phlo_src_path=phlo_src_path,
         user_overrides=user_overrides,
+        deployment_profile="production" if production else "development",
     )
 
     compose_file = phlo_dir / "docker-compose.yml"
@@ -284,7 +344,6 @@ def init_cmd(
     # Generate .env + .env.local
     env_file = phlo_dir / ".env"
     env_local_file = phlo_dir / ".env.local"
-    existing_env_local = parse_env_file(env_local_file)
     env_content = composer.generate_env(services_to_install, env_overrides=env_overrides)
     env_local_content = composer.generate_env_local(
         services_to_install,

--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -64,6 +64,11 @@ class ComposeGenerator:
         Returns:
             Docker compose YAML content as string.
         """
+        if deployment_profile == "production" and (dev_mode or service_dev_mode):
+            raise ValueError(
+                "production deployment profile cannot use dev_mode or service_dev_mode"
+            )
+
         # Sort services by dependencies
         sorted_services = self.discovery.resolve_dependencies(services)
         user_overrides = user_overrides or {}
@@ -123,12 +128,25 @@ class ComposeGenerator:
     def _required_credential_expression(self, variable: str) -> str:
         return f"${{{variable}:?Phlo production requires {variable}}}"
 
+    def _require_production_environment_assignment(self, value: Any) -> Any:
+        """Normalize a protected list-form environment assignment."""
+        if isinstance(value, str):
+            variable, separator, _assigned_value = value.partition("=")
+            if variable in _PRODUCTION_CREDENTIAL_DEFAULTS and (separator or value == variable):
+                return f"{variable}={self._required_credential_expression(variable)}"
+        return self._require_production_credentials(value)
+
     def _require_production_credentials(self, value: Any) -> Any:
         """Replace bundled credential fallbacks with Compose required-variable syntax."""
         if isinstance(value, dict):
             for key, nested_value in value.items():
                 if key in _PRODUCTION_CREDENTIAL_DEFAULTS:
                     value[key] = self._required_credential_expression(key)
+                elif key == "environment" and isinstance(nested_value, list):
+                    value[key] = [
+                        self._require_production_environment_assignment(item)
+                        for item in nested_value
+                    ]
                 else:
                     value[key] = self._require_production_credentials(nested_value)
             return value

--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -8,7 +8,7 @@ import os
 import platform
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import yaml
 
@@ -22,6 +22,15 @@ from phlo.plugins.compose.env import (
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
 
 logger = get_logger(__name__)
+
+
+_PRODUCTION_INTERNAL_SERVICES = frozenset({"postgres", "minio", "nessie", "trino", "dagster"})
+_PRODUCTION_CREDENTIAL_DEFAULTS = {
+    "POSTGRES_USER": "phlo",
+    "POSTGRES_PASSWORD": "phlo",
+    "MINIO_ROOT_USER": "minio",
+    "MINIO_ROOT_PASSWORD": "minio123",
+}
 
 
 class ComposeGenerator:
@@ -39,6 +48,7 @@ class ComposeGenerator:
         service_dev_mode: bool = False,
         phlo_src_path: str | None = None,
         user_overrides: dict[str, Any] | None = None,
+        deployment_profile: Literal["development", "production"] = "development",
     ) -> str:
         """Generate docker-compose.yml content.
 
@@ -49,6 +59,7 @@ class ComposeGenerator:
             service_dev_mode: If True, apply service-specific `dev:` overrides.
             phlo_src_path: Path to phlo source (relative to project root).
             user_overrides: Dict of service name to ServiceOverride config from phlo.yaml.
+            deployment_profile: Deployment posture for generated service bindings.
 
         Returns:
             Docker compose YAML content as string.
@@ -71,6 +82,8 @@ class ComposeGenerator:
                 phlo_src_path=phlo_src_path,
                 user_override=service_override,
             )
+            if deployment_profile == "production":
+                self._apply_production_profile(service.name, compose["services"][service.name])
 
         named_volumes = self._collect_named_volumes(compose["services"].values())
         if named_volumes:
@@ -85,6 +98,30 @@ class ComposeGenerator:
 
 """
         return header + yaml.dump(compose, default_flow_style=False, sort_keys=False)
+
+    def _apply_production_profile(self, service_name: str, config: dict[str, Any]) -> None:
+        """Apply the bounded production network and credential posture."""
+        if service_name in _PRODUCTION_INTERNAL_SERVICES:
+            config.pop("ports", None)
+        self._require_production_credentials(config)
+
+    def _require_production_credentials(self, value: Any) -> Any:
+        """Replace bundled credential fallbacks with Compose required-variable syntax."""
+        if isinstance(value, dict):
+            for key, nested_value in value.items():
+                value[key] = self._require_production_credentials(nested_value)
+            return value
+        if isinstance(value, list):
+            return [self._require_production_credentials(item) for item in value]
+        if not isinstance(value, str):
+            return value
+
+        for variable, default in _PRODUCTION_CREDENTIAL_DEFAULTS.items():
+            bundled = f"${{{variable}:-{default}}}"
+            if bundled in value:
+                required = f"${{{variable}:?Phlo production requires {variable}}}"
+                value = value.replace(bundled, required)
+        return value
 
     def _collect_named_volumes(self, services: Any) -> set[str]:
         """Collect named service volumes that need top-level compose declarations."""

--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -103,13 +103,34 @@ class ComposeGenerator:
         """Apply the bounded production network and credential posture."""
         if service_name in _PRODUCTION_INTERNAL_SERVICES:
             config.pop("ports", None)
+            self._remove_traefik_labels(config)
         self._require_production_credentials(config)
+
+    def _remove_traefik_labels(self, config: dict[str, Any]) -> None:
+        """Remove public Traefik routes while retaining unrelated service labels."""
+        labels = config.get("labels")
+        if isinstance(labels, dict):
+            config["labels"] = {
+                key: value for key, value in labels.items() if not str(key).startswith("traefik.")
+            }
+        elif isinstance(labels, list):
+            config["labels"] = [
+                label
+                for label in labels
+                if not isinstance(label, str) or not label.startswith("traefik.")
+            ]
+
+    def _required_credential_expression(self, variable: str) -> str:
+        return f"${{{variable}:?Phlo production requires {variable}}}"
 
     def _require_production_credentials(self, value: Any) -> Any:
         """Replace bundled credential fallbacks with Compose required-variable syntax."""
         if isinstance(value, dict):
             for key, nested_value in value.items():
-                value[key] = self._require_production_credentials(nested_value)
+                if key in _PRODUCTION_CREDENTIAL_DEFAULTS:
+                    value[key] = self._required_credential_expression(key)
+                else:
+                    value[key] = self._require_production_credentials(nested_value)
             return value
         if isinstance(value, list):
             return [self._require_production_credentials(item) for item in value]
@@ -119,7 +140,7 @@ class ComposeGenerator:
         for variable, default in _PRODUCTION_CREDENTIAL_DEFAULTS.items():
             bundled = f"${{{variable}:-{default}}}"
             if bundled in value:
-                required = f"${{{variable}:?Phlo production requires {variable}}}"
+                required = self._required_credential_expression(variable)
                 value = value.replace(bundled, required)
         return value
 

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -347,6 +347,77 @@ def test_compose_generator_development_profile_keeps_core_host_ports(tmp_path) -
     assert data["services"]["postgres"]["ports"] == ["10000:5432"]
 
 
+def test_production_profile_neutralizes_protected_service_environment_overrides(
+    tmp_path,
+) -> None:
+    service = ServiceDefinition(
+        name="postgres",
+        description="postgres",
+        category="core",
+        default=True,
+        compose={"environment": {}},
+    )
+    overrides = {
+        "postgres": {
+            "environment": {
+                "POSTGRES_USER": "phlo",
+                "POSTGRES_PASSWORD": "literal-password",
+                "MINIO_ROOT_USER": "${MINIO_ROOT_USER:-minio}",
+                "MINIO_ROOT_PASSWORD": "${MINIO_ROOT_PASSWORD:-override-password}",
+                "UNRELATED": "preserved",
+            }
+        }
+    }
+
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+    data = yaml.safe_load(
+        generator.generate_compose(
+            [service],
+            output_dir=tmp_path,
+            user_overrides=overrides,
+            deployment_profile="production",
+        )
+    )
+    environment = data["services"]["postgres"]["environment"]
+
+    assert environment == {
+        "POSTGRES_USER": "${POSTGRES_USER:?Phlo production requires POSTGRES_USER}",
+        "POSTGRES_PASSWORD": "${POSTGRES_PASSWORD:?Phlo production requires POSTGRES_PASSWORD}",
+        "MINIO_ROOT_USER": "${MINIO_ROOT_USER:?Phlo production requires MINIO_ROOT_USER}",
+        "MINIO_ROOT_PASSWORD": (
+            "${MINIO_ROOT_PASSWORD:?Phlo production requires MINIO_ROOT_PASSWORD}"
+        ),
+        "UNRELATED": "preserved",
+    }
+
+
+def test_production_profile_removes_internal_traefik_labels_but_preserves_other_labels(
+    tmp_path,
+) -> None:
+    service = ServiceDefinition(
+        name="trino",
+        description="trino",
+        category="core",
+        default=True,
+        compose={
+            "labels": {
+                "traefik.enable": "true",
+                "traefik.http.routers.trino.rule": "Host(`trino.phlo.localhost`)",
+                "phlo.metrics.enabled": "false",
+            }
+        },
+    )
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+
+    production = yaml.safe_load(
+        generator.generate_compose([service], output_dir=tmp_path, deployment_profile="production")
+    )
+    development = yaml.safe_load(generator.generate_compose([service], output_dir=tmp_path))
+
+    assert production["services"]["trino"]["labels"] == {"phlo.metrics.enabled": "false"}
+    assert development["services"]["trino"]["labels"] == service.compose["labels"]
+
+
 def test_production_profile_renders_bundled_core_without_public_ports_or_credential_defaults(
     tmp_path,
 ) -> None:
@@ -361,6 +432,8 @@ def test_production_profile_renders_bundled_core_without_public_ports_or_credent
 
     for name in ("postgres", "minio", "nessie", "trino", "dagster"):
         assert "ports" not in data["services"][name]
+        labels = data["services"][name].get("labels", {})
+        assert not any(str(label).startswith("traefik.") for label in labels)
     assert "${POSTGRES_PASSWORD:-phlo}" not in compose
     assert "${MINIO_ROOT_PASSWORD:-minio123}" not in compose
 

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -4,6 +4,7 @@ import os
 import re
 from typing import cast
 
+import click
 import pytest
 import yaml
 from click.testing import CliRunner
@@ -15,6 +16,77 @@ from phlo.plugins.compose.env import generate_env, generate_env_local
 from phlo.plugins.compose.generator import ComposeGenerator
 from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
 from tests.helpers import FakeDiscovery, _service
+
+
+def test_production_credentials_reject_defaults_and_require_safe_usernames() -> None:
+    from phlo.cli.commands.services.init import _validate_production_credentials
+
+    with pytest.raises(click.ClickException, match="MINIO_ROOT_USER, POSTGRES_USER"):
+        _validate_production_credentials({}, {})
+
+    with pytest.raises(click.ClickException, match="POSTGRES_PASSWORD"):
+        _validate_production_credentials(
+            {"POSTGRES_USER": "lakehouse", "MINIO_ROOT_USER": "object-admin"},
+            {"POSTGRES_PASSWORD": "phlo", "MINIO_ROOT_PASSWORD": "independent-secret"},
+        )
+
+
+def test_production_credentials_allow_generated_passwords_and_safe_usernames() -> None:
+    from phlo.cli.commands.services.init import _validate_production_credentials
+
+    _validate_production_credentials(
+        {"POSTGRES_USER": "lakehouse", "MINIO_ROOT_USER": "object-admin"},
+        {},
+    )
+
+
+def test_services_init_production_selects_the_secure_compose_profile(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    postgres = _service("postgres", default=True)
+    discovery = FakeDiscovery({postgres.name: postgres}, default_names=(postgres.name,))
+    captured: dict[str, object] = {}
+
+    class FakeComposer:
+        def __init__(self, _discovery) -> None:
+            pass
+
+        def generate_compose(self, _services, _output_dir, **kwargs) -> str:
+            captured.update(kwargs)
+            return "services: {}\n"
+
+        def generate_env(self, _services, env_overrides=None) -> str:
+            captured["env_overrides"] = env_overrides
+            return ""
+
+        def generate_env_local(self, _services, **_kwargs) -> str:
+            return ""
+
+        def generate_gitignore(self, _services) -> str:
+            return ""
+
+        def copy_service_files(self, _services, _output_dir) -> list[str]:
+            return []
+
+    (tmp_path / "phlo.yaml").write_text(
+        "env:\n  POSTGRES_USER: lakehouse\n  MINIO_ROOT_USER: object-admin\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    from phlo.cli.commands.services import init as init_module
+
+    monkeypatch.setattr(init_module, "ServiceDiscovery", lambda: discovery)
+    monkeypatch.setattr(init_module, "ComposeGenerator", FakeComposer)
+
+    result = CliRunner().invoke(init_module.init_cmd, ["--production"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["deployment_profile"] == "production"
+    assert captured["dev_mode"] is False
+    assert captured["env_overrides"] == {
+        "POSTGRES_USER": "lakehouse",
+        "MINIO_ROOT_USER": "object-admin",
+        "PHLO_ENVIRONMENT": "production",
+    }
 
 
 def test_select_services_to_install_respects_enabled_disabled_and_profiles() -> None:
@@ -202,6 +274,95 @@ def test_compose_generator_passthrough_compose_keys(tmp_path) -> None:
     assert trino["mem_limit"] == "3g"
     assert trino["cpus"] == "2.0"
     assert trino["ulimits"] == {"nofile": {"soft": 16384, "hard": 16384}}
+
+
+def test_compose_generator_production_profile_hides_core_host_ports_and_requires_credentials(
+    tmp_path,
+) -> None:
+    class MinimalFakeDiscovery(FakeDiscovery):
+        def resolve_dependencies(
+            self, services: list[ServiceDefinition]
+        ) -> list[ServiceDefinition]:
+            return services
+
+    services = [
+        ServiceDefinition(
+            name=name,
+            description=name,
+            category="core",
+            default=True,
+            compose={
+                "ports": ["10000:5432"],
+                "environment": {
+                    "POSTGRES_USER": "${POSTGRES_USER:-phlo}",
+                    "POSTGRES_PASSWORD": "${POSTGRES_PASSWORD:-phlo}",
+                    "MINIO_ROOT_USER": "${MINIO_ROOT_USER:-minio}",
+                    "MINIO_ROOT_PASSWORD": "${MINIO_ROOT_PASSWORD:-minio123}",
+                },
+            },
+        )
+        for name in ("postgres", "minio", "nessie", "trino", "dagster")
+    ]
+
+    generator = ComposeGenerator(cast(ServiceDiscovery, MinimalFakeDiscovery()))
+    data = yaml.safe_load(
+        generator.generate_compose(
+            services=services,
+            output_dir=tmp_path,
+            deployment_profile="production",
+        )
+    )
+
+    for name in ("postgres", "minio", "nessie", "trino", "dagster"):
+        assert "ports" not in data["services"][name]
+        environment = data["services"][name]["environment"]
+        assert (
+            environment["POSTGRES_USER"]
+            == "${POSTGRES_USER:?Phlo production requires POSTGRES_USER}"
+        )
+        assert environment["POSTGRES_PASSWORD"] == (
+            "${POSTGRES_PASSWORD:?Phlo production requires POSTGRES_PASSWORD}"
+        )
+        assert (
+            environment["MINIO_ROOT_USER"]
+            == "${MINIO_ROOT_USER:?Phlo production requires MINIO_ROOT_USER}"
+        )
+        assert environment["MINIO_ROOT_PASSWORD"] == (
+            "${MINIO_ROOT_PASSWORD:?Phlo production requires MINIO_ROOT_PASSWORD}"
+        )
+
+
+def test_compose_generator_development_profile_keeps_core_host_ports(tmp_path) -> None:
+    service = ServiceDefinition(
+        name="postgres",
+        description="postgres",
+        category="core",
+        default=True,
+        compose={"ports": ["10000:5432"]},
+    )
+
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+    data = yaml.safe_load(generator.generate_compose([service], output_dir=tmp_path))
+
+    assert data["services"]["postgres"]["ports"] == ["10000:5432"]
+
+
+def test_production_profile_renders_bundled_core_without_public_ports_or_credential_defaults(
+    tmp_path,
+) -> None:
+    discovery = ServiceDiscovery()
+    generator = ComposeGenerator(discovery)
+    compose = generator.generate_compose(
+        discovery.get_default_services(),
+        output_dir=tmp_path,
+        deployment_profile="production",
+    )
+    data = yaml.safe_load(compose)
+
+    for name in ("postgres", "minio", "nessie", "trino", "dagster"):
+        assert "ports" not in data["services"][name]
+    assert "${POSTGRES_PASSWORD:-phlo}" not in compose
+    assert "${MINIO_ROOT_PASSWORD:-minio123}" not in compose
 
 
 def test_compose_generator_declares_named_volumes(tmp_path) -> None:

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -347,6 +347,36 @@ def test_compose_generator_development_profile_keeps_core_host_ports(tmp_path) -
     assert data["services"]["postgres"]["ports"] == ["10000:5432"]
 
 
+@pytest.mark.parametrize(
+    ("dev_mode", "service_dev_mode"),
+    [(True, False), (False, True), (True, True)],
+)
+def test_compose_generator_rejects_dev_options_for_production_profile(
+    tmp_path,
+    dev_mode: bool,
+    service_dev_mode: bool,
+) -> None:
+    service = ServiceDefinition(
+        name="dagster",
+        description="dagster",
+        category="orchestration",
+        default=True,
+        phlo_dev=True,
+        compose={},
+    )
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+
+    with pytest.raises(ValueError, match="production.*dev_mode.*service_dev_mode"):
+        generator.generate_compose(
+            [service],
+            output_dir=tmp_path,
+            dev_mode=dev_mode,
+            service_dev_mode=service_dev_mode,
+            phlo_src_path="../phlo/src/phlo",
+            deployment_profile="production",
+        )
+
+
 def test_production_profile_neutralizes_protected_service_environment_overrides(
     tmp_path,
 ) -> None:
@@ -389,6 +419,39 @@ def test_production_profile_neutralizes_protected_service_environment_overrides(
         ),
         "UNRELATED": "preserved",
     }
+
+
+def test_production_profile_normalizes_list_form_protected_environment_assignments(
+    tmp_path,
+) -> None:
+    service = ServiceDefinition(
+        name="postgres",
+        description="postgres",
+        category="core",
+        default=True,
+        compose={
+            "environment": [
+                "POSTGRES_USER=literal-user",
+                "POSTGRES_PASSWORD=phlo",
+                "MINIO_ROOT_USER=${MINIO_ROOT_USER:-override-user}",
+                "MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:-minio123}",
+                "UNRELATED=preserved",
+            ]
+        },
+    )
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+
+    data = yaml.safe_load(
+        generator.generate_compose([service], output_dir=tmp_path, deployment_profile="production")
+    )
+
+    assert data["services"]["postgres"]["environment"] == [
+        "POSTGRES_USER=${POSTGRES_USER:?Phlo production requires POSTGRES_USER}",
+        "POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?Phlo production requires POSTGRES_PASSWORD}",
+        "MINIO_ROOT_USER=${MINIO_ROOT_USER:?Phlo production requires MINIO_ROOT_USER}",
+        "MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD:?Phlo production requires MINIO_ROOT_PASSWORD}",
+        "UNRELATED=preserved",
+    ]
 
 
 def test_production_profile_removes_internal_traefik_labels_but_preserves_other_labels(


### PR DESCRIPTION
## Outcome

Add a bounded production Compose profile for the blessed Phlo stack. `phlo services init --production` disables development mounts, removes direct host ports and Traefik routes from PostgreSQL, MinIO, Nessie, Trino, and Dagster, and requires independent non-default core credentials.

## Why

The v1 roadmap requires a production generation path that cannot silently retain local-development credentials or expose data-plane services. Existing generation only supported development and non-development build modes, without a security posture.

## Review corrections included

- Protected credentials supplied through service-level overrides are replaced with Compose required-variable expressions, closing the override bypass.
- Traefik routing labels are removed from internal services in production while unrelated labels and development behavior are preserved.

## Validation

- `uv run pytest tests/cli/test_cli_services_init.py tests/cli/test_cli_services_utils.py --import-mode=importlib -q` — 36 passed
- Targeted Ruff format/check
- `uv run ty check src/phlo/plugins/compose/generator.py`
- `git diff --check origin/main...HEAD`
- Commit pre-hooks

## Non-goals

This slice does not implement TLS termination, ingress, workload identity, backend RBAC convergence, or durable audit enforcement; those remain separate v1 workstreams.
