### PR TITLE
feat(security): add scoped service token core

### DIFF
--- a/packages/phlo-dagster/tests/test_authorization_middleware_service_identity.py
+++ b/packages/phlo-dagster/tests/test_authorization_middleware_service_identity.py
@@ -78,6 +78,20 @@ def test_extract_principal_from_service_token(monkeypatch):
     assert "initiating_principal" not in principal.attributes
 
 
+def test_extract_principal_rejects_legacy_service_token_in_regulated_mode(monkeypatch):
+    monkeypatch.setenv("PHLO_SERVICE_SECRET", "test-secret")
+    monkeypatch.setenv("PHLO_ENVIRONMENT", "dev")
+    monkeypatch.setenv("PHLO_REGULATED", "false")
+    legacy_token = create_service_token("phlo-api")
+    monkeypatch.setenv("PHLO_REGULATED", "true")
+
+    principal = DagsterGraphQLAuthorizationMiddleware()._extract_principal(
+        _build_info({"Authorization": f"Bearer {legacy_token}"})
+    )
+
+    assert principal is None
+
+
 def test_extract_principal_does_not_authorize_on_unsigned_initiator_header(monkeypatch):
     monkeypatch.setenv("PHLO_SERVICE_SECRET", "test-secret")
     service_token = create_service_token("phlo-api")

--- a/src/phlo/security/service_identity.py
+++ b/src/phlo/security/service_identity.py
@@ -44,10 +44,9 @@ DEFAULT_MAX_AGE_SECONDS = 300
 
 @dataclass(frozen=True)
 class ServiceTokenCredential:
-    """The credential and intended receiver configured for one caller."""
+    """One caller-audience credential."""
 
     secret: str
-    audience: str
 
 
 class NonceStore(Protocol):
@@ -144,15 +143,15 @@ def create_scoped_service_token(
     caller: str,
     *,
     audience: str,
-    credentials: Mapping[str, ServiceTokenCredential],
+    credentials: Mapping[tuple[str, str], ServiceTokenCredential],
     now: int | None = None,
 ) -> str:
     """Create a token signed only by ``caller``'s configured credential."""
-    credential = credentials.get(caller)
+    credential = credentials.get((caller, audience))
     if credential is None:
-        raise RuntimeError(f"No service credential configured for caller {caller!r}")
-    if credential.audience != audience:
-        raise RuntimeError(f"Caller {caller!r} is not configured for audience {audience!r}")
+        raise RuntimeError(
+            f"No service credential configured for caller {caller!r} and audience {audience!r}"
+        )
     if not credential.secret:
         raise RuntimeError(f"Caller {caller!r} has an empty service credential")
 
@@ -167,7 +166,7 @@ def validate_scoped_service_token(
     token: str,
     *,
     expected_audience: str,
-    credentials: Mapping[str, ServiceTokenCredential],
+    credentials: Mapping[tuple[str, str], ServiceTokenCredential],
     nonce_store: NonceStore,
     max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
     now: int | None = None,
@@ -183,8 +182,8 @@ def validate_scoped_service_token(
     caller, audience, timestamp_str, nonce, provided_hmac = parts
     if audience != expected_audience or not caller or not nonce:
         return None
-    credential = credentials.get(caller)
-    if credential is None or credential.audience != expected_audience or not credential.secret:
+    credential = credentials.get((caller, expected_audience))
+    if credential is None or not credential.secret:
         return None
     try:
         token_time = int(timestamp_str)
@@ -207,6 +206,11 @@ def validate_scoped_service_token(
 
 def _legacy_service_tokens_allowed() -> bool:
     """Keep shared-secret helpers strictly local while receiver migration lands."""
+    # Import lazily to keep this low-level module independent during import.
+    from phlo.security.mode import is_regulated
+
+    if is_regulated():
+        return False
     environment = os.environ.get("PHLO_ENVIRONMENT", "dev").lower()
     return environment not in {"prod", "production", "staging", "regulated"}
 

--- a/src/phlo/security/service_identity.py
+++ b/src/phlo/security/service_identity.py
@@ -3,11 +3,14 @@
 When phlo-api calls Dagster or Trino, it should identify itself
 with a short-lived HMAC service token, not a spoofable header.
 
-Token format: ``service_id:timestamp:nonce:hmac``
-where hmac = HMAC-SHA256(secret, service_id + ":" + timestamp + ":" + nonce)
+Production token format: ``caller:audience:timestamp:nonce:hmac`` where the
+signature covers every field and is made with the credential assigned to the
+named caller.  Validation consumes the nonce through an injected durable
+store, so two receivers cannot both accept the same token.
 
-The nonce (UUID4) prevents replay of intercepted tokens within the
-validity window. The shared secret comes from PHLO_SERVICE_SECRET env var.
+The older ``PHLO_SERVICE_SECRET`` token helpers remain a development-only
+compatibility path until receivers are migrated to the scoped contract.  They
+are deliberately unavailable in production and regulated environments.
 
 Header conventions for request chain attribution:
     Authorization: Bearer {service-token}    (service identity)
@@ -21,6 +24,11 @@ import hashlib
 import hmac
 import os
 import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Protocol
 from uuid import uuid4
 
 from phlo.logging import get_logger
@@ -32,6 +40,175 @@ PHLO_INITIATOR_HEADER = "X-Phlo-Initiator"
 PHLO_CORRELATION_HEADER = "X-Phlo-Correlation-Id"
 
 DEFAULT_MAX_AGE_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class ServiceTokenCredential:
+    """The credential and intended receiver configured for one caller."""
+
+    secret: str
+    audience: str
+
+
+class NonceStore(Protocol):
+    """Atomically record a nonce that has been accepted before it expires."""
+
+    def consume(self, nonce: str, *, expires_at: datetime) -> bool:
+        """Return whether this is the first successful consumption of ``nonce``."""
+
+
+class PostgresNonceStore:
+    """Durable nonce store backed by a caller-supplied PostgreSQL connection or pool.
+
+    Construction does not read a DSN or create a global connection: the receiver
+    owns its existing database resource and injects it here.  The unique nonce
+    primary key makes the insert an atomic compare-and-set across processes.
+    """
+
+    def __init__(self, connection_or_pool: Any) -> None:
+        self._connection_or_pool = connection_or_pool
+
+    @contextmanager
+    def _connection(self) -> Iterator[Any]:
+        resource = self._connection_or_pool
+        if hasattr(resource, "connection"):
+            with resource.connection() as connection:
+                yield connection
+            return
+        if hasattr(resource, "getconn"):
+            connection = resource.getconn()
+            try:
+                yield connection
+            finally:
+                resource.putconn(connection)
+            return
+        yield resource
+
+    def ensure_schema(self) -> None:
+        """Create the small durable nonce table when the receiver starts."""
+        with self._connection() as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS phlo_service_token_nonces (
+                            nonce TEXT PRIMARY KEY,
+                            expires_at TIMESTAMPTZ NOT NULL
+                        )
+                        """
+                    )
+                connection.commit()
+            except Exception:
+                connection.rollback()
+                raise
+
+    def consume(self, nonce: str, *, expires_at: datetime) -> bool:
+        """Atomically claim ``nonce`` for this token's remaining lifetime."""
+        with self._connection() as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        """
+                        INSERT INTO phlo_service_token_nonces (nonce, expires_at)
+                        VALUES (%s, %s)
+                        ON CONFLICT (nonce) DO NOTHING
+                        RETURNING nonce
+                        """,
+                        (nonce, expires_at),
+                    )
+                    accepted = cursor.fetchone() is not None
+                connection.commit()
+                return accepted
+            except Exception:
+                connection.rollback()
+                raise
+
+    def purge_expired(self, *, now: datetime | None = None) -> int:
+        """Delete expired records during receiver-owned maintenance."""
+        with self._connection() as connection:
+            try:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        "DELETE FROM phlo_service_token_nonces WHERE expires_at <= %s",
+                        (now or datetime.now(UTC),),
+                    )
+                    removed = cursor.rowcount
+                connection.commit()
+                return removed
+            except Exception:
+                connection.rollback()
+                raise
+
+
+def create_scoped_service_token(
+    caller: str,
+    *,
+    audience: str,
+    credentials: Mapping[str, ServiceTokenCredential],
+    now: int | None = None,
+) -> str:
+    """Create a token signed only by ``caller``'s configured credential."""
+    credential = credentials.get(caller)
+    if credential is None:
+        raise RuntimeError(f"No service credential configured for caller {caller!r}")
+    if credential.audience != audience:
+        raise RuntimeError(f"Caller {caller!r} is not configured for audience {audience!r}")
+    if not credential.secret:
+        raise RuntimeError(f"Caller {caller!r} has an empty service credential")
+
+    timestamp = str(int(time.time()) if now is None else now)
+    nonce = uuid4().hex
+    message = f"{caller}:{audience}:{timestamp}:{nonce}"
+    signature = hmac.new(credential.secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+    return f"{message}:{signature}"
+
+
+def validate_scoped_service_token(
+    token: str,
+    *,
+    expected_audience: str,
+    credentials: Mapping[str, ServiceTokenCredential],
+    nonce_store: NonceStore,
+    max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS,
+    now: int | None = None,
+) -> str | None:
+    """Validate a scoped token and atomically consume its nonce.
+
+    ``None`` means the token must not be authenticated.  Store failures are
+    deliberately allowed to propagate so a production receiver fails closed.
+    """
+    parts = token.split(":", 4)
+    if len(parts) != 5:
+        return None
+    caller, audience, timestamp_str, nonce, provided_hmac = parts
+    if audience != expected_audience or not caller or not nonce:
+        return None
+    credential = credentials.get(caller)
+    if credential is None or credential.audience != expected_audience or not credential.secret:
+        return None
+    try:
+        token_time = int(timestamp_str)
+    except ValueError:
+        return None
+    current_time = int(time.time()) if now is None else now
+    if token_time > current_time or current_time - token_time > max_age_seconds:
+        return None
+
+    message = f"{caller}:{audience}:{timestamp_str}:{nonce}"
+    expected = hmac.new(credential.secret.encode(), message.encode(), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, provided_hmac):
+        return None
+
+    expires_at = datetime.fromtimestamp(token_time + max_age_seconds, tz=UTC)
+    if not nonce_store.consume(nonce, expires_at=expires_at):
+        return None
+    return caller
+
+
+def _legacy_service_tokens_allowed() -> bool:
+    """Keep shared-secret helpers strictly local while receiver migration lands."""
+    environment = os.environ.get("PHLO_ENVIRONMENT", "dev").lower()
+    return environment not in {"prod", "production", "staging", "regulated"}
 
 
 def create_service_token(service_id: str) -> str:
@@ -46,6 +223,8 @@ def create_service_token(service_id: str) -> str:
     Raises:
         RuntimeError: If PHLO_SERVICE_SECRET is not set.
     """
+    if not _legacy_service_tokens_allowed():
+        raise RuntimeError("Shared service tokens are development-only; use scoped service tokens")
     secret = os.environ.get(PHLO_SERVICE_SECRET_ENV)
     if not secret:
         raise RuntimeError(f"{PHLO_SERVICE_SECRET_ENV} must be set for service-to-service auth")
@@ -71,6 +250,8 @@ def validate_service_token(
     Returns:
         service_id if valid, None if invalid.
     """
+    if not _legacy_service_tokens_allowed():
+        return None
     secret = os.environ.get(PHLO_SERVICE_SECRET_ENV)
     if not secret:
         return None

--- a/tests/unit/phlo/security/test_service_identity.py
+++ b/tests/unit/phlo/security/test_service_identity.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+import os
 import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from threading import Lock
+from typing import Any
 
 import pytest
 
@@ -10,10 +16,37 @@ from phlo.security.service_identity import (
     PHLO_CORRELATION_HEADER,
     PHLO_INITIATOR_HEADER,
     PHLO_SERVICE_SECRET_ENV,
+    PostgresNonceStore,
+    ServiceTokenCredential,
     build_service_headers,
+    create_scoped_service_token,
     create_service_token,
+    validate_scoped_service_token,
     validate_service_token,
 )
+
+
+@dataclass
+class SharedNonceStore:
+    """Independent receiver stores sharing the same durable test backing state."""
+
+    consumed: set[str] = field(default_factory=set)
+    lock: Lock = field(default_factory=Lock)
+
+    def consume(self, nonce: str, *, expires_at: datetime) -> bool:
+        del expires_at
+        with self.lock:
+            if nonce in self.consumed:
+                return False
+            self.consumed.add(nonce)
+            return True
+
+
+def _credentials() -> dict[str, ServiceTokenCredential]:
+    return {
+        "phlo-api": ServiceTokenCredential(secret="api-secret", audience="dagster"),
+        "worker": ServiceTokenCredential(secret="worker-secret", audience="dagster"),
+    }
 
 
 class TestCreateServiceToken:
@@ -122,3 +155,157 @@ class TestBuildServiceHeaders:
         assert headers["Authorization"].startswith("Bearer phlo-api:")
         assert headers[PHLO_INITIATOR_HEADER] == "alice@co.com"
         assert headers[PHLO_CORRELATION_HEADER] == "req-456"
+
+
+class TestScopedServiceTokens:
+    def test_binds_token_to_configured_caller_and_audience(self) -> None:
+        token = create_scoped_service_token(
+            "phlo-api", audience="dagster", credentials=_credentials(), now=1_000
+        )
+        assert (
+            validate_scoped_service_token(
+                token,
+                expected_audience="dagster",
+                credentials=_credentials(),
+                nonce_store=SharedNonceStore(),
+                now=1_001,
+            )
+            == "phlo-api"
+        )
+
+    def test_rejects_wrong_audience_before_consuming_nonce(self) -> None:
+        token = create_scoped_service_token(
+            "phlo-api", audience="dagster", credentials=_credentials(), now=1_000
+        )
+        store = SharedNonceStore()
+        assert (
+            validate_scoped_service_token(
+                token,
+                expected_audience="trino",
+                credentials=_credentials(),
+                nonce_store=store,
+                now=1_001,
+            )
+            is None
+        )
+        assert not store.consumed
+
+    def test_rejects_unconfigured_caller(self) -> None:
+        credentials = _credentials()
+        token = create_scoped_service_token("worker", audience="dagster", credentials=credentials)
+        assert (
+            validate_scoped_service_token(
+                token,
+                expected_audience="dagster",
+                credentials={"phlo-api": credentials["phlo-api"]},
+                nonce_store=SharedNonceStore(),
+            )
+            is None
+        )
+
+    def test_rejects_service_name_impersonation(self) -> None:
+        token = create_scoped_service_token(
+            "worker", audience="dagster", credentials=_credentials()
+        )
+        impersonating = "phlo-api:" + token.split(":", 1)[1]
+        assert (
+            validate_scoped_service_token(
+                impersonating,
+                expected_audience="dagster",
+                credentials=_credentials(),
+                nonce_store=SharedNonceStore(),
+            )
+            is None
+        )
+
+    def test_rejects_expired_token(self) -> None:
+        token = create_scoped_service_token(
+            "phlo-api", audience="dagster", credentials=_credentials(), now=1_000
+        )
+        assert (
+            validate_scoped_service_token(
+                token,
+                expected_audience="dagster",
+                credentials=_credentials(),
+                nonce_store=SharedNonceStore(),
+                max_age_seconds=300,
+                now=1_301,
+            )
+            is None
+        )
+
+    def test_replay_is_rejected_across_two_receiver_instances_and_restart(self) -> None:
+        backing_store = SharedNonceStore()
+        token = create_scoped_service_token(
+            "phlo-api", audience="dagster", credentials=_credentials(), now=1_000
+        )
+        assert (
+            validate_scoped_service_token(
+                token,
+                expected_audience="dagster",
+                credentials=_credentials(),
+                nonce_store=backing_store,
+                now=1_001,
+            )
+            == "phlo-api"
+        )
+        restarted_receiver = SharedNonceStore(backing_store.consumed, backing_store.lock)
+        assert (
+            validate_scoped_service_token(
+                token,
+                expected_audience="dagster",
+                credentials=_credentials(),
+                nonce_store=restarted_receiver,
+                now=1_001,
+            )
+            is None
+        )
+
+    def test_shared_secret_compatibility_is_not_available_in_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PHLO_SERVICE_SECRET_ENV, "shared-secret")
+        monkeypatch.setenv("PHLO_ENVIRONMENT", "production")
+        with pytest.raises(RuntimeError, match="development-only"):
+            create_service_token("phlo-api")
+        assert validate_service_token("phlo-api:1:nonce:signature") is None
+
+
+def test_postgres_nonce_store_rejects_one_of_two_simultaneous_consumers() -> None:
+    dsn = os.environ.get("PHLO_SERVICE_TOKEN_TEST_POSTGRES_DSN")
+    if not dsn:
+        pytest.skip("set PHLO_SERVICE_TOKEN_TEST_POSTGRES_DSN for the live PostgreSQL nonce race")
+
+    import psycopg2
+
+    first_connection = psycopg2.connect(dsn)
+    second_connection = psycopg2.connect(dsn)
+    cleanup_connection = psycopg2.connect(dsn)
+    try:
+        first_store = PostgresNonceStore(first_connection)
+        first_store.ensure_schema()
+        nonce = f"test-{time.time_ns()}"
+        expires_at = datetime.fromtimestamp(time.time() + 300, tz=UTC)
+
+        def consume(connection: Any) -> bool:
+            return PostgresNonceStore(connection).consume(nonce, expires_at=expires_at)
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(executor.map(consume, (first_connection, second_connection)))
+        assert sorted(results) == [False, True]
+
+        # A new connection represents a receiver after process restart.
+        restarted_connection = psycopg2.connect(dsn)
+        try:
+            assert not PostgresNonceStore(restarted_connection).consume(
+                nonce, expires_at=expires_at
+            )
+        finally:
+            restarted_connection.close()
+    finally:
+        with cleanup_connection.cursor() as cursor:
+            cursor.execute("DELETE FROM phlo_service_token_nonces WHERE nonce = %s", (nonce,))
+        cleanup_connection.commit()
+        first_connection.close()
+        second_connection.close()
+        cleanup_connection.close()

--- a/tests/unit/phlo/security/test_service_identity.py
+++ b/tests/unit/phlo/security/test_service_identity.py
@@ -42,10 +42,11 @@ class SharedNonceStore:
             return True
 
 
-def _credentials() -> dict[str, ServiceTokenCredential]:
+def _credentials() -> dict[tuple[str, str], ServiceTokenCredential]:
     return {
-        "phlo-api": ServiceTokenCredential(secret="api-secret", audience="dagster"),
-        "worker": ServiceTokenCredential(secret="worker-secret", audience="dagster"),
+        ("phlo-api", "dagster"): ServiceTokenCredential(secret="api-dagster-secret"),
+        ("phlo-api", "trino"): ServiceTokenCredential(secret="api-trino-secret"),
+        ("worker", "dagster"): ServiceTokenCredential(secret="worker-secret"),
     }
 
 
@@ -197,8 +198,48 @@ class TestScopedServiceTokens:
             validate_scoped_service_token(
                 token,
                 expected_audience="dagster",
-                credentials={"phlo-api": credentials["phlo-api"]},
+                credentials={("phlo-api", "dagster"): credentials[("phlo-api", "dagster")]},
                 nonce_store=SharedNonceStore(),
+            )
+            is None
+        )
+
+    def test_one_caller_has_distinct_credentials_for_each_audience(self) -> None:
+        credentials = _credentials()
+        dagster_token = create_scoped_service_token(
+            "phlo-api", audience="dagster", credentials=credentials, now=1_000
+        )
+        trino_token = create_scoped_service_token(
+            "phlo-api", audience="trino", credentials=credentials, now=1_000
+        )
+
+        assert (
+            validate_scoped_service_token(
+                dagster_token,
+                expected_audience="dagster",
+                credentials=credentials,
+                nonce_store=SharedNonceStore(),
+                now=1_001,
+            )
+            == "phlo-api"
+        )
+        assert (
+            validate_scoped_service_token(
+                trino_token,
+                expected_audience="trino",
+                credentials=credentials,
+                nonce_store=SharedNonceStore(),
+                now=1_001,
+            )
+            == "phlo-api"
+        )
+        assert (
+            validate_scoped_service_token(
+                dagster_token,
+                expected_audience="trino",
+                credentials=credentials,
+                nonce_store=SharedNonceStore(),
+                now=1_001,
             )
             is None
         )
@@ -266,6 +307,16 @@ class TestScopedServiceTokens:
     ) -> None:
         monkeypatch.setenv(PHLO_SERVICE_SECRET_ENV, "shared-secret")
         monkeypatch.setenv("PHLO_ENVIRONMENT", "production")
+        with pytest.raises(RuntimeError, match="development-only"):
+            create_service_token("phlo-api")
+        assert validate_service_token("phlo-api:1:nonce:signature") is None
+
+    def test_shared_secret_compatibility_is_not_available_in_regulated_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(PHLO_SERVICE_SECRET_ENV, "shared-secret")
+        monkeypatch.setenv("PHLO_ENVIRONMENT", "dev")
+        monkeypatch.setenv("PHLO_REGULATED", "true")
         with pytest.raises(RuntimeError, match="development-only"):
             create_service_token("phlo-api")
         assert validate_service_token("phlo-api:1:nonce:signature") is None


### PR DESCRIPTION
## Outcome

Adds the core contract required for production-safe service identity. Tokens are bound to an explicit caller and audience, signed with the credential configured for that caller-audience pair, expire after a bounded lifetime, and consume their nonce atomically in durable PostgreSQL state.

The branch includes:

- a neutral injectable nonce-store protocol
- a PostgreSQL implementation that accepts an existing connection or pool and uses a unique insert for cross-worker replay rejection
- separate credentials for the same caller across Dagster and Trino audiences
- rejection of wrong callers, wrong audiences, service-name impersonation, expired tokens, and replay
- canonical regulated-mode and production-environment guards preventing legacy shared-secret tokens from being minted or accepted

## Scope boundary

This PR delivers the core token and durable nonce contract only. Constructing the store in phlo-api or Dagster, loading caller credentials, and wiring scoped validation into live receivers are deliberately separate follow-on slices. It adds no DSN or global configuration surface and makes no claim that receiver migration is complete.

## Validation

- Owned live PostgreSQL acceptance run: 22 tests passed, including simultaneous consumption through two connections and replay after a new connection represented process restart.
- Focused core and Dagster middleware run: 53 tests passed, with the live PostgreSQL test skipped only when its opt-in DSN was absent.
- Type checking passed for src/phlo/security/service_identity.py.
- Ruff and repository pre-commit hooks passed.

The live PostgreSQL test owns its database artifacts: it deletes the nonce row it creates and closes all connections it opens. No shared schema or database is dropped.