### PR TITLE
fix(evidence): identify runtime observation resources

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
@@ -410,6 +410,21 @@ def _emit_wap_observation(
         catalog_change={
             "operation": operation,
             "catalog_ref": catalog_ref,
+            "resource_identity": {
+                "resource_type": "catalog_ref",
+                "resource_id": catalog_ref,
+                "tenant": project_id,
+                "attributes": {
+                    key: value
+                    for key, value in {
+                        "operation": operation,
+                        "source_hash": source_hash,
+                        "target_hash": target_hash,
+                        "merge_outcome": merge_outcome,
+                    }.items()
+                    if isinstance(value, str) and value
+                },
+            },
             "source_hash": source_hash,
             "target_hash": target_hash,
             "merge_outcome": merge_outcome,

--- a/packages/phlo-dlt/src/phlo_dlt/executor.py
+++ b/packages/phlo-dlt/src/phlo_dlt/executor.py
@@ -95,6 +95,22 @@ from phlo_dlt.pandera_checks import (
 from phlo_dlt.registry import TableConfig
 
 
+def _resource_identity(
+    *,
+    project_id: str | None,
+    resource_type: str,
+    resource_id: str,
+    attributes: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build the provider's canonical, project-scoped report identity."""
+    return {
+        "resource_type": resource_type,
+        "resource_id": resource_id,
+        "tenant": project_id,
+        "attributes": attributes or {},
+    }
+
+
 class DltIngester(BaseIngester):
     """DLT-specific implementation of the ingestion engine.
 
@@ -318,6 +334,18 @@ class DltIngester(BaseIngester):
                                 "resource_kind": "external_source",
                                 "role": "input",
                                 "normalized_identity": source_identity,
+                                "resource_identity": _resource_identity(
+                                    project_id=project_id,
+                                    resource_type=(
+                                        "external_source" if source_identity else "ingestion_asset"
+                                    ),
+                                    resource_id=source_identity
+                                    or self.table_config.full_table_name,
+                                    attributes={
+                                        "table_name": self.table_config.full_table_name,
+                                        "partition_key": partition_key,
+                                    },
+                                ),
                                 "ref_name": branch_name,
                                 "metadata": {
                                     "partition": {"status": "observed", "value": partition_key},
@@ -405,6 +433,15 @@ class DltIngester(BaseIngester):
                     "resource_kind": "external_source",
                     "role": "input",
                     "normalized_identity": source_identity,
+                    "resource_identity": _resource_identity(
+                        project_id=project_id,
+                        resource_type=("external_source" if source_identity else "ingestion_asset"),
+                        resource_id=source_identity or self.table_config.full_table_name,
+                        attributes={
+                            "table_name": self.table_config.full_table_name,
+                            "partition_key": partition_key,
+                        },
+                    ),
                     "ref_name": branch_name,
                     "record_count": dlt_metrics.get("records_read"),
                     "byte_count": dlt_metrics.get("bytes_read"),
@@ -420,6 +457,21 @@ class DltIngester(BaseIngester):
                 {
                     "resource_kind": "staged_object",
                     "role": "staged",
+                    "resource_identity": _resource_identity(
+                        project_id=project_id,
+                        resource_type="staged_object",
+                        resource_id=execution_identity
+                        or ",".join(
+                            str(item["identity"])
+                            for item in staged_objects
+                            if isinstance(item.get("identity"), str)
+                        )
+                        or self.table_config.full_table_name,
+                        attributes={
+                            "table_name": self.table_config.full_table_name,
+                            "partition_key": partition_key,
+                        },
+                    ),
                     "ref_name": branch_name,
                     "staged_objects": staged_objects,
                     "record_count": staged_record_count,
@@ -450,6 +502,12 @@ class DltIngester(BaseIngester):
                 "resource_kind": "iceberg_table",
                 "role": "output",
                 "table_name": self.table_config.full_table_name,
+                "resource_identity": _resource_identity(
+                    project_id=project_id,
+                    resource_type="iceberg_table",
+                    resource_id=self.table_config.full_table_name,
+                    attributes={"catalog_ref": branch_name},
+                ),
                 "ref_name": branch_name,
                 "schema_hash": before_state["schema_hash"],
                 "schema_hash_before": before_state["schema_hash"],

--- a/packages/phlo-dlt/tests/test_ingestion_decorator.py
+++ b/packages/phlo-dlt/tests/test_ingestion_decorator.py
@@ -105,6 +105,16 @@ def test_blessed_decorator_persists_runtime_correlation(monkeypatch, tmp_path) -
     assert captured[0]["project_id"] == "project-decorated"
     assert captured[0]["attempt"] == 2
     assert captured[0]["resources"]
+    assert all(
+        resource["resource_identity"]["tenant"] == "project-decorated"
+        for resource in captured[0]["resources"]
+    )
+    assert captured[0]["resources"][-1]["resource_identity"] == {
+        "resource_type": "iceberg_table",
+        "resource_id": "raw.events",
+        "tenant": "project-decorated",
+        "attributes": {"catalog_ref": "main"},
+    }
 
 
 def test_blessed_decorator_persists_runtime_correlation_through_sqlite(


### PR DESCRIPTION
## What changed

Adds canonical project-scoped resource identities to the Dagster WAP catalog-change and dlt ingestion observation producers.

## Why

The report authorization contract must receive authoritative identities from every active producer; these two paths were missing from the failed combined implementation.

## Validation

- Focused Dagster and dlt producer tests: 26 passed
- Combined identity suite before publication: 104 passed, 2 skipped
- Provider suites before publication: 438 passed, 1 skipped
- Ruff, formatting, hooks, and diff check passed

Stacked follow-ons add Iceberg producer coverage and the core contract.