### PR TITLE
feat(dagster): coordinate safe WAP materialization launches

### DIFF
--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1198,15 +1198,16 @@ for the structured failure details.
 
 WAP creates or reuses a `pipeline-run-<logical-run-id>` catalog branch before
 asking Dagster to start exactly one asset. It requires the Dagster job and
-repository selector plus a verified user access token; set the repository and
-token values with the shown options or their `PHLO_DAGSTER_*` environment
-variables. If the launch response is ambiguous, Phlo retains a newly created
-branch so the caller can reconcile or retry with the same `--wap-run-id`.
+repository selector plus a verified user access token. Set the repository with
+the shown options or `PHLO_DAGSTER_REPOSITORY_*` environment variables. The
+token is accepted only through `PHLO_DAGSTER_ACCESS_TOKEN`, so it doesn't appear
+in process arguments or shell history. If the launch response is ambiguous,
+Phlo retains a newly created branch so the caller can reconcile or retry with
+the same `--wap-run-id`; a retry reuses the run Dagster already accepted.
 
 ```bash
 phlo materialize dlt_events --wap --job-name __ASSET_JOB \
-  --repository-location-name phlo_dagster --repository-name phlo_dagster \
-  --access-token "$PHLO_DAGSTER_ACCESS_TOKEN"
+  --repository-location-name phlo_dagster --repository-name phlo_dagster
 ```
 
 **Selection Syntax**:

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1194,6 +1194,21 @@ for the structured failure details.
 --dry-run                # Show command without executing
 ```
 
+**Write-audit-publish (WAP) launch**:
+
+WAP creates or reuses a `pipeline-run-<logical-run-id>` catalog branch before
+asking Dagster to start exactly one asset. It requires the Dagster job and
+repository selector plus a verified user access token; set the repository and
+token values with the shown options or their `PHLO_DAGSTER_*` environment
+variables. If the launch response is ambiguous, Phlo retains a newly created
+branch so the caller can reconcile or retry with the same `--wap-run-id`.
+
+```bash
+phlo materialize dlt_events --wap --job-name __ASSET_JOB \
+  --repository-location-name phlo_dagster --repository-name phlo_dagster \
+  --access-token "$PHLO_DAGSTER_ACCESS_TOKEN"
+```
+
 **Selection Syntax**:
 
 ```bash

--- a/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
@@ -41,6 +41,7 @@ Example:
 from __future__ import annotations
 
 import asyncio
+import os
 import platform
 import subprocess
 import sys
@@ -123,11 +124,6 @@ def wait_for_dagster_runtime(
     help="Dagster repository name for a WAP launch",
 )
 @click.option(
-    "--access-token",
-    envvar="PHLO_DAGSTER_ACCESS_TOKEN",
-    help="Verified user access token for a WAP launch",
-)
-@click.option(
     "--dagster-url",
     envvar="DAGSTER_GRAPHQL_URL",
     default="http://localhost:3000/graphql",
@@ -149,7 +145,6 @@ def materialize(
     job_name: str | None,
     repository_location_name: str | None,
     repository_name: str | None,
-    access_token: str | None,
     dagster_url: str,
     no_contract_refresh: bool,
     dry_run: bool,
@@ -184,10 +179,9 @@ def materialize(
                 "WAP materialization requires --repository-location-name and --repository-name "
                 "(or PHLO_DAGSTER_REPOSITORY_LOCATION_NAME and PHLO_DAGSTER_REPOSITORY_NAME)."
             )
+        access_token = os.environ.get("PHLO_DAGSTER_ACCESS_TOKEN")
         if not access_token:
-            raise click.UsageError(
-                "WAP materialization requires --access-token or PHLO_DAGSTER_ACCESS_TOKEN."
-            )
+            raise click.UsageError("WAP materialization requires PHLO_DAGSTER_ACCESS_TOKEN.")
 
         logical_run_id = wap_run_id or uuid.uuid4().hex
         if dry_run:

--- a/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
@@ -40,10 +40,12 @@ Example:
 
 from __future__ import annotations
 
+import asyncio
 import platform
 import subprocess
 import sys
 import time
+import uuid
 from collections import deque
 from typing import Optional
 
@@ -56,6 +58,8 @@ from phlo.cli.infrastructure.container_backend import (
 from phlo.cli.infrastructure.utils import get_project_name
 from phlo.cli.output import command_failed_error, service_unavailable_error
 from phlo_dagster.containers import find_dagster_container
+from phlo_dagster.operations import launch_materialize
+from phlo_dagster.wap_launch import prepare_wap_launch
 from phlo.logging import get_logger
 
 
@@ -105,6 +109,18 @@ def wait_for_dagster_runtime(
 @click.argument("asset_name", required=False)
 @click.option("-p", "--partition", help="Partition date (YYYY-MM-DD)")
 @click.option("--select", help="Asset selector expression")
+@click.option("--wap", is_flag=True, help="Launch one asset through the WAP branch lifecycle")
+@click.option("--wap-run-id", help="Reuse this logical run identity for a WAP retry")
+@click.option("--job-name", help="Dagster job name required for a WAP launch")
+@click.option("--repository-location-name", help="Dagster repository location for a WAP launch")
+@click.option("--repository-name", help="Dagster repository name for a WAP launch")
+@click.option(
+    "--dagster-url",
+    envvar="DAGSTER_GRAPHQL_URL",
+    default="http://localhost:3000/graphql",
+    show_default=True,
+    help="Dagster GraphQL endpoint for a WAP launch",
+)
 @click.option(
     "--no-contract-refresh",
     is_flag=True,
@@ -115,6 +131,12 @@ def materialize(
     asset_name: str | None,
     partition: Optional[str],
     select: Optional[str],
+    wap: bool,
+    wap_run_id: str | None,
+    job_name: str | None,
+    repository_location_name: str | None,
+    repository_name: str | None,
+    dagster_url: str,
     no_contract_refresh: bool,
     dry_run: bool,
 ) -> None:
@@ -136,6 +158,49 @@ def materialize(
     """
     if not asset_name and not select:
         raise click.UsageError("Provide ASSET_NAME or --select.")
+    if wap:
+        if not asset_name or select:
+            raise click.UsageError(
+                "WAP materialization requires one ASSET_NAME and does not support --select."
+            )
+        if not job_name:
+            raise click.UsageError("WAP materialization requires --job-name.")
+
+        logical_run_id = wap_run_id or uuid.uuid4().hex
+        if dry_run:
+            click.echo(
+                "WAP dry run - would launch "
+                f"{asset_name} with logical run ID {logical_run_id} through {dagster_url}"
+            )
+            return
+
+        wap_launch = prepare_wap_launch(logical_run_id=logical_run_id)
+        try:
+            result = asyncio.run(
+                launch_materialize(
+                    dagster_url=dagster_url,
+                    asset_key_path=asset_name,
+                    job_name=job_name,
+                    repository_location_name=repository_location_name,
+                    repository_name=repository_name,
+                    partition_key=partition,
+                    idempotency_key=logical_run_id,
+                    tags=wap_launch.tags,
+                )
+            )
+        except Exception:
+            wap_launch.cleanup_if_created()
+            raise
+
+        if not result.accepted:
+            wap_launch.cleanup_if_created()
+            raise click.ClickException(result.message)
+
+        click.echo(
+            f"Launched WAP materialization for {asset_name} on {wap_launch.branch} "
+            f"(logical run {logical_run_id}, Dagster run {result.run_id})"
+        )
+        return
     effective_selection = select or asset_name or ""
 
     logger = get_logger("phlo.dagster.materialize", service="dagster")

--- a/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
@@ -112,8 +112,21 @@ def wait_for_dagster_runtime(
 @click.option("--wap", is_flag=True, help="Launch one asset through the WAP branch lifecycle")
 @click.option("--wap-run-id", help="Reuse this logical run identity for a WAP retry")
 @click.option("--job-name", help="Dagster job name required for a WAP launch")
-@click.option("--repository-location-name", help="Dagster repository location for a WAP launch")
-@click.option("--repository-name", help="Dagster repository name for a WAP launch")
+@click.option(
+    "--repository-location-name",
+    envvar="PHLO_DAGSTER_REPOSITORY_LOCATION_NAME",
+    help="Dagster repository location for a WAP launch",
+)
+@click.option(
+    "--repository-name",
+    envvar="PHLO_DAGSTER_REPOSITORY_NAME",
+    help="Dagster repository name for a WAP launch",
+)
+@click.option(
+    "--access-token",
+    envvar="PHLO_DAGSTER_ACCESS_TOKEN",
+    help="Verified user access token for a WAP launch",
+)
 @click.option(
     "--dagster-url",
     envvar="DAGSTER_GRAPHQL_URL",
@@ -136,6 +149,7 @@ def materialize(
     job_name: str | None,
     repository_location_name: str | None,
     repository_name: str | None,
+    access_token: str | None,
     dagster_url: str,
     no_contract_refresh: bool,
     dry_run: bool,
@@ -165,6 +179,15 @@ def materialize(
             )
         if not job_name:
             raise click.UsageError("WAP materialization requires --job-name.")
+        if not repository_location_name or not repository_name:
+            raise click.UsageError(
+                "WAP materialization requires --repository-location-name and --repository-name "
+                "(or PHLO_DAGSTER_REPOSITORY_LOCATION_NAME and PHLO_DAGSTER_REPOSITORY_NAME)."
+            )
+        if not access_token:
+            raise click.UsageError(
+                "WAP materialization requires --access-token or PHLO_DAGSTER_ACCESS_TOKEN."
+            )
 
         logical_run_id = wap_run_id or uuid.uuid4().hex
         if dry_run:
@@ -183,13 +206,16 @@ def materialize(
                     job_name=job_name,
                     repository_location_name=repository_location_name,
                     repository_name=repository_name,
+                    access_token=access_token,
                     partition_key=partition,
                     idempotency_key=logical_run_id,
                     tags=wap_launch.tags,
                 )
             )
         except Exception:
-            wap_launch.cleanup_if_created()
+            # A timeout or transport failure can occur after Dagster accepts the
+            # mutation. Retain a branch we created so the run can be reconciled
+            # or retried with the same logical run ID.
             raise
 
         if not result.accepted:

--- a/packages/phlo-dagster/src/phlo_dagster/operations.py
+++ b/packages/phlo-dagster/src/phlo_dagster/operations.py
@@ -107,6 +107,7 @@ async def launch_materialize(
     run_config: dict[str, Any] | None = None,
     idempotency_key: str | None = None,
     tags: dict[str, str] | None = None,
+    access_token: str | None = None,
 ) -> DagsterOperationResult:
     execution_tags = {"phlo/operation": "materialize_asset", "phlo/asset_key": asset_key_path}
     if idempotency_key:
@@ -130,6 +131,7 @@ async def launch_materialize(
                 "executionMetadata": {"tags": _tags_for_execution(execution_tags)},
             }
         },
+        access_token=access_token,
     )
     return _launch_result(
         operation="materialize_asset",
@@ -268,12 +270,21 @@ async def list_partitions(*, dagster_url: str, asset_key_path: str) -> list[dict
     return [{"partition_key": key, "status": "UNKNOWN"} for key in keys]
 
 
-async def _graphql(url: str, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+async def _graphql(
+    url: str,
+    query: str,
+    variables: dict[str, Any],
+    *,
+    access_token: str | None = None,
+) -> dict[str, Any]:
     headers = {"Content-Type": "application/json"}
-    try:
-        headers.update(build_service_headers("phlo-api", initiator="observatory"))
-    except RuntimeError:
-        pass
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+    else:
+        try:
+            headers.update(build_service_headers("phlo-api", initiator="observatory"))
+        except RuntimeError:
+            pass
     async with httpx.AsyncClient(timeout=30.0) as client:
         response = await client.post(
             url, json={"query": query, "variables": variables}, headers=headers

--- a/packages/phlo-dagster/src/phlo_dagster/operations.py
+++ b/packages/phlo-dagster/src/phlo_dagster/operations.py
@@ -23,6 +23,18 @@ mutation LaunchPipelineExecution($executionParams: ExecutionParams!) {
 }
 """
 
+EXISTING_MATERIALIZATION_RUN_QUERY = """
+query ExistingMaterializationRun($filter: RunsFilter!) {
+    runsOrError(filter: $filter, limit: 1) {
+        __typename
+        ... on Runs {
+            results { runId status }
+        }
+        ... on PythonError { message }
+    }
+}
+"""
+
 LAUNCH_PIPELINE_REEXECUTION_MUTATION = """
 mutation LaunchPipelineReexecution($executionParams: ExecutionParams, $reexecutionParams: ReexecutionParams) {
     launchPipelineReexecution(executionParams: $executionParams, reexecutionParams: $reexecutionParams) {
@@ -115,6 +127,42 @@ async def launch_materialize(
     execution_tags.update(tags or {})
     if partition_key:
         execution_tags.setdefault("dagster/partition", partition_key)
+    if idempotency_key:
+        existing = await _graphql(
+            dagster_url,
+            EXISTING_MATERIALIZATION_RUN_QUERY,
+            {
+                "filter": {
+                    "tags": _tags_for_execution(
+                        {
+                            "phlo/operation": "materialize_asset",
+                            "phlo/idempotency_key": idempotency_key,
+                        }
+                    )
+                }
+            },
+            access_token=access_token,
+        )
+        runs_or_error = existing.get("data", {}).get("runsOrError", {})
+        if runs_or_error.get("__typename") != "Runs":
+            raise RuntimeError(_error_message(runs_or_error))
+        results = runs_or_error.get("results") or []
+        if results:
+            run = results[0]
+            run_id = str(run.get("runId") or "")
+            if not run_id:
+                raise RuntimeError("Dagster returned an existing run without a run ID")
+            return DagsterOperationResult(
+                operation="materialize_asset",
+                dry_run=False,
+                accepted=True,
+                run_id=run_id,
+                asset_key_path=asset_key_path,
+                partition_key=partition_key,
+                status=str(run.get("status") or "UNKNOWN"),
+                message="Dagster previously accepted materialize_asset.",
+                details={"typename": "LaunchRunSuccess", "reconciled": True},
+            )
     result = await _graphql(
         dagster_url,
         LAUNCH_PIPELINE_EXECUTION_MUTATION,

--- a/packages/phlo-dagster/src/phlo_dagster/wap_launch.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_launch.py
@@ -1,0 +1,75 @@
+"""Pre-launch Write-Audit-Publish coordination for Dagster runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from phlo.capabilities.interfaces import VersionedCatalog
+from phlo.capabilities.resolver import resolve_capability
+from phlo.exceptions import PhloConfigError
+
+WAP_BRANCH_TAG = "phlo/wap_branch"
+WAP_RUN_ID_TAG = "phlo/run_id"
+WAP_BRANCH_PREFIX = "pipeline-run-"
+
+
+@dataclass(frozen=True)
+class WapLaunch:
+    """The logical identity and branch prepared before a Dagster run starts."""
+
+    logical_run_id: str
+    branch: str
+    catalog: VersionedCatalog
+    created_branch: bool
+
+    @property
+    def tags(self) -> dict[str, str]:
+        """Return the Dagster tags that bind stages to this WAP branch."""
+        return {WAP_RUN_ID_TAG: self.logical_run_id, WAP_BRANCH_TAG: self.branch}
+
+    def cleanup_if_created(self) -> None:
+        """Remove only the branch created by this launch attempt."""
+        if self.created_branch:
+            self.catalog.delete_branch(self.branch)
+
+
+def prepare_wap_launch(*, logical_run_id: str) -> WapLaunch:
+    """Ensure a WAP branch and tags exist before asking Dagster to start work."""
+    resolution = resolve_capability("catalog")
+    if resolution is None or not (
+        resolution.support.supports_refs and resolution.support.supports_promote
+    ):
+        raise PhloConfigError(
+            message="WAP materialization requires a catalog with refs and promotion support.",
+            suggestions=["Configure a versioned catalog such as phlo-nessie before using --wap."],
+        )
+
+    catalog: Any = resolution.provider
+    if not isinstance(catalog, VersionedCatalog):
+        raise PhloConfigError(
+            message="Configured catalog does not implement the WAP branch lifecycle.",
+            suggestions=["Configure a VersionedCatalog-compatible provider before using --wap."],
+        )
+
+    branch = f"{WAP_BRANCH_PREFIX}{logical_run_id}"
+    if catalog.get_branch_hash(branch):
+        return WapLaunch(
+            logical_run_id=logical_run_id,
+            branch=branch,
+            catalog=catalog,
+            created_branch=False,
+        )
+
+    if catalog.create_branch(branch, from_ref="main") is None:
+        raise PhloConfigError(
+            message=f"Could not create WAP branch {branch!r} from main.",
+            suggestions=["Confirm the configured catalog can create branches from main."],
+        )
+
+    return WapLaunch(
+        logical_run_id=logical_run_id,
+        branch=branch,
+        catalog=catalog,
+        created_branch=True,
+    )

--- a/packages/phlo-dagster/tests/test_cli_materialize.py
+++ b/packages/phlo-dagster/tests/test_cli_materialize.py
@@ -3,6 +3,7 @@
 from subprocess import PIPE, STDOUT
 from unittest.mock import patch
 
+import httpx
 from click.testing import CliRunner
 
 from phlo_dagster.cli_materialize import materialize, wait_for_dagster_runtime
@@ -141,6 +142,9 @@ def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
         assert kwargs["job_name"] == "__ASSET_JOB"
         assert kwargs["idempotency_key"] == "request-42"
         assert kwargs["tags"] == Launch.tags
+        assert kwargs["repository_location_name"] == "phlo_dagster"
+        assert kwargs["repository_name"] == "phlo_dagster"
+        assert kwargs["access_token"] == "user-access-token"
         return type(
             "Result", (), {"accepted": False, "message": "Dagster rejected run", "run_id": None}
         )()
@@ -150,12 +154,137 @@ def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
 
     result = CliRunner().invoke(
         materialize,
-        ["dlt_orders", "--wap", "--wap-run-id", "request-42", "--job-name", "__ASSET_JOB"],
+        [
+            "dlt_orders",
+            "--wap",
+            "--wap-run-id",
+            "request-42",
+            "--job-name",
+            "__ASSET_JOB",
+            "--repository-location-name",
+            "phlo_dagster",
+            "--repository-name",
+            "phlo_dagster",
+            "--access-token",
+            "user-access-token",
+        ],
     )
 
     assert result.exit_code != 0
     assert "Dagster rejected run" in result.output
     assert cleaned == [True]
+
+
+def test_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
+    monkeypatch,
+) -> None:
+    cleaned: list[bool] = []
+
+    class Launch:
+        logical_run_id = "request-42"
+        branch = "pipeline-run-request-42"
+        tags = {"phlo/run_id": logical_run_id, "phlo/wap_branch": branch}
+
+        def cleanup_if_created(self) -> None:
+            cleaned.append(True)
+
+    async def timeout_launch(**_kwargs):
+        raise httpx.ReadTimeout("response lost")
+
+    monkeypatch.setattr("phlo_dagster.cli_materialize.prepare_wap_launch", lambda **_: Launch())
+    monkeypatch.setattr("phlo_dagster.cli_materialize.launch_materialize", timeout_launch)
+
+    result = CliRunner().invoke(
+        materialize,
+        [
+            "dlt_orders",
+            "--wap",
+            "--job-name",
+            "__ASSET_JOB",
+            "--repository-location-name",
+            "phlo_dagster",
+            "--repository-name",
+            "phlo_dagster",
+            "--access-token",
+            "user-access-token",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert cleaned == []
+
+
+def test_wap_materialize_requires_a_complete_selector_and_user_credential(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.prepare_wap_launch",
+        lambda **_: (_ for _ in ()).throw(AssertionError("must not create a branch")),
+    )
+    runner = CliRunner()
+
+    incomplete_selector = runner.invoke(
+        materialize,
+        ["dlt_orders", "--wap", "--job-name", "__ASSET_JOB", "--access-token", "token"],
+    )
+    missing_credential = runner.invoke(
+        materialize,
+        [
+            "dlt_orders",
+            "--wap",
+            "--job-name",
+            "__ASSET_JOB",
+            "--repository-location-name",
+            "phlo_dagster",
+            "--repository-name",
+            "phlo_dagster",
+        ],
+    )
+
+    assert incomplete_selector.exit_code != 0
+    assert "requires --repository-location-name and --repository-name" in incomplete_selector.output
+    assert missing_credential.exit_code != 0
+    assert "requires --access-token or PHLO_DAGSTER_ACCESS_TOKEN" in missing_credential.output
+
+
+def test_wap_materialize_resolves_the_required_selector_and_credential_from_environment(
+    monkeypatch,
+) -> None:
+    captured: dict[str, str] = {}
+
+    class Launch:
+        logical_run_id = "request-42"
+        branch = "pipeline-run-request-42"
+        tags = {"phlo/run_id": logical_run_id, "phlo/wap_branch": branch}
+
+        def cleanup_if_created(self) -> None:
+            raise AssertionError("accepted launches retain their branch")
+
+    async def accepted_launch(**kwargs):
+        captured.update(
+            {
+                "repository_location_name": kwargs["repository_location_name"],
+                "repository_name": kwargs["repository_name"],
+                "access_token": kwargs["access_token"],
+            }
+        )
+        return type("Result", (), {"accepted": True, "message": "", "run_id": "run-1"})()
+
+    monkeypatch.setenv("PHLO_DAGSTER_REPOSITORY_LOCATION_NAME", "phlo_dagster")
+    monkeypatch.setenv("PHLO_DAGSTER_REPOSITORY_NAME", "phlo_dagster")
+    monkeypatch.setenv("PHLO_DAGSTER_ACCESS_TOKEN", "verified-user-token")
+    monkeypatch.setattr("phlo_dagster.cli_materialize.prepare_wap_launch", lambda **_: Launch())
+    monkeypatch.setattr("phlo_dagster.cli_materialize.launch_materialize", accepted_launch)
+
+    result = CliRunner().invoke(
+        materialize,
+        ["dlt_orders", "--wap", "--job-name", "__ASSET_JOB", "--wap-run-id", "request-42"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {
+        "repository_location_name": "phlo_dagster",
+        "repository_name": "phlo_dagster",
+        "access_token": "verified-user-token",
+    }
 
 
 @patch(

--- a/packages/phlo-dagster/tests/test_cli_materialize.py
+++ b/packages/phlo-dagster/tests/test_cli_materialize.py
@@ -123,6 +123,41 @@ def test_materialize_can_disable_contract_refresh(mock_project, mock_container) 
     assert "PHLO_AUTO_REFRESH_CONTRACTS=0" in result.output
 
 
+def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
+    monkeypatch,
+) -> None:
+    cleaned: list[bool] = []
+
+    class Launch:
+        logical_run_id = "request-42"
+        branch = "pipeline-run-request-42"
+        tags = {"phlo/run_id": logical_run_id, "phlo/wap_branch": branch}
+
+        def cleanup_if_created(self) -> None:
+            cleaned.append(True)
+
+    async def rejected_launch(**kwargs):
+        assert kwargs["asset_key_path"] == "dlt_orders"
+        assert kwargs["job_name"] == "__ASSET_JOB"
+        assert kwargs["idempotency_key"] == "request-42"
+        assert kwargs["tags"] == Launch.tags
+        return type(
+            "Result", (), {"accepted": False, "message": "Dagster rejected run", "run_id": None}
+        )()
+
+    monkeypatch.setattr("phlo_dagster.cli_materialize.prepare_wap_launch", lambda **_: Launch())
+    monkeypatch.setattr("phlo_dagster.cli_materialize.launch_materialize", rejected_launch)
+
+    result = CliRunner().invoke(
+        materialize,
+        ["dlt_orders", "--wap", "--wap-run-id", "request-42", "--job-name", "__ASSET_JOB"],
+    )
+
+    assert result.exit_code != 0
+    assert "Dagster rejected run" in result.output
+    assert cleaned == [True]
+
+
 @patch(
     "phlo_dagster.cli_materialize.find_dagster_container",
     side_effect=AssertionError("dry-run should not inspect Docker"),

--- a/packages/phlo-dagster/tests/test_cli_materialize.py
+++ b/packages/phlo-dagster/tests/test_cli_materialize.py
@@ -151,6 +151,7 @@ def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
 
     monkeypatch.setattr("phlo_dagster.cli_materialize.prepare_wap_launch", lambda **_: Launch())
     monkeypatch.setattr("phlo_dagster.cli_materialize.launch_materialize", rejected_launch)
+    monkeypatch.setenv("PHLO_DAGSTER_ACCESS_TOKEN", "user-access-token")
 
     result = CliRunner().invoke(
         materialize,
@@ -165,8 +166,6 @@ def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
             "phlo_dagster",
             "--repository-name",
             "phlo_dagster",
-            "--access-token",
-            "user-access-token",
         ],
     )
 
@@ -193,6 +192,7 @@ def test_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
 
     monkeypatch.setattr("phlo_dagster.cli_materialize.prepare_wap_launch", lambda **_: Launch())
     monkeypatch.setattr("phlo_dagster.cli_materialize.launch_materialize", timeout_launch)
+    monkeypatch.setenv("PHLO_DAGSTER_ACCESS_TOKEN", "user-access-token")
 
     result = CliRunner().invoke(
         materialize,
@@ -205,8 +205,6 @@ def test_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
             "phlo_dagster",
             "--repository-name",
             "phlo_dagster",
-            "--access-token",
-            "user-access-token",
         ],
     )
 
@@ -221,10 +219,12 @@ def test_wap_materialize_requires_a_complete_selector_and_user_credential(monkey
     )
     runner = CliRunner()
 
+    monkeypatch.setenv("PHLO_DAGSTER_ACCESS_TOKEN", "user-access-token")
     incomplete_selector = runner.invoke(
         materialize,
-        ["dlt_orders", "--wap", "--job-name", "__ASSET_JOB", "--access-token", "token"],
+        ["dlt_orders", "--wap", "--job-name", "__ASSET_JOB"],
     )
+    monkeypatch.delenv("PHLO_DAGSTER_ACCESS_TOKEN")
     missing_credential = runner.invoke(
         materialize,
         [
@@ -242,7 +242,10 @@ def test_wap_materialize_requires_a_complete_selector_and_user_credential(monkey
     assert incomplete_selector.exit_code != 0
     assert "requires --repository-location-name and --repository-name" in incomplete_selector.output
     assert missing_credential.exit_code != 0
-    assert "requires --access-token or PHLO_DAGSTER_ACCESS_TOKEN" in missing_credential.output
+    assert "requires PHLO_DAGSTER_ACCESS_TOKEN" in missing_credential.output
+
+    help_result = runner.invoke(materialize, ["--help"])
+    assert "--access-token" not in help_result.output
 
 
 def test_wap_materialize_resolves_the_required_selector_and_credential_from_environment(

--- a/packages/phlo-dagster/tests/test_operations.py
+++ b/packages/phlo-dagster/tests/test_operations.py
@@ -48,6 +48,50 @@ def test_launch_materialize_posts_asset_selection(monkeypatch) -> None:
     assert selector["assetSelection"] == [{"path": ["silver", "orders"]}]
 
 
+def test_launch_materialize_uses_the_explicit_user_access_token(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_post(self, url, json=None, headers=None):  # noqa: ANN001, ANN202, ARG001
+        captured["headers"] = headers
+        return httpx.Response(
+            200,
+            request=httpx.Request("POST", url),
+            json={
+                "data": {
+                    "launchPipelineExecution": {
+                        "__typename": "LaunchRunSuccess",
+                        "run": {"runId": "run-1", "status": "STARTED"},
+                    }
+                }
+            },
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(
+        "phlo_dagster.operations.build_service_headers",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("must not impersonate phlo-api")
+        ),
+    )
+
+    result = asyncio.run(
+        launch_materialize(
+            dagster_url="http://dagster.test/graphql",
+            asset_key_path="silver/orders",
+            job_name="orders_job",
+            repository_location_name="phlo_dagster",
+            repository_name="phlo_dagster",
+            access_token="verified-user-token",
+        )
+    )
+
+    assert result.accepted is True
+    assert captured["headers"] == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer verified-user-token",
+    }
+
+
 def test_wap_materialize_tags_survive_retry(monkeypatch) -> None:
     payloads: list[dict[str, object]] = []
 

--- a/packages/phlo-dagster/tests/test_operations.py
+++ b/packages/phlo-dagster/tests/test_operations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 
 import httpx
+import pytest
 
 from phlo_dagster.operations import launch_materialize, launch_retry, list_partitions, terminate
 
@@ -96,6 +97,12 @@ def test_wap_materialize_tags_survive_retry(monkeypatch) -> None:
     payloads: list[dict[str, object]] = []
 
     async def fake_post(self, url, json=None, headers=None):  # noqa: ANN001, ANN202, ARG001
+        if "ExistingMaterializationRun" in json["query"]:
+            return httpx.Response(
+                200,
+                request=httpx.Request("POST", url),
+                json={"data": {"runsOrError": {"__typename": "Runs", "results": []}}},
+            )
         payloads.append(json)
         mutation = "launchPipelineExecution" if len(payloads) == 1 else "launchPipelineReexecution"
         return httpx.Response(
@@ -139,6 +146,66 @@ def test_wap_materialize_tags_survive_retry(monkeypatch) -> None:
     assert launch_tag_map["phlo/idempotency_key"] == "request-42"
     assert retry["useParentRunTags"] is True
     assert {tag["key"]: tag["value"] for tag in retry["extraTags"]}["phlo/run_id"] == "request-42"
+
+
+def test_wap_materialize_reconciles_a_lost_response_without_a_duplicate_launch(
+    monkeypatch,
+) -> None:
+    accepted_run: dict[str, str] | None = None
+    launch_calls = 0
+    lookup_filters: list[dict[str, object]] = []
+
+    async def fake_post(self, url, json=None, headers=None):  # noqa: ANN001, ANN202, ARG001
+        nonlocal accepted_run, launch_calls
+        if "ExistingMaterializationRun" in json["query"]:
+            lookup_filters.append(json["variables"]["filter"])
+            results = [accepted_run] if accepted_run else []
+            return httpx.Response(
+                200,
+                request=httpx.Request("POST", url),
+                json={"data": {"runsOrError": {"__typename": "Runs", "results": results}}},
+            )
+
+        launch_calls += 1
+        accepted_run = {"runId": "dagster-run", "status": "STARTED"}
+        raise httpx.ReadTimeout("Dagster accepted the run but the response was lost")
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    kwargs = {
+        "dagster_url": "http://dagster.test/graphql",
+        "asset_key_path": "silver/orders",
+        "job_name": "orders_job",
+        "idempotency_key": "request-42",
+        "tags": {
+            "phlo/run_id": "request-42",
+            "phlo/wap_branch": "pipeline-run-request-42",
+        },
+        "access_token": "verified-user-token",
+    }
+
+    with pytest.raises(httpx.ReadTimeout):
+        asyncio.run(launch_materialize(**kwargs))
+    reconciled = asyncio.run(launch_materialize(**kwargs))
+
+    assert launch_calls == 1
+    assert reconciled.accepted is True
+    assert reconciled.run_id == "dagster-run"
+    assert reconciled.status == "STARTED"
+    assert reconciled.details["reconciled"] is True
+    assert lookup_filters == [
+        {
+            "tags": [
+                {"key": "phlo/operation", "value": "materialize_asset"},
+                {"key": "phlo/idempotency_key", "value": "request-42"},
+            ]
+        },
+        {
+            "tags": [
+                {"key": "phlo/operation", "value": "materialize_asset"},
+                {"key": "phlo/idempotency_key", "value": "request-42"},
+            ]
+        },
+    ]
 
 
 def test_terminate_maps_dagster_error(monkeypatch) -> None:

--- a/packages/phlo-dagster/tests/test_operations.py
+++ b/packages/phlo-dagster/tests/test_operations.py
@@ -6,7 +6,7 @@ import asyncio
 
 import httpx
 
-from phlo_dagster.operations import launch_materialize, list_partitions, terminate
+from phlo_dagster.operations import launch_materialize, launch_retry, list_partitions, terminate
 
 
 def test_launch_materialize_posts_asset_selection(monkeypatch) -> None:
@@ -46,6 +46,55 @@ def test_launch_materialize_posts_asset_selection(monkeypatch) -> None:
     selector = variables["executionParams"]["selector"]
     assert selector["pipelineName"] == "orders_job"
     assert selector["assetSelection"] == [{"path": ["silver", "orders"]}]
+
+
+def test_wap_materialize_tags_survive_retry(monkeypatch) -> None:
+    payloads: list[dict[str, object]] = []
+
+    async def fake_post(self, url, json=None, headers=None):  # noqa: ANN001, ANN202, ARG001
+        payloads.append(json)
+        mutation = "launchPipelineExecution" if len(payloads) == 1 else "launchPipelineReexecution"
+        return httpx.Response(
+            200,
+            request=httpx.Request("POST", url),
+            json={
+                "data": {
+                    mutation: {
+                        "__typename": "LaunchRunSuccess",
+                        "run": {"runId": "dagster-run", "status": "STARTED"},
+                    }
+                }
+            },
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    tags = {"phlo/run_id": "request-42", "phlo/wap_branch": "pipeline-run-request-42"}
+
+    asyncio.run(
+        launch_materialize(
+            dagster_url="http://dagster.test/graphql",
+            asset_key_path="silver/orders",
+            job_name="orders_job",
+            idempotency_key="request-42",
+            tags=tags,
+        )
+    )
+    asyncio.run(
+        launch_retry(
+            dagster_url="http://dagster.test/graphql",
+            run_id="dagster-run",
+            strategy="FROM_FAILURE",
+            tags=tags,
+        )
+    )
+
+    launch_tags = payloads[0]["variables"]["executionParams"]["executionMetadata"]["tags"]  # type: ignore[index]
+    retry = payloads[1]["variables"]["reexecutionParams"]  # type: ignore[index]
+    launch_tag_map = {tag["key"]: tag["value"] for tag in launch_tags}
+    assert launch_tag_map["phlo/wap_branch"] == "pipeline-run-request-42"
+    assert launch_tag_map["phlo/idempotency_key"] == "request-42"
+    assert retry["useParentRunTags"] is True
+    assert {tag["key"]: tag["value"] for tag in retry["extraTags"]}["phlo/run_id"] == "request-42"
 
 
 def test_terminate_maps_dagster_error(monkeypatch) -> None:

--- a/packages/phlo-dagster/tests/test_wap_launch.py
+++ b/packages/phlo-dagster/tests/test_wap_launch.py
@@ -1,0 +1,71 @@
+"""Tests for WAP launch coordination before Dagster starts a run."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from phlo_dagster.wap_launch import WAP_BRANCH_TAG, WAP_RUN_ID_TAG, prepare_wap_launch
+
+
+class _Catalog:
+    def __init__(self, branches: dict[str, str] | None = None) -> None:
+        self.branches = branches or {"main": "main-hash"}
+        self.created: list[tuple[str, str]] = []
+        self.deleted: list[str] = []
+
+    def get_branch_hash(self, name: str) -> str | None:
+        return self.branches.get(name)
+
+    def list_branches(self) -> list[object]:
+        return []
+
+    def create_branch(self, name: str, from_ref: str = "main") -> str:
+        self.created.append((name, from_ref))
+        self.branches[name] = "branch-hash"
+        return "branch-hash"
+
+    def delete_branch(self, name: str) -> bool:
+        self.deleted.append(name)
+        return self.branches.pop(name, None) is not None
+
+    def merge_branch(self, source: str, target: str = "main") -> bool:
+        return False
+
+
+def test_prepare_wap_launch_creates_deterministic_branch_and_tags(monkeypatch) -> None:
+    catalog = _Catalog()
+    monkeypatch.setattr(
+        "phlo_dagster.wap_launch.resolve_capability",
+        lambda _: SimpleNamespace(
+            provider=catalog,
+            support=SimpleNamespace(supports_refs=True, supports_promote=True),
+        ),
+    )
+
+    launch = prepare_wap_launch(logical_run_id="request-42")
+
+    assert launch.branch == "pipeline-run-request-42"
+    assert launch.created_branch is True
+    assert launch.tags == {
+        WAP_RUN_ID_TAG: "request-42",
+        WAP_BRANCH_TAG: "pipeline-run-request-42",
+    }
+    assert catalog.created == [("pipeline-run-request-42", "main")]
+
+
+def test_prepare_wap_launch_reuses_existing_branch_for_retry(monkeypatch) -> None:
+    catalog = _Catalog({"main": "main-hash", "pipeline-run-request-42": "old-hash"})
+    monkeypatch.setattr(
+        "phlo_dagster.wap_launch.resolve_capability",
+        lambda _: SimpleNamespace(
+            provider=catalog,
+            support=SimpleNamespace(supports_refs=True, supports_promote=True),
+        ),
+    )
+
+    launch = prepare_wap_launch(logical_run_id="request-42")
+    launch.cleanup_if_created()
+
+    assert launch.created_branch is False
+    assert catalog.created == []
+    assert catalog.deleted == []


### PR DESCRIPTION
## What changed

- add an explicit `phlo materialize ASSET --wap` path that creates or reuses the deterministic `pipeline-run-<logical-run-id>` catalog branch before launch
- require a complete Dagster job/repository selector before GraphQL submission
- require the verified user bearer token through `PHLO_DAGSTER_ACCESS_TOKEN`, preserving direct user attribution without placing credentials in argv or shell command history
- retain a newly created branch after an ambiguous transport response, while cleaning it up after a confirmed Dagster rejection
- reconcile retries by querying Dagster for the operation and logical idempotency tags before launching, returning the already accepted run instead of starting a duplicate

Normal `phlo materialize` behavior is unchanged unless `--wap` is selected.

## Why

A WAP branch must exist before the run starts, but the launch boundary also has to remain safe when the response is lost. Deleting the branch after an ambiguous response could remove a branch used by a live run, while retrying without reconciliation could start duplicate work against the retained branch. This change gives the launch a stable logical identity and reconciles it through Dagster's run tags.

The direct CLI path also needs the caller's verified identity and an authoritative Dagster selector. It therefore fails before branch creation when the selector or environment-provided user token is missing.

## Validation

- `uv run pytest --import-mode=importlib packages/phlo-dagster/tests/test_cli_materialize.py packages/phlo-dagster/tests/test_operations.py packages/phlo-dagster/tests/test_wap_launch.py` — 22 passed
- `uv run pytest --import-mode=importlib packages/phlo-dagster/tests` — 310 passed, 1 skipped, 15 deselected
- `uv run ruff check packages/phlo-dagster/src/phlo_dagster/cli_materialize.py packages/phlo-dagster/src/phlo_dagster/operations.py packages/phlo-dagster/tests/test_cli_materialize.py packages/phlo-dagster/tests/test_operations.py`
- `uv run ruff format --check packages/phlo-dagster/src/phlo_dagster/cli_materialize.py packages/phlo-dagster/src/phlo_dagster/operations.py packages/phlo-dagster/tests/test_cli_materialize.py packages/phlo-dagster/tests/test_operations.py`
- commit hooks passed
