### PR TITLE
fix(testing): use generated MinIO credentials for host reads

### DIFF
--- a/packages/phlo-testing/src/phlo_testing/profile_harness.py
+++ b/packages/phlo-testing/src/phlo_testing/profile_harness.py
@@ -1569,13 +1569,22 @@ QualityResultEventEmitter(
         from phlo_iceberg.resource import IcebergResource
         from phlo_iceberg.settings import get_settings as get_iceberg_settings
 
+        env_vars = self.read_env()
+        minio_access_key = os.environ.get(
+            "PHLO_TEST_MINIO_ACCESS_KEY",
+            env_vars.get("MINIO_ROOT_USER", "minio"),
+        )
+        minio_secret_key = os.environ.get(
+            "PHLO_TEST_MINIO_SECRET_KEY",
+            env_vars.get("MINIO_ROOT_PASSWORD", "minio123"),
+        )
         env_updates = {
             "ICEBERG_S3_ENDPOINT": f"http://127.0.0.1:{self.ports.minio_api}",
             "ICEBERG_NESSIE_URI": f"http://127.0.0.1:{self.ports.nessie}/iceberg",
-            "AWS_ACCESS_KEY_ID": os.environ.get("PHLO_TEST_MINIO_ACCESS_KEY", "minio"),
-            "AWS_SECRET_ACCESS_KEY": os.environ.get("PHLO_TEST_MINIO_SECRET_KEY", "minio123"),
-            "ICEBERG_S3_ACCESS_KEY": os.environ.get("PHLO_TEST_MINIO_ACCESS_KEY", "minio"),
-            "ICEBERG_S3_SECRET_KEY": os.environ.get("PHLO_TEST_MINIO_SECRET_KEY", "minio123"),
+            "AWS_ACCESS_KEY_ID": minio_access_key,
+            "AWS_SECRET_ACCESS_KEY": minio_secret_key,
+            "ICEBERG_S3_ACCESS_KEY": minio_access_key,
+            "ICEBERG_S3_SECRET_KEY": minio_secret_key,
         }
         previous = {key: os.environ.get(key) for key in env_updates}
         try:

--- a/packages/phlo-testing/tests/test_profile_harness.py
+++ b/packages/phlo-testing/tests/test_profile_harness.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -289,6 +291,83 @@ def test_bundled_stack_harness_get_run_status_reads_metadata_db(monkeypatch) -> 
         "SELECT status FROM runs WHERE run_id = %s",
         ("run-1",),
     )
+
+
+@pytest.mark.parametrize(
+    ("override_access_key", "override_secret_key", "expected_access_key", "expected_secret_key"),
+    [
+        (None, None, "generated-user", "generated-password"),
+        ("override-user", "override-password", "override-user", "override-password"),
+    ],
+)
+def test_bundled_stack_harness_snapshot_read_uses_resolved_minio_credentials(
+    monkeypatch,
+    override_access_key: str | None,
+    override_secret_key: str | None,
+    expected_access_key: str,
+    expected_secret_key: str,
+) -> None:
+    captured: dict[str, str | None] = {}
+
+    class FakeIcebergResource:
+        def __init__(self, *, ref: str) -> None:
+            captured["ref"] = ref
+
+        def list_snapshots(self, *, table_name: str, limit: int) -> list[dict[str, Any]]:
+            captured.update(
+                table_name=table_name,
+                limit=str(limit),
+                aws_access_key=os.environ.get("AWS_ACCESS_KEY_ID"),
+                aws_secret_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+                iceberg_access_key=os.environ.get("ICEBERG_S3_ACCESS_KEY"),
+                iceberg_secret_key=os.environ.get("ICEBERG_S3_SECRET_KEY"),
+            )
+            return [{"snapshot-id": 1}]
+
+    monkeypatch.setattr("phlo_iceberg.resource.IcebergResource", FakeIcebergResource)
+    monkeypatch.setattr("phlo_iceberg.catalog.reset_catalog_cache", lambda: None)
+    monkeypatch.setattr("phlo_iceberg.settings.get_settings.cache_clear", lambda: None)
+    for name, value in {
+        "PHLO_TEST_MINIO_ACCESS_KEY": override_access_key,
+        "PHLO_TEST_MINIO_SECRET_KEY": override_secret_key,
+    }.items():
+        if value is None:
+            monkeypatch.delenv(name, raising=False)
+        else:
+            monkeypatch.setenv(name, value)
+
+    harness = BundledStackHarness(
+        project_dir=Path("/tmp/project"),
+        phlo_source=Path("/tmp/source"),
+        python_executable=Path("/tmp/project/.venv/bin/python"),
+        ports=BundledStackPorts(
+            phlo_api=54000,
+            dagster=3000,
+            minio_api=9000,
+            nessie=19120,
+        ),
+    )
+    monkeypatch.setattr(
+        BundledStackHarness,
+        "read_env",
+        lambda self: {
+            "MINIO_ROOT_USER": "generated-user",
+            "MINIO_ROOT_PASSWORD": "generated-password",
+        },
+    )
+
+    assert harness.list_table_snapshots(table_name="raw.posts", ref="main", limit=3) == [
+        {"snapshot-id": 1}
+    ]
+    assert captured == {
+        "ref": "main",
+        "table_name": "raw.posts",
+        "limit": "3",
+        "aws_access_key": expected_access_key,
+        "aws_secret_key": expected_secret_key,
+        "iceberg_access_key": expected_access_key,
+        "iceberg_secret_key": expected_secret_key,
+    }
 
 
 def test_bundled_stack_harness_installs_optional_workspace_packages(monkeypatch) -> None:


### PR DESCRIPTION
## What changed

The bundled-stack host snapshot helper now resolves MinIO credentials from the generated project environment, including local secrets, while preserving explicit PHLO_TEST_MINIO_ACCESS_KEY and PHLO_TEST_MINIO_SECRET_KEY overrides.

This fixes the maintenance proof harness using the old fixed minio/minio123 fallback against a stack whose MinIO password was generated during service initialization.

## Validation

- Focused profile-harness suite: 17 passed.
- Fresh generated-stack versioned-flow proof: 1 passed in 208.66 seconds.
- The real-stack proof promoted the workload to main and completed the host-side Iceberg snapshot read without PHLO_TEST MinIO overrides.
- git diff --check passed.
- One bounded standards and specification review found no blocking issues.

## Scope

The change is confined to phlo-testing: one production file with 13 additions and 4 deletions, plus its existing focused test file.

## Non-goals

This does not change product maintenance behavior or providers, add orphan deletion, introduce a maintenance abstraction, rewrite policy, change security behavior, touch release PR #574, or update the v1 dashboard.
