### PR TITLE
fix(iceberg): stabilize maintenance planning and recovery

### DIFF
--- a/packages/phlo-iceberg/pyproject.toml
+++ b/packages/phlo-iceberg/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
 dependencies = [
     "phlo>=0.1.0",
     "pandera>=0.26.1",
-    "pyiceberg[s3fs,pyarrow]>=0.10.0",
+    "pyiceberg[s3fs,pyarrow]>=0.11.0",
 ]
 description = "Iceberg table-store capability plugin for Phlo"
 name = "phlo-iceberg"

--- a/packages/phlo-iceberg/src/phlo_iceberg/resource.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/resource.py
@@ -109,7 +109,13 @@ def _validate_compaction_table_name(table_name: str) -> str:
 def _maintenance_plan_token(plan: dict[str, object]) -> str:
     """Hash only plan fields that change the requested mutation."""
     basis = json.loads(json.dumps(plan, sort_keys=True, default=str))
-    for key in ("plan_token", "observed_at_ms", "age_seconds", "trino_boundary"):
+    for key in (
+        "plan_token",
+        "observed_at_ms",
+        "age_seconds",
+        "retention_cutoff",
+        "trino_boundary",
+    ):
         _remove_plan_field(basis, key)
     encoded = json.dumps(basis, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
@@ -2241,8 +2247,8 @@ class IcebergResource:
     ) -> dict:
         """Roll back a table to a previous snapshot.
 
-        Restores the table to a specific point in time using the snapshot ID.
-        Creates a new snapshot that points to the historical state.
+        Restores the table to a specific point in time using the snapshot ID by
+        repointing the current snapshot reference to that existing ancestor.
 
         Args:
             table_name: Fully qualified table name (``namespace.table``).
@@ -2269,8 +2275,8 @@ class IcebergResource:
                 print(f"Rolled back to snapshot {result['rolled_back_to']}")
 
         Warning:
-            Rollback creates a new snapshot. The newer snapshots are not
-            deleted and can still be accessed if needed.
+            Rollback does not delete newer snapshots, but they are no longer
+            ancestors of the table's current state.
 
         """
         logger.info(

--- a/packages/phlo-iceberg/src/phlo_iceberg/tables.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/tables.py
@@ -780,7 +780,7 @@ def rollback_table_to_snapshot(
     try:
         catalog = get_catalog(ref=ref)
         table = catalog.load_table(table_name)
-        table.manage_snapshots().rollback_to(snapshot_id).commit()
+        table.manage_snapshots().rollback_to_snapshot(snapshot_id).commit()
     except Exception as exc:
         logger.error(
             "iceberg_table_rollback_failed",

--- a/packages/phlo-iceberg/tests/test_retention_contract.py
+++ b/packages/phlo-iceberg/tests/test_retention_contract.py
@@ -627,6 +627,84 @@ def test_orphan_execute_is_blocked_and_non_retryable(monkeypatch) -> None:
     assert result["planned"]["trino_boundary"] == "not_invoked"
 
 
+def test_orphan_execute_accepts_same_plan_after_only_inventory_cutoff_moves(monkeypatch) -> None:
+    resource = IcebergResource(ref="main")
+    planned = _plan("cleanup_orphan_files")
+    planned["inventory"] = {
+        "complete": True,
+        "digest": "complete-inventory",
+        "retention_cutoff": "2026-07-19T09:00:00+00:00",
+    }
+    planned["plan_token"] = _maintenance_plan_token(planned)
+    revalidated = {
+        **planned,
+        "inventory": {
+            **planned["inventory"],
+            "retention_cutoff": "2026-07-19T09:00:01+00:00",
+        },
+    }
+    revalidated["plan_token"] = _maintenance_plan_token(revalidated)
+    plans = iter([planned, revalidated])
+    monkeypatch.setattr(resource, "_orphan_retention_metadata", lambda **_: (next(plans), object()))
+
+    dry_run = resource.cleanup_orphan_files(
+        table_name="raw.events", catalog="iceberg", dry_run=True
+    )
+    result = resource.cleanup_orphan_files(
+        table_name="raw.events",
+        catalog="iceberg",
+        dry_run=False,
+        expected_snapshot_id=41,
+        confirmation_token=dry_run["plan_token"],
+        max_affected_objects=10,
+        max_affected_bytes=1000,
+    )
+
+    assert dry_run["plan_token"] == revalidated["plan_token"]
+    assert result["failure"]["code"] == "bounded_execution_unsupported"
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"inventory": {"complete": True, "digest": "changed-inventory"}},
+        {"before_snapshot_id": 42},
+        {"retention_hours": SAFE_MIN_RETENTION_HOURS + 24},
+    ],
+    ids=["inventory", "snapshot", "request"],
+)
+def test_orphan_execute_rejects_changed_inventory_snapshot_or_request(
+    monkeypatch, change: dict[str, object]
+) -> None:
+    resource = IcebergResource(ref="main")
+    planned = _plan("cleanup_orphan_files")
+    planned["inventory"] = {
+        "complete": True,
+        "digest": "complete-inventory",
+        "retention_cutoff": "2026-07-19T09:00:00+00:00",
+    }
+    planned["plan_token"] = _maintenance_plan_token(planned)
+    revalidated = {**planned, **change}
+    revalidated["plan_token"] = _maintenance_plan_token(revalidated)
+    plans = iter([planned, revalidated])
+    monkeypatch.setattr(resource, "_orphan_retention_metadata", lambda **_: (next(plans), object()))
+
+    dry_run = resource.cleanup_orphan_files(
+        table_name="raw.events", catalog="iceberg", dry_run=True
+    )
+    result = resource.cleanup_orphan_files(
+        table_name="raw.events",
+        catalog="iceberg",
+        dry_run=False,
+        expected_snapshot_id=41,
+        confirmation_token=dry_run["plan_token"],
+        max_affected_objects=10,
+        max_affected_bytes=1000,
+    )
+
+    assert result["failure"]["code"] == "plan_token_invalid"
+
+
 @pytest.mark.parametrize(
     ("error", "retryable"),
     [

--- a/packages/phlo-iceberg/tests/test_tables_rollback.py
+++ b/packages/phlo-iceberg/tests/test_tables_rollback.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+from pyiceberg.catalog.memory import InMemoryCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import LongType, NestedField
+
+from phlo_iceberg import tables
+
+
+def _table_with_two_snapshots(tmp_path, monkeypatch):
+    catalog = InMemoryCatalog("test", warehouse=f"file://{tmp_path}")
+    catalog.create_namespace("raw")
+    table = catalog.create_table(
+        "raw.events",
+        schema=Schema(NestedField(1, "id", LongType(), required=False)),
+    )
+    table.append(pa.table({"id": pa.array([1], type=pa.int64())}))
+    first_snapshot_id = table.current_snapshot().snapshot_id
+    table.append(pa.table({"id": pa.array([2], type=pa.int64())}))
+    second_snapshot_id = table.current_snapshot().snapshot_id
+    monkeypatch.setattr(tables, "get_catalog", lambda ref: catalog)
+    return catalog, first_snapshot_id, second_snapshot_id
+
+
+def _row_ids(catalog: InMemoryCatalog) -> list[int]:
+    return catalog.load_table("raw.events").scan().to_arrow()["id"].to_pylist()
+
+
+def test_rollback_restores_an_ancestor_snapshot(tmp_path, monkeypatch) -> None:
+    catalog, first_snapshot_id, _ = _table_with_two_snapshots(tmp_path, monkeypatch)
+
+    result = tables.rollback_table_to_snapshot("raw.events", first_snapshot_id)
+
+    restored = catalog.load_table("raw.events")
+    assert result == {"rolled_back_to": first_snapshot_id}
+    assert restored.current_snapshot().snapshot_id == first_snapshot_id
+    assert _row_ids(catalog) == [1]
+
+
+def test_rollback_rejects_an_unknown_snapshot_without_mutation(tmp_path, monkeypatch) -> None:
+    catalog, _, second_snapshot_id = _table_with_two_snapshots(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="unknown snapshot"):
+        tables.rollback_table_to_snapshot("raw.events", -1)
+
+    assert catalog.load_table("raw.events").current_snapshot().snapshot_id == second_snapshot_id
+    assert sorted(_row_ids(catalog)) == [1, 2]
+
+
+def test_rollback_rejects_a_non_ancestor_without_mutation(tmp_path, monkeypatch) -> None:
+    catalog, first_snapshot_id, original_second_id = _table_with_two_snapshots(
+        tmp_path, monkeypatch
+    )
+    table = catalog.load_table("raw.events")
+    table.manage_snapshots().rollback_to_snapshot(first_snapshot_id).commit()
+    table = catalog.load_table("raw.events")
+    table.append(pa.table({"id": pa.array([3], type=pa.int64())}))
+    divergent_snapshot_id = catalog.load_table("raw.events").current_snapshot().snapshot_id
+
+    with pytest.raises(ValueError, match="not an ancestor"):
+        tables.rollback_table_to_snapshot("raw.events", original_second_id)
+
+    assert catalog.load_table("raw.events").current_snapshot().snapshot_id == divergent_snapshot_id
+    assert sorted(_row_ids(catalog)) == [1, 3]

--- a/uv.lock
+++ b/uv.lock
@@ -3660,7 +3660,7 @@ requires-dist = [
     { name = "phlo", editable = "." },
     { name = "phlo-minio", marker = "extra == 'minio'", editable = "packages/phlo-minio" },
     { name = "phlo-nessie", marker = "extra == 'nessie'", editable = "packages/phlo-nessie" },
-    { name = "pyiceberg", extras = ["s3fs", "pyarrow"], specifier = ">=0.10.0" },
+    { name = "pyiceberg", extras = ["s3fs", "pyarrow"], specifier = ">=0.11.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
 ]


### PR DESCRIPTION
## What changed

- Make orphan-maintenance confirmation tokens stable when only the observed inventory cutoff moves, while continuing to bind the token to the inventory digest, snapshot, and requested retention semantics.
- Use PyIceberg's supported generic `rollback_to_snapshot(...).commit()` API, raise the `phlo-iceberg` PyIceberg floor to 0.11, and correct the public rollback description: it repoints the current snapshot reference rather than creating a new snapshot.
- Add focused in-memory coverage for successful ancestor rollback and fail-closed unknown or non-ancestor targets.

## Why

Dry-run and execute orphan plans observe the clock independently. Including the resulting cutoff timestamp in the token made an unchanged inventory and unchanged request fail confirmation. The previous rollback helper also called an API name that does not exist in supported PyIceberg.

The generated Trino/Nessie metadata model does not retain older snapshots in the PyIceberg table metadata, so snapshot-ID rollback is unsupported for that runtime path. Generated-stack recovery is instead proven through a guarded Nessie tag/hash restoration: `5f28089c… -> fb77ab69… -> 5f28089c…`. Actual orphan deletion remains out of scope; discovery, bounded refusal, and preservation are the supported v1 behavior.

## Validation

Focused local validation:

- `uv run pytest --import-mode=importlib packages/phlo-iceberg/tests/test_tables_rollback.py packages/phlo-iceberg/tests/test_retention_contract.py -q` — 30 passed.
- Ruff lint and format checks passed on all changed Python files.
- Package-scoped `ty` completed with only eight pre-existing diagnostics outside this repair.
- `git diff --check` and `uv lock --check` passed.
- The commit's full configured pre-commit hook set passed.

Fresh generated-stack proof completed all five maintenance phases:

1. Compaction reduced 12 files to 1, changed the snapshot, and preserved all 12 rows.
2. A one-hour unsafe expiry was refused before execution; the safe 168-hour plan was a protected no-op with the snapshot and rows unchanged.
3. Complete MinIO inventory found the controlled orphan among 13 candidates / 4,607 bytes; repeated planning produced a stable token, deletion was refused, and the object, snapshot, and rows were preserved.
4. One-object and one-byte ceilings failed closed before mutation with the object, snapshot, and rows preserved.
5. Recovery restored the generated stack through the guarded Nessie hash/tag path `5f28089c… -> fb77ab69… -> 5f28089c…`, preserving the catalog and data evidence. Snapshot-ID rollback was separately confirmed unsupported on this generated metadata model.
