### PR TITLE
feat(security): bind service tokens to run reports

### DIFF
--- a/packages/phlo-api/src/phlo_api/security_manifest.py
+++ b/packages/phlo-api/src/phlo_api/security_manifest.py
@@ -50,6 +50,7 @@ class OperationSpec:
 
 HTTP_ROUTE_KEY_MANIFEST: dict[tuple[str, str], OperationSpec] = {}
 logger = get_logger(__name__)
+RUN_REPORT_RESOURCE_ID_ATTRIBUTE = "phlo.run_report_resource_id"
 
 
 def _specs(
@@ -675,6 +676,25 @@ def _raise_unauthorized() -> None:
     )
 
 
+def _enforce_scoped_run_report_service_identity(
+    principal: Any,
+    spec: OperationSpec,
+    resource: ResourceRef,
+) -> None:
+    """Bind a deliberately run-scoped service token to its one report resource."""
+    if (
+        spec.operation_name != "get_observatory_run_report"
+        or principal.principal_type != "service"
+        or RUN_REPORT_RESOURCE_ID_ATTRIBUTE not in principal.attributes
+    ):
+        return
+    if principal.attributes[RUN_REPORT_RESOURCE_ID_ATTRIBUTE] != resource.resource_id:
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "forbidden", "reason": "run_report_scope_mismatch"},
+        )
+
+
 async def enforce_http_operation(
     request: Request,
     spec: OperationSpec,
@@ -691,6 +711,7 @@ async def enforce_http_operation(
     spec = await _specialize_operation(request, spec)
     await _validate_request_payload(request, spec)
     resource = await resolve_resource(request, spec, path_params)
+    _enforce_scoped_run_report_service_identity(auth_principal, spec, resource)
     context: DecisionContext = create_decision_context(request)
     correlation_id = get_request_correlation_id(request)
 

--- a/packages/phlo-api/tests/test_observatory_api.py
+++ b/packages/phlo-api/tests/test_observatory_api.py
@@ -11,7 +11,10 @@ from typing import Any
 import pytest
 from fastapi.testclient import TestClient
 
+from phlo.capabilities import ResourceRef
 from phlo.capabilities.registry import CapabilityRegistry
+from phlo.capabilities.authentication import ServiceTokenAuthenticationProvider
+from phlo.capabilities.authorization import DefaultAuthorizationPolicyBackend
 from phlo.capabilities.specs import CatalogSpec
 from phlo_api.main import app
 from security_test_support import authenticated_client
@@ -52,6 +55,7 @@ from phlo_api.observatory_api.observatory_services import fallback_services as _
 from phlo_api.observatory_api.observatory_services import (
     load_docker_service_statuses as _load_docker_service_statuses,
 )
+from phlo_api.security_manifest import RUN_REPORT_RESOURCE_ID_ATTRIBUTE
 
 _PROVIDER_URL_SETTING_NAMES = (
     "dagster_url",
@@ -134,6 +138,76 @@ def test_authenticated_run_report_isolated_by_attempt_and_path_identity(
         .status_code
         == 403
     )
+
+
+def test_scoped_service_token_cannot_read_another_run_report(monkeypatch, tmp_path) -> None:
+    database = tmp_path / "run-evidence.sqlite"
+    store = SQLiteRunEvidenceStore(database)
+    for run_id in ("allowed", "other"):
+        store.append_pipeline_run(PipelineRun(project_id="project", run_id=run_id, attempt=1))
+        store.append_event(
+            RunEvent(
+                project_id="project",
+                run_id=run_id,
+                event_id=f"{run_id}-event",
+                event_type="run.terminal",
+                producer="dagster",
+                payload={"status": "success"},
+                attempt=1,
+                resource_ref=ResourceRef(
+                    resource_type="run",
+                    resource_id=run_id,
+                    tenant="project",
+                    attributes={"attempt": "1"},
+                ),
+            )
+        )
+    monkeypatch.setenv("PHLO_RUN_EVIDENCE_SQLITE_PATH", str(database))
+    monkeypatch.setenv("PHLO_REGULATED", "false")
+    allowed_resource_id = "project_id=project|run_id=allowed|attempt=1"
+    provider = ServiceTokenAuthenticationProvider(
+        {
+            "dagster-report-token": {
+                "subject": "dagster:report-reader",
+                "attributes": {RUN_REPORT_RESOURCE_ID_ATTRIBUTE: allowed_resource_id},
+            }
+        }
+    )
+    backend = DefaultAuthorizationPolicyBackend(
+        policies=[
+            {
+                "policy_id": "service-report-read",
+                "effect": "allow",
+                "principal": {"attributes": {RUN_REPORT_RESOURCE_ID_ATTRIBUTE: "*"}},
+                "action": "run.read",
+                "resource": {"type": "run", "id_pattern": "*"},
+            }
+        ]
+    )
+    monkeypatch.setattr("phlo_api.api.authentication.get_authentication_provider", lambda: provider)
+    monkeypatch.setattr("phlo_api.security_manifest.get_authorization_backend", lambda: backend)
+
+    client = TestClient(app)
+    allowed = client.get(
+        "/api/observatory/projects/project/runs/allowed/attempts/1/report",
+        headers={"Authorization": "Bearer dagster-report-token"},
+    )
+    denied = client.get(
+        "/api/observatory/projects/project/runs/other/attempts/1/report",
+        headers={"Authorization": "Bearer dagster-report-token"},
+    )
+
+    assert allowed.status_code == 200
+    assert allowed.json()["run_id"] == "allowed"
+    assert allowed.json()["lifecycle"]["events"][0]["resource_identity"] == {
+        "project_id": "project",
+        "resource_type": "run",
+        "resource_id": "allowed",
+        "tenant": "project",
+        "attributes": {"attempt": "1"},
+    }
+    assert denied.status_code == 403
+    assert denied.json() == {"error": "forbidden", "reason": "run_report_scope_mismatch"}
 
 
 class _FakeOrchestratorOperations:

--- a/packages/phlo-dagster/src/phlo_dagster/run_evidence.py
+++ b/packages/phlo-dagster/src/phlo_dagster/run_evidence.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
 
+from phlo.capabilities import ResourceRef
 from phlo.run_evidence import (
     EvidenceCompleteness,
     RunEvent,
@@ -259,6 +260,12 @@ class DagsterRunEvidenceSource:
             and successful_event
         )
         no_data = tagged_no_data and successful_terminal
+        run_resource_ref = ResourceRef(
+            resource_type="run",
+            resource_id=logical_run_id,
+            tenant=project_id,
+            attributes={"attempt": str(attempt)},
+        )
         events: list[RunEvent] = []
         stages: list[RunStage] = []
         for index, (entry, record_storage_id) in enumerate(entries):
@@ -381,6 +388,7 @@ class DagsterRunEvidenceSource:
                     observed_at=observed_at,
                     sequence=int(storage_id) if isinstance(storage_id, int) else index,
                     attempt=attempt,
+                    resource_ref=run_resource_ref,
                 )
             )
             if stage_id is not None:
@@ -400,6 +408,7 @@ class DagsterRunEvidenceSource:
                         if stage_status not in {"running", "retrying"}
                         else None,
                         error=message if stage_status == "failed" else None,
+                        resource_ref=run_resource_ref,
                     )
                 )
         if no_data:
@@ -415,6 +424,7 @@ class DagsterRunEvidenceSource:
                         payload={"status": "no_data", "source": "phlo/no_data"},
                         observed_at=tag_timestamp,
                         attempt=attempt,
+                        resource_ref=run_resource_ref,
                     )
                 )
             run_status = "no_data"

--- a/packages/phlo-dagster/tests/test_run_evidence.py
+++ b/packages/phlo-dagster/tests/test_run_evidence.py
@@ -105,6 +105,12 @@ def test_dagster_source_maps_durable_run_and_event_log_records() -> None:
     assert observation.events[1].payload["stage_id"] == observation.stages[0].stage_id
     assert observation.stages[0].asset == "raw.orders"
     assert observation.stages[0].provider == "dagster"
+    for item in (*observation.events, *observation.stages):
+        assert item.resource_ref is not None
+        assert item.resource_ref.resource_type == "run"
+        assert item.resource_ref.resource_id == "root-run"
+        assert item.resource_ref.tenant == "project"
+        assert item.resource_ref.attributes == {"attempt": "2"}
 
 
 def test_dagster_source_requires_injected_project_identity() -> None:

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -304,13 +304,12 @@ def release_golden_path_wap_check() -> dg.AssetCheckResult:
     )
 
 
-def write_report_policy_fixture(config: RunConfig, logical_run_id: str) -> None:
-    """Grant the ephemeral report reader access only to the promoted WAP run report."""
+def write_report_policy_fixture(config: RunConfig) -> None:
+    """Allow the scoped report reader through the policy boundary."""
     authorization_dir = config.project_dir / ".phlo" / "authorization"
     authorization_dir.mkdir(parents=True, exist_ok=True)
-    report_resource_id = f"project_id={config.project_name}|run_id={logical_run_id}|attempt=1"
     (authorization_dir / "policies.yaml").write_text(
-        f"""version: 1
+        """version: 1
 
 policies:
   - policy_id: release-golden-path-wap-catalog-read
@@ -348,7 +347,7 @@ policies:
     action: run.read
     resource:
       type: run
-      id_pattern: "{report_resource_id}"
+      id_pattern: "*"
 """,
         encoding="utf-8",
     )
@@ -392,7 +391,7 @@ def install_project_dependencies(config: RunConfig) -> None:
     )
 
 
-def configure_non_dev_compose(config: RunConfig) -> None:
+def configure_non_dev_compose(config: RunConfig, logical_run_id: str) -> None:
     run(
         command(
             str(config.operator_bin),
@@ -424,7 +423,12 @@ def configure_non_dev_compose(config: RunConfig) -> None:
         tokens = {
             config.report_token: {
                 "subject": "qa001-report-reader",
-                "attributes": {"qa001_role": "report_reader"},
+                "attributes": {
+                    "qa001_role": "report_reader",
+                    "phlo.run_report_resource_id": (
+                        f"project_id={config.project_name}|run_id={logical_run_id}|attempt=1"
+                    ),
+                },
             }
         }
         stream.write(f"PHLO_AUTH_SERVICE_TOKENS={json.dumps(tokens, separators=(',', ':'))}\n")
@@ -657,7 +661,7 @@ def wait_for_wap_promotion(config: RunConfig, wap_run: WapRun) -> None:
 
 
 def verify_run_report(config: RunConfig, wap_run: WapRun) -> None:
-    """Fetch the promoted report with the ephemeral run-read service principal."""
+    """Prove the scoped service token reads its report and no other report."""
     url = service_url(
         config,
         "phlo-api",
@@ -675,12 +679,38 @@ def verify_run_report(config: RunConfig, wap_run: WapRun) -> None:
             with urllib.request.urlopen(request, timeout=10) as response:  # noqa: S310
                 payload = json.load(response)
             if isinstance(payload, dict) and payload.get("run_id") == wap_run.logical_run_id:
-                return
+                break
             raise RuntimeError(f"run report returned the wrong run: {payload!r}")
         except (urllib.error.HTTPError, urllib.error.URLError, RuntimeError) as exc:
             last_error = exc
             time.sleep(1)
-    raise RuntimeError(f"run report was not available for {wap_run.logical_run_id}: {last_error}")
+    else:
+        raise RuntimeError(
+            f"run report was not available for {wap_run.logical_run_id}: {last_error}"
+        )
+
+    other_url = service_url(
+        config,
+        "phlo-api",
+        4000,
+        f"/api/observatory/projects/{config.project_name}/runs/{wap_run.logical_run_id}-other/attempts/1/report",
+    )
+    request = urllib.request.Request(
+        other_url,
+        headers={"Authorization": f"Bearer {config.report_token}"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=10):  # noqa: S310
+            pass
+    except urllib.error.HTTPError as exc:
+        body = json.load(exc)
+        if exc.code == 403 and body == {
+            "error": "forbidden",
+            "reason": "run_report_scope_mismatch",
+        }:
+            return
+        raise RuntimeError(f"unexpected scoped report response: {exc.code} {body!r}") from exc
+    raise RuntimeError("scoped report token read another run report")
 
 
 def verify_rows(
@@ -838,9 +868,9 @@ def main(argv: list[str] | None = None) -> int:
         write_wap_fixture(config)
         align_project_name(config)
         install_project_dependencies(config)
-        configure_non_dev_compose(config)
         logical_run_id = uuid.uuid4().hex
-        write_report_policy_fixture(config, logical_run_id)
+        configure_non_dev_compose(config, logical_run_id)
+        write_report_policy_fixture(config)
         start_stack(config)
         stack_started = True
         materialize_partition(config)

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -144,12 +144,12 @@ def test_wap_fixture_defines_a_blocking_passing_asset_check(tmp_path: Path) -> N
     assert "return dg.AssetCheckResult(passed=True)" in fixture
 
 
-def test_report_policy_fixture_grants_only_its_generated_run_to_report_reader(
+def test_report_policy_fixture_relies_on_the_service_token_scope(
     tmp_path: Path,
 ) -> None:
     config = _config(tmp_path)
 
-    release_golden_path.write_report_policy_fixture(config, "promoted-logical-run")
+    release_golden_path.write_report_policy_fixture(config)
 
     policy = (config.project_dir / ".phlo" / "authorization" / "policies.yaml").read_text(
         encoding="utf-8"
@@ -162,16 +162,12 @@ def test_report_policy_fixture_grants_only_its_generated_run_to_report_reader(
     assert 'action: "*"' not in policy
     report_policy = policy.split("  - policy_id: release-golden-path-report-read", 1)[1]
     assert "action: run.read" in report_policy
-    assert (
-        'id_pattern: "project_id=phlo-qa001-test|run_id=promoted-logical-run|attempt=1"'
-        in report_policy
-    )
-    assert 'id_pattern: "*"' not in report_policy
+    assert 'id_pattern: "*"' in report_policy
     assert "action: catalog.read" not in report_policy
     assert "action: run.execute" not in report_policy
 
 
-def test_main_binds_report_policy_and_wap_to_the_same_generated_logical_run_id(
+def test_main_binds_report_scope_and_wap_to_the_same_generated_logical_run_id(
     tmp_path: Path, monkeypatch
 ) -> None:
     captured: dict[str, str] = {}
@@ -195,14 +191,14 @@ def test_main_binds_report_policy_and_wap_to_the_same_generated_logical_run_id(
     ):
         monkeypatch.setattr(release_golden_path, name, lambda *_args, **_kwargs: None)
 
-    def write_policy(_config, logical_run_id: str) -> None:
-        captured["policy"] = logical_run_id
+    def configure(_config, logical_run_id: str) -> None:
+        captured["scope"] = logical_run_id
 
     def materialize(_config, logical_run_id: str) -> release_golden_path.WapRun:
         captured["wap"] = logical_run_id
         return release_golden_path.WapRun(logical_run_id, "dagster-run")
 
-    monkeypatch.setattr(release_golden_path, "write_report_policy_fixture", write_policy)
+    monkeypatch.setattr(release_golden_path, "configure_non_dev_compose", configure)
     monkeypatch.setattr(release_golden_path, "materialize_wap", materialize)
     monkeypatch.setattr(release_golden_path, "project_name", lambda: "phlo-qa001-test")
     monkeypatch.setattr(
@@ -215,7 +211,7 @@ def test_main_binds_report_policy_and_wap_to_the_same_generated_logical_run_id(
         )
         == 0
     )
-    assert captured == {"policy": "promoted-logical-run", "wap": "promoted-logical-run"}
+    assert captured == {"scope": "promoted-logical-run", "wap": "promoted-logical-run"}
 
 
 def test_transform_materialization_preserves_the_partition(tmp_path: Path, monkeypatch) -> None:
@@ -340,9 +336,7 @@ def test_run_report_requires_the_wap_logical_run_id(tmp_path: Path, monkeypatch)
     monkeypatch.setattr(
         release_golden_path,
         "service_url",
-        lambda *_: (
-            "http://127.0.0.1:4000/api/observatory/projects/phlo-qa001-test/runs/logical/attempts/1/report"
-        ),
+        lambda _config, _service, _port, path: f"http://127.0.0.1:4000{path}",
     )
 
     class Response(io.BytesIO):
@@ -356,7 +350,17 @@ def test_run_report_requires_the_wap_logical_run_id(tmp_path: Path, monkeypatch)
 
     def urlopen(request, **_kwargs):
         requests.append(request)
-        return Response(json.dumps({"run_id": "logical"}).encode())
+        if request.full_url.endswith("/runs/logical/attempts/1/report"):
+            return Response(json.dumps({"run_id": "logical"}).encode())
+        raise release_golden_path.urllib.error.HTTPError(
+            request.full_url,
+            403,
+            "Forbidden",
+            {},
+            Response(
+                json.dumps({"error": "forbidden", "reason": "run_report_scope_mismatch"}).encode()
+            ),
+        )
 
     monkeypatch.setattr(release_golden_path.urllib.request, "urlopen", urlopen)
 
@@ -365,6 +369,7 @@ def test_run_report_requires_the_wap_logical_run_id(tmp_path: Path, monkeypatch)
     )
 
     assert requests[0].get_header("Authorization") == f"Bearer {config.report_token}"
+    assert requests[1].get_header("Authorization") == f"Bearer {config.report_token}"
 
 
 def test_existing_project_or_sibling_is_rejected_without_touching_it(
@@ -705,7 +710,7 @@ def test_configure_non_dev_compose_uses_docker_ephemeral_ports(tmp_path: Path, m
     )
     monkeypatch.setattr(release_golden_path, "run", lambda *args, **kwargs: None)
 
-    release_golden_path.configure_non_dev_compose(config)
+    release_golden_path.configure_non_dev_compose(config, "promoted-logical-run")
 
     env_local = config.project_dir.joinpath(".phlo/.env.local").read_text()
     assert all(f"{name}=0\n" in env_local for name in release_golden_path.PORT_NAMES)
@@ -722,6 +727,11 @@ def test_configure_non_dev_compose_uses_docker_ephemeral_ports(tmp_path: Path, m
     assert configured_tokens == {
         config.report_token: {
             "subject": "qa001-report-reader",
-            "attributes": {"qa001_role": "report_reader"},
+            "attributes": {
+                "qa001_role": "report_reader",
+                "phlo.run_report_resource_id": (
+                    "project_id=phlo-qa001-test|run_id=promoted-logical-run|attempt=1"
+                ),
+            },
         }
     }


### PR DESCRIPTION
## Outcome

A report-scoped service token can read only its exact project, run, and attempt. A request for another report is rejected before the report handler runs, even when the configured policy is broader.

## Changes

- Added an API boundary check for the `phlo.run_report_resource_id` service-token attribute.
- Made Dagster evidence attach the canonical project, run, and attempt identity to its events and stages.
- Extended the existing generated-stack release path to make both requests: the intended report must return 200 and a second report must return 403 with `run_report_scope_mismatch`.
- Kept existing user authorization unchanged.

## Validation

- Focused API, Dagster, and release-harness suites: 149 passed.
- Ruff, formatting, whitespace checks, and commit hooks passed.
- Local generated-stack execution built the artifacts but could not start Compose because the local Docker daemon was unavailable. CI runs the same generated-stack proof.