### PR TITLE
feat(maintenance): add complete orphan inventory evidence

### DIFF
--- a/packages/phlo-iceberg/src/phlo_iceberg/resource.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/resource.py
@@ -61,11 +61,13 @@ from pyiceberg.schema import Schema
 from pyiceberg.table import Table
 
 from phlo.capabilities import (
+    InventoryObject,
     MaintenanceExecutionError,
     MaintenanceExecutionPhase,
     MaintenanceOperationResult,
     MaintenanceOperationState,
     MaintenancePreconditionError,
+    ObjectInventory,
     SAFE_MIN_RETENTION_HOURS,
 )
 from phlo.capabilities.interfaces import MaintenanceExecutor
@@ -173,6 +175,223 @@ def _list_storage_files(io: object, location: str) -> list[Any]:
     filesystem = fs_by_scheme(scheme, netloc)
     infos = filesystem.get_file_info(FileSelector(path, recursive=True, allow_not_found=False))
     return [info for info in infos if getattr(info, "type", None) is FileType.File]
+
+
+def _empty_inventory(
+    *,
+    prefix: str,
+    retention_cutoff: datetime,
+    page_count: int,
+    failure: str,
+) -> ObjectInventory:
+    """Return a fail-closed result without exposing a partial object set."""
+    return ObjectInventory(
+        prefix=prefix,
+        retention_cutoff=retention_cutoff,
+        objects=(),
+        page_count=page_count,
+        continuation_exhausted=False,
+        complete=False,
+        digest=None,
+        failure=failure,
+    )
+
+
+def _s3_location(location: str) -> tuple[str, str, str]:
+    """Return an S3 bucket, owned key prefix, and canonical URI."""
+    parsed = urlsplit(location)
+    if parsed.scheme not in {"s3", "s3a", "s3n"} or not parsed.netloc or not parsed.path.strip("/"):
+        raise ValueError("A complete object inventory requires a non-root S3 table prefix.")
+    prefix = parsed.path.strip("/") + "/"
+    return parsed.netloc, prefix, f"s3://{parsed.netloc}/{prefix}"
+
+
+def _s3_inventory_client() -> object:
+    """Create the configured S3-compatible client supplied by pyiceberg[s3fs]."""
+    import s3fs
+
+    settings = get_settings()
+    return s3fs.S3FileSystem(
+        key=settings.iceberg_s3_access_key,
+        secret=settings.iceberg_s3_secret_key,
+        client_kwargs={
+            "endpoint_url": settings.iceberg_s3_endpoint,
+            "region_name": settings.iceberg_s3_region,
+        },
+        config_kwargs={"s3": {"addressing_style": "path"}},
+    )
+
+
+def inventory_owned_s3_prefix(
+    *,
+    location: str,
+    retention_cutoff: datetime,
+    page_size: int = 1_000,
+    client: object | None = None,
+) -> ObjectInventory:
+    """Enumerate every object below an owned prefix through ``ListObjectsV2``.
+
+    PyArrow's recursive listing does not expose S3 continuation evidence, so it
+    cannot prove that an orphan scan is complete.  This uses the S3-compatible
+    client's public ListObjectsV2 operation instead and discards all partial
+    observations if pagination becomes ambiguous.
+    """
+    try:
+        bucket, prefix, canonical_prefix = _s3_location(location)
+    except ValueError as exc:
+        return _empty_inventory(
+            prefix=location,
+            retention_cutoff=retention_cutoff,
+            page_count=0,
+            failure=str(exc),
+        )
+    if not 1 <= page_size <= 1_000:
+        return _empty_inventory(
+            prefix=canonical_prefix,
+            retention_cutoff=retention_cutoff,
+            page_count=0,
+            failure="S3 inventory page_size must be between 1 and 1000.",
+        )
+
+    try:
+        active_client = client or _s3_inventory_client()
+        call_s3 = getattr(active_client, "call_s3")
+        if not callable(call_s3):
+            raise TypeError("Configured S3 client does not expose call_s3.")
+    except Exception as exc:  # noqa: BLE001 - no evidence is safer than a fallback listing
+        return _empty_inventory(
+            prefix=canonical_prefix,
+            retention_cutoff=retention_cutoff,
+            page_count=0,
+            failure=f"S3 inventory client unavailable: {type(exc).__name__}: {exc}",
+        )
+
+    token: str | None = None
+    seen_tokens: set[str] = set()
+    observed: dict[str, InventoryObject] = {}
+    page_count = 0
+    while True:
+        request: dict[str, object] = {"Bucket": bucket, "Prefix": prefix, "MaxKeys": page_size}
+        if token is not None:
+            request["ContinuationToken"] = token
+        try:
+            page = call_s3("list_objects_v2", **request)
+        except Exception as exc:  # noqa: BLE001 - a partial listing must never become a plan
+            return _empty_inventory(
+                prefix=canonical_prefix,
+                retention_cutoff=retention_cutoff,
+                page_count=page_count,
+                failure=f"S3 ListObjectsV2 failed: {type(exc).__name__}: {exc}",
+            )
+        if not isinstance(page, dict):
+            return _empty_inventory(
+                prefix=canonical_prefix,
+                retention_cutoff=retention_cutoff,
+                page_count=page_count + 1,
+                failure="S3 ListObjectsV2 returned a non-mapping page.",
+            )
+        page_count += 1
+        contents = page.get("Contents", [])
+        if not isinstance(contents, list):
+            return _empty_inventory(
+                prefix=canonical_prefix,
+                retention_cutoff=retention_cutoff,
+                page_count=page_count,
+                failure="S3 ListObjectsV2 returned non-list Contents.",
+            )
+        for item in contents:
+            if not isinstance(item, dict):
+                return _empty_inventory(
+                    prefix=canonical_prefix,
+                    retention_cutoff=retention_cutoff,
+                    page_count=page_count,
+                    failure="S3 ListObjectsV2 returned a malformed object entry.",
+                )
+            key = item.get("Key")
+            size = item.get("Size")
+            if not isinstance(key, str) or not key.startswith(prefix) or not isinstance(size, int):
+                return _empty_inventory(
+                    prefix=canonical_prefix,
+                    retention_cutoff=retention_cutoff,
+                    page_count=page_count,
+                    failure="S3 ListObjectsV2 returned an object outside the owned prefix or without size.",
+                )
+            modified = item.get("LastModified")
+            if modified is not None and not isinstance(modified, datetime):
+                return _empty_inventory(
+                    prefix=canonical_prefix,
+                    retention_cutoff=retention_cutoff,
+                    page_count=page_count,
+                    failure="S3 ListObjectsV2 returned an object with malformed LastModified.",
+                )
+            if isinstance(modified, datetime) and modified.tzinfo is None:
+                modified = modified.replace(tzinfo=UTC)
+            version = item.get("VersionId") or item.get("ETag")
+            if version is not None and not isinstance(version, str):
+                return _empty_inventory(
+                    prefix=canonical_prefix,
+                    retention_cutoff=retention_cutoff,
+                    page_count=page_count,
+                    failure="S3 ListObjectsV2 returned an object with malformed version evidence.",
+                )
+            observation = InventoryObject(
+                identity=f"s3://{bucket}/{key}",
+                size_bytes=size,
+                modified_at=modified,
+                checksum_or_version=version.strip('"') if version else None,
+            )
+            previous = observed.get(key)
+            if previous is not None:
+                return _empty_inventory(
+                    prefix=canonical_prefix,
+                    retention_cutoff=retention_cutoff,
+                    page_count=page_count,
+                    failure="S3 pagination repeated an object; traversal may have changed.",
+                )
+            observed[key] = observation
+
+        truncated = page.get("IsTruncated")
+        next_token = page.get("NextContinuationToken")
+        if truncated is True:
+            if not isinstance(next_token, str) or not next_token or next_token in seen_tokens:
+                return _empty_inventory(
+                    prefix=canonical_prefix,
+                    retention_cutoff=retention_cutoff,
+                    page_count=page_count,
+                    failure="S3 pagination ended or repeated a continuation token before completion.",
+                )
+            seen_tokens.add(next_token)
+            token = next_token
+            continue
+        if truncated is not False or next_token is not None:
+            return _empty_inventory(
+                prefix=canonical_prefix,
+                retention_cutoff=retention_cutoff,
+                page_count=page_count,
+                failure="S3 pagination returned inconsistent terminal continuation evidence.",
+            )
+        ordered = tuple(observed[key] for key in sorted(observed))
+        digest_basis = [
+            {
+                "identity": item.identity,
+                "size_bytes": item.size_bytes,
+                "modified_at": item.modified_at.isoformat() if item.modified_at else None,
+                "checksum_or_version": item.checksum_or_version,
+            }
+            for item in ordered
+        ]
+        digest = hashlib.sha256(
+            json.dumps(digest_basis, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        return ObjectInventory(
+            prefix=canonical_prefix,
+            retention_cutoff=retention_cutoff,
+            objects=ordered,
+            page_count=page_count,
+            continuation_exhausted=True,
+            complete=True,
+            digest=digest,
+        )
 
 
 def _compaction_failure(
@@ -328,6 +547,20 @@ class IcebergResource:
             print(f"Inserted {result['rows_inserted']} rows")
 
     """
+
+    def inventory_owned_prefix(
+        self,
+        *,
+        location: str,
+        retention_cutoff: datetime,
+        page_size: int = 1_000,
+    ) -> ObjectInventory:
+        """Return paginated completeness evidence for one owned S3 prefix."""
+        return inventory_owned_s3_prefix(
+            location=location,
+            retention_cutoff=retention_cutoff,
+            page_size=page_size,
+        )
 
     ref: str = field(default_factory=lambda: get_settings().iceberg_default_ref)
 
@@ -1352,22 +1585,23 @@ class IcebergResource:
                 referenced_files.add(str(manifest.manifest_path))
                 for entry in manifest.fetch_manifest_entry(table.io):
                     referenced_files.add(str(entry.data_file.file_path))
-        cutoff = datetime.now(UTC) - timedelta(hours=retention_hours)
+        observed_at = datetime.now(UTC)
+        cutoff = observed_at - timedelta(hours=retention_hours)
         candidates: list[dict[str, object]] = []
         unavailable_fields: list[str] = []
-        scan_status = "available"
-        try:
+        inventory = self.inventory_owned_prefix(
+            location=f"{table.location()}/data",
+            retention_cutoff=cutoff,
+        )
+        scan_status = "available" if inventory.complete else "unavailable"
+        if inventory.complete:
             normalized_references = {_storage_path_key(path) for path in referenced_files}
-            for file_info in _list_storage_files(table.io, f"{table.location()}/data"):
-                path = str(file_info.path)
+            for object_info in inventory.objects:
+                path = object_info.identity
                 if _storage_path_key(path) in normalized_references:
                     continue
-                mtime = getattr(file_info, "mtime", None)
-                if isinstance(mtime, datetime):
-                    mtime_value = mtime if mtime.tzinfo else mtime.replace(tzinfo=UTC)
-                elif mtime is not None:
-                    mtime_value = datetime.fromtimestamp(float(mtime), tz=UTC)
-                else:
+                mtime_value = object_info.modified_at
+                if mtime_value is None:
                     unavailable_fields.append("candidate_age")
                     continue
                 if mtime_value < cutoff:
@@ -1375,15 +1609,13 @@ class IcebergResource:
                         {
                             "path": path,
                             "mtime": mtime_value.isoformat(),
-                            "age_seconds": round(
-                                (datetime.now(UTC) - mtime_value).total_seconds(), 3
-                            ),
-                            "size_bytes": _safe_file_size(file_info),
+                            "age_seconds": round((observed_at - mtime_value).total_seconds(), 3),
+                            "size_bytes": object_info.size_bytes,
+                            "checksum_or_version": object_info.checksum_or_version,
                         }
                     )
-        except Exception as exc:  # noqa: BLE001 - fail closed on destructive scans
-            scan_status = "unavailable"
-            unavailable_fields.append(f"candidate_listing: {type(exc).__name__}")
+        else:
+            unavailable_fields.append(f"candidate_listing: {inventory.failure or 'incomplete'}")
         sizes = [cast(int | None, candidate.get("size_bytes")) for candidate in candidates]
         if any(size is None for size in sizes):
             affected_bytes = None if candidates else 0
@@ -1411,6 +1643,15 @@ class IcebergResource:
             "table_snapshot_ref_evidence": "available" if refs_available else "unavailable",
             "nessie_ref_evidence": "unavailable",
             "scan_status": scan_status,
+            "inventory": {
+                "prefix": inventory.prefix,
+                "complete": inventory.complete,
+                "page_count": inventory.page_count,
+                "continuation_exhausted": inventory.continuation_exhausted,
+                "digest": inventory.digest,
+                "retention_cutoff": inventory.retention_cutoff.isoformat(),
+                "failure": inventory.failure,
+            },
             "affected_objects": len(candidates),
             "affected_bytes": affected_bytes,
             "limits_scope": ("candidate_orphan_files; provider_internal_metadata_not_counted"),
@@ -1421,7 +1662,7 @@ class IcebergResource:
             "snapshot_guard": "fresh_table_metadata_only",
             "trino_boundary": "pending",
             "execution_support": "unsupported_without_bound_deletion_set",
-            "observed_at_ms": int(datetime.now(UTC).timestamp() * 1000),
+            "observed_at_ms": int(observed_at.timestamp() * 1000),
             "unavailable_fields": sorted(set(unavailable_fields)),
         }
         plan["plan_token"] = _maintenance_plan_token(plan)

--- a/packages/phlo-iceberg/tests/test_complete_object_inventory.py
+++ b/packages/phlo-iceberg/tests/test_complete_object_inventory.py
@@ -1,0 +1,143 @@
+"""S3 pagination evidence for orphan-maintenance inventory."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from phlo_iceberg.resource import inventory_owned_s3_prefix
+
+
+class _Pages:
+    def __init__(self, pages: list[dict[str, object]]) -> None:
+        self.pages = pages
+        self.requests: list[dict[str, object]] = []
+
+    def call_s3(self, method: str, **kwargs: object) -> dict[str, object]:
+        assert method == "list_objects_v2"
+        self.requests.append(kwargs)
+        return self.pages.pop(0)
+
+
+def _object(key: str, *, version: str = "v1", size: int = 2) -> dict[str, object]:
+    return {
+        "Key": key,
+        "Size": size,
+        "LastModified": datetime(2026, 1, 1, tzinfo=UTC),
+        "ETag": version,
+    }
+
+
+def test_inventory_proves_continuation_exhaustion_and_stable_digest() -> None:
+    cutoff = datetime(2026, 1, 2, tzinfo=UTC)
+    first = _Pages(
+        [
+            {
+                "IsTruncated": True,
+                "NextContinuationToken": "page-2",
+                "Contents": [_object("warehouse/raw/events/data/b.parquet")],
+            },
+            {
+                "IsTruncated": False,
+                "Contents": [_object("warehouse/raw/events/data/a.parquet")],
+            },
+        ]
+    )
+    second = _Pages(
+        [
+            {
+                "IsTruncated": True,
+                "NextContinuationToken": "page-2",
+                "Contents": [_object("warehouse/raw/events/data/b.parquet")],
+            },
+            {
+                "IsTruncated": False,
+                "Contents": [_object("warehouse/raw/events/data/a.parquet")],
+            },
+        ]
+    )
+
+    one = inventory_owned_s3_prefix(
+        location="s3://lake/warehouse/raw/events/data",
+        retention_cutoff=cutoff,
+        page_size=1,
+        client=first,
+    )
+    two = inventory_owned_s3_prefix(
+        location="s3://lake/warehouse/raw/events/data",
+        retention_cutoff=cutoff,
+        page_size=1,
+        client=second,
+    )
+
+    assert one.complete is True
+    assert one.continuation_exhausted is True
+    assert one.page_count == 2
+    assert [item.identity for item in one.objects] == [
+        "s3://lake/warehouse/raw/events/data/a.parquet",
+        "s3://lake/warehouse/raw/events/data/b.parquet",
+    ]
+    assert one.digest == two.digest
+    assert first.requests[1]["ContinuationToken"] == "page-2"
+
+
+def test_inventory_fails_closed_on_missing_or_repeated_continuations() -> None:
+    cutoff = datetime(2026, 1, 2, tzinfo=UTC)
+    missing = inventory_owned_s3_prefix(
+        location="s3://lake/warehouse/raw/events/data",
+        retention_cutoff=cutoff,
+        client=_Pages([{"IsTruncated": True, "Contents": []}]),
+    )
+    repeated = inventory_owned_s3_prefix(
+        location="s3://lake/warehouse/raw/events/data",
+        retention_cutoff=cutoff,
+        client=_Pages(
+            [
+                {"IsTruncated": True, "NextContinuationToken": "again", "Contents": []},
+                {"IsTruncated": True, "NextContinuationToken": "again", "Contents": []},
+            ]
+        ),
+    )
+
+    assert missing.complete is False
+    assert missing.objects == ()
+    assert missing.digest is None
+    assert repeated.complete is False
+    assert repeated.objects == ()
+    assert repeated.page_count == 2
+
+
+def test_inventory_fails_closed_when_a_mutated_traversal_repeats_an_object() -> None:
+    result = inventory_owned_s3_prefix(
+        location="s3://lake/warehouse/raw/events/data",
+        retention_cutoff=datetime(2026, 1, 2, tzinfo=UTC),
+        client=_Pages(
+            [
+                {
+                    "IsTruncated": True,
+                    "NextContinuationToken": "next",
+                    "Contents": [_object("warehouse/raw/events/data/a.parquet", version="old")],
+                },
+                {
+                    "IsTruncated": False,
+                    "Contents": [_object("warehouse/raw/events/data/a.parquet", version="new")],
+                },
+            ]
+        ),
+    )
+
+    assert result.complete is False
+    assert result.objects == ()
+    assert "repeated an object" in str(result.failure)
+
+
+def test_inventory_rejects_objects_outside_the_owned_prefix() -> None:
+    result = inventory_owned_s3_prefix(
+        location="s3://lake/warehouse/raw/events/data",
+        retention_cutoff=datetime(2026, 1, 2, tzinfo=UTC),
+        client=_Pages(
+            [{"IsTruncated": False, "Contents": [_object("warehouse/raw/other/outside.parquet")]}]
+        ),
+    )
+
+    assert result.complete is False
+    assert result.objects == ()
+    assert "outside the owned prefix" in str(result.failure)

--- a/packages/phlo-iceberg/tests/test_integration_iceberg.py
+++ b/packages/phlo-iceberg/tests/test_integration_iceberg.py
@@ -10,9 +10,11 @@ Per TEST_STRATEGY.md Level 2 (Functional):
 import socket
 import os
 import tempfile
+from datetime import UTC, datetime
 from urllib.parse import urlparse
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pandas as pd
 import pytest
@@ -578,3 +580,53 @@ class TestIcebergExports:
         from phlo_iceberg.resource import IcebergResource
 
         assert IcebergResource is not None
+
+
+def test_owned_minio_inventory_uses_multiple_continuation_pages_and_cleans_up():
+    """The actual S3-compatible API proves completion rather than PyArrow listing."""
+    from phlo_iceberg.resource import _s3_inventory_client, inventory_owned_s3_prefix
+    from phlo_iceberg.settings import get_settings
+
+    get_settings.cache_clear()
+    client = _s3_inventory_client()
+    try:
+        client.call_s3("list_buckets")
+    except Exception as exc:
+        pytest.skip(f"MinIO inventory test requires the configured owned service: {exc}")
+    prefix = f"warehouse/phlo-inventory-{uuid4().hex}/data"
+    keys = [f"{prefix}/{number:02}.parquet" for number in range(5)]
+    outside_key = f"warehouse/phlo-inventory-{uuid4().hex}/outside.parquet"
+    bucket = f"phlo-inventory-{uuid4().hex[:16]}"
+    try:
+        client.call_s3("create_bucket", Bucket=bucket)
+        for key in keys:
+            client.call_s3("put_object", Bucket=bucket, Key=key, Body=b"inventory-test")
+        client.call_s3("put_object", Bucket=bucket, Key=outside_key, Body=b"x")
+        first = inventory_owned_s3_prefix(
+            location=f"s3://{bucket}/{prefix}",
+            retention_cutoff=datetime(2026, 1, 1, tzinfo=UTC),
+            page_size=2,
+            client=client,
+        )
+        second = inventory_owned_s3_prefix(
+            location=f"s3://{bucket}/{prefix}",
+            retention_cutoff=datetime(2026, 1, 1, tzinfo=UTC),
+            page_size=2,
+            client=client,
+        )
+        assert first.complete is True
+        assert first.continuation_exhausted is True
+        assert first.page_count == 3
+        assert len(first.objects) == 5
+        assert first.digest == second.digest
+        assert all(item.identity.startswith(f"s3://{bucket}/{prefix}/") for item in first.objects)
+    finally:
+        for key in [*keys, outside_key]:
+            try:
+                client.call_s3("delete_object", Bucket=bucket, Key=key)
+            except Exception:
+                pass
+        try:
+            client.call_s3("delete_bucket", Bucket=bucket)
+        except Exception:
+            pass

--- a/packages/phlo-iceberg/tests/test_retention_contract.py
+++ b/packages/phlo-iceberg/tests/test_retention_contract.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 from pyarrow.fs import FileType
 
-from phlo.capabilities import MaintenanceRetentionStore
+from phlo.capabilities import InventoryObject, MaintenanceRetentionStore, ObjectInventory
 from phlo.capabilities import MaintenanceExecutionError, MaintenanceExecutionPhase
 import phlo_iceberg.resource as resource_module
 from phlo_iceberg.resource import (
@@ -168,6 +168,28 @@ def _real_planner_resource(monkeypatch) -> tuple[IcebergResource, _FakeTable]:
             "total_size_bytes": 110,
         },
     )
+    cutoff = now - timedelta(days=7)
+    monkeypatch.setattr(
+        IcebergResource,
+        "inventory_owned_prefix",
+        lambda self, **_: ObjectInventory(
+            prefix="s3://bucket/warehouse/raw/events/data/",
+            retention_cutoff=cutoff,
+            objects=tuple(
+                InventoryObject(
+                    identity=f"s3://{file_info.path}",
+                    size_bytes=file_info.size,
+                    modified_at=file_info.mtime,
+                    checksum_or_version="test-version",
+                )
+                for file_info in storage_files
+            ),
+            page_count=2,
+            continuation_exhausted=True,
+            complete=True,
+            digest="complete-inventory",
+        ),
+    )
     return IcebergResource(ref="main"), table
 
 
@@ -282,12 +304,46 @@ def test_real_orphan_planner_normalizes_paths_and_counts_old_candidates(monkeypa
     assert result["status"] == "planned"
     assert result["planned"]["scan_status"] == "available"
     assert [candidate["path"] for candidate in result["planned"]["candidate_files"]] == [
-        "bucket/warehouse/raw/events/data/orphan-old.parquet"
+        "s3://bucket/warehouse/raw/events/data/orphan-old.parquet"
     ]
+    assert result["planned"]["inventory"] | {"retention_cutoff": None} == {
+        "prefix": "s3://bucket/warehouse/raw/events/data/",
+        "complete": True,
+        "page_count": 2,
+        "continuation_exhausted": True,
+        "digest": "complete-inventory",
+        "retention_cutoff": None,
+        "failure": None,
+    }
     assert result["planned"]["affected_objects"] == 1
     assert result["planned"]["affected_bytes"] == 70
     assert result["planned"]["protected_snapshot_ids"] == [2, 8]
     assert "shared.parquet" not in str(result["planned"]["candidate_files"])
+
+
+def test_orphan_planner_never_exposes_candidates_from_an_incomplete_inventory(monkeypatch) -> None:
+    resource, _ = _real_planner_resource(monkeypatch)
+    monkeypatch.setattr(
+        resource,
+        "inventory_owned_prefix",
+        lambda **_: ObjectInventory(
+            prefix="s3://bucket/warehouse/raw/events/data/",
+            retention_cutoff=datetime.now(UTC),
+            objects=(),
+            page_count=1,
+            continuation_exhausted=False,
+            complete=False,
+            digest=None,
+            failure="S3 pagination ended before completion.",
+        ),
+    )
+
+    result = resource.cleanup_orphan_files(table_name="raw.events", catalog="iceberg", dry_run=True)
+
+    assert result["status"] == "blocked"
+    assert result["accepted"] is False
+    assert result["planned"]["candidate_files"] == []
+    assert result["planned"]["inventory"]["complete"] is False
 
 
 def test_support_distinguishes_retention_planning_from_executable_vacuum() -> None:

--- a/src/phlo/capabilities/__init__.py
+++ b/src/phlo/capabilities/__init__.py
@@ -97,6 +97,7 @@ from phlo.capabilities.interfaces import (
     MaintenanceReadModel,
     MaintenanceRetentionStore,
     MaintenanceTableStore,
+    ObjectInventoryStore,
     OrchestratorOperationsProvider,
     Principal,
     QueryEngine,
@@ -112,6 +113,7 @@ from phlo.capabilities.interfaces import (
     TraceSpanFilter,
     WorkflowAuthoringProvider,
 )
+from phlo.capabilities.inventory import InventoryObject, ObjectInventory
 from phlo.capabilities.maintenance import (
     SAFE_MIN_RETENTION_HOURS,
     DefaultMaintenanceReadModel,
@@ -228,6 +230,9 @@ __all__ = [
     "MaintenanceExecutor",
     "MaintenanceDiscovery",
     "MaintenanceRetentionStore",
+    "ObjectInventoryStore",
+    "InventoryObject",
+    "ObjectInventory",
     "MaintenanceTableStore",
     "MaintenanceExecutorSpec",
     "DefaultObservabilityBackend",

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+from phlo.capabilities.inventory import ObjectInventory
+
 
 @dataclass(frozen=True, slots=True)
 class TableStoreSupport:
@@ -389,6 +391,21 @@ class MaintenanceRetentionStore(Protocol):
         operation_id: str | None = None,
     ) -> dict[str, object]:
         """Plan or execute guarded orphan-file cleanup."""
+        ...
+
+
+@runtime_checkable
+class ObjectInventoryStore(Protocol):
+    """Provider-neutral evidence source for a complete owned-prefix scan."""
+
+    def inventory_owned_prefix(
+        self,
+        *,
+        location: str,
+        retention_cutoff: datetime,
+        page_size: int = 1_000,
+    ) -> ObjectInventory:
+        """Return a complete inventory or a failure result with no partial set."""
         ...
 
 

--- a/src/phlo/capabilities/inventory.py
+++ b/src/phlo/capabilities/inventory.py
@@ -1,0 +1,35 @@
+"""Provider-neutral evidence for a complete object-prefix inventory."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(frozen=True, slots=True)
+class InventoryObject:
+    """One immutable observation from an owned object-storage prefix."""
+
+    identity: str
+    size_bytes: int
+    modified_at: datetime | None
+    checksum_or_version: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectInventory:
+    """The result of enumerating an owned prefix through a paginated API.
+
+    Consumers must treat ``objects`` as unusable for a destructive operation
+    unless ``complete`` is true.  A failed traversal deliberately contains no
+    partial object set or digest.
+    """
+
+    prefix: str
+    retention_cutoff: datetime
+    objects: tuple[InventoryObject, ...]
+    page_count: int
+    continuation_exhausted: bool
+    complete: bool
+    digest: str | None
+    failure: str | None = None


### PR DESCRIPTION
## Summary
- add a neutral complete-object inventory contract and an Iceberg S3 ListObjectsV2 implementation
- make orphan-maintenance planning fail closed when pagination or object evidence is incomplete or malformed
- record inventory prefix, page count, continuation completion, digest, and retention cutoff in the plan

## Validation
- `uv run pytest --import-mode=importlib packages/phlo-iceberg/tests/test_complete_object_inventory.py packages/phlo-iceberg/tests/test_retention_contract.py packages/phlo-iceberg/tests/test_integration_iceberg.py`
- `uv run pytest --import-mode=importlib tests/plugins/test_capabilities_runtime.py tests/plugins/test_capability_catalog.py tests/plugins/test_default_capabilities.py`
- `uv run ruff check ...` and `uv run ruff format --check ...`
- pre-commit hooks

The optional real-MinIO pagination test was attempted and skipped because no configured owned MinIO service was reachable. This PR does not implement object deletion.