### PR TITLE
feat(evidence): require canonical report identities

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
@@ -410,6 +410,21 @@ def _emit_wap_observation(
         catalog_change={
             "operation": operation,
             "catalog_ref": catalog_ref,
+            "resource_identity": {
+                "resource_type": "catalog_ref",
+                "resource_id": catalog_ref,
+                "tenant": project_id,
+                "attributes": {
+                    key: value
+                    for key, value in {
+                        "operation": operation,
+                        "source_hash": source_hash,
+                        "target_hash": target_hash,
+                        "merge_outcome": merge_outcome,
+                    }.items()
+                    if isinstance(value, str) and value
+                },
+            },
             "source_hash": source_hash,
             "target_hash": target_hash,
             "merge_outcome": merge_outcome,

--- a/packages/phlo-dlt/src/phlo_dlt/executor.py
+++ b/packages/phlo-dlt/src/phlo_dlt/executor.py
@@ -95,6 +95,22 @@ from phlo_dlt.pandera_checks import (
 from phlo_dlt.registry import TableConfig
 
 
+def _resource_identity(
+    *,
+    project_id: str | None,
+    resource_type: str,
+    resource_id: str,
+    attributes: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build the provider's canonical, project-scoped report identity."""
+    return {
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "tenant": project_id,
+        "attributes": attributes or {},
+    }
+
+
 class DltIngester(BaseIngester):
     """DLT-specific implementation of the ingestion engine.
 
@@ -318,6 +334,18 @@ class DltIngester(BaseIngester):
                                 "resource_kind": "external_source",
                                 "role": "input",
                                 "normalized_identity": source_identity,
+                                "resource_identity": _resource_identity(
+                                    project_id=project_id,
+                                    resource_type=(
+                                        "external_source" if source_identity else "ingestion_asset"
+                                    ),
+                                    resource_id=source_identity
+                                    or self.table_config.full_table_name,
+                                    attributes={
+                                        "table_name": self.table_config.full_table_name,
+                                        "partition_key": partition_key,
+                                    },
+                                ),
                                 "ref_name": branch_name,
                                 "metadata": {
                                     "partition": {"status": "observed", "value": partition_key},
@@ -405,6 +433,15 @@ class DltIngester(BaseIngester):
                     "resource_kind": "external_source",
                     "role": "input",
                     "normalized_identity": source_identity,
+                    "resource_identity": _resource_identity(
+                        project_id=project_id,
+                        resource_type=("external_source" if source_identity else "ingestion_asset"),
+                        resource_id=source_identity or self.table_config.full_table_name,
+                        attributes={
+                            "table_name": self.table_config.full_table_name,
+                            "partition_key": partition_key,
+                        },
+                    ),
                     "ref_name": branch_name,
                     "record_count": dlt_metrics.get("records_read"),
                     "byte_count": dlt_metrics.get("bytes_read"),
@@ -420,6 +457,21 @@ class DltIngester(BaseIngester):
                 {
                     "resource_kind": "staged_object",
                     "role": "staged",
+                    "resource_identity": _resource_identity(
+                        project_id=project_id,
+                        resource_type="staged_object",
+                        resource_id=execution_identity
+                        or ",".join(
+                            str(item["identity"])
+                            for item in staged_objects
+                            if isinstance(item.get("identity"), str)
+                        )
+                        or self.table_config.full_table_name,
+                        attributes={
+                            "table_name": self.table_config.full_table_name,
+                            "partition_key": partition_key,
+                        },
+                    ),
                     "ref_name": branch_name,
                     "staged_objects": staged_objects,
                     "record_count": staged_record_count,
@@ -450,6 +502,12 @@ class DltIngester(BaseIngester):
                 "resource_kind": "iceberg_table",
                 "role": "output",
                 "table_name": self.table_config.full_table_name,
+                "resource_identity": _resource_identity(
+                    project_id=project_id,
+                    resource_type="iceberg_table",
+                    resource_id=self.table_config.full_table_name,
+                    attributes={"catalog_ref": branch_name},
+                ),
                 "ref_name": branch_name,
                 "schema_hash": before_state["schema_hash"],
                 "schema_hash_before": before_state["schema_hash"],

--- a/packages/phlo-dlt/tests/test_ingestion_decorator.py
+++ b/packages/phlo-dlt/tests/test_ingestion_decorator.py
@@ -105,6 +105,16 @@ def test_blessed_decorator_persists_runtime_correlation(monkeypatch, tmp_path) -
     assert captured[0]["project_id"] == "project-decorated"
     assert captured[0]["attempt"] == 2
     assert captured[0]["resources"]
+    assert all(
+        resource["resource_identity"]["tenant"] == "project-decorated"
+        for resource in captured[0]["resources"]
+    )
+    assert captured[0]["resources"][-1]["resource_identity"] == {
+        "resource_type": "iceberg_table",
+        "resource_id": "raw.events",
+        "tenant": "project-decorated",
+        "attributes": {"catalog_ref": "main"},
+    }
 
 
 def test_blessed_decorator_persists_runtime_correlation_through_sqlite(

--- a/packages/phlo-iceberg/src/phlo_iceberg/evidence.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/evidence.py
@@ -99,6 +99,12 @@ def emit_mutation(
                     "resource_kind": "iceberg_table",
                     "role": "output",
                     "table_name": table_name,
+                    "resource_identity": {
+                        "resource_type": "iceberg_table",
+                        "resource_id": table_name,
+                        "tenant": context["project_id"],
+                        "attributes": {"catalog_ref": ref},
+                    },
                     "ref_name": ref,
                     "schema_hash": after.get("schema_hash"),
                     "schema_hash_before": before.get("schema_hash"),

--- a/packages/phlo-iceberg/tests/test_evidence.py
+++ b/packages/phlo-iceberg/tests/test_evidence.py
@@ -22,6 +22,12 @@ def test_successful_mutation_with_absent_readback_keeps_provider_success(monkeyp
     )
 
     assert captured[0]["status"] == "success"
+    assert captured[0]["resources"][0]["resource_identity"] == {
+        "resource_type": "iceberg_table",
+        "resource_id": "raw.events",
+        "tenant": "project",
+        "attributes": {"catalog_ref": "main"},
+    }
     assert captured[0]["resources"][0]["metadata"]["outcome"] == "contradictory"
     assert captured[0]["resources"][0]["metadata"]["evidence_completeness"] == "incomplete"
 

--- a/src/phlo/hooks/events.py
+++ b/src/phlo/hooks/events.py
@@ -424,6 +424,7 @@ class RunEvidenceObservationEvent(HookEvent):
     stage_id: str | None = None
     resources: list[dict[str, Any]] = field(default_factory=list)
     catalog_change: dict[str, Any] | None = None
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
     metrics: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
 

--- a/src/phlo/run_evidence/emit.py
+++ b/src/phlo/run_evidence/emit.py
@@ -56,6 +56,7 @@ def emit_observation(
     stage_id: str | None = None,
     resources: list[dict[str, Any]] | None = None,
     catalog_change: dict[str, Any] | None = None,
+    artifacts: list[dict[str, Any]] | None = None,
     metrics: dict[str, Any] | None = None,
     error: str | None = None,
     event_id: str | None = None,
@@ -110,6 +111,7 @@ def emit_observation(
             stage_id=stage_id,
             resources=resources or [],
             catalog_change=catalog_change,
+            artifacts=artifacts or [],
             metrics=metrics or {},
             error=error,
             correlation=HookCorrelation(

--- a/src/phlo/run_evidence/hooks.py
+++ b/src/phlo/run_evidence/hooks.py
@@ -6,6 +6,7 @@ import hashlib
 from dataclasses import asdict
 from typing import Any
 
+from phlo.capabilities import ResourceRef
 from phlo.hooks.events import (
     HookEvent,
     IngestionEvent,
@@ -18,6 +19,7 @@ from phlo.hooks.events import (
 from phlo.plugins.hooks import FailurePolicy, HookFilter, HookRegistration
 from phlo.run_evidence.models import (
     PipelineRun,
+    RunArtifact,
     RunCatalogChange,
     RunEvent,
     RunLineageEdge,
@@ -116,6 +118,7 @@ class CoreRunEvidenceHookProvider:
         lineage_edges = _lineage_for_event(event, project_id=project_id, run_id=run_id)
         resources = _resources_for_event(event, project_id=project_id, run_id=run_id)
         catalog_change = _catalog_change_for_event(event, project_id=project_id, run_id=run_id)
+        artifacts = _artifacts_for_event(event, project_id=project_id, run_id=run_id)
         store.append_event(
             RunEvent(
                 project_id=project_id,
@@ -128,6 +131,9 @@ class CoreRunEvidenceHookProvider:
                 payload=_event_payload(event),
                 attempt=event.correlation.attempt,
                 stage_id=stage.stage_id if stage else None,
+                resource_ref=stage.resource_ref
+                if stage is not None
+                else ResourceRef(resource_type="run", resource_id=run_id, tenant=project_id),
             ),
             run=run,
             stage=stage,
@@ -135,6 +141,7 @@ class CoreRunEvidenceHookProvider:
             lineage_edges=tuple(lineage_edges),
             resources=tuple(resources),
             catalog_change=catalog_change,
+            artifacts=tuple(artifacts),
         )
 
 
@@ -202,6 +209,11 @@ def _stage_for_event(event: HookEvent, *, project_id: str, run_id: str) -> RunSt
         finished_at=stage_finished_at,
         metrics=getattr(event, "metrics", {}) or {},
         error=getattr(event, "error", None),
+        resource_ref=ResourceRef(
+            resource_type="asset" if asset else "stage",
+            resource_id=asset or stage_id,
+            tenant=project_id,
+        ),
     )
 
 
@@ -231,6 +243,9 @@ def _quality_for_event(
         evaluated_count=_as_int(metadata.get("evaluated_count", metadata.get("total_rows"))),
         failed_count=_as_int(metadata.get("failed_count", metadata.get("failed_rows"))),
         metadata=metadata,
+        resource_ref=ResourceRef(
+            resource_type="quality_check", resource_id=event.check_name, tenant=project_id
+        ),
     )
 
 
@@ -257,6 +272,8 @@ def _lineage_for_event(
             origin=str(metadata.get("origin", "observed")),
             derivation=str(metadata.get("derivation", "exact")),
             confidence=_as_float(metadata.get("confidence")),
+            source_resource_ref=_asset_resource_ref(source, project_id),
+            target_resource_ref=_asset_resource_ref(target, project_id),
         )
         for index, (source, target) in enumerate(event.edges)
     ]
@@ -295,6 +312,13 @@ def _resources_for_event(event: HookEvent, *, project_id: str, run_id: str) -> l
         values["project_id"] = project_id
         values["run_id"] = run_id
         values.setdefault("attempt", event.correlation.attempt)
+        values["resource_ref"] = _resource_ref_from_mapping(
+            values.get("resource_identity"), project_id
+        )
+        if values["resource_ref"] is None:
+            raise ValueError(
+                "observation resource requires canonical project-scoped resource_identity"
+            )
         allowed = {
             "project_id",
             "run_id",
@@ -317,6 +341,7 @@ def _resources_for_event(event: HookEvent, *, project_id: str, run_id: str) -> l
             "snapshot_before",
             "snapshot_after",
             "metadata",
+            "resource_ref",
         }
         resources.append(
             RunResource(**{key: value for key, value in values.items() if key in allowed})
@@ -336,6 +361,9 @@ def _catalog_change_for_event(
     )
     values.update(project_id=project_id, run_id=run_id)
     values.setdefault("attempt", event.correlation.attempt)
+    values["resource_ref"] = _resource_ref_from_mapping(values.get("resource_identity"), project_id)
+    if values["resource_ref"] is None:
+        raise ValueError("catalog change requires canonical project-scoped resource_identity")
     allowed = {
         "project_id",
         "run_id",
@@ -353,8 +381,74 @@ def _catalog_change_for_event(
         "snapshot_after",
         "quality_decision_id",
         "metadata",
+        "resource_ref",
     }
     return RunCatalogChange(**{key: value for key, value in values.items() if key in allowed})
+
+
+def _artifacts_for_event(event: HookEvent, *, project_id: str, run_id: str) -> list[RunArtifact]:
+    if not isinstance(event, RunEvidenceObservationEvent):
+        return []
+    artifacts: list[RunArtifact] = []
+    for raw in event.artifacts:
+        if not isinstance(raw, dict) or not isinstance(raw.get("artifact_id"), str):
+            continue
+        values = dict(raw)
+        values.update(project_id=project_id, run_id=run_id)
+        values.setdefault("attempt", event.correlation.attempt)
+        values["resource_ref"] = _resource_ref_from_mapping(
+            values.get("resource_identity"), project_id
+        ) or ResourceRef(
+            resource_type="artifact", resource_id=values["artifact_id"], tenant=project_id
+        )
+        allowed = {
+            "project_id",
+            "run_id",
+            "artifact_id",
+            "artifact_kind",
+            "uri",
+            "content_type",
+            "checksum",
+            "retention_class",
+            "expires_at",
+            "legal_hold",
+            "status",
+            "attempt",
+            "resource_ref",
+        }
+        artifacts.append(
+            RunArtifact(**{key: value for key, value in values.items() if key in allowed})
+        )
+    return artifacts
+
+
+def _resource_ref_from_mapping(value: Any, project_id: str) -> ResourceRef | None:
+    if not isinstance(value, dict):
+        return None
+    resource_type = value.get("resource_type")
+    resource_id = value.get("resource_id")
+    attributes = value.get("attributes", {})
+    if (
+        not isinstance(resource_type, str)
+        or not resource_type.strip()
+        or not isinstance(resource_id, str)
+        or not resource_id.strip()
+        or value.get("tenant") != project_id
+        or not isinstance(attributes, dict)
+        or not all(
+            isinstance(key, str) and isinstance(item, str) for key, item in attributes.items()
+        )
+    ):
+        return None
+    return ResourceRef(resource_type, resource_id, tenant=project_id, attributes=attributes)
+
+
+def _asset_resource_ref(value: str, project_id: str) -> ResourceRef | None:
+    return (
+        ResourceRef(resource_type="asset", resource_id=value, tenant=project_id)
+        if value.strip()
+        else None
+    )
 
 
 def _run_status(event: HookEvent) -> str:

--- a/src/phlo/run_evidence/hooks.py
+++ b/src/phlo/run_evidence/hooks.py
@@ -398,9 +398,9 @@ def _artifacts_for_event(event: HookEvent, *, project_id: str, run_id: str) -> l
         values.setdefault("attempt", event.correlation.attempt)
         values["resource_ref"] = _resource_ref_from_mapping(
             values.get("resource_identity"), project_id
-        ) or ResourceRef(
-            resource_type="artifact", resource_id=values["artifact_id"], tenant=project_id
         )
+        if values["resource_ref"] is None:
+            raise ValueError("artifact requires canonical project-scoped resource_identity")
         allowed = {
             "project_id",
             "run_id",

--- a/src/phlo/run_evidence/models.py
+++ b/src/phlo/run_evidence/models.py
@@ -7,7 +7,9 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, TypedDict
 
-RUN_EVIDENCE_SCHEMA_VERSION = 3
+from phlo.capabilities.interfaces import ResourceRef
+
+RUN_EVIDENCE_SCHEMA_VERSION = 4
 
 
 def _now() -> datetime:
@@ -80,9 +82,11 @@ class RunEvent:
     observed_at: datetime = field(default_factory=_now)
     sequence: int | None = None
     attempt: int = 1
+    resource_ref: ResourceRef | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "attempt", _positive_attempt(self.attempt))
+        _validate_resource_ref(self.resource_ref, self.project_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -102,9 +106,11 @@ class RunStage:
     finished_at: datetime | None = None
     metrics: dict[str, Any] = field(default_factory=dict)
     error: str | None = None
+    resource_ref: ResourceRef | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "attempt", _positive_attempt(self.attempt))
+        _validate_resource_ref(self.resource_ref, self.project_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -132,9 +138,11 @@ class RunResource:
     schema_hash_before: str | None = None
     schema_hash_after: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    resource_ref: ResourceRef | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "attempt", _positive_attempt(self.attempt))
+        _validate_resource_ref(self.resource_ref, self.project_id)
         for item in self.staged_objects:
             if isinstance(item, str):
                 continue
@@ -156,9 +164,13 @@ class RunLineageEdge:
     derivation: str = "exact"
     confidence: float | None = None
     attempt: int = 1
+    source_resource_ref: ResourceRef | None = None
+    target_resource_ref: ResourceRef | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "attempt", _positive_attempt(self.attempt))
+        _validate_resource_ref(self.source_resource_ref, self.project_id)
+        _validate_resource_ref(self.target_resource_ref, self.project_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -179,9 +191,11 @@ class RunQualityResult:
     failure_artifact_id: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     attempt: int = 1
+    resource_ref: ResourceRef | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "attempt", _positive_attempt(self.attempt))
+        _validate_resource_ref(self.resource_ref, self.project_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -204,9 +218,11 @@ class RunCatalogChange:
     metadata: dict[str, Any] = field(default_factory=dict)
     attempt: int = 1
     quality_decision_id: str | None = None
+    resource_ref: ResourceRef | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "attempt", _positive_attempt(self.attempt))
+        _validate_resource_ref(self.resource_ref, self.project_id)
 
 
 @dataclass(frozen=True, slots=True)
@@ -225,6 +241,18 @@ class RunArtifact:
     legal_hold: bool = False
     status: EvidenceCompleteness = EvidenceCompleteness.COMPLETE
     attempt: int = 1
+    resource_ref: ResourceRef | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "attempt", _positive_attempt(self.attempt))
+        _validate_resource_ref(self.resource_ref, self.project_id)
+
+
+def _validate_resource_ref(value: ResourceRef | None, project_id: str) -> None:
+    """Keep report authorization identities project-scoped and serializable."""
+    if value is None:
+        return
+    if not value.resource_type.strip() or not value.resource_id.strip():
+        raise ValueError("resource_ref requires non-empty resource_type and resource_id")
+    if value.tenant != project_id:
+        raise ValueError("resource_ref tenant must match the evidence project_id")

--- a/src/phlo/run_evidence/report.py
+++ b/src/phlo/run_evidence/report.py
@@ -45,6 +45,17 @@ class ReportGap:
 
 
 @dataclass(frozen=True)
+class ReportResourceIdentity:
+    """Canonical project-scoped authorization identity carried by evidence."""
+
+    project_id: str
+    resource_type: str
+    resource_id: str
+    tenant: str
+    attributes: dict[str, str]
+
+
+@dataclass(frozen=True)
 class ReportEvent:
     event_id: str
     producer: str
@@ -52,6 +63,8 @@ class ReportEvent:
     observed_at: str | None
     sequence: int | None
     payload_checksum: str | None
+    resource_identity: ReportResourceIdentity | None
+    resource_identity_status: str
 
 
 @dataclass(frozen=True)
@@ -65,6 +78,8 @@ class ReportStage:
     started_at: str | None
     finished_at: str | None
     error_fingerprint: str | None
+    resource_identity: ReportResourceIdentity | None
+    resource_identity_status: str
 
 
 @dataclass(frozen=True)
@@ -83,6 +98,8 @@ class ReportResource:
     staged_objects: tuple[dict[str, Scalar], ...]
     snapshot_before: str | None
     snapshot_after: str | None
+    resource_identity: ReportResourceIdentity | None
+    resource_identity_status: str
 
 
 @dataclass(frozen=True)
@@ -92,6 +109,10 @@ class ReportLineage:
     target: str
     origin: str
     derivation: str
+    source_resource_identity: ReportResourceIdentity | None
+    source_resource_identity_status: str
+    target_resource_identity: ReportResourceIdentity | None
+    target_resource_identity_status: str
 
 
 @dataclass(frozen=True)
@@ -106,6 +127,8 @@ class ReportQuality:
     evaluated_count: int | None
     failed_count: int | None
     failure_artifact_id: str | None
+    resource_identity: ReportResourceIdentity | None
+    resource_identity_status: str
 
 
 @dataclass(frozen=True)
@@ -121,6 +144,8 @@ class ReportCatalogChange:
     snapshot_before: str | None
     snapshot_after: str | None
     metadata: dict[str, Scalar]
+    resource_identity: ReportResourceIdentity | None
+    resource_identity_status: str
 
 
 @dataclass(frozen=True)
@@ -133,6 +158,8 @@ class ReportArtifact:
     expires_at: str | None
     legal_hold: bool
     status: str
+    resource_identity: ReportResourceIdentity | None
+    resource_identity_status: str
 
 
 @dataclass(frozen=True)
@@ -225,6 +252,34 @@ def _safe_metadata(value: Any) -> dict[str, Scalar]:
     return safe
 
 
+def _resource_identity(
+    row: dict[str, Any], field: str, project_id: str
+) -> tuple[ReportResourceIdentity | None, str]:
+    """Expose only producer-supplied canonical identities; never infer display text."""
+    value = row.get(field)
+    if not isinstance(value, dict):
+        return None, "incomplete"
+    resource_type = value.get("resource_type")
+    resource_id = value.get("resource_id")
+    attributes = value.get("attributes", {})
+    if (
+        not isinstance(resource_type, str)
+        or not resource_type.strip()
+        or not isinstance(resource_id, str)
+        or not resource_id.strip()
+        or value.get("tenant") != project_id
+        or not isinstance(attributes, dict)
+        or not all(
+            isinstance(key, str) and isinstance(item, str) for key, item in attributes.items()
+        )
+    ):
+        return None, "incomplete"
+    return (
+        ReportResourceIdentity(project_id, resource_type, resource_id, project_id, attributes),
+        "complete",
+    )
+
+
 def _fingerprint(value: Any) -> str | None:
     if value is None:
         return None
@@ -249,6 +304,7 @@ def _run_header(row: dict[str, Any] | None) -> ReportRunHeader | None:
 
 
 def _event(row: dict[str, Any]) -> ReportEvent:
+    identity, identity_status = _resource_identity(row, "resource_identity", str(row["project_id"]))
     return ReportEvent(
         event_id=str(row["event_id"]),
         producer=str(row["producer"]),
@@ -256,10 +312,13 @@ def _event(row: dict[str, Any]) -> ReportEvent:
         observed_at=row.get("observed_at"),
         sequence=row.get("sequence"),
         payload_checksum=row.get("payload_checksum"),
+        resource_identity=identity,
+        resource_identity_status=identity_status,
     )
 
 
 def _stage(row: dict[str, Any]) -> ReportStage:
+    identity, identity_status = _resource_identity(row, "resource_identity", str(row["project_id"]))
     return ReportStage(
         stage_id=str(row["stage_id"]),
         stage_type=str(row["stage_type"]),
@@ -270,10 +329,13 @@ def _stage(row: dict[str, Any]) -> ReportStage:
         started_at=row.get("started_at"),
         finished_at=row.get("finished_at"),
         error_fingerprint=_fingerprint(row.get("error")),
+        resource_identity=identity,
+        resource_identity_status=identity_status,
     )
 
 
 def _resource(row: dict[str, Any]) -> ReportResource:
+    identity, identity_status = _resource_identity(row, "resource_identity", str(row["project_id"]))
     return ReportResource(
         resource_id=str(row["resource_id"]),
         resource_kind=str(row["resource_kind"]),
@@ -289,6 +351,8 @@ def _resource(row: dict[str, Any]) -> ReportResource:
         staged_objects=_safe_staged_objects(row.get("staged_objects")),
         snapshot_before=row.get("snapshot_before"),
         snapshot_after=row.get("snapshot_after"),
+        resource_identity=identity,
+        resource_identity_status=identity_status,
     )
 
 
@@ -385,6 +449,28 @@ def build_run_report(
         gaps.append(
             ReportGap("historical_fields", "unavailable", "attempt_reconciliation_not_proven")
         )
+    identity_fields = {
+        "events": ("resource_identity",),
+        "stages": ("resource_identity",),
+        "resources": ("resource_identity",),
+        "lineage": ("source_resource_identity", "target_resource_identity"),
+        "quality": ("resource_identity",),
+        "catalog_changes": ("resource_identity",),
+        "artifacts": ("resource_identity",),
+    }
+    if any(
+        _resource_identity(row, field, project_id)[1] != "complete"
+        for family, fields in identity_fields.items()
+        for row in rows[family]
+        for field in fields
+    ):
+        gaps.append(
+            ReportGap(
+                "resource_identities",
+                "incomplete",
+                "one_or_more_evidence_records_lack_authoritative_resource_identity",
+            )
+        )
 
     return RunReport(
         schema_version=1,
@@ -405,6 +491,8 @@ def build_run_report(
                 str(row["target"]),
                 str(row["origin"]),
                 str(row["derivation"]),
+                *_resource_identity(row, "source_resource_identity", project_id),
+                *_resource_identity(row, "target_resource_identity", project_id),
             )
             for row in rows["lineage"]
         ),
@@ -423,6 +511,7 @@ def build_run_report(
                 row.get("evaluated_count"),
                 row.get("failed_count"),
                 row.get("failure_artifact_id"),
+                *_resource_identity(row, "resource_identity", project_id),
             )
             for row in rows["quality"]
         ),
@@ -444,6 +533,7 @@ def build_run_report(
                 row.get("snapshot_before"),
                 row.get("snapshot_after"),
                 _safe_metadata(row.get("metadata")),
+                *_resource_identity(row, "resource_identity", project_id),
             )
             for row in rows["catalog_changes"]
         ),
@@ -457,6 +547,7 @@ def build_run_report(
                 row.get("expires_at"),
                 bool(row["legal_hold"]),
                 str(row["status"]),
+                *_resource_identity(row, "resource_identity", project_id),
             )
             for row in rows["artifacts"]
         ),

--- a/src/phlo/run_evidence/store.py
+++ b/src/phlo/run_evidence/store.py
@@ -86,6 +86,11 @@ def _json(value: Any) -> str:
     return canonical_json(value)
 
 
+def _resource_identity(value: Any) -> str | None:
+    """Serialize the shared core authorization vocabulary without aliases."""
+    return _json(asdict(value)) if value is not None else None
+
+
 def _text(value: str | None) -> str | None:
     redacted = redact_payload(value)
     return redacted if isinstance(redacted, str) or redacted is None else str(redacted)
@@ -93,7 +98,7 @@ def _text(value: str | None) -> str | None:
 
 def _resource_checksum_payload(resource: RunResource) -> dict[str, Any]:
     payload = {key: value for key, value in asdict(resource).items() if key != "resource_id"}
-    for key in ("schema_hash_before", "schema_hash_after", "metadata"):
+    for key in ("schema_hash_before", "schema_hash_after", "metadata", "resource_ref"):
         if payload.get(key) in (None, {}):
             payload.pop(key, None)
     return payload
@@ -103,6 +108,9 @@ def _lineage_checksum_payload(edge: RunLineageEdge) -> dict[str, Any]:
     payload = {key: value for key, value in asdict(edge).items() if key != "lineage_edge_id"}
     if edge.attempt == 1:
         payload.pop("attempt", None)
+    for key in ("source_resource_ref", "target_resource_ref"):
+        if payload.get(key) is None:
+            payload.pop(key, None)
     return payload
 
 
@@ -110,6 +118,22 @@ def _catalog_checksum_payload(change: RunCatalogChange) -> dict[str, Any]:
     payload = {key: value for key, value in asdict(change).items() if key != "catalog_change_id"}
     if change.quality_decision_id is None:
         payload.pop("quality_decision_id", None)
+    if change.resource_ref is None:
+        payload.pop("resource_ref", None)
+    return payload
+
+
+def _quality_checksum_payload(result: RunQualityResult) -> dict[str, Any]:
+    payload = {key: value for key, value in asdict(result).items() if key != "quality_result_id"}
+    if result.resource_ref is None:
+        payload.pop("resource_ref", None)
+    return payload
+
+
+def _artifact_checksum_payload(artifact: RunArtifact) -> dict[str, Any]:
+    payload = {key: value for key, value in asdict(artifact).items() if key != "artifact_id"}
+    if artifact.resource_ref is None:
+        payload.pop("resource_ref", None)
     return payload
 
 
@@ -121,6 +145,15 @@ _JSON_ROW_FIELDS: dict[str, dict[str, type]] = {
     "run_catalog_change": {"metadata": dict},
     "run_quality_result": {"metadata": dict},
     "run_reconciliation_decision": {"missing_evidence": list},
+}
+_OPTIONAL_JSON_ROW_FIELDS: dict[str, set[str]] = {
+    "run_event": {"resource_identity"},
+    "run_stage": {"resource_identity"},
+    "run_resource": {"resource_identity"},
+    "run_lineage_edge": {"source_resource_identity", "target_resource_identity"},
+    "run_catalog_change": {"resource_identity"},
+    "run_quality_result": {"resource_identity"},
+    "run_artifact": {"resource_identity"},
 }
 _BOOLEAN_ROW_FIELDS = {
     "run_quality_result": {"blocking", "passed"},
@@ -227,6 +260,7 @@ class _SqlRunEvidenceStore:
         lineage_edges: tuple[RunLineageEdge, ...] = (),
         resources: tuple[RunResource, ...] = (),
         catalog_change: RunCatalogChange | None = None,
+        artifacts: tuple[RunArtifact, ...] = (),
     ) -> bool:
         """Append one event and optional derived records in one transaction."""
         self._validate_append_event_inputs(
@@ -237,6 +271,7 @@ class _SqlRunEvidenceStore:
             lineage_edges=lineage_edges,
             resources=resources,
             catalog_change=catalog_change,
+            artifacts=artifacts,
         )
         with self._transaction() as (_, cursor):
             existing = self._event_identity(cursor, event)
@@ -277,6 +312,8 @@ class _SqlRunEvidenceStore:
                     self._insert_resource(cursor, resource)
                 if catalog_change is not None:
                     self._insert_catalog_change(cursor, catalog_change)
+                for artifact in artifacts:
+                    self._insert_artifact(cursor, artifact)
             return inserted
 
     def _validate_append_event_inputs(
@@ -289,6 +326,7 @@ class _SqlRunEvidenceStore:
         lineage_edges: tuple[RunLineageEdge, ...],
         resources: tuple[RunResource, ...],
         catalog_change: RunCatalogChange | None,
+        artifacts: tuple[RunArtifact, ...],
     ) -> None:
         """Reject cross-boundary bundles before a placeholder parent can be created."""
         self._require_id("project_id", event.project_id)
@@ -352,6 +390,10 @@ class _SqlRunEvidenceStore:
                 catalog_change,
                 object_id=catalog_change.catalog_change_id,
                 attempt=catalog_change.attempt,
+            )
+        for artifact in artifacts:
+            validate_object(
+                "artifact", artifact, object_id=artifact.artifact_id, attempt=artifact.attempt
             )
 
     def _event_identity(self, cursor: Any, event: RunEvent) -> tuple[Any, ...] | None:
@@ -942,11 +984,12 @@ class _SqlRunEvidenceStore:
             event.attempt,
             _json(redacted),
             checksum,
+            _resource_identity(event.resource_ref),
         )
         cursor.execute(
             f"INSERT INTO {self._table('run_event')} "
             "(project_id, run_id, stage_id, event_id, event_type, schema_version, producer, "
-            "observed_at, sequence, attempt, payload, payload_checksum) VALUES ("
+            "observed_at, sequence, attempt, payload, payload_checksum, resource_identity) VALUES ("
             + ", ".join([self.placeholder] * len(values))
             + ") ON CONFLICT (project_id, producer, event_id) DO NOTHING",
             values,
@@ -954,7 +997,7 @@ class _SqlRunEvidenceStore:
         inserted = cursor.rowcount == 1
         cursor.execute(
             f"SELECT project_id, run_id, event_type, schema_version, stage_id, observed_at, "
-            f"sequence, attempt, payload_checksum FROM {self._table('run_event')} "
+            f"sequence, attempt, payload_checksum, resource_identity FROM {self._table('run_event')} "
             f"WHERE project_id = {self.placeholder} AND producer = {self.placeholder} "
             f"AND event_id = {self.placeholder}",
             (event.project_id, event.producer, event.event_id),
@@ -966,12 +1009,23 @@ class _SqlRunEvidenceStore:
             raise IdempotencyConflict(
                 f"event {event.producer}/{event.event_id} is correlated to another run"
             )
-        if (existing[2], existing[3], existing[4], existing[7], existing[8]) != (
+        existing_resource_identity = existing[9]
+        if isinstance(existing_resource_identity, dict):
+            existing_resource_identity = _json(existing_resource_identity)
+        if (
+            existing[2],
+            existing[3],
+            existing[4],
+            existing[7],
+            existing[8],
+            existing_resource_identity,
+        ) != (
             event.event_type,
             event.schema_version,
             event.stage_id,
             event.attempt,
             checksum,
+            _resource_identity(event.resource_ref),
         ):
             raise IdempotencyConflict(
                 f"event {event.producer}/{event.event_id} was replayed with different attempt or payload"
@@ -1170,18 +1224,19 @@ class _SqlRunEvidenceStore:
     def _insert_stage(self, cursor: Any, stage: RunStage) -> None:
         self._require_id("stage_id", stage.stage_id)
         self._validate_stage_write_references(cursor, stage)
-        immutable_checksum = payload_checksum(
-            {
-                "stage_id": stage.stage_id,
-                "project_id": stage.project_id,
-                "run_id": stage.run_id,
-                "stage_type": stage.stage_type,
-                "provider": stage.provider,
-                "tool": stage.tool,
-                "asset": stage.asset,
-                "attempt": stage.attempt,
-            }
-        )
+        immutable_payload = {
+            "stage_id": stage.stage_id,
+            "project_id": stage.project_id,
+            "run_id": stage.run_id,
+            "stage_type": stage.stage_type,
+            "provider": stage.provider,
+            "tool": stage.tool,
+            "asset": stage.asset,
+            "attempt": stage.attempt,
+        }
+        if stage.resource_ref is not None:
+            immutable_payload["resource_ref"] = asdict(stage.resource_ref)
+        immutable_checksum = payload_checksum(immutable_payload)
         values = (
             stage.stage_id,
             stage.project_id,
@@ -1197,11 +1252,12 @@ class _SqlRunEvidenceStore:
             _json(stage.metrics),
             _text(stage.error),
             immutable_checksum,
+            _resource_identity(stage.resource_ref),
         )
         cursor.execute(
             f"INSERT INTO {self._table('run_stage')} "
             "(stage_id, project_id, run_id, stage_type, provider, tool, asset, attempt, status, "
-            "started_at, finished_at, metrics, error, record_checksum) VALUES ("
+            "started_at, finished_at, metrics, error, record_checksum, resource_identity) VALUES ("
             + ", ".join([self.placeholder] * len(values))
             + ") ON CONFLICT (project_id, run_id, stage_id) DO NOTHING",
             values,
@@ -1277,13 +1333,14 @@ class _SqlRunEvidenceStore:
             _text(resource.snapshot_after),
             _json(resource.metadata),
             record_checksum,
+            _resource_identity(resource.resource_ref),
         )
         cursor.execute(
             f"INSERT INTO {self._table('run_resource')} "
             "(resource_id, project_id, run_id, attempt, resource_kind, role, normalized_identity, uri, "
             "table_name, catalog, ref_name, schema_hash, schema_hash_before, schema_hash_after, "
             "watermark, record_count, byte_count, staged_objects, snapshot_before, snapshot_after, "
-            "metadata, record_checksum) VALUES ("
+            "metadata, record_checksum, resource_identity) VALUES ("
             + ", ".join([self.placeholder] * len(values))
             + ") ON CONFLICT (project_id, run_id, resource_id) DO NOTHING",
             values,
@@ -1314,11 +1371,13 @@ class _SqlRunEvidenceStore:
             _text(edge.derivation),
             edge.confidence,
             record_checksum,
+            _resource_identity(edge.source_resource_ref),
+            _resource_identity(edge.target_resource_ref),
         )
         cursor.execute(
             f"INSERT INTO {self._table('run_lineage_edge')} "
             "(lineage_edge_id, project_id, run_id, attempt, source, target, column_mapping, origin, "
-            "derivation, confidence, record_checksum) VALUES ("
+            "derivation, confidence, record_checksum, source_resource_identity, target_resource_identity) VALUES ("
             + ", ".join([self.placeholder] * len(values))
             + ") ON CONFLICT (project_id, run_id, lineage_edge_id) DO NOTHING",
             values,
@@ -1344,9 +1403,7 @@ class _SqlRunEvidenceStore:
                 stage_id=result.stage_id,
                 attempt=result.attempt,
             )
-        record_checksum = payload_checksum(
-            {key: value for key, value in asdict(result).items() if key != "quality_result_id"}
-        )
+        record_checksum = payload_checksum(_quality_checksum_payload(result))
         values = (
             result.quality_result_id,
             result.project_id,
@@ -1363,11 +1420,12 @@ class _SqlRunEvidenceStore:
             _text(result.failure_artifact_id),
             _json(result.metadata),
             record_checksum,
+            _resource_identity(result.resource_ref),
         )
         cursor.execute(
             f"INSERT INTO {self._table('run_quality_result')} "
             "(quality_result_id, project_id, run_id, attempt, stage_id, check_id, asset, severity, blocking, "
-            "passed, evaluated_count, failed_count, failure_artifact_id, metadata, record_checksum) VALUES ("
+            "passed, evaluated_count, failed_count, failure_artifact_id, metadata, record_checksum, resource_identity) VALUES ("
             + ", ".join([self.placeholder] * len(values))
             + ") ON CONFLICT (project_id, run_id, quality_result_id) DO NOTHING",
             values,
@@ -1404,12 +1462,13 @@ class _SqlRunEvidenceStore:
             _text(change.quality_decision_id),
             _json(change.metadata),
             record_checksum,
+            _resource_identity(change.resource_ref),
         )
         cursor.execute(
             f"INSERT INTO {self._table('run_catalog_change')} "
             "(catalog_change_id, project_id, run_id, attempt, catalog_ref, content_key, operation, "
             "source_hash, target_hash, commit_hash, commit_message, merge_outcome, snapshot_before, "
-            "snapshot_after, quality_decision_id, metadata, record_checksum) VALUES ("
+            "snapshot_after, quality_decision_id, metadata, record_checksum, resource_identity) VALUES ("
             + ", ".join([self.placeholder] * len(values))
             + ") ON CONFLICT (project_id, run_id, catalog_change_id) DO NOTHING",
             values,
@@ -1427,9 +1486,7 @@ class _SqlRunEvidenceStore:
 
     def _insert_artifact(self, cursor: Any, artifact: RunArtifact) -> None:
         self._require_id("artifact_id", artifact.artifact_id)
-        record_checksum = payload_checksum(
-            {key: value for key, value in asdict(artifact).items() if key != "artifact_id"}
-        )
+        record_checksum = payload_checksum(_artifact_checksum_payload(artifact))
         values = (
             artifact.artifact_id,
             artifact.project_id,
@@ -1444,11 +1501,12 @@ class _SqlRunEvidenceStore:
             artifact.legal_hold,
             artifact.status.value,
             record_checksum,
+            _resource_identity(artifact.resource_ref),
         )
         cursor.execute(
             f"INSERT INTO {self._table('run_artifact')} "
             "(artifact_id, project_id, run_id, attempt, artifact_kind, uri, content_type, checksum, "
-            "retention_class, expires_at, legal_hold, status, record_checksum) VALUES ("
+            "retention_class, expires_at, legal_hold, status, record_checksum, resource_identity) VALUES ("
             + ", ".join([self.placeholder] * len(values))
             + ") ON CONFLICT (project_id, run_id, artifact_id) DO NOTHING",
             values,
@@ -1486,6 +1544,18 @@ class _SqlRunEvidenceStore:
                 value = [] if expected_type is list else {}
             if not isinstance(value, expected_type):
                 raise ValueError(f"{table}.{field} must be a {expected_type.__name__}")
+            result[field] = value
+        for field in _OPTIONAL_JSON_ROW_FIELDS.get(table, set()):
+            value = result.get(field)
+            if isinstance(value, (bytes, bytearray)):
+                value = value.decode("utf-8")
+            if isinstance(value, str):
+                try:
+                    value = json.loads(value)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"{table}.{field} must be JSON") from exc
+            if value is not None and not isinstance(value, dict):
+                raise ValueError(f"{table}.{field} must be an object or null")
             result[field] = value
         for field in _BOOLEAN_ROW_FIELDS.get(table, set()):
             if result.get(field) is not None:
@@ -1570,6 +1640,18 @@ class SQLiteRunEvidenceStore(_SqlRunEvidenceStore):
         self._connection.executescript(sql)
         self._migrate_sqlite_reconciliation_schema()
         migration = (sql_root / "004_run_evidence_instrumentation_sqlite.sql").read_text(
+            encoding="utf-8"
+        )
+        for statement in migration.split(";"):
+            statement = statement.strip()
+            if not statement:
+                continue
+            try:
+                self._connection.execute(statement)
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    raise
+        migration = (sql_root / "005_run_evidence_resource_identity_sqlite.sql").read_text(
             encoding="utf-8"
         )
         for statement in migration.split(";"):
@@ -1783,6 +1865,11 @@ class PostgresRunEvidenceStore(_SqlRunEvidenceStore):
                 )
                 cursor.execute(
                     (sql_root / "004_run_evidence_instrumentation.sql").read_text(encoding="utf-8")
+                )
+                cursor.execute(
+                    (sql_root / "005_run_evidence_resource_identity.sql").read_text(
+                        encoding="utf-8"
+                    )
                 )
             connection.commit()
         except Exception:

--- a/src/phlo/sql/005_run_evidence_resource_identity.sql
+++ b/src/phlo/sql/005_run_evidence_resource_identity.sql
@@ -1,0 +1,13 @@
+-- Canonical authorization identities for report children (migration 005).
+-- NULL means a historical or incomplete record; projections must never infer it.
+ALTER TABLE phlo.run_event ADD COLUMN IF NOT EXISTS resource_identity JSONB;
+ALTER TABLE phlo.run_stage ADD COLUMN IF NOT EXISTS resource_identity JSONB;
+ALTER TABLE phlo.run_resource ADD COLUMN IF NOT EXISTS resource_identity JSONB;
+ALTER TABLE phlo.run_lineage_edge ADD COLUMN IF NOT EXISTS source_resource_identity JSONB;
+ALTER TABLE phlo.run_lineage_edge ADD COLUMN IF NOT EXISTS target_resource_identity JSONB;
+ALTER TABLE phlo.run_quality_result ADD COLUMN IF NOT EXISTS resource_identity JSONB;
+ALTER TABLE phlo.run_catalog_change ADD COLUMN IF NOT EXISTS resource_identity JSONB;
+ALTER TABLE phlo.run_artifact ADD COLUMN IF NOT EXISTS resource_identity JSONB;
+
+INSERT INTO phlo.run_evidence_schema_version(version) VALUES (4)
+ON CONFLICT (version) DO NOTHING;

--- a/src/phlo/sql/005_run_evidence_resource_identity_sqlite.sql
+++ b/src/phlo/sql/005_run_evidence_resource_identity_sqlite.sql
@@ -1,0 +1,10 @@
+-- SQLite form of the canonical report-resource identity migration.
+ALTER TABLE run_event ADD COLUMN resource_identity TEXT;
+ALTER TABLE run_stage ADD COLUMN resource_identity TEXT;
+ALTER TABLE run_resource ADD COLUMN resource_identity TEXT;
+ALTER TABLE run_lineage_edge ADD COLUMN source_resource_identity TEXT;
+ALTER TABLE run_lineage_edge ADD COLUMN target_resource_identity TEXT;
+ALTER TABLE run_quality_result ADD COLUMN resource_identity TEXT;
+ALTER TABLE run_catalog_change ADD COLUMN resource_identity TEXT;
+ALTER TABLE run_artifact ADD COLUMN resource_identity TEXT;
+INSERT OR IGNORE INTO run_evidence_schema_version(version) VALUES (4);

--- a/tests/observability/test_run_evidence.py
+++ b/tests/observability/test_run_evidence.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 import pytest
 
 from phlo.capabilities import ResourceRef
+from phlo.hooks import HookBus
 from phlo.hooks.emitters import (
     IngestionEventContext,
     IngestionEventEmitter,
@@ -1745,6 +1746,72 @@ def test_observation_rejects_catalog_change_without_canonical_producer_identity(
         )
 
     assert store.get_run("project", "run") is None
+
+
+@pytest.mark.parametrize(
+    "resource_identity",
+    [
+        None,
+        {"resource_type": "log", "resource_id": "run-log", "tenant": "other"},
+    ],
+)
+def test_observation_rejects_artifact_without_canonical_producer_identity(
+    resource_identity: dict[str, object] | None,
+) -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    artifact: dict[str, object] = {
+        "artifact_id": "run-log",
+        "artifact_kind": "log",
+    }
+    if resource_identity is not None:
+        artifact["resource_identity"] = resource_identity
+
+    with pytest.raises(ValueError, match="artifact requires canonical"):
+        CoreRunEvidenceHookProvider(store)._handle_event(
+            RunEvidenceObservationEvent(
+                event_type="run_evidence.observation",
+                observation_type="publish",
+                status="success",
+                artifacts=[artifact],
+                correlation=HookCorrelation(project_id="project", run_id="run"),
+            )
+        )
+
+    assert store.get_run("project", "run") is None
+
+
+def test_public_observation_boundary_persists_canonical_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    bus = HookBus()
+    bus.register_provider(CoreRunEvidenceHookProvider(store), plugin_name="test")
+    monkeypatch.setattr("phlo.run_evidence.emit.get_hook_bus", lambda: bus)
+
+    emit_observation(
+        project_id="project",
+        run_id="run",
+        observation_type="publish",
+        status="success",
+        producer="provider",
+        artifacts=[
+            {
+                "artifact_id": "run-log",
+                "artifact_kind": "log",
+                "resource_identity": {
+                    "resource_type": "log",
+                    "resource_id": "run-log",
+                    "tenant": "project",
+                    "attributes": {"classification": "internal"},
+                },
+            }
+        ],
+    )
+
+    report = build_run_report(store, "project", "run", 1)
+    assert report.artifacts[0].resource_identity == ReportResourceIdentity(
+        "project", "log", "run-log", "project", {"classification": "internal"}
+    )
 
 
 def test_observation_redacts_rows_and_credentials() -> None:

--- a/tests/observability/test_run_evidence.py
+++ b/tests/observability/test_run_evidence.py
@@ -7,7 +7,7 @@ import sqlite3
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import asdict, replace
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -15,6 +15,7 @@ from uuid import uuid4
 
 import pytest
 
+from phlo.capabilities import ResourceRef
 from phlo.hooks.emitters import (
     IngestionEventContext,
     IngestionEventEmitter,
@@ -51,8 +52,14 @@ from phlo.run_evidence import (
 from phlo.run_evidence.emit import emit_observation
 from phlo.run_evidence.hooks import CoreRunEvidenceHookProvider
 from phlo.run_evidence.redaction import canonical_json, payload_checksum
-from phlo.run_evidence.report import build_run_report
-from phlo.run_evidence.store import _catalog_checksum_payload, _resource_checksum_payload
+from phlo.run_evidence.report import ReportResourceIdentity, build_run_report
+from phlo.run_evidence.store import (
+    _artifact_checksum_payload,
+    _catalog_checksum_payload,
+    _lineage_checksum_payload,
+    _quality_checksum_payload,
+    _resource_checksum_payload,
+)
 
 
 def _store_with_run(*, project_id: str = "project", run_id: str = "run") -> SQLiteRunEvidenceStore:
@@ -208,6 +215,119 @@ def test_run_report_orders_cross_producer_events_and_redacts_legacy_locations() 
     assert report.artifacts[0].uri == "https://example.test/report?token=<redacted>"
 
 
+def test_report_round_trips_canonical_resource_identities_without_display_inference() -> None:
+    store = _store_with_run()
+    run_ref = ResourceRef("run", "run", tenant="project")
+    stage_ref = ResourceRef("asset", "raw.orders", tenant="project")
+    resource_ref = ResourceRef(
+        "dataset",
+        "warehouse.orders",
+        tenant="project",
+        attributes={"classification": "restricted", "owner": "finance"},
+    )
+    quality_ref = ResourceRef("quality_check", "orders-freshness", tenant="project")
+    catalog_ref = ResourceRef("catalog_change", "promotion-1", tenant="project")
+    artifact_ref = ResourceRef("artifact", "report-1", tenant="project")
+    store.append_event(
+        RunEvent(
+            project_id="project",
+            run_id="run",
+            event_id="event",
+            event_type="stage.finished",
+            producer="test",
+            payload={},
+            resource_ref=run_ref,
+        ),
+        stage=RunStage(
+            project_id="project",
+            run_id="run",
+            stage_id="stage",
+            asset="display-only-asset",
+            resource_ref=stage_ref,
+        ),
+        resources=(
+            RunResource(
+                project_id="project",
+                run_id="run",
+                resource_id="resource",
+                role="input",
+                normalized_identity="display-only-resource",
+                resource_ref=resource_ref,
+            ),
+        ),
+        lineage_edges=(
+            RunLineageEdge(
+                project_id="project",
+                run_id="run",
+                lineage_edge_id="edge",
+                source="display-source",
+                target="display-target",
+                source_resource_ref=stage_ref,
+                target_resource_ref=resource_ref,
+            ),
+        ),
+        quality_result=RunQualityResult(
+            project_id="project",
+            run_id="run",
+            quality_result_id="quality",
+            check_id="display-only-check",
+            resource_ref=quality_ref,
+        ),
+        catalog_change=RunCatalogChange(
+            project_id="project",
+            run_id="run",
+            catalog_change_id="catalog",
+            operation="promotion",
+            resource_ref=catalog_ref,
+        ),
+        artifacts=(
+            RunArtifact(
+                project_id="project",
+                run_id="run",
+                artifact_id="artifact",
+                artifact_kind="log",
+                resource_ref=artifact_ref,
+            ),
+        ),
+    )
+
+    report = build_run_report(store, "project", "run", 1)
+
+    assert report.lifecycle.events[0].resource_identity == ReportResourceIdentity(
+        "project", "run", "run", "project", {}
+    )
+    assert report.stages[0].resource_identity == ReportResourceIdentity(
+        "project", "asset", "raw.orders", "project", {}
+    )
+    assert report.inputs[0].resource_identity == ReportResourceIdentity(
+        "project",
+        "dataset",
+        "warehouse.orders",
+        "project",
+        {"classification": "restricted", "owner": "finance"},
+    )
+    assert report.lineage[0].source_resource_identity == ReportResourceIdentity(
+        "project", "asset", "raw.orders", "project", {}
+    )
+    assert report.lineage[0].target_resource_identity == ReportResourceIdentity(
+        "project",
+        "dataset",
+        "warehouse.orders",
+        "project",
+        {"classification": "restricted", "owner": "finance"},
+    )
+    assert report.quality[0].resource_identity == ReportResourceIdentity(
+        "project", "quality_check", "orders-freshness", "project", {}
+    )
+    assert report.catalog_changes[0].resource_identity == ReportResourceIdentity(
+        "project", "catalog_change", "promotion-1", "project", {}
+    )
+    assert report.artifacts[0].resource_identity == ReportResourceIdentity(
+        "project", "artifact", "report-1", "project", {}
+    )
+    assert not any(gap.field == "resource_identities" for gap in report.gaps)
+
+
 def _insert_v2_fixture_rows(store: object) -> dict[str, object]:
     """Insert rows using only the columns available after migrations 002+003."""
     project_id = "legacy-project"
@@ -283,9 +403,36 @@ def _insert_v2_fixture_rows(store: object) -> dict[str, object]:
         started_at=datetime(2026, 7, 1, 1, 2, 3, tzinfo=UTC),
         finished_at=datetime(2026, 7, 1, 1, 3, 4, tzinfo=UTC),
     )
-    store.append_stage(stage)
     with store._transaction() as (_, cursor):
         p = store.placeholder
+        stage_checksum = payload_checksum(
+            {
+                "stage_id": stage.stage_id,
+                "project_id": project_id,
+                "run_id": run_id,
+                "stage_type": stage.stage_type,
+                "provider": stage.provider,
+                "tool": stage.tool,
+                "asset": stage.asset,
+                "attempt": attempt,
+            }
+        )
+        cursor.execute(
+            f"INSERT INTO {store._table('run_stage')} "
+            "(stage_id, project_id, run_id, stage_type, attempt, status, started_at, finished_at, "
+            "record_checksum) VALUES (" + ", ".join([p] * 9) + ")",
+            (
+                stage.stage_id,
+                project_id,
+                run_id,
+                stage.stage_type,
+                attempt,
+                stage.status,
+                stage.started_at.isoformat(),
+                stage.finished_at.isoformat(),
+                stage_checksum,
+            ),
+        )
         cursor.execute(
             f"INSERT INTO {store._table('run_event')} "
             "(project_id, run_id, event_id, event_type, schema_version, producer, observed_at, "
@@ -336,9 +483,7 @@ def _insert_v2_fixture_rows(store: object) -> dict[str, object]:
                 catalog_checksum,
             ),
         )
-        quality_checksum = payload_checksum(
-            {key: value for key, value in asdict(quality).items() if key != "quality_result_id"}
-        )
+        quality_checksum = payload_checksum(_quality_checksum_payload(quality))
         cursor.execute(
             f"INSERT INTO {store._table('run_quality_result')} "
             "(quality_result_id, project_id, run_id, attempt, check_id, blocking, passed, metadata, "
@@ -355,9 +500,7 @@ def _insert_v2_fixture_rows(store: object) -> dict[str, object]:
                 quality_checksum,
             ),
         )
-        artifact_checksum = payload_checksum(
-            {key: value for key, value in asdict(artifact).items() if key != "artifact_id"}
-        )
+        artifact_checksum = payload_checksum(_artifact_checksum_payload(artifact))
         cursor.execute(
             f"INSERT INTO {store._table('run_artifact')} "
             "(artifact_id, project_id, run_id, attempt, artifact_kind, expires_at, legal_hold, status, "
@@ -1250,7 +1393,7 @@ def test_sqlite_migration_is_versioned_and_idempotent() -> None:
     store._initialize_schema()
     with store._transaction() as (_, cursor):
         cursor.execute("SELECT version FROM run_evidence_schema_version")
-        assert [row[0] for row in cursor.fetchall()] == [1, 2, RUN_EVIDENCE_SCHEMA_VERSION]
+        assert [row[0] for row in cursor.fetchall()] == [1, 2, 3, RUN_EVIDENCE_SCHEMA_VERSION]
         for table in (
             "run_event",
             "run_resource",
@@ -1460,8 +1603,15 @@ def test_observation_persists_provider_resources_and_catalog_change() -> None:
             producer="provider",
             resources=[
                 {
+                    "resource_id": "stage-object-1",
                     "resource_kind": "staged_object",
                     "role": "staged",
+                    "resource_identity": {
+                        "resource_type": "staged_object",
+                        "resource_id": "stage-object-1",
+                        "tenant": "project",
+                        "attributes": {"classification": "internal"},
+                    },
                     "staged_objects": [
                         {"identity": "sha256:abc", "checksum": "abc", "byte_count": 10}
                     ],
@@ -1469,12 +1619,30 @@ def test_observation_persists_provider_resources_and_catalog_change() -> None:
                 }
             ],
             catalog_change={
+                "catalog_change_id": "promotion-1",
                 "operation": "promotion",
                 "catalog_ref": "main",
+                "resource_identity": {
+                    "resource_type": "catalog",
+                    "resource_id": "main",
+                    "tenant": "project",
+                    "attributes": {"environment": "production"},
+                },
                 "source_hash": "source",
                 "target_hash": "target",
                 "merge_outcome": "promoted",
             },
+            artifacts=[
+                {
+                    "artifact_id": "run-log-1",
+                    "artifact_kind": "log",
+                    "resource_identity": {
+                        "resource_type": "log",
+                        "resource_id": "run-log-1",
+                        "tenant": "project",
+                    },
+                }
+            ],
             correlation=HookCorrelation(project_id="project", run_id="run", attempt=2),
         )
     )
@@ -1491,6 +1659,92 @@ def test_observation_persists_provider_resources_and_catalog_change() -> None:
     assert resource[2] == '{"watermark":{"status":"unavailable"}}'
     assert change[0] == 2
     assert tuple(change[1:]) == ("source", "target", "promoted")
+    report = build_run_report(store, "project", "run", 2)
+    assert report.staging[0].resource_identity == ReportResourceIdentity(
+        "project",
+        "staged_object",
+        "stage-object-1",
+        "project",
+        {"classification": "internal"},
+    )
+    assert report.catalog_changes[0].resource_identity == ReportResourceIdentity(
+        "project", "catalog", "main", "project", {"environment": "production"}
+    )
+    assert report.artifacts[0].resource_identity == ReportResourceIdentity(
+        "project", "log", "run-log-1", "project", {}
+    )
+
+
+@pytest.mark.parametrize(
+    "resource_identity",
+    [
+        None,
+        {"resource_type": "dataset", "resource_id": "raw.orders", "tenant": "other"},
+        {
+            "resource_type": "dataset",
+            "resource_id": "raw.orders",
+            "tenant": "project",
+            "attributes": {"classification": 7},
+        },
+    ],
+)
+def test_observation_rejects_resource_without_canonical_producer_identity(
+    resource_identity: dict[str, object] | None,
+) -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    raw_resource: dict[str, object] = {
+        "resource_id": "local-correlation-id",
+        "resource_kind": "dataset",
+        "role": "output",
+    }
+    if resource_identity is not None:
+        raw_resource["resource_identity"] = resource_identity
+
+    with pytest.raises(ValueError, match="observation resource requires canonical"):
+        CoreRunEvidenceHookProvider(store)._handle_event(
+            RunEvidenceObservationEvent(
+                event_type="run_evidence.observation",
+                observation_type="ingest",
+                status="success",
+                resources=[raw_resource],
+                correlation=HookCorrelation(project_id="project", run_id="run"),
+            )
+        )
+
+    assert store.get_run("project", "run") is None
+
+
+@pytest.mark.parametrize(
+    "resource_identity",
+    [
+        None,
+        {"resource_type": "catalog", "resource_id": "main", "tenant": "other"},
+    ],
+)
+def test_observation_rejects_catalog_change_without_canonical_producer_identity(
+    resource_identity: dict[str, object] | None,
+) -> None:
+    store = SQLiteRunEvidenceStore(":memory:")
+    catalog_change: dict[str, object] = {
+        "catalog_change_id": "local-correlation-id",
+        "operation": "promotion",
+        "catalog_ref": "main",
+    }
+    if resource_identity is not None:
+        catalog_change["resource_identity"] = resource_identity
+
+    with pytest.raises(ValueError, match="catalog change requires canonical"):
+        CoreRunEvidenceHookProvider(store)._handle_event(
+            RunEvidenceObservationEvent(
+                event_type="run_evidence.observation",
+                observation_type="publish",
+                status="success",
+                catalog_change=catalog_change,
+                correlation=HookCorrelation(project_id="project", run_id="run"),
+            )
+        )
+
+    assert store.get_run("project", "run") is None
 
 
 def test_observation_redacts_rows_and_credentials() -> None:
@@ -1507,6 +1761,11 @@ def test_observation_redacts_rows_and_credentials() -> None:
                 {
                     "resource_kind": "staged_object",
                     "role": "staged",
+                    "resource_identity": {
+                        "resource_type": "staged_object",
+                        "resource_id": "redacted-object",
+                        "tenant": "project",
+                    },
                     "uri": "https://example.test/object?client_secret=TOPSECRET",
                     "metadata": {"rows": [{"email": "alice@example.test"}]},
                 }
@@ -1672,24 +1931,30 @@ def test_sqlite_v1_store_upgrades_additive_instrumentation_columns(tmp_path) -> 
     assert "attempt" in lineage_columns
     assert "attempt" in quality_columns
     assert "attempt" in artifact_columns
-    assert versions == [1, 2, RUN_EVIDENCE_SCHEMA_VERSION]
+    assert versions == [1, 2, 3, RUN_EVIDENCE_SCHEMA_VERSION]
 
 
 def test_v2_field_order_and_additive_checksums_are_compatibility_safe() -> None:
     from dataclasses import fields
 
-    assert [field.name for field in fields(RunResource)][-4:] == [
+    assert [field.name for field in fields(RunResource)][-5:] == [
         "attempt",
         "schema_hash_before",
         "schema_hash_after",
         "metadata",
+        "resource_ref",
     ]
-    assert [field.name for field in fields(RunCatalogChange)][-2:] == [
+    assert [field.name for field in fields(RunCatalogChange)][-3:] == [
         "attempt",
         "quality_decision_id",
+        "resource_ref",
     ]
-    assert [field.name for field in fields(RunArtifact)][-1:] == ["attempt"]
-    assert [field.name for field in fields(RunLineageEdge)][-1:] == ["attempt"]
+    assert [field.name for field in fields(RunArtifact)][-2:] == ["attempt", "resource_ref"]
+    assert [field.name for field in fields(RunLineageEdge)][-3:] == [
+        "attempt",
+        "source_resource_ref",
+        "target_resource_ref",
+    ]
 
     store = _store_with_run()
     resource = RunResource(project_id="project", run_id="run", resource_id="resource")
@@ -1718,28 +1983,9 @@ def test_v2_field_order_and_additive_checksums_are_compatibility_safe() -> None:
             ("lineage",),
         )
         lineage_checksum = cursor.fetchone()[0]
-    assert resource_checksum == payload_checksum(
-        {
-            key: value
-            for key, value in asdict(resource).items()
-            if key != "resource_id"
-            and key not in {"schema_hash_before", "schema_hash_after", "metadata"}
-        }
-    )
-    assert catalog_checksum == payload_checksum(
-        {
-            key: value
-            for key, value in asdict(catalog_change).items()
-            if key != "catalog_change_id" and key != "quality_decision_id"
-        }
-    )
-    assert lineage_checksum == payload_checksum(
-        {
-            key: value
-            for key, value in asdict(lineage).items()
-            if key not in {"lineage_edge_id", "attempt"}
-        }
-    )
+    assert resource_checksum == payload_checksum(_resource_checksum_payload(resource))
+    assert catalog_checksum == payload_checksum(_catalog_checksum_payload(catalog_change))
+    assert lineage_checksum == payload_checksum(_lineage_checksum_payload(lineage))
     with pytest.raises(IdempotencyConflict):
         store.append_resource(replace(resource, schema_hash_before="changed"))
     with pytest.raises(IdempotencyConflict):
@@ -1752,7 +1998,7 @@ def test_v2_field_order_and_additive_checksums_are_compatibility_safe() -> None:
         store.append_lineage_edge(replace(lineage, attempt=2))
 
 
-def test_true_v2_to_v3_upgrade_is_idempotent_and_compatible(tmp_path) -> None:
+def test_true_v2_to_v4_upgrade_is_idempotent_and_marks_legacy_identity_incomplete(tmp_path) -> None:
     store = _make_sqlite_v2_store(tmp_path / "v2-evidence.db")
     fixture = _insert_v2_fixture_rows(store)
     before_checksums = _fixture_checksums(store)
@@ -1767,7 +2013,7 @@ def test_true_v2_to_v3_upgrade_is_idempotent_and_compatible(tmp_path) -> None:
 
     with store._transaction() as (_, cursor):
         cursor.execute("SELECT version FROM run_evidence_schema_version ORDER BY version")
-        assert [row[0] for row in cursor.fetchall()] == [1, 2, 3]
+        assert [row[0] for row in cursor.fetchall()] == [1, 2, 3, 4]
     assert _fixture_checksums(store) == before_checksums
 
     assert store.append_event(fixture["event"]) is False
@@ -1775,6 +2021,13 @@ def test_true_v2_to_v3_upgrade_is_idempotent_and_compatible(tmp_path) -> None:
     assert store.append_catalog_change(fixture["catalog"]) is None
     assert store.append_quality_result(fixture["quality"]) is None
     assert store.append_artifact(fixture["artifact"]) is None
+    report = build_run_report(store, fixture["project_id"], fixture["run_id"], fixture["attempt"])
+    assert report.staging[0].resource_identity is None
+    assert report.staging[0].resource_identity_status == "incomplete"
+    assert report.artifacts[0].resource_identity is None
+    assert any(
+        gap.field == "resource_identities" and gap.status == "incomplete" for gap in report.gaps
+    )
     with pytest.raises(IdempotencyConflict):
         store.append_resource(replace(fixture["resource"], uri="https://changed.example"))
     with pytest.raises(IdempotencyConflict):
@@ -1908,6 +2161,11 @@ def test_wap_rejection_is_failed_terminal_publish_evidence() -> None:
                 "operation": "promotion",
                 "catalog_ref": "main",
                 "merge_outcome": "rejected_quality",
+                "resource_identity": {
+                    "resource_type": "catalog",
+                    "resource_id": "main",
+                    "tenant": "project",
+                },
             },
             correlation=HookCorrelation(project_id="project", run_id="run", attempt=1),
         )
@@ -1999,7 +2257,15 @@ def test_wap_rejection_preserves_authoritative_success_status() -> None:
             status="rejected",
             run_status="success",
             producer="phlo-dagster-nessie",
-            catalog_change={"operation": "promotion", "merge_outcome": "rejected_quality"},
+            catalog_change={
+                "operation": "promotion",
+                "merge_outcome": "rejected_quality",
+                "resource_identity": {
+                    "resource_type": "catalog",
+                    "resource_id": "main",
+                    "tenant": "project",
+                },
+            },
             correlation=HookCorrelation(project_id="project", run_id="run"),
         )
     )


### PR DESCRIPTION
## What changed

Adds canonical resource identity to run-evidence models, persistence, migration, and report projections. New resources and artifacts fail closed when identity is missing, malformed, or cross-project; historical identity-less rows remain readable and explicitly incomplete.

## Why

Report-node authorization needs authoritative child-resource and artifact identities without silently rewriting tenant scope.

## Validation

- Combined WAP, dlt, Iceberg, and observability suite: 104 passed, 2 skipped
- Dagster, dlt, and Iceberg provider suites: 438 passed, 1 skipped
- Ruff, formatting, hooks, and diff check passed

This PR is stacked on #606. Together, #605–#607 replace failed PR #601; #601 remains open until the replacement stack is green.