### PR TITLE
fix(testing): preserve host Iceberg endpoint

### DIFF
--- a/packages/phlo-testing/src/phlo_testing/profile_harness.py
+++ b/packages/phlo-testing/src/phlo_testing/profile_harness.py
@@ -1565,7 +1565,7 @@ QualityResultEventEmitter(
             List of snapshot dictionaries.
 
         """
-        from phlo_iceberg.catalog import reset_catalog_cache
+        from phlo_iceberg.catalog import get_catalog, reset_catalog_cache
         from phlo_iceberg.resource import IcebergResource
         from phlo_iceberg.settings import get_settings as get_iceberg_settings
 
@@ -1586,18 +1586,39 @@ QualityResultEventEmitter(
             "ICEBERG_S3_ACCESS_KEY": minio_access_key,
             "ICEBERG_S3_SECRET_KEY": minio_secret_key,
         }
+        host_file_io_properties = {
+            "s3.endpoint": env_updates["ICEBERG_S3_ENDPOINT"],
+            "s3.access-key-id": minio_access_key,
+            "s3.secret-access-key": minio_secret_key,
+        }
         previous = {key: os.environ.get(key) for key in env_updates}
+        catalog = None
+        original_load_file_io = None
         try:
             for key, value in env_updates.items():
                 os.environ[key] = value
             get_iceberg_settings.cache_clear()
             reset_catalog_cache()
+            catalog = get_catalog(ref=ref)
+            original_load_file_io = catalog._load_file_io
+
+            def load_host_file_io(
+                properties: dict[str, Any] | None = None,
+                location: str | None = None,
+            ) -> Any:
+                return original_load_file_io(
+                    {**(properties or {}), **host_file_io_properties}, location
+                )
+
+            catalog._load_file_io = load_host_file_io
             resource = IcebergResource(ref=ref)
             try:
                 return resource.list_snapshots(table_name=table_name, limit=limit)
             except Exception:
                 return []
         finally:
+            if catalog is not None and original_load_file_io is not None:
+                catalog._load_file_io = original_load_file_io
             for key, value in previous.items():
                 if value is None:
                     os.environ.pop(key, None)

--- a/packages/phlo-testing/tests/test_profile_harness.py
+++ b/packages/phlo-testing/tests/test_profile_harness.py
@@ -309,11 +309,27 @@ def test_bundled_stack_harness_snapshot_read_uses_resolved_minio_credentials(
 ) -> None:
     captured: dict[str, str | None] = {}
 
+    class FakeCatalog:
+        def _load_file_io(self, properties: dict[str, str], location: str | None = None) -> object:
+            captured.update(properties)
+            captured["location"] = location
+            return object()
+
+    catalog = FakeCatalog()
+
     class FakeIcebergResource:
         def __init__(self, *, ref: str) -> None:
             captured["ref"] = ref
 
         def list_snapshots(self, *, table_name: str, limit: int) -> list[dict[str, Any]]:
+            catalog._load_file_io(
+                {
+                    "s3.endpoint": "http://minio:9000/",
+                    "s3.access-key-id": "catalog-user",
+                    "s3.secret-access-key": "catalog-password",
+                },
+                "s3://lake/warehouse/raw/posts/metadata.json",
+            )
             captured.update(
                 table_name=table_name,
                 limit=str(limit),
@@ -325,6 +341,7 @@ def test_bundled_stack_harness_snapshot_read_uses_resolved_minio_credentials(
             return [{"snapshot-id": 1}]
 
     monkeypatch.setattr("phlo_iceberg.resource.IcebergResource", FakeIcebergResource)
+    monkeypatch.setattr("phlo_iceberg.catalog.get_catalog", lambda *, ref: catalog)
     monkeypatch.setattr("phlo_iceberg.catalog.reset_catalog_cache", lambda: None)
     monkeypatch.setattr("phlo_iceberg.settings.get_settings.cache_clear", lambda: None)
     for name, value in {
@@ -367,7 +384,12 @@ def test_bundled_stack_harness_snapshot_read_uses_resolved_minio_credentials(
         "aws_secret_key": expected_secret_key,
         "iceberg_access_key": expected_access_key,
         "iceberg_secret_key": expected_secret_key,
+        "s3.endpoint": "http://127.0.0.1:9000",
+        "s3.access-key-id": expected_access_key,
+        "s3.secret-access-key": expected_secret_key,
+        "location": "s3://lake/warehouse/raw/posts/metadata.json",
     }
+    assert catalog._load_file_io.__func__ is FakeCatalog._load_file_io
 
 
 def test_bundled_stack_harness_installs_optional_workspace_packages(monkeypatch) -> None:


### PR DESCRIPTION
## What changed

`phlo-testing` now keeps the generated host-reachable MinIO endpoint and resolved credentials authoritative when PyIceberg builds host-side FileIO instances. Nessie's REST catalog can return the container-only `http://minio:9000/` endpoint in table configuration; the harness overlays its host endpoint and credentials after that response and restores the original catalog loader when the read finishes.

The focused regression covers generated MinIO credentials and explicit test overrides, verifies that the host endpoint wins over the Nessie response, and confirms the original loader is restored.

## Validation

- `uv run pytest packages/phlo-testing/tests/test_profile_harness.py -q` — 17 passed
- `uv run pytest packages/phlo-testing/tests -q` — 51 passed, 3 deselected
- Ruff and repository pre-commit hooks passed
- `git diff --check` passed
- The real generated-stack versioned contract passed in 207.28 seconds. It used generated secrets and host port mappings, completed Workload-Aware Promotion branch promotion and owned-branch cleanup, then returned a non-empty host-side snapshot list after Nessie supplied its container endpoint.

## Scope

This changes one production file and its existing focused test in `phlo-testing`. It does not change a maintenance provider, executor, or policy; redesign service networking; add orphan deletion; or touch release PR #574.
