### PR TITLE
fix(wap): persist rejected quality evidence

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
@@ -355,6 +355,8 @@ def _quality_evidence(
         report = json.loads(raw.decode("utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         report = None
+    if report is not None and not isinstance(report, dict):
+        report = None
     if report is not None and report.get("run_id") != run_id:
         return None, {"quality_evidence": {"status": "unavailable"}}
     quality_id = None

--- a/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
@@ -349,12 +349,13 @@ def _quality_evidence(
 ) -> tuple[str | None, dict[str, Any]]:
     """Read report evidence and bind promotion to a durable aggregate decision."""
     path = _report_path(run_id)
+    raw: bytes | None = None
     try:
         raw = path.read_bytes()
         report = json.loads(raw.decode("utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
-        return None, {"quality_evidence": {"status": "unavailable"}}
-    if report.get("run_id") != run_id:
+        report = None
+    if report is not None and report.get("run_id") != run_id:
         return None, {"quality_evidence": {"status": "unavailable"}}
     quality_id = None
     checks = _quality_check_records(instance, run_id) if instance is not None else None
@@ -370,12 +371,12 @@ def _quality_evidence(
         )
         if aggregate_id is not None:
             quality_id = aggregate_id
-    checksum = hashlib.sha256(raw).hexdigest()
-    snapshot_path = _report_snapshot_path(run_id, checksum)
-    evidence_path = snapshot_path if snapshot_path.exists() else path
+    checksum = hashlib.sha256(raw).hexdigest() if raw is not None else None
+    snapshot_path = _report_snapshot_path(run_id, checksum) if checksum is not None else None
+    evidence_path = snapshot_path if snapshot_path is not None and snapshot_path.exists() else path
     return quality_id, {
         "quality_evidence": {
-            "uri": str(evidence_path),
+            "uri": str(evidence_path) if raw is not None else None,
             "checksum": checksum,
             "status": "observed" if quality_id else "unavailable",
             "identifier_source": (

--- a/packages/phlo-dagster/tests/test_wap_sensors.py
+++ b/packages/phlo-dagster/tests/test_wap_sensors.py
@@ -505,6 +505,46 @@ def test_wap_quality_evidence_ignores_forged_report_ids_when_checks_unavailable(
     assert metadata["quality_evidence"]["identifier_source"] is None
 
 
+def test_wap_quality_evidence_persists_decision_without_a_preexisting_report(monkeypatch, tmp_path):
+    """Launches have Dagster check records before the sensor writes its WAP report."""
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    dagster_run_id = "dagster-run"
+    logical_run_id = "logical-run"
+    instance = SimpleNamespace(
+        get_records_for_run=lambda *_args, **_kwargs: SimpleNamespace(
+            records=[
+                SimpleNamespace(
+                    storage_id=1,
+                    event_log_entry=SimpleNamespace(
+                        asset_check_evaluation=SimpleNamespace(passed=False)
+                    ),
+                )
+            ]
+        )
+    )
+    store = SQLiteRunEvidenceStore(":memory:")
+    bus = HookBus()
+    bus.register_provider(CoreRunEvidenceHookProvider(store), plugin_name="test")
+    monkeypatch.setattr("phlo_dagster.wap_sensors.get_hook_bus", lambda: bus)
+    monkeypatch.setattr("phlo_dagster.wap_sensors.default_run_evidence_store", lambda: store)
+
+    quality_id, metadata = _quality_evidence(
+        dagster_run_id,
+        instance,
+        project_id="project-quality",
+        attempt=1,
+        evidence_run_id=logical_run_id,
+    )
+
+    results = store.list_quality_results("project-quality", logical_run_id, attempt=1)
+    assert quality_id == results[0]["quality_result_id"]
+    assert results[0]["check_id"] == "wap.aggregate"
+    assert results[0]["passed"] == 0
+    assert metadata["quality_evidence"]["status"] == "observed"
+    assert metadata["quality_evidence"]["uri"] is None
+    assert metadata["quality_evidence"]["checksum"] is None
+
+
 def test_wap_merge_failure_preserves_successful_dagster_run_status(monkeypatch, tmp_path):
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     run_id = "run-merge-failure"

--- a/packages/phlo-dagster/tests/test_wap_sensors.py
+++ b/packages/phlo-dagster/tests/test_wap_sensors.py
@@ -505,6 +505,57 @@ def test_wap_quality_evidence_ignores_forged_report_ids_when_checks_unavailable(
     assert metadata["quality_evidence"]["identifier_source"] is None
 
 
+@pytest.mark.parametrize("report", ["[]", '"not-a-report"'])
+def test_wap_quality_evidence_ignores_non_mapping_reports(monkeypatch, tmp_path, report):
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    run_id = "run-non-mapping-quality"
+    report_path = tmp_path / ".phlo" / "wap-reports" / f"{run_id}.json"
+    report_path.parent.mkdir(parents=True)
+    report_path.write_text(report)
+    instance = SimpleNamespace(
+        get_records_for_run=lambda *_args, **_kwargs: SimpleNamespace(
+            records=[
+                SimpleNamespace(
+                    storage_id=1,
+                    event_log_entry=SimpleNamespace(
+                        asset_check_evaluation=SimpleNamespace(passed=False)
+                    ),
+                )
+            ]
+        )
+    )
+    store = SQLiteRunEvidenceStore(":memory:")
+    bus = HookBus()
+    bus.register_provider(CoreRunEvidenceHookProvider(store), plugin_name="test")
+    monkeypatch.setattr("phlo_dagster.wap_sensors.get_hook_bus", lambda: bus)
+    monkeypatch.setattr("phlo_dagster.wap_sensors.default_run_evidence_store", lambda: store)
+
+    quality_id, metadata = _quality_evidence(
+        run_id, instance, project_id="project-quality", attempt=1
+    )
+
+    results = store.list_quality_results("project-quality", run_id, attempt=1)
+    assert quality_id == results[0]["quality_result_id"]
+    assert metadata["quality_evidence"]["status"] == "observed"
+
+
+def test_wap_quality_evidence_rejects_report_with_wrong_run_id(monkeypatch, tmp_path):
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    run_id = "run-quality"
+    report_path = tmp_path / ".phlo" / "wap-reports" / f"{run_id}.json"
+    report_path.parent.mkdir(parents=True)
+    report_path.write_text(json.dumps({"run_id": "different-run"}))
+    instance = MagicMock()
+
+    quality_id, metadata = _quality_evidence(
+        run_id, instance, project_id="project-quality", attempt=1
+    )
+
+    assert quality_id is None
+    assert metadata["quality_evidence"]["status"] == "unavailable"
+    instance.get_records_for_run.assert_not_called()
+
+
 def test_wap_quality_evidence_persists_decision_without_a_preexisting_report(monkeypatch, tmp_path):
     """Launches have Dagster check records before the sensor writes its WAP report."""
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))

--- a/scripts/release_golden_path.py
+++ b/scripts/release_golden_path.py
@@ -55,6 +55,7 @@ class RunConfig:
     project_name: str
     partition: str = PARTITION
     report_token: str = field(default_factory=lambda: secrets.token_hex(32), repr=False)
+    rejection_report_token: str = field(default_factory=lambda: secrets.token_hex(32), repr=False)
 
     @property
     def operator_python(self) -> Path:
@@ -289,16 +290,21 @@ from {{ source('raw', 'events') }}
     )
 
 
-def write_wap_fixture(config: RunConfig) -> None:
-    """Add one blocking quality check so WAP promotion has durable evidence."""
+def write_wap_fixture(config: RunConfig, rejected_logical_run_id: str) -> None:
+    """Add a check that rejects one WAP run and passes the happy path."""
     fixture = config.project_dir / "workflows" / "ingestion" / "csv" / "release_wap_check.py"
     fixture.write_text(
-        """import dagster as dg
+        f"""import dagster as dg
 
 
-@dg.asset_check(asset=\"dlt_events\", blocking=True)
-def release_golden_path_wap_check() -> dg.AssetCheckResult:
-    return dg.AssetCheckResult(passed=True)
+@dg.asset_check(asset=\"dlt_events\")
+def release_golden_path_wap_check(context) -> dg.AssetCheckResult:
+    run_tags = context.run.tags or {{}}
+    rejected = run_tags.get(\"phlo/run_id\") == \"{rejected_logical_run_id}\"
+    return dg.AssetCheckResult(
+        passed=not rejected,
+        metadata={{\"reason\": \"intentional_quality_rejection\" if rejected else \"happy_path\"}},
+    )
 """,
         encoding="utf-8",
     )
@@ -391,7 +397,11 @@ def install_project_dependencies(config: RunConfig) -> None:
     )
 
 
-def configure_non_dev_compose(config: RunConfig, logical_run_id: str) -> None:
+def configure_non_dev_compose(
+    config: RunConfig,
+    promoted_logical_run_id: str,
+    rejected_logical_run_id: str,
+) -> None:
     run(
         command(
             str(config.operator_bin),
@@ -426,10 +436,19 @@ def configure_non_dev_compose(config: RunConfig, logical_run_id: str) -> None:
                 "attributes": {
                     "qa001_role": "report_reader",
                     "phlo.run_report_resource_id": (
-                        f"project_id={config.project_name}|run_id={logical_run_id}|attempt=1"
+                        f"project_id={config.project_name}|run_id={promoted_logical_run_id}|attempt=1"
                     ),
                 },
-            }
+            },
+            config.rejection_report_token: {
+                "subject": "qa002-rejection-report-reader",
+                "attributes": {
+                    "qa001_role": "report_reader",
+                    "phlo.run_report_resource_id": (
+                        f"project_id={config.project_name}|run_id={rejected_logical_run_id}|attempt=1"
+                    ),
+                },
+            },
         }
         stream.write(f"PHLO_AUTH_SERVICE_TOKENS={json.dumps(tokens, separators=(',', ':'))}\n")
         stream.writelines(f"{name}=0\n" for name in PORT_NAMES)
@@ -660,8 +679,8 @@ def wait_for_wap_promotion(config: RunConfig, wap_run: WapRun) -> None:
     raise TimeoutError(f"WAP run was not promoted: {wap_run.dagster_run_id}")
 
 
-def verify_run_report(config: RunConfig, wap_run: WapRun) -> None:
-    """Prove the scoped service token reads its report and no other report."""
+def fetch_run_report(config: RunConfig, wap_run: WapRun, token: str) -> dict[str, object]:
+    """Read one exact run report, waiting for its durable projection."""
     url = service_url(
         config,
         "phlo-api",
@@ -674,12 +693,12 @@ def verify_run_report(config: RunConfig, wap_run: WapRun) -> None:
         try:
             request = urllib.request.Request(
                 url,
-                headers={"Authorization": f"Bearer {config.report_token}"},
+                headers={"Authorization": f"Bearer {token}"},
             )
             with urllib.request.urlopen(request, timeout=10) as response:  # noqa: S310
                 payload = json.load(response)
             if isinstance(payload, dict) and payload.get("run_id") == wap_run.logical_run_id:
-                break
+                return payload
             raise RuntimeError(f"run report returned the wrong run: {payload!r}")
         except (urllib.error.HTTPError, urllib.error.URLError, RuntimeError) as exc:
             last_error = exc
@@ -688,6 +707,11 @@ def verify_run_report(config: RunConfig, wap_run: WapRun) -> None:
         raise RuntimeError(
             f"run report was not available for {wap_run.logical_run_id}: {last_error}"
         )
+
+
+def verify_run_report(config: RunConfig, wap_run: WapRun) -> None:
+    """Prove the scoped service token reads its report and no other report."""
+    fetch_run_report(config, wap_run, config.report_token)
 
     other_url = service_url(
         config,
@@ -711,6 +735,50 @@ def verify_run_report(config: RunConfig, wap_run: WapRun) -> None:
             return
         raise RuntimeError(f"unexpected scoped report response: {exc.code} {body!r}") from exc
     raise RuntimeError("scoped report token read another run report")
+
+
+def verify_rejected_wap_report(config: RunConfig, wap_run: WapRun) -> None:
+    """Require durable rejected-quality evidence and prove that run was not promoted."""
+    payload = fetch_run_report(config, wap_run, config.rejection_report_token)
+    quality = payload.get("quality")
+    if not isinstance(quality, list) or not any(
+        isinstance(result, dict)
+        and result.get("blocking") is True
+        and result.get("passed") is False
+        for result in quality
+    ):
+        raise RuntimeError(
+            f"rejected WAP report lacks a blocking failed quality result: {payload!r}"
+        )
+    catalog_changes = payload.get("catalog_changes")
+    if not isinstance(catalog_changes, list) or not any(
+        isinstance(change, dict) and change.get("merge_outcome") == "rejected_quality"
+        for change in catalog_changes
+    ):
+        raise RuntimeError(f"rejected WAP report lacks rejection evidence: {payload!r}")
+
+    token = service_token("phlo-api", wap_service_secret(config))
+    dagster_url = service_url(config, "dagster", 3000, "/graphql")
+    run_query = """query Run($runId: ID!) {
+  pipelineRunOrError(runId: $runId) {
+    __typename
+    ... on Run { tags { key value } }
+    ... on PythonError { message }
+  }
+}"""
+    response = graphql(dagster_url, run_query, {"runId": wap_run.dagster_run_id}, token)
+    run_data = (response.get("data", {}) if isinstance(response.get("data"), dict) else {}).get(
+        "pipelineRunOrError", {}
+    )
+    if not isinstance(run_data, dict):
+        raise RuntimeError(f"Dagster did not return rejected WAP run data: {run_data!r}")
+    tags = {
+        str(tag.get("key")): str(tag.get("value"))
+        for tag in run_data.get("tags", [])
+        if isinstance(tag, dict) and tag.get("key") is not None and tag.get("value") is not None
+    }
+    if tags.get("phlo/wap_promoted") == "true":
+        raise RuntimeError(f"quality-rejected WAP run was promoted: {wap_run.dagster_run_id}")
 
 
 def verify_rows(
@@ -865,11 +933,12 @@ def main(argv: list[str] | None = None) -> int:
         install_operator(config)
         create_project(config)
         write_transform_fixture(config)
-        write_wap_fixture(config)
+        rejected_logical_run_id = uuid.uuid4().hex
+        promoted_logical_run_id = uuid.uuid4().hex
+        write_wap_fixture(config, rejected_logical_run_id)
         align_project_name(config)
         install_project_dependencies(config)
-        logical_run_id = uuid.uuid4().hex
-        configure_non_dev_compose(config, logical_run_id)
+        configure_non_dev_compose(config, promoted_logical_run_id, rejected_logical_run_id)
         write_report_policy_fixture(config)
         start_stack(config)
         stack_started = True
@@ -878,9 +947,11 @@ def main(argv: list[str] | None = None) -> int:
         verify_rows(config, expected_count=FIXTURE_ROW_COUNT)
         materialize_transform(config)
         verify_rows(config, table="raw_marts.events_mart", expected_count=FIXTURE_ROW_COUNT)
-        wap_run = materialize_wap(config, logical_run_id)
-        wait_for_wap_promotion(config, wap_run)
-        verify_run_report(config, wap_run)
+        rejected_wap_run = materialize_wap(config, rejected_logical_run_id)
+        verify_rejected_wap_report(config, rejected_wap_run)
+        promoted_wap_run = materialize_wap(config, promoted_logical_run_id)
+        wait_for_wap_promotion(config, promoted_wap_run)
+        verify_run_report(config, promoted_wap_run)
     except Exception as exc:
         primary_error = exc
     finally:

--- a/tests/scripts/test_release_golden_path.py
+++ b/tests/scripts/test_release_golden_path.py
@@ -5,6 +5,7 @@ import io
 import json
 import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _spec = importlib.util.spec_from_file_location(
@@ -132,16 +133,40 @@ def test_transform_fixture_has_a_raw_events_mart(tmp_path: Path) -> None:
     )
 
 
-def test_wap_fixture_defines_a_blocking_passing_asset_check(tmp_path: Path) -> None:
+def test_wap_fixture_rejects_one_run_and_preserves_the_happy_path(
+    tmp_path: Path, monkeypatch
+) -> None:
     config = _config(tmp_path)
     fixture_dir = config.project_dir / "workflows" / "ingestion" / "csv"
     fixture_dir.mkdir(parents=True)
 
-    release_golden_path.write_wap_fixture(config)
+    release_golden_path.write_wap_fixture(config, "rejected-run")
 
     fixture = (fixture_dir / "release_wap_check.py").read_text(encoding="utf-8")
-    assert '@dg.asset_check(asset="dlt_events", blocking=True)' in fixture
-    assert "return dg.AssetCheckResult(passed=True)" in fixture
+    assert '@dg.asset_check(asset="dlt_events")' in fixture
+    assert "blocking=True" not in fixture
+    assert "run_tags = context.run.tags or {}" in fixture
+    assert 'run_tags.get("phlo/run_id") == "rejected-run"' in fixture
+    assert "passed=not rejected" in fixture
+    assert "intentional_quality_rejection" in fixture
+
+    fake_dagster = ModuleType("dagster")
+    fake_dagster.asset_check = lambda **_: lambda check: check
+    fake_dagster.AssetCheckResult = lambda **kwargs: kwargs
+    monkeypatch.setitem(sys.modules, "dagster", fake_dagster)
+    namespace: dict[str, object] = {}
+    exec(compile(fixture, str(fixture_dir / "release_wap_check.py"), "exec"), namespace)
+    check = namespace["release_golden_path_wap_check"]
+
+    assert callable(check)
+    assert check(SimpleNamespace(run=SimpleNamespace(tags={}))) == {
+        "passed": True,
+        "metadata": {"reason": "happy_path"},
+    }
+    assert check(SimpleNamespace(run=SimpleNamespace(tags={"phlo/run_id": "rejected-run"}))) == {
+        "passed": False,
+        "metadata": {"reason": "intentional_quality_rejection"},
+    }
 
 
 def test_report_policy_fixture_relies_on_the_service_token_scope(
@@ -167,7 +192,7 @@ def test_report_policy_fixture_relies_on_the_service_token_scope(
     assert "action: run.execute" not in report_policy
 
 
-def test_main_binds_report_scope_and_wap_to_the_same_generated_logical_run_id(
+def test_main_binds_each_report_scope_to_its_matching_generated_wap_run(
     tmp_path: Path, monkeypatch
 ) -> None:
     captured: dict[str, str] = {}
@@ -188,21 +213,26 @@ def test_main_binds_report_scope_and_wap_to_the_same_generated_logical_run_id(
         "verify_rows",
         "wait_for_wap_promotion",
         "verify_run_report",
+        "verify_rejected_wap_report",
     ):
         monkeypatch.setattr(release_golden_path, name, lambda *_args, **_kwargs: None)
 
-    def configure(_config, logical_run_id: str) -> None:
-        captured["scope"] = logical_run_id
+    def configure(_config, promoted_logical_run_id: str, rejected_logical_run_id: str) -> None:
+        captured["promoted_scope"] = promoted_logical_run_id
+        captured["rejected_scope"] = rejected_logical_run_id
 
     def materialize(_config, logical_run_id: str) -> release_golden_path.WapRun:
-        captured["wap"] = logical_run_id
+        captured[f"wap_{logical_run_id}"] = logical_run_id
         return release_golden_path.WapRun(logical_run_id, "dagster-run")
 
     monkeypatch.setattr(release_golden_path, "configure_non_dev_compose", configure)
     monkeypatch.setattr(release_golden_path, "materialize_wap", materialize)
     monkeypatch.setattr(release_golden_path, "project_name", lambda: "phlo-qa001-test")
+    logical_run_ids = iter(("rejected-logical-run", "promoted-logical-run"))
     monkeypatch.setattr(
-        release_golden_path.uuid, "uuid4", lambda: type("Id", (), {"hex": "promoted-logical-run"})()
+        release_golden_path.uuid,
+        "uuid4",
+        lambda: type("Id", (), {"hex": next(logical_run_ids)})(),
     )
 
     assert (
@@ -211,7 +241,12 @@ def test_main_binds_report_scope_and_wap_to_the_same_generated_logical_run_id(
         )
         == 0
     )
-    assert captured == {"scope": "promoted-logical-run", "wap": "promoted-logical-run"}
+    assert captured == {
+        "rejected_scope": "rejected-logical-run",
+        "promoted_scope": "promoted-logical-run",
+        "wap_rejected-logical-run": "rejected-logical-run",
+        "wap_promoted-logical-run": "promoted-logical-run",
+    }
 
 
 def test_transform_materialization_preserves_the_partition(tmp_path: Path, monkeypatch) -> None:
@@ -370,6 +405,65 @@ def test_run_report_requires_the_wap_logical_run_id(tmp_path: Path, monkeypatch)
 
     assert requests[0].get_header("Authorization") == f"Bearer {config.report_token}"
     assert requests[1].get_header("Authorization") == f"Bearer {config.report_token}"
+
+
+def test_rejected_wap_report_requires_failed_quality_and_rejection_evidence(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    wap_run = release_golden_path.WapRun("rejected", "dagster-rejected")
+    monkeypatch.setattr(
+        release_golden_path,
+        "fetch_run_report",
+        lambda *_: {
+            "run_id": "rejected",
+            "quality": [{"blocking": True, "passed": False}],
+            "catalog_changes": [{"merge_outcome": "rejected_quality"}],
+        },
+    )
+    monkeypatch.setattr(release_golden_path, "service_url", lambda *_: "http://dagster/graphql")
+    monkeypatch.setattr(release_golden_path, "service_token", lambda *_: "service-token")
+    monkeypatch.setattr(release_golden_path, "wap_service_secret", lambda _: "secret")
+    monkeypatch.setattr(
+        release_golden_path,
+        "graphql",
+        lambda *_: {"data": {"pipelineRunOrError": {"tags": []}}},
+    )
+
+    release_golden_path.verify_rejected_wap_report(config, wap_run)
+
+
+def test_rejected_wap_report_rejects_any_promotion(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    wap_run = release_golden_path.WapRun("rejected", "dagster-rejected")
+    monkeypatch.setattr(
+        release_golden_path,
+        "fetch_run_report",
+        lambda *_: {
+            "run_id": "rejected",
+            "quality": [{"blocking": True, "passed": False}],
+            "catalog_changes": [{"merge_outcome": "rejected_quality"}],
+        },
+    )
+    monkeypatch.setattr(release_golden_path, "service_url", lambda *_: "http://dagster/graphql")
+    monkeypatch.setattr(release_golden_path, "service_token", lambda *_: "service-token")
+    monkeypatch.setattr(release_golden_path, "wap_service_secret", lambda _: "secret")
+    monkeypatch.setattr(
+        release_golden_path,
+        "graphql",
+        lambda *_: {
+            "data": {
+                "pipelineRunOrError": {"tags": [{"key": "phlo/wap_promoted", "value": "true"}]}
+            }
+        },
+    )
+
+    try:
+        release_golden_path.verify_rejected_wap_report(config, wap_run)
+    except RuntimeError as exc:
+        assert "was promoted" in str(exc)
+    else:
+        raise AssertionError("a rejected WAP run must not be promoted")
 
 
 def test_existing_project_or_sibling_is_rejected_without_touching_it(
@@ -710,7 +804,9 @@ def test_configure_non_dev_compose_uses_docker_ephemeral_ports(tmp_path: Path, m
     )
     monkeypatch.setattr(release_golden_path, "run", lambda *args, **kwargs: None)
 
-    release_golden_path.configure_non_dev_compose(config, "promoted-logical-run")
+    release_golden_path.configure_non_dev_compose(
+        config, "promoted-logical-run", "rejected-logical-run"
+    )
 
     env_local = config.project_dir.joinpath(".phlo/.env.local").read_text()
     assert all(f"{name}=0\n" in env_local for name in release_golden_path.PORT_NAMES)
@@ -733,5 +829,14 @@ def test_configure_non_dev_compose_uses_docker_ephemeral_ports(tmp_path: Path, m
                     "project_id=phlo-qa001-test|run_id=promoted-logical-run|attempt=1"
                 ),
             },
-        }
+        },
+        config.rejection_report_token: {
+            "subject": "qa002-rejection-report-reader",
+            "attributes": {
+                "qa001_role": "report_reader",
+                "phlo.run_report_resource_id": (
+                    "project_id=phlo-qa001-test|run_id=rejected-logical-run|attempt=1"
+                ),
+            },
+        },
     }


### PR DESCRIPTION
## Outcome

A non-blocking failed WAP asset check now produces one durable `wap.aggregate` rejection under the logical run identity, so the authorised report can show the rejection and WAP does not promote the branch.

## Scope

- Persist aggregate quality from Dagster check records even before a local WAP report exists.
- Extend the existing release golden path with one rejected WAP run and retain the existing promoted run.

## Evidence

- `uv run pytest packages/phlo-dagster/tests/test_wap_sensors.py tests/scripts/test_release_golden_path.py -q` — 61 passed.
- Focused Ruff format and lint checks passed.
- Real generated stack: rejected logical run recorded failed blocking `wap.aggregate` and `rejected_quality`; the normal run recorded `promoted`. The owned Docker stack, volumes, and temporary project were removed after inspection.