### PR TITLE
ci: require recovery continuity release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,6 +312,56 @@ jobs:
       - name: Run release artifact golden path
         run: python3 scripts/release_golden_path.py
 
+  recovery-continuity-drill:
+    name: python / recovery continuity drill
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          version: "0.10.10"
+
+      - name: Run owned backup and restore drill
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p cairn-artifacts
+          uv run --locked python scripts/recovery_drill.py | tee cairn-artifacts/recovery-drill.json
+
+      - name: Summarize recovery evidence
+        if: always()
+        shell: bash
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          from pathlib import Path
+
+          report = Path("cairn-artifacts/recovery-drill.json")
+          print("### Recovery continuity drill")
+          if not report.is_file():
+              print("The drill produced no report; inspect the job log.")
+          else:
+              result = json.loads(report.read_text(encoding="utf-8"))
+              print(f"- Outcome: `{result.get('outcome', 'unknown')}`")
+              print(f"- Backup duration: `{result.get('backup_seconds', 'unavailable')}` seconds")
+              print(f"- Restore duration: `{result.get('restore_seconds', 'unavailable')}` seconds")
+              print("- Scope: owned PostgreSQL run evidence, Nessie/Iceberg catalog state, and object checksum.")
+              print("- This drill records observed durations; it does not assert an RPO or RTO.")
+          PY
+
+      - name: Upload recovery evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: recovery-continuity-drill
+          path: cairn-artifacts/recovery-drill.json
+          if-no-files-found: warn
+
   windows-release-contract:
     name: windows / release golden path contract
     runs-on: windows-latest
@@ -447,6 +497,7 @@ jobs:
       - python-core-tests
       - quickstart-smoke
       - release-golden-path
+      - recovery-continuity-drill
       - windows-release-contract
       - python-package-tests
       - frontend
@@ -459,6 +510,7 @@ jobs:
           PYTHON_CORE_TESTS: ${{ needs.python-core-tests.result }}
           QUICKSTART_SMOKE: ${{ needs.quickstart-smoke.result }}
           RELEASE_GOLDEN_PATH: ${{ needs.release-golden-path.result }}
+          RECOVERY_CONTINUITY_DRILL: ${{ needs.recovery-continuity-drill.result }}
           WINDOWS_RELEASE_CONTRACT: ${{ needs.windows-release-contract.result }}
           PYTHON_PACKAGE_TESTS: ${{ needs.python-package-tests.result }}
           FRONTEND: ${{ needs.frontend.result }}
@@ -475,6 +527,7 @@ jobs:
             echo "| python / core tests | ${PYTHON_CORE_TESTS} |"
             echo "| python / quickstart smoke | ${QUICKSTART_SMOKE} |"
             echo "| python / release golden path | ${RELEASE_GOLDEN_PATH} |"
+            echo "| python / recovery continuity drill | ${RECOVERY_CONTINUITY_DRILL} |"
             echo "| windows / release golden path contract | ${WINDOWS_RELEASE_CONTRACT} |"
             echo "| python / package tests | ${PYTHON_PACKAGE_TESTS} |"
             echo "| frontend / observatory | ${FRONTEND} |"
@@ -486,6 +539,7 @@ jobs:
             "${PYTHON_CORE_TESTS}" \
             "${QUICKSTART_SMOKE}" \
             "${RELEASE_GOLDEN_PATH}" \
+            "${RECOVERY_CONTINUITY_DRILL}" \
             "${WINDOWS_RELEASE_CONTRACT}" \
             "${PYTHON_PACKAGE_TESTS}" \
             "${FRONTEND}"; do

--- a/docs/operations/operations-guide.md
+++ b/docs/operations/operations-guide.md
@@ -637,10 +637,12 @@ SLACK_CHANNEL=#data-alerts
 
 ### Recovery Plan
 
-**RTO/RPO targets**:
+**Recovery timing**:
 
-- **RTO** (Recovery Time Objective): 4 hours
-- **RPO** (Recovery Point Objective): 24 hours
+Phlo does not publish an RTO or RPO commitment. The required recovery continuity
+drill records the backup and restore durations it observes for its owned
+PostgreSQL, Nessie/Iceberg, and object-store fixture, but those measurements do
+not establish a production timing objective.
 
 **Recovery steps**:
 

--- a/scripts/recovery_drill.py
+++ b/scripts/recovery_drill.py
@@ -25,6 +25,7 @@ from uuid import uuid4
 POSTGRES_IMAGE = "postgres:16-alpine"
 MINIO_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z"
 NESSIE_IMAGE = "ghcr.io/projectnessie/nessie:0.107.2"
+NESSIE_ADMIN_IMAGE = "ghcr.io/projectnessie/nessie-server-admin@sha256:94e67d471380e6da17680e166e3111819058a64c6717c96beafd1f3df6ec5876"
 MC_IMAGE = "minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
 HELPER_IMAGE = "python@sha256:db3ff2e1800a8581e2c48a27c3995339d47bdf046da21c7627accd3d51053a93"
 OWNER_MARKER = ".phlo-recovery-drill-owner.json"
@@ -93,7 +94,7 @@ def compose_yaml(stack: Stack) -> str:
     image: {NESSIE_IMAGE}
     environment:
       NESSIE_VERSION_STORE_TYPE: JDBC
-      QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/phlo
+      QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/phlo?currentSchema=public
       QUARKUS_DATASOURCE_USERNAME: phlo
       QUARKUS_DATASOURCE_PASSWORD: phlo
       nessie.catalog.default-warehouse: warehouse
@@ -104,7 +105,11 @@ def compose_yaml(stack: Stack) -> str:
       nessie.catalog.service.s3.default-options.access-key: urn:nessie-secret:quarkus:nessie.catalog.secrets.access-key
       nessie.catalog.secrets.access-key.name: minio
       nessie.catalog.secrets.access-key.secret: minio123
-    depends_on: [postgres, minio]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_started
     ports: [\"127.0.0.1::19120\"]
 volumes:
   postgres-data: {{}}
@@ -222,6 +227,47 @@ def restore_bucket(target: Stack, backup_dir: Path) -> None:
 def object_checksum(stack: Stack, key: str) -> str:
     command = f"mc alias set target http://minio:9000 minio minio123 >/dev/null && mc cat target/lake/{key} | sha256sum"
     return mc(stack, command).stdout.decode().split()[0]
+
+
+def nessie_admin(stack: Stack, backup_dir: Path, *args: str) -> None:
+    """Export or import Nessie's repository without running a target server."""
+    run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            f"{stack.project}_default",
+            "-v",
+            f"{backup_dir.resolve()}:/backup",
+            "-e",
+            "NESSIE_VERSION_STORE_TYPE=JDBC",
+            "-e",
+            "QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://postgres:5432/phlo?currentSchema=public",
+            "-e",
+            "QUARKUS_DATASOURCE_USERNAME=phlo",
+            "-e",
+            "QUARKUS_DATASOURCE_PASSWORD=phlo",
+            NESSIE_ADMIN_IMAGE,
+            *args,
+        ],
+        timeout=300,
+    )
+
+
+def export_nessie(stack: Stack, backup_dir: Path) -> None:
+    nessie_admin(stack, backup_dir, "export", "--path", "/backup/nessie.zip")
+
+
+def import_nessie(stack: Stack, backup_dir: Path) -> None:
+    nessie_admin(
+        stack,
+        backup_dir,
+        "import",
+        "--erase-before-import",
+        "--path",
+        "/backup/nessie.zip",
+    )
 
 
 def helper_source() -> str:
@@ -432,6 +478,7 @@ def read_manifest(backup_dir: Path) -> dict[str, Any]:
     checksum = payload.get("probe_checksum") if isinstance(payload, dict) else None
     if (
         not (backup_dir / "postgres.sql").is_file()
+        or not (backup_dir / "nessie.zip").is_file()
         or not (backup_dir / "lake").is_dir()
         or not isinstance(fixture, dict)
         or not all(
@@ -520,6 +567,7 @@ def drill(root: Path, *, keep_artifacts: bool = False) -> dict[str, float]:
             timeout=300,
         ).stdout
         (backup / "postgres.sql").write_bytes(dump)
+        export_nessie(source, backup)
         mirror_bucket(source, backup)
         write_manifest(backup, fixture, checksum)
         backup_seconds = time.monotonic() - backup_started
@@ -545,6 +593,7 @@ def drill(root: Path, *, keep_artifacts: bool = False) -> dict[str, float]:
             input=(backup / "postgres.sql").read_bytes(),
             timeout=300,
         )
+        import_nessie(target, backup)
         compose(target, "up", "-d", "nessie", timeout=300)
         wait_for(
             f"http://127.0.0.1:{published_port(target, 'nessie', 19120)}/api/v1/config",

--- a/scripts/recovery_drill.py
+++ b/scripts/recovery_drill.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import hmac
 import json
 import os
 import shutil
@@ -462,9 +463,42 @@ def verify_evidence(store: Any, fixture: dict[str, Any]) -> None:
         )
 
 
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def sha256_tree(root: Path) -> str:
+    digest = hashlib.sha256(b"phlo-recovery-tree-v1\0")
+    paths = sorted(root.rglob("*"), key=lambda path: path.relative_to(root).as_posix())
+    for path in paths:
+        if path.is_symlink():
+            raise RecoveryDrillError(f"backup lake contains unsupported entry: {path}")
+        if path.is_dir():
+            continue
+        if not path.is_file():
+            raise RecoveryDrillError(f"backup lake contains unsupported entry: {path}")
+        relative = path.relative_to(root).as_posix().encode()
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(bytes.fromhex(sha256_file(path)))
+    return digest.hexdigest()
+
+
 def write_manifest(backup_dir: Path, fixture: dict[str, Any], checksum: str) -> None:
+    artifacts = {
+        "postgres.sql": {"sha256": sha256_file(backup_dir / "postgres.sql")},
+        "nessie.zip": {"sha256": sha256_file(backup_dir / "nessie.zip")},
+        "lake": {"sha256": sha256_tree(backup_dir / "lake")},
+    }
     (backup_dir / "manifest.json").write_text(
-        json.dumps({"fixture": fixture, "probe_checksum": checksum}, sort_keys=True),
+        json.dumps(
+            {"artifacts": artifacts, "fixture": fixture, "probe_checksum": checksum},
+            sort_keys=True,
+        ),
         encoding="utf-8",
     )
 
@@ -476,10 +510,12 @@ def read_manifest(backup_dir: Path) -> dict[str, Any]:
         raise RecoveryDrillError("backup manifest is missing or corrupt") from exc
     fixture = payload.get("fixture") if isinstance(payload, dict) else None
     checksum = payload.get("probe_checksum") if isinstance(payload, dict) else None
+    artifacts = payload.get("artifacts") if isinstance(payload, dict) else None
     if (
         not (backup_dir / "postgres.sql").is_file()
         or not (backup_dir / "nessie.zip").is_file()
         or not (backup_dir / "lake").is_dir()
+        or not isinstance(artifacts, dict)
         or not isinstance(fixture, dict)
         or not all(
             isinstance(fixture.get(key), str) and fixture[key]
@@ -490,7 +526,39 @@ def read_manifest(backup_dir: Path) -> dict[str, Any]:
         or any(character not in "0123456789abcdef" for character in checksum.lower())
     ):
         raise RecoveryDrillError("backup manifest is missing required verification evidence")
+    actual_digests = {
+        "postgres.sql": sha256_file(backup_dir / "postgres.sql"),
+        "nessie.zip": sha256_file(backup_dir / "nessie.zip"),
+        "lake": sha256_tree(backup_dir / "lake"),
+    }
+    for name, actual in actual_digests.items():
+        artifact = artifacts.get(name)
+        expected = artifact.get("sha256") if isinstance(artifact, dict) else None
+        if not isinstance(expected, str) or not hmac.compare_digest(expected, actual):
+            raise RecoveryDrillError(f"backup manifest digest mismatch for {name}")
     return payload
+
+
+def restore_recovery_set(target: Stack, backup_dir: Path) -> dict[str, Any]:
+    manifest = read_manifest(backup_dir)
+    restore_bucket(target, backup_dir)
+    compose(
+        target,
+        "exec",
+        "-T",
+        "postgres",
+        "psql",
+        "-v",
+        "ON_ERROR_STOP=1",
+        "-U",
+        "phlo",
+        "-d",
+        "phlo",
+        input=(backup_dir / "postgres.sql").read_bytes(),
+        timeout=300,
+    )
+    import_nessie(target, backup_dir)
+    return manifest
 
 
 def cleanup(stack: Stack) -> RecoveryDrillError | None:
@@ -576,24 +644,7 @@ def drill(root: Path, *, keep_artifacts: bool = False) -> dict[str, float]:
 
         restore_started = time.monotonic()
         start(target, with_nessie=False)
-        manifest = read_manifest(backup)
-        restore_bucket(target, backup)
-        compose(
-            target,
-            "exec",
-            "-T",
-            "postgres",
-            "psql",
-            "-v",
-            "ON_ERROR_STOP=1",
-            "-U",
-            "phlo",
-            "-d",
-            "phlo",
-            input=(backup / "postgres.sql").read_bytes(),
-            timeout=300,
-        )
-        import_nessie(target, backup)
+        manifest = restore_recovery_set(target, backup)
         compose(target, "up", "-d", "nessie", timeout=300)
         wait_for(
             f"http://127.0.0.1:{published_port(target, 'nessie', 19120)}/api/v1/config",

--- a/scripts/recovery_drill.py
+++ b/scripts/recovery_drill.py
@@ -232,11 +232,13 @@ def object_checksum(stack: Stack, key: str) -> str:
 
 def nessie_admin(stack: Stack, backup_dir: Path, *args: str) -> None:
     """Export or import Nessie's repository without running a target server."""
+    host_user = ["--user", f"{os.getuid()}:{os.getgid()}"] if os.name == "posix" else []
     run(
         [
             "docker",
             "run",
             "--rm",
+            *host_user,
             "--network",
             f"{stack.project}_default",
             "-v",

--- a/scripts/recovery_drill.py
+++ b/scripts/recovery_drill.py
@@ -191,7 +191,17 @@ def start(stack: Stack, *, with_nessie: bool) -> None:
 def mc(
     stack: Stack, command: str, *, mounts: list[tuple[Path, str]] = (), timeout: int = 180
 ) -> subprocess.CompletedProcess[bytes]:
-    args = ["docker", "run", "--rm", "--network", f"{stack.project}_default"]
+    host_user = ["--user", f"{os.getuid()}:{os.getgid()}"] if os.name == "posix" else []
+    args = [
+        "docker",
+        "run",
+        "--rm",
+        *host_user,
+        "-e",
+        "HOME=/tmp",
+        "--network",
+        f"{stack.project}_default",
+    ]
     for source, target in mounts:
         args.extend(["-v", f"{source.resolve()}:{target}"])
     args.extend(["--entrypoint", "/bin/sh", MC_IMAGE, "-c", command])

--- a/tests/scripts/test_recovery_drill.py
+++ b/tests/scripts/test_recovery_drill.py
@@ -25,10 +25,15 @@ def test_compose_uses_isolated_ports_and_supported_stack_images(tmp_path):
     assert "minio/minio:RELEASE.2025-09-07T16-13-09Z" in compose
     assert "ghcr.io/projectnessie/nessie:0.107.2" in compose
     assert "127.0.0.1::5432" in compose
+    assert "condition: service_healthy" in compose
+    assert "jdbc:postgresql://postgres:5432/phlo?currentSchema=public" in compose
     assert "nessie.catalog.warehouses.warehouse.location: s3://lake/warehouse" in compose
     assert "nessie.catalog.service.s3.default-options.endpoint: http://minio:9000/" in compose
     assert 'nessie.catalog.service.s3.default-options.path-style-access: "true"' in compose
     assert recovery_drill.MC_IMAGE.startswith("minio/mc@sha256:")
+    assert recovery_drill.NESSIE_ADMIN_IMAGE.startswith(
+        "ghcr.io/projectnessie/nessie-server-admin@sha256:"
+    )
     assert ":latest" not in recovery_drill.MC_IMAGE
 
 
@@ -64,6 +69,7 @@ def test_helper_is_network_local_and_uses_locked_dependency_export(tmp_path, mon
 def test_manifest_round_trip_requires_fixture_and_checksum(tmp_path):
     fixture = {"project_id": "project", "table_name": "recovery.rows", "snapshot_id": "42"}
     (tmp_path / "postgres.sql").write_text("backup", encoding="utf-8")
+    (tmp_path / "nessie.zip").write_text("backup", encoding="utf-8")
     (tmp_path / "lake").mkdir()
 
     recovery_drill.write_manifest(tmp_path, fixture, "a" * 64)
@@ -102,6 +108,38 @@ def test_manifest_rejects_missing_backup_files(tmp_path):
 
     with pytest.raises(recovery_drill.RecoveryDrillError, match="backup manifest"):
         recovery_drill.read_manifest(tmp_path)
+
+
+def test_nessie_export_and_import_use_the_pinned_admin_tool(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(recovery_drill, "run", lambda command, **_: calls.append(command))
+    stack = recovery_drill.Stack("owned-drill", tmp_path / "source")
+
+    recovery_drill.export_nessie(stack, tmp_path)
+    recovery_drill.import_nessie(stack, tmp_path)
+
+    common = [
+        "docker",
+        "run",
+        "--rm",
+        "--network",
+        "owned-drill_default",
+        "-v",
+        f"{tmp_path.resolve()}:/backup",
+        "-e",
+        "NESSIE_VERSION_STORE_TYPE=JDBC",
+        "-e",
+        "QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://postgres:5432/phlo?currentSchema=public",
+        "-e",
+        "QUARKUS_DATASOURCE_USERNAME=phlo",
+        "-e",
+        "QUARKUS_DATASOURCE_PASSWORD=phlo",
+        recovery_drill.NESSIE_ADMIN_IMAGE,
+    ]
+    assert calls == [
+        [*common, "export", "--path", "/backup/nessie.zip"],
+        [*common, "import", "--erase-before-import", "--path", "/backup/nessie.zip"],
+    ]
 
 
 def test_restored_evidence_requires_exact_resource_and_catalog_change():

--- a/tests/scripts/test_recovery_drill.py
+++ b/tests/scripts/test_recovery_drill.py
@@ -234,6 +234,38 @@ def test_nessie_export_and_import_use_the_pinned_admin_tool(tmp_path, monkeypatc
     ]
 
 
+def test_minio_client_uses_host_owner_for_backup_mounts(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(recovery_drill, "run", lambda command, **_: calls.append(command))
+    monkeypatch.setattr(recovery_drill.os, "name", "posix")
+    monkeypatch.setattr(recovery_drill.os, "getuid", lambda: 1001, raising=False)
+    monkeypatch.setattr(recovery_drill.os, "getgid", lambda: 118, raising=False)
+    stack = recovery_drill.Stack("owned-drill", tmp_path / "source")
+
+    recovery_drill.mc(stack, "true", mounts=[(tmp_path, "/backup")])
+
+    assert calls == [
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--user",
+            "1001:118",
+            "-e",
+            "HOME=/tmp",
+            "--network",
+            "owned-drill_default",
+            "-v",
+            f"{tmp_path.resolve()}:/backup",
+            "--entrypoint",
+            "/bin/sh",
+            recovery_drill.MC_IMAGE,
+            "-c",
+            "true",
+        ]
+    ]
+
+
 def test_restored_evidence_requires_exact_resource_and_catalog_change():
     fixture = {"project_id": "project", "table_name": "recovery.rows", "snapshot_id": "42"}
 

--- a/tests/scripts/test_recovery_drill.py
+++ b/tests/scripts/test_recovery_drill.py
@@ -200,6 +200,9 @@ def test_mixed_recovery_set_stops_before_restore_mutation(tmp_path, monkeypatch)
 def test_nessie_export_and_import_use_the_pinned_admin_tool(tmp_path, monkeypatch):
     calls = []
     monkeypatch.setattr(recovery_drill, "run", lambda command, **_: calls.append(command))
+    monkeypatch.setattr(recovery_drill.os, "name", "posix")
+    monkeypatch.setattr(recovery_drill.os, "getuid", lambda: 1001, raising=False)
+    monkeypatch.setattr(recovery_drill.os, "getgid", lambda: 118, raising=False)
     stack = recovery_drill.Stack("owned-drill", tmp_path / "source")
 
     recovery_drill.export_nessie(stack, tmp_path)
@@ -209,6 +212,8 @@ def test_nessie_export_and_import_use_the_pinned_admin_tool(tmp_path, monkeypatc
         "docker",
         "run",
         "--rm",
+        "--user",
+        "1001:118",
         "--network",
         "owned-drill_default",
         "-v",

--- a/tests/scripts/test_recovery_drill.py
+++ b/tests/scripts/test_recovery_drill.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -71,13 +72,34 @@ def test_manifest_round_trip_requires_fixture_and_checksum(tmp_path):
     (tmp_path / "postgres.sql").write_text("backup", encoding="utf-8")
     (tmp_path / "nessie.zip").write_text("backup", encoding="utf-8")
     (tmp_path / "lake").mkdir()
+    (tmp_path / "lake" / "metadata.json").write_text("metadata", encoding="utf-8")
 
     recovery_drill.write_manifest(tmp_path, fixture, "a" * 64)
 
-    assert recovery_drill.read_manifest(tmp_path) == {
-        "fixture": fixture,
-        "probe_checksum": "a" * 64,
+    manifest = recovery_drill.read_manifest(tmp_path)
+    assert manifest["fixture"] == fixture
+    assert manifest["probe_checksum"] == "a" * 64
+    assert manifest["artifacts"] == {
+        "postgres.sql": {"sha256": recovery_drill.sha256_file(tmp_path / "postgres.sql")},
+        "nessie.zip": {"sha256": recovery_drill.sha256_file(tmp_path / "nessie.zip")},
+        "lake": {"sha256": recovery_drill.sha256_tree(tmp_path / "lake")},
     }
+
+
+def test_lake_tree_digest_is_stable_and_path_sensitive(tmp_path):
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "a").write_bytes(b"alpha")
+    (first / "b").write_bytes(b"beta")
+    (second / "b").write_bytes(b"beta")
+    (second / "a").write_bytes(b"alpha")
+
+    assert recovery_drill.sha256_tree(first) == recovery_drill.sha256_tree(second)
+
+    (second / "a").rename(second / "renamed")
+    assert recovery_drill.sha256_tree(first) != recovery_drill.sha256_tree(second)
 
 
 @pytest.mark.parametrize(
@@ -102,12 +124,77 @@ def test_manifest_rejects_missing_or_corrupt_verification_evidence(tmp_path, con
 
 
 def test_manifest_rejects_missing_backup_files(tmp_path):
+    (tmp_path / "postgres.sql").write_text("backup", encoding="utf-8")
+    (tmp_path / "nessie.zip").write_text("backup", encoding="utf-8")
+    (tmp_path / "lake").mkdir()
     recovery_drill.write_manifest(
         tmp_path, {"project_id": "p", "table_name": "t", "snapshot_id": "s"}, "a" * 64
     )
+    (tmp_path / "nessie.zip").unlink()
 
     with pytest.raises(recovery_drill.RecoveryDrillError, match="backup manifest"):
         recovery_drill.read_manifest(tmp_path)
+
+
+def write_backup_set(path, marker):
+    path.mkdir()
+    (path / "postgres.sql").write_text(f"postgres-{marker}", encoding="utf-8")
+    (path / "nessie.zip").write_text(f"nessie-{marker}", encoding="utf-8")
+    (path / "lake").mkdir()
+    (path / "lake" / "metadata.json").write_text(f"metadata-{marker}", encoding="utf-8")
+    recovery_drill.write_manifest(
+        path,
+        {"project_id": "p", "table_name": "t", "snapshot_id": marker},
+        "a" * 64,
+    )
+
+
+@pytest.mark.parametrize(
+    ("artifact", "path"),
+    [
+        ("postgres.sql", "postgres.sql"),
+        ("nessie.zip", "nessie.zip"),
+        ("lake", "lake/metadata.json"),
+    ],
+)
+def test_corrupt_recovery_set_stops_before_restore_mutation(tmp_path, monkeypatch, artifact, path):
+    backup = tmp_path / "backup"
+    write_backup_set(backup, "original")
+    (backup / path).write_text("corrupt", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(recovery_drill, "restore_bucket", lambda *_: calls.append("bucket"))
+    monkeypatch.setattr(
+        recovery_drill, "compose", lambda *_args, **_kwargs: calls.append("postgres")
+    )
+    monkeypatch.setattr(recovery_drill, "import_nessie", lambda *_: calls.append("nessie"))
+
+    with pytest.raises(recovery_drill.RecoveryDrillError, match=f"digest mismatch for {artifact}"):
+        recovery_drill.restore_recovery_set(
+            recovery_drill.Stack("owned-drill", tmp_path / "target"), backup
+        )
+
+    assert calls == []
+
+
+def test_mixed_recovery_set_stops_before_restore_mutation(tmp_path, monkeypatch):
+    original = tmp_path / "original"
+    replacement = tmp_path / "replacement"
+    write_backup_set(original, "original")
+    write_backup_set(replacement, "replacement")
+    shutil.copy2(original / "manifest.json", replacement / "manifest.json")
+    calls = []
+    monkeypatch.setattr(recovery_drill, "restore_bucket", lambda *_: calls.append("bucket"))
+    monkeypatch.setattr(
+        recovery_drill, "compose", lambda *_args, **_kwargs: calls.append("postgres")
+    )
+    monkeypatch.setattr(recovery_drill, "import_nessie", lambda *_: calls.append("nessie"))
+
+    with pytest.raises(recovery_drill.RecoveryDrillError, match="digest mismatch"):
+        recovery_drill.restore_recovery_set(
+            recovery_drill.Stack("owned-drill", tmp_path / "target"), replacement
+        )
+
+    assert calls == []
 
 
 def test_nessie_export_and_import_use_the_pinned_admin_tool(tmp_path, monkeypatch):
@@ -278,8 +365,11 @@ def test_start_waits_for_postgres_before_other_health_checks(monkeypatch, tmp_pa
 def test_manifest_requires_regular_postgres_file_and_lake_directory(tmp_path):
     fixture = {"project_id": "p", "table_name": "t", "snapshot_id": "s"}
     (tmp_path / "postgres.sql").mkdir()
+    (tmp_path / "nessie.zip").write_text("backup", encoding="utf-8")
     (tmp_path / "lake").write_text("not a directory", encoding="utf-8")
-    recovery_drill.write_manifest(tmp_path, fixture, "a" * 64)
+    (tmp_path / "manifest.json").write_text(
+        json.dumps({"fixture": fixture, "probe_checksum": "a" * 64}), encoding="utf-8"
+    )
 
     with pytest.raises(recovery_drill.RecoveryDrillError, match="backup manifest"):
         recovery_drill.read_manifest(tmp_path)


### PR DESCRIPTION
## Summary

- make the owned recovery drill use Nessie's supported Server Admin export/import flow, with the target Nessie server stopped during import
- bind `postgres.sql`, `nessie.zip`, and the mirrored lake tree into one manifest using SHA-256 digests verified before any restore mutation
- add the real recovery continuity drill as a required CI lane, upload its JSON evidence, and include it in the aggregate CI status
- replace the unsupported 4-hour RTO and 24-hour RPO documentation claims with an accurate description of observed drill timing

## Why

The existing drill used a PostgreSQL logical dump for Nessie catalog recovery. A clean runtime exposed two concrete problems: Nessie could start before PostgreSQL was healthy, and a restored database could resolve Nessie's repository from the wrong schema once Phlo's run-evidence schema existed. The supported Nessie Admin export/import path, an explicit `public` schema, and health-gated startup make the catalog restore truthful.

The recovery set also needed integrity binding. The manifest now records individual PostgreSQL and Nessie archive digests plus a stable, domain-separated digest over sorted lake paths and file contents. Corrupt or mixed artifacts fail before object restore, PostgreSQL import, or Nessie import.

## Validation

- `uv run --locked pytest tests/scripts/test_recovery_drill.py --tb=short` — 25 passed
- `uv run --locked ruff check scripts/recovery_drill.py tests/scripts/test_recovery_drill.py`
- `uv run --locked ruff format --check scripts/recovery_drill.py tests/scripts/test_recovery_drill.py`
- `make actionlint`
- `make zizmor` — no findings
- real owned Docker recovery drill — verified with observed backup duration 2.46 seconds and restore duration 30.111 seconds; catalog snapshot, row count, object checksum, and PostgreSQL run evidence all matched, and owned resources were cleaned

The durations above are observations from one local drill. This change does not assert or enforce an RPO or RTO.

## Local Agent CI note

The full local Agent CI run paused before this lane on two unrelated baseline/environment failures: `docs.yml` could not resolve a `pymdx==0.1.4` wheel for its current platform, and `security.yml` invoked `uv audit --all-groups`, which the locally selected `uv audit` does not support. Neither workflow is changed here.
