### PR TITLE
fix(security): enforce regulated backend isolation

### DIFF
--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -25,7 +25,11 @@ from phlo.plugins.discovery import ServiceDefinition, ServiceDiscovery
 logger = get_logger(__name__)
 
 
-_PRODUCTION_INTERNAL_SERVICES = frozenset({"postgres", "minio", "nessie", "trino", "dagster"})
+# These are implementation backends, rather than regulated user entry points.
+# Dagster remains reachable in the production profile because its webserver is a
+# regulated operator surface.  Keep this list deliberately small: applying it
+# to an entry point would silently remove its supported route.
+_PRODUCTION_INTERNAL_SERVICES = frozenset({"postgres", "minio", "nessie", "trino"})
 _PRODUCTION_CREDENTIAL_DEFAULTS = {
     "POSTGRES_USER": "phlo",
     "POSTGRES_PASSWORD": "phlo",

--- a/src/phlo/security/validation.py
+++ b/src/phlo/security/validation.py
@@ -291,7 +291,7 @@ def _check_internal_backend_boundary() -> ValidationResult:
 
     try:
         document = yaml.safe_load(compose_path.read_text()) or {}
-    except (OSError, yaml.YAMLError) as exc:
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
         return ValidationResult(
             name="internal_backend_boundary",
             passed=False,

--- a/src/phlo/security/validation.py
+++ b/src/phlo/security/validation.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 import os
 from contextlib import suppress
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 from phlo.logging import get_logger
 from phlo.rbac.compiler import COMPILER_REGISTRY
@@ -23,6 +26,11 @@ logger = get_logger(__name__)
 REQUIRED_AUTHORIZATION_MODE = "required"
 PHLO_AUDIT_HMAC_KEY_ENV = "PHLO_AUDIT_HMAC_KEY"
 PHLO_SIGNATURE_HMAC_KEY_ENV = "PHLO_SIGNATURE_HMAC_KEY"
+
+# These services are v1 implementation backends. They are not supported as
+# direct user-facing entry points in a regulated deployment; the production
+# Compose profile must keep them off the host network and out of Traefik.
+INTERNAL_BACKEND_SERVICES = frozenset({"postgres", "minio", "nessie", "trino"})
 
 
 def _project_rbac_loader() -> RBACConfigLoader:
@@ -242,6 +250,95 @@ def _check_backend_coverage() -> ValidationResult:
         name="backend_sync_status",
         passed=True,
         message="Backend compilers are available and cover all configured actions",
+    )
+
+
+def _production_compose_path() -> Path:
+    """Return the generated Compose file for the configured project."""
+    from phlo.infrastructure.config import _default_project_root
+
+    return _default_project_root() / ".phlo" / "docker-compose.yml"
+
+
+def _has_public_traefik_route(config: dict[str, Any]) -> bool:
+    """Return whether a Compose service retains a Traefik route label."""
+    labels = config.get("labels", {})
+    if isinstance(labels, dict):
+        return any(str(key).startswith("traefik.") for key in labels)
+    if isinstance(labels, list):
+        return any(isinstance(label, str) and label.startswith("traefik.") for label in labels)
+    return False
+
+
+def _check_internal_backend_boundary() -> ValidationResult:
+    """Reject a regulated deployment whose generated backend services are public.
+
+    This validates the rendered deployment contract rather than trying to
+    infer it from service manifests. A production project can safely use these
+    backends over the internal Compose network, but a published host port,
+    Traefik route, or host network mode would bypass that v1 boundary.
+    """
+    compose_path = _production_compose_path()
+    if not compose_path.exists():
+        return ValidationResult(
+            name="internal_backend_boundary",
+            passed=False,
+            message=(
+                "Regulated mode requires a generated .phlo/docker-compose.yml; "
+                "render it with 'phlo services init --production'"
+            ),
+        )
+
+    try:
+        document = yaml.safe_load(compose_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return ValidationResult(
+            name="internal_backend_boundary",
+            passed=False,
+            message=f"Could not read generated Compose configuration: {exc}",
+        )
+
+    services = document.get("services") if isinstance(document, dict) else None
+    if not isinstance(services, dict):
+        return ValidationResult(
+            name="internal_backend_boundary",
+            passed=False,
+            message="Generated Compose configuration must contain a services mapping",
+        )
+
+    violations: list[str] = []
+    for service_name in sorted(INTERNAL_BACKEND_SERVICES):
+        config = services.get(service_name)
+        if config is None:
+            continue
+        if not isinstance(config, dict):
+            violations.append(f"{service_name} has an invalid service configuration")
+            continue
+        if config.get("ports"):
+            violations.append(f"{service_name} publishes host ports")
+        if config.get("network_mode") == "host":
+            violations.append(f"{service_name} uses host networking")
+        if _has_public_traefik_route(config):
+            violations.append(f"{service_name} has public Traefik labels")
+
+    if violations:
+        return ValidationResult(
+            name="internal_backend_boundary",
+            passed=False,
+            message=(
+                "Regulated backend boundary is not internal: "
+                f"{'; '.join(violations)}. Regenerate with 'phlo services init --production'."
+            ),
+        )
+
+    configured = sorted(name for name in INTERNAL_BACKEND_SERVICES if name in services)
+    return ValidationResult(
+        name="internal_backend_boundary",
+        passed=True,
+        message=(
+            "Generated regulated Compose keeps backend services internal"
+            + (f": {', '.join(configured)}" if configured else "")
+        ),
     )
 
 
@@ -516,6 +613,7 @@ def run_regulated_validation(
         _check_canonical_taxonomy(list(effective_actions), list(effective_resource_types))
     )
     report.add_check(_check_backend_coverage())
+    report.add_check(_check_internal_backend_boundary())
 
     report.add_check(_check_phlo_api_adapter(runtime))
 

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -460,7 +460,7 @@ def test_compose_generator_production_profile_hides_core_host_ports_and_requires
         )
     )
 
-    for name in ("postgres", "minio", "nessie", "trino", "dagster"):
+    for name in ("postgres", "minio", "nessie", "trino"):
         assert "ports" not in data["services"][name]
         environment = data["services"][name]["environment"]
         assert (
@@ -478,6 +478,8 @@ def test_compose_generator_production_profile_hides_core_host_ports_and_requires
             "${MINIO_ROOT_PASSWORD:?Phlo production requires MINIO_ROOT_PASSWORD}"
         )
 
+    assert data["services"]["dagster"]["ports"] == ["10000:5432"]
+
 
 def test_compose_generator_development_profile_keeps_core_host_ports(tmp_path) -> None:
     service = ServiceDefinition(
@@ -492,6 +494,24 @@ def test_compose_generator_development_profile_keeps_core_host_ports(tmp_path) -
     data = yaml.safe_load(generator.generate_compose([service], output_dir=tmp_path))
 
     assert data["services"]["postgres"]["ports"] == ["10000:5432"]
+
+
+def test_development_profile_keeps_bundled_backends_open(tmp_path) -> None:
+    """The regulated production boundary must not change development access."""
+    discovery = ServiceDiscovery()
+    data = yaml.safe_load(
+        ComposeGenerator(discovery).generate_compose(
+            discovery.get_default_services(), output_dir=tmp_path
+        )
+    )
+
+    for name in ("postgres", "minio", "nessie", "trino"):
+        assert data["services"][name]["ports"]
+
+    for name in ("minio", "nessie", "trino"):
+        labels = data["services"][name]["labels"]
+        assert labels["traefik.enable"] == "true"
+    assert "traefik.enable" not in data["services"]["postgres"].get("labels", {})
 
 
 @pytest.mark.parametrize(
@@ -640,10 +660,12 @@ def test_production_profile_renders_bundled_core_without_public_ports_or_credent
     )
     data = yaml.safe_load(compose)
 
-    for name in ("postgres", "minio", "nessie", "trino", "dagster"):
+    for name in ("postgres", "minio", "nessie", "trino"):
         assert "ports" not in data["services"][name]
         labels = data["services"][name].get("labels", {})
         assert not any(str(label).startswith("traefik.") for label in labels)
+    assert data["services"]["dagster"]["ports"] == ["${DAGSTER_PORT:-10006}:3000"]
+    assert data["services"]["dagster"]["labels"]["traefik.enable"] == "true"
     assert "${POSTGRES_PASSWORD:-phlo}" not in compose
     assert "${MINIO_ROOT_PASSWORD:-minio123}" not in compose
 

--- a/tests/security/test_regulated_validation.py
+++ b/tests/security/test_regulated_validation.py
@@ -2,7 +2,80 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import yaml
+
 from phlo.security.validation import run_regulated_validation
+
+
+def _write_generated_compose(tmp_path: Path, services: dict[str, object]) -> None:
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / "docker-compose.yml").write_text(yaml.safe_dump({"services": services}))
+
+
+def test_regulated_backend_boundary_accepts_internal_generated_backends(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from phlo.security.validation import _check_internal_backend_boundary
+
+    _write_generated_compose(
+        tmp_path,
+        {
+            "postgres": {"environment": {"POSTGRES_DB": "phlo"}},
+            "minio": {"environment": {"MINIO_ROOT_USER": "configured"}},
+            "nessie": {},
+            "trino": {},
+            "dagster": {
+                "ports": ["10006:3000"],
+                "labels": {"traefik.enable": "true"},
+            },
+            "phlo-api": {"ports": ["4000:4000"]},
+        },
+    )
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+
+    result = _check_internal_backend_boundary()
+
+    assert result.passed is True
+    assert "minio, nessie, postgres, trino" in result.message
+
+
+def test_regulated_backend_boundary_rejects_published_or_routed_backend(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from phlo.security.validation import _check_internal_backend_boundary
+
+    _write_generated_compose(
+        tmp_path,
+        {
+            "postgres": {"ports": ["10000:5432"]},
+            "minio": {"labels": ["traefik.enable=true"]},
+            "nessie": {"network_mode": "host"},
+            "trino": {},
+            "dagster": {"ports": ["10006:3000"]},
+        },
+    )
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+
+    result = _check_internal_backend_boundary()
+
+    assert result.passed is False
+    assert "postgres publishes host ports" in result.message
+    assert "minio has public Traefik labels" in result.message
+    assert "nessie uses host networking" in result.message
+
+
+def test_regulated_backend_boundary_requires_a_production_render(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from phlo.security.validation import _check_internal_backend_boundary
+
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+
+    result = _check_internal_backend_boundary()
+
+    assert result.passed is False
+    assert "phlo services init --production" in result.message
 
 
 def test_regulated_validation_requires_audit_hmac_key(monkeypatch) -> None:

--- a/tests/security/test_regulated_validation.py
+++ b/tests/security/test_regulated_validation.py
@@ -78,6 +78,22 @@ def test_regulated_backend_boundary_requires_a_production_render(
     assert "phlo services init --production" in result.message
 
 
+def test_regulated_backend_boundary_rejects_invalid_utf8_compose(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from phlo.security.validation import _check_internal_backend_boundary
+
+    phlo_dir = tmp_path / ".phlo"
+    phlo_dir.mkdir()
+    (phlo_dir / "docker-compose.yml").write_bytes(b"\xff")
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+
+    result = _check_internal_backend_boundary()
+
+    assert result.passed is False
+    assert "Could not read generated Compose configuration" in result.message
+
+
 def test_regulated_validation_requires_audit_hmac_key(monkeypatch) -> None:
     monkeypatch.setenv("PHLO_REGULATED", "true")
     monkeypatch.delenv("PHLO_AUDIT_HMAC_KEY", raising=False)


### PR DESCRIPTION
## Outcome

Production and regulated deployments keep PostgreSQL, MinIO, Nessie, and Trino internal. Dagster remains a supported operator surface. Development mode keeps its existing open ports and routes.

## What changed

- Production Compose removes host ports and Traefik labels from the four backend services, including when a project override tries to add them.
- Regulated validation reads the generated Compose file and rejects a backend exposed through a host port, Traefik, or host networking.
- A missing generated production Compose file fails regulated validation.

## Scope

This PR covers only the generated deployment boundary and its validation. It does not add backend permission systems, service-token wiring, report authorization, UI, tenancy, maintenance, or release work.

## Validation

- 60 focused generator and regulated-validation tests passed.
- Lint, formatting, diff checks, and commit hooks passed.