### PR TITLE
fix(runtime): prefer WAP branch refs

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/adapter.py
+++ b/packages/phlo-dagster/src/phlo_dagster/adapter.py
@@ -56,6 +56,7 @@ from phlo.capabilities.runtime import (
     RuntimeRouting,
     attempt_from_tags,
     capability_overrides_from_tags,
+    runtime_ref_from_tags,
 )
 from phlo.config import get_settings
 from phlo.capabilities.specs import (
@@ -253,7 +254,7 @@ class DagsterRuntime(RuntimeContext):
             capability_overrides.setdefault(capability_type, provider_name)
         return RuntimeRouting(
             environment=tags.get("environment") or tags.get("env"),
-            ref=tags.get("phlo/ref") or tags.get("ref") or tags.get("branch"),
+            ref=runtime_ref_from_tags(tags),
             partition_key=self.partition_key,
             run_id=self.run_id,
             project_id=project.project_id,

--- a/packages/phlo-dagster/tests/test_integration_dagster.py
+++ b/packages/phlo-dagster/tests/test_integration_dagster.py
@@ -156,7 +156,12 @@ def test_dagster_runtime_builds_routing_without_recursion():
     from phlo_dagster.adapter import DagsterRuntime
 
     context = SimpleNamespace(
-        tags={"environment": "dev", "phlo/ref": "feature/orders", "feature/wap": "true"},
+        tags={
+            "environment": "dev",
+            "phlo/wap_branch": "pipeline-run-abc123",
+            "phlo/ref": "feature/orders",
+            "feature/wap": "true",
+        },
         run=SimpleNamespace(run_id="abc123"),
         has_partition_key=True,
         partition_key="2025-01-01",
@@ -167,7 +172,7 @@ def test_dagster_runtime_builds_routing_without_recursion():
     runtime = DagsterRuntime(context=cast(AssetExecutionContext, context))
 
     assert runtime.routing.environment == "dev"
-    assert runtime.routing.ref == "feature/orders"
+    assert runtime.routing.ref == "pipeline-run-abc123"
     assert runtime.routing.partition_key == "2025-01-01"
     assert runtime.routing.run_id == "abc123"
     assert runtime.routing.feature_flags == {"wap": "true"}

--- a/packages/phlo-dbt/tests/test_runtime_config.py
+++ b/packages/phlo-dbt/tests/test_runtime_config.py
@@ -93,6 +93,36 @@ def test_resolve_dbt_runtime_config_uses_ref_aware_catalog() -> None:
     assert config.catalog == "iceberg_feature_orders"
 
 
+def test_resolve_dbt_runtime_config_prefers_wap_branch_catalog() -> None:
+    runtime = SimpleNamespace(
+        run_id="run-1",
+        partition_key=None,
+        tags={
+            "environment": "dev",
+            "phlo/wap_branch": "pipeline-run-run-1",
+            "phlo/ref": "feature_orders",
+        },
+        resources={},
+    )
+
+    config = resolve_dbt_runtime_config(runtime)
+
+    assert config.catalog == "iceberg_pipeline-run-run-1"
+
+
+def test_resolve_dbt_runtime_config_ignores_blank_wap_branch() -> None:
+    runtime = SimpleNamespace(
+        run_id="run-1",
+        partition_key=None,
+        tags={"phlo/wap_branch": "  ", "phlo/ref": "feature_orders"},
+        resources={},
+    )
+
+    config = resolve_dbt_runtime_config(runtime)
+
+    assert config.catalog == "iceberg_feature_orders"
+
+
 def test_resolve_dbt_runtime_config_defaults_to_main_catalog() -> None:
     config = resolve_dbt_runtime_config()
 

--- a/src/phlo/capabilities/runtime.py
+++ b/src/phlo/capabilities/runtime.py
@@ -46,6 +46,18 @@ def capability_overrides_from_tags(tags: Mapping[str, str]) -> dict[str, str]:
     return overrides
 
 
+def runtime_ref_from_tags(tags: Mapping[str, object]) -> str | None:
+    """Resolve the first non-blank runtime ref using canonical precedence."""
+    for key in ("phlo/wap_branch", "phlo/ref", "ref", "branch"):
+        value = tags.get(key)
+        if value is None:
+            continue
+        normalized = str(value).strip()
+        if normalized:
+            return normalized
+    return None
+
+
 class RuntimeContext(Protocol):
     """Orchestrator-agnostic runtime context."""
 
@@ -107,7 +119,7 @@ def routing_from_context(context: RuntimeContext) -> RuntimeRouting:
     }
     capability_overrides = capability_overrides_from_tags(tags)
     environment = tags.get("environment") or tags.get("env")
-    ref = tags.get("phlo/ref") or tags.get("ref") or tags.get("branch")
+    ref = runtime_ref_from_tags(tags)
 
     attempt, attempt_error = attempt_from_tags(tags)
     project = resolve_project_identity(tags)

--- a/tests/plugins/test_capabilities_runtime.py
+++ b/tests/plugins/test_capabilities_runtime.py
@@ -260,6 +260,8 @@ def test_routing_from_context_reads_canonical_tags() -> None:
         partition_key = "2025-01-01"
         tags = {
             "environment": "dev",
+            "phlo/wap_branch": "pipeline-run-123",
+            "phlo/ref": "canonical-ref",
             "branch": "feature/orders",
             "feature/wap": "true",
             "phlo/capability/table_store": "delta",
@@ -279,12 +281,36 @@ def test_routing_from_context_reads_canonical_tags() -> None:
 
     routing = routing_from_context(StubRuntime())
     assert routing.environment == "dev"
-    assert routing.ref == "feature/orders"
+    assert routing.ref == "pipeline-run-123"
     assert routing.partition_key == "2025-01-01"
     assert routing.run_id == "run-123"
     assert routing.feature_flags == {"wap": "true"}
     assert routing.capability_overrides == {"table_store": "delta"}
     assert "table_store" in routing.resources
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected"),
+    [
+        ({"phlo/wap_branch": "", "phlo/ref": "canonical"}, "canonical"),
+        ({"phlo/wap_branch": "   ", "ref": "legacy-ref"}, "legacy-ref"),
+        ({"phlo/ref": "", "ref": "", "branch": "legacy-branch"}, "legacy-branch"),
+    ],
+)
+def test_routing_from_context_ignores_blank_ref_values(tags, expected) -> None:
+    runtime = type(
+        "StubRuntime",
+        (),
+        {
+            "run_id": "run-123",
+            "partition_key": None,
+            "tags": tags,
+            "resources": {},
+            "routing": property(lambda self: (_ for _ in ()).throw(AttributeError())),
+        },
+    )()
+
+    assert routing_from_context(runtime).ref == expected
 
 
 def test_resolve_capability_uses_global_default(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Outcome

Make the WAP branch tag the canonical runtime ref across core routing, Dagster adaptation, and dbt configuration.

`phlo/wap_branch` now takes precedence over `phlo/ref`, `ref`, and `branch`; whitespace-only values are ignored and legacy fallbacks remain supported. This lets dlt and dbt in one Dagster run target the same Nessie branch.

## Why

The v1 release journey cannot truthfully validate transform and promotion while ingestion and dbt may resolve different refs from the same run tags.

## Validation

- Core precedence, blank-value, and fallback tests
- Dagster routing integration tests
- dbt WAP-catalog and legacy fallback tests
- `uv run pytest tests/plugins/test_capabilities_runtime.py packages/phlo-dbt/tests/test_runtime_config.py packages/phlo-dagster/tests/test_integration_dagster.py --import-mode=importlib -q`
- Focused Ruff and diff checks

## Follow-on boundary

Strict dlt whitespace normalization is intentionally split into a stacked one-package PR to preserve the repository's package scope ceiling. Ref-aware Pandera quality and WAP launch coordination are separate prerequisites.
