### PR TITLE
fix(testing): correlate bundled WAP runs

### DIFF
--- a/packages/phlo-testing/src/phlo_testing/profile_harness.py
+++ b/packages/phlo-testing/src/phlo_testing/profile_harness.py
@@ -413,11 +413,14 @@ def _allocate_unique_port(
     return candidate
 
 
-def build_bundled_stack_env_updates(resolve_port: Any) -> dict[str, str]:
+def build_bundled_stack_env_updates(
+    resolve_port: Any, *, project_name: str | None = None
+) -> dict[str, str]:
     """Build environment variable updates for bundled stack ports.
 
     Args:
         resolve_port: Function to resolve service ports.
+        project_name: Stable project identity for generated service processes.
 
     Returns:
         Dictionary of environment variable updates with unique ports.
@@ -436,6 +439,9 @@ def build_bundled_stack_env_updates(resolve_port: Any) -> dict[str, str]:
         for env_key, (service_name, default_port) in _BUNDLED_STACK_PORT_DEFAULTS.items()
     }
     updates["PHLO_DEV_EXTRA_PACKAGES"] = ",".join(BUNDLED_STACK_DEV_PACKAGES)
+    if project_name:
+        updates["PHLO_PROJECT"] = project_name
+    updates["PHLO_WAP_SENSORS_ENABLED"] = "true"
     updates["PHLO_WAP_BRANCH_CREATION_INTERVAL_SECONDS"] = "1"
     updates["PHLO_WAP_PROMOTION_INTERVAL_SECONDS"] = "1"
     return updates
@@ -1392,13 +1398,19 @@ QualityResultEventEmitter(
         """
         from phlo_nessie.resource import NessieResource
 
-        branch_name = f"pipeline-run-{uuid.uuid4().hex[:12]}"
+        logical_run_id = uuid.uuid4().hex
+        branch_name = f"pipeline-run-{logical_run_id}"
         nessie = NessieResource(base_url=f"http://127.0.0.1:{self.ports.nessie}")
         created_hash = nessie.create_branch(branch_name, from_ref="main")
         if created_hash is None:
             raise RuntimeError(f"Unable to create WAP branch {branch_name}")
 
-        tags: dict[str, str] = {"phlo/wap_branch": branch_name}
+        tags: dict[str, str] = {
+            "phlo/wap_branch": branch_name,
+            "phlo/run_id": logical_run_id,
+            "phlo/project_id": self.project_dir.name,
+            "phlo/attempt": "1",
+        }
         if partition_date:
             tags[PARTITION_NAME_TAG] = partition_date
 
@@ -1947,7 +1959,7 @@ def bootstrap_bundled_stack_harness(
         )
         utils.apply_env_updates(
             target_project_dir / ".phlo",
-            build_bundled_stack_env_updates(utils.resolve_port),
+            build_bundled_stack_env_updates(utils.resolve_port, project_name=project_name),
         )
         _write_bundled_stack_workflow(
             project_dir=target_project_dir,

--- a/packages/phlo-testing/tests/test_profile_harness.py
+++ b/packages/phlo-testing/tests/test_profile_harness.py
@@ -39,6 +39,7 @@ def test_build_bundled_stack_env_updates_resolves_core_ports(monkeypatch) -> Non
     assert updates["DAGSTER_PORT"] == "3010"
     assert updates["POSTGRES_PORT"] == "5442"
     assert updates["PHLO_DEV_EXTRA_PACKAGES"] == ",".join(BUNDLED_STACK_DEV_PACKAGES)
+    assert updates["PHLO_WAP_SENSORS_ENABLED"] == "true"
     assert ("Dagster", 3000) in calls
     assert ("Nessie", 19120) in calls
     assert ("Hasura", 8082) in calls
@@ -64,6 +65,16 @@ def test_build_bundled_stack_env_updates_avoids_duplicate_ports(monkeypatch) -> 
     assert updates["OBSERVATORY_PORT"] == "3002"
     assert updates["MINIO_API_PORT"] == "9002"
     assert updates["MINIO_CONSOLE_PORT"] == "9003"
+
+
+def test_build_bundled_stack_env_updates_sets_generated_project_identity(monkeypatch) -> None:
+    monkeypatch.setattr("phlo_testing.profile_harness._port_in_use", lambda port: False)
+
+    updates = build_bundled_stack_env_updates(
+        lambda _service_name, port: port, project_name="proof"
+    )
+
+    assert updates["PHLO_PROJECT"] == "proof"
 
 
 def test_bundled_stack_harness_materialize_adds_partition(monkeypatch) -> None:

--- a/tests/contracts/test_bundled_stack_versioned_contract.py
+++ b/tests/contracts/test_bundled_stack_versioned_contract.py
@@ -28,6 +28,9 @@ def test_bundled_stack_versioned_flow_uses_isolated_branch_then_promotes(
 
     run_tags = bundled_stack_harness.get_run_tags(run_id)
     assert run_tags.get("phlo/wap_branch") == branch_name
+    assert run_tags.get("phlo/project_id") == bundled_stack_harness.project_dir.name
+    assert run_tags.get("phlo/run_id") == branch_name.removeprefix("pipeline-run-")
+    assert run_tags.get("phlo/attempt") == "1"
 
     bundled_stack_harness.wait_for_run_status(
         run_id,


### PR DESCRIPTION
## Outcome

The generated development stack now gives WAP runs the same stable project, logical-run, and attempt correlation used by the existing WAP lifecycle. Its real validation result can be persisted as the durable quality decision, so the existing sensor promotes the run and cleans up only its owned branch.

## Scope

- Configure the generated stack with its project identity and enable its existing local WAP sensors.
- Launch harness WAP runs with canonical correlation tags.
- Assert those persisted tags in the existing real-stack versioned contract.

No WAP sensor policy, regulated behavior, maintenance-provider behavior, or quality framework changed.

## Validation

- `uv run pytest --import-mode=importlib packages/phlo-testing/tests/test_profile_harness.py tests/contracts/test_bundled_stack_versioned_contract.py --tb=short`
- `PHLO_RUN_BUNDLED_STACK_CONTRACT=1 uv run --locked pytest -m integration -s tests/contracts/test_bundled_stack_versioned_contract.py --tb=short` — passed in 198.18s, including real promotion and branch cleanup.
- `uv run ruff check …` and `uv run ruff format --check …`
- Commit hooks, including ruff, AST, codespell, and conflict checks.