### PR TITLE
fix(security): enforce canonical regulated roles

### DIFF
--- a/packages/phlo-api/src/phlo_api/api/operation_controls.py
+++ b/packages/phlo-api/src/phlo_api/api/operation_controls.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from fastapi import HTTPException, Request
 
+from phlo.security import is_regulated
 from phlo_api.api.authentication import get_request_principal
 
 _TOKEN_CONFIG_ENV = "PHLO_API_TOKENS"
@@ -29,6 +30,9 @@ def project_root() -> Path:
 
 def require_scope(request: Request, required_scope: str) -> dict[str, Any]:
     """Require a bearer token with the requested scope or admin."""
+    if not is_regulated():
+        return {"subject": "development:anonymous", "scopes": ["admin"]}
+
     principal = get_request_principal(request)
     if principal is not None:
         scopes = _principal_scopes(principal.claims, principal.attributes, principal.groups)

--- a/packages/phlo-api/src/phlo_api/security_manifest.py
+++ b/packages/phlo-api/src/phlo_api/security_manifest.py
@@ -704,6 +704,9 @@ async def enforce_http_operation(
     if spec.public:
         return
 
+    if not is_regulated():
+        return
+
     auth_principal = get_request_principal(request)
     if auth_principal is None:
         _raise_unauthorized()

--- a/packages/phlo-api/src/phlo_api/security_manifest.py
+++ b/packages/phlo-api/src/phlo_api/security_manifest.py
@@ -705,6 +705,15 @@ async def enforce_http_operation(
         return
 
     if not is_regulated():
+        if spec.operation_name == "get_observatory_run_report":
+            auth_principal = get_request_principal(request)
+            if (
+                auth_principal is not None
+                and auth_principal.principal_type == "service"
+                and RUN_REPORT_RESOURCE_ID_ATTRIBUTE in auth_principal.attributes
+            ):
+                resource = await resolve_resource(request, spec, path_params)
+                _enforce_scoped_run_report_service_identity(auth_principal, spec, resource)
         return
 
     auth_principal = get_request_principal(request)

--- a/packages/phlo-api/tests/security_test_support.py
+++ b/packages/phlo-api/tests/security_test_support.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 from typing import Any, Literal
 
+import pytest
 from fastapi.testclient import TestClient
 
 from phlo.capabilities import (
@@ -22,8 +23,9 @@ from phlo.capabilities import (
     register_capability,
 )
 from phlo.capabilities.authorization import DefaultAuthorizationPolicyBackend
-from phlo.capabilities.interfaces import RequestContext
+from phlo.capabilities.interfaces import Principal, RequestContext
 from phlo.rbac.models import CanonicalAction
+from phlo.security.adapters import EnforcementResult
 from phlo_api.main import app
 
 PrincipalName = Literal["viewer", "analyst", "operator", "admin"]
@@ -145,3 +147,34 @@ class _AuthenticatedTestClient(TestClient):
 def authenticated_client(principal: PrincipalName) -> TestClient:
     """Create a client with an explicitly named narrow test principal."""
     return _AuthenticatedTestClient(principal)
+
+
+@pytest.fixture(name="regulated_api_boundary")
+def _regulated_api_boundary(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run API authorization expectations through an explicit regulated boundary."""
+    from phlo_api import security_manifest
+
+    monkeypatch.setenv("PHLO_REGULATED", "true")
+    monkeypatch.setattr(security_manifest, "is_regulated", lambda: True)
+
+    def enforce_with_test_backend(*, principal, action, resource, context, **_kwargs):  # noqa: ANN001
+        backend = security_manifest.get_authorization_backend()
+        if backend is None:
+            return EnforcementResult.error(reason_code="backend_unavailable")
+        test_role = principal.attributes.get("test_principal")
+        decision = backend.explain_decision(
+            Principal(
+                subject=principal.subject,
+                principal_type=principal.principal_type,
+                roles=(test_role,) if isinstance(test_role, str) else principal.groups,
+                attributes=principal.attributes,
+            ),
+            action,
+            resource,
+            context,
+        )
+        if decision.allowed:
+            return EnforcementResult.allow()
+        return EnforcementResult.deny(reason_code=decision.reason_code)
+
+    monkeypatch.setattr(security_manifest, "enforce", enforce_with_test_backend)

--- a/packages/phlo-api/tests/test_auth_helper_meta.py
+++ b/packages/phlo-api/tests/test_auth_helper_meta.py
@@ -39,6 +39,10 @@ def _direct_test_client_calls(function: ast.AST) -> list[ast.Call]:
     return calls
 
 
+def _is_explicit_development_test(function: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    return "unregulated" in function.name and _contains_status_assertion(function, 200)
+
+
 def test_protected_testclient_calls_name_an_auth_helper_or_401() -> None:
     test_root = Path(__file__).parent
     violations: list[str] = []
@@ -59,7 +63,11 @@ def test_protected_testclient_calls_name_an_auth_helper_or_401() -> None:
                 if method == "OPTIONS" or (method, route_path) not in HTTP_ROUTE_KEY_MANIFEST:
                     continue
                 has_headers = any(keyword.arg == "headers" for keyword in call.keywords)
-                if has_headers or _contains_status_assertion(function, 401):
+                if (
+                    has_headers
+                    or _contains_status_assertion(function, 401)
+                    or _is_explicit_development_test(function)
+                ):
                     continue
                 violations.append(f"{path.name}:{call.lineno} {method} {route_path}")
 

--- a/packages/phlo-api/tests/test_authoring_api.py
+++ b/packages/phlo-api/tests/test_authoring_api.py
@@ -142,6 +142,7 @@ def test_authoring_create_workflow_uses_project_root_and_provider(monkeypatch, t
 def test_authoring_write_routes_require_project_write_scope(monkeypatch, tmp_path) -> None:
     from phlo_api.api import authoring
 
+    monkeypatch.setattr("phlo_api.api.operation_controls.is_regulated", lambda: True)
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     monkeypatch.setenv(
         "PHLO_API_TOKENS",
@@ -176,6 +177,24 @@ def test_authoring_write_routes_require_project_write_scope(monkeypatch, tmp_pat
     assert allowed.json()["valid"] is True
     audit_path = tmp_path / ".phlo" / "audit" / "operations.jsonl"
     assert "validate_workflow" in audit_path.read_text(encoding="utf-8")
+
+
+def test_unregulated_authoring_validation_uses_development_identity(monkeypatch, tmp_path) -> None:
+    from phlo_api.api import authoring
+
+    workflow_file = tmp_path / "workflow.py"
+    workflow_file.write_text("# workflow\n", encoding="utf-8")
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setattr("phlo_api.api.operation_controls.is_regulated", lambda: False)
+    monkeypatch.setattr(authoring, "_validate_workflow_file", lambda path: None)
+
+    response = TestClient(app).post(
+        "/api/authoring/workflows/validate", json={"workflow_path": str(workflow_file)}
+    )
+
+    assert response.status_code == 200
+    audit_path = tmp_path / ".phlo" / "audit" / "operations.jsonl"
+    assert '"subject": "development:anonymous"' in audit_path.read_text(encoding="utf-8")
 
 
 def test_authoring_validation_rejects_paths_outside_project(monkeypatch, tmp_path) -> None:

--- a/packages/phlo-api/tests/test_observatory_api.py
+++ b/packages/phlo-api/tests/test_observatory_api.py
@@ -17,7 +17,7 @@ from phlo.capabilities.authentication import ServiceTokenAuthenticationProvider
 from phlo.capabilities.authorization import DefaultAuthorizationPolicyBackend
 from phlo.capabilities.specs import CatalogSpec
 from phlo_api.main import app
-from security_test_support import authenticated_client
+from security_test_support import _regulated_api_boundary, authenticated_client  # noqa: F401
 from phlo.run_evidence import PipelineRun, RunEvent, RunStage, SQLiteRunEvidenceStore
 from phlo_api.observatory_api import observatory
 from phlo_api.observatory_api import observatory_services
@@ -69,7 +69,7 @@ _PROVIDER_URL_SETTING_NAMES = (
 
 
 def test_authenticated_run_report_isolated_by_attempt_and_path_identity(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, regulated_api_boundary
 ) -> None:
     database = tmp_path / "run-evidence.sqlite"
     store = SQLiteRunEvidenceStore(database)
@@ -140,7 +140,9 @@ def test_authenticated_run_report_isolated_by_attempt_and_path_identity(
     )
 
 
-def test_scoped_service_token_cannot_read_another_run_report(monkeypatch, tmp_path) -> None:
+def test_scoped_service_token_cannot_read_another_run_report(
+    monkeypatch, tmp_path, regulated_api_boundary
+) -> None:
     database = tmp_path / "run-evidence.sqlite"
     store = SQLiteRunEvidenceStore(database)
     for run_id in ("allowed", "other"):
@@ -163,7 +165,6 @@ def test_scoped_service_token_cannot_read_another_run_report(monkeypatch, tmp_pa
             )
         )
     monkeypatch.setenv("PHLO_RUN_EVIDENCE_SQLITE_PATH", str(database))
-    monkeypatch.setenv("PHLO_REGULATED", "false")
     allowed_resource_id = "project_id=project|run_id=allowed|attempt=1"
     provider = ServiceTokenAuthenticationProvider(
         {
@@ -1538,7 +1539,7 @@ def test_observatory_run_operational_routes_use_observatory_paths(
 
 
 def test_observatory_operation_routes_enforce_scope_idempotency_audit_and_rate_limit(
-    monkeypatch, tmp_path: Path
+    monkeypatch, tmp_path: Path, regulated_api_boundary
 ) -> None:
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     monkeypatch.setenv("PHLO_API_RATE_LIMIT_MATERIALIZE", "2")

--- a/packages/phlo-api/tests/test_observatory_api.py
+++ b/packages/phlo-api/tests/test_observatory_api.py
@@ -211,6 +211,42 @@ def test_scoped_service_token_cannot_read_another_run_report(
     assert denied.json() == {"error": "forbidden", "reason": "run_report_scope_mismatch"}
 
 
+def test_unregulated_run_report_keeps_anonymous_open_but_enforces_supplied_scope(
+    monkeypatch, tmp_path
+) -> None:
+    database = tmp_path / "run-evidence.sqlite"
+    SQLiteRunEvidenceStore(database).append_pipeline_run(
+        PipelineRun(project_id="project", run_id="allowed", attempt=1)
+    )
+    monkeypatch.setenv("PHLO_REGULATED", "false")
+    monkeypatch.setenv("PHLO_RUN_EVIDENCE_SQLITE_PATH", str(database))
+    provider = ServiceTokenAuthenticationProvider(
+        {
+            "dagster-report-token": {
+                "subject": "dagster:report-reader",
+                "attributes": {
+                    RUN_REPORT_RESOURCE_ID_ATTRIBUTE: (
+                        "project_id=project|run_id=allowed|attempt=1"
+                    )
+                },
+            }
+        }
+    )
+    monkeypatch.setattr("phlo_api.api.authentication.get_authentication_provider", lambda: provider)
+    client = TestClient(app)
+    path = "/api/observatory/projects/project/runs/allowed/attempts/1/report"
+    headers = {"Authorization": "Bearer dagster-report-token"}
+
+    anonymous = client.get(path)
+    allowed = client.get(path, headers=headers)
+    denied = client.get(path.replace("/allowed/", "/other/"), headers=headers)
+
+    assert anonymous.status_code == 200
+    assert allowed.status_code == 200
+    assert denied.status_code == 403
+    assert denied.json() == {"error": "forbidden", "reason": "run_report_scope_mismatch"}
+
+
 class _FakeOrchestratorOperations:
     def __init__(self, **handlers: Any) -> None:
         self._handlers = handlers

--- a/packages/phlo-api/tests/test_observatory_workflow_wizard.py
+++ b/packages/phlo-api/tests/test_observatory_workflow_wizard.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 
 from phlo.capabilities import WorkflowFilePreview, WorkflowProposal
 from phlo_api.main import app
-from security_test_support import authenticated_client
+from security_test_support import _regulated_api_boundary, authenticated_client  # noqa: F401
 from phlo_api.observatory_api import observatory
 from phlo_api.observatory_api import observatory_workflow_wizard as wizard
 
@@ -75,7 +75,7 @@ def test_workflow_wizard_proposal_requires_graph_nodes() -> None:
 
 
 def test_workflow_wizard_proposal_requires_project_write(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, regulated_api_boundary
 ) -> None:
     request = {
         "workflow_name": "customer_health",
@@ -458,7 +458,7 @@ def test_workflow_wizard_conflict_records_failed_operation(
 
 
 def test_workflow_wizard_apply_requires_project_write(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, regulated_api_boundary
 ) -> None:
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     proposal = client.post(
@@ -501,7 +501,7 @@ def test_workflow_wizard_apply_requires_project_write(
 
 
 def test_workflow_wizard_proposal_is_bound_to_issuing_principal(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, regulated_api_boundary
 ) -> None:
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     monkeypatch.setenv(

--- a/packages/phlo-api/tests/test_security_manifest.py
+++ b/packages/phlo-api/tests/test_security_manifest.py
@@ -47,6 +47,34 @@ def _principal(subject: str = "viewer") -> tuple[AuthPrincipal, Principal]:
     return auth, canonical
 
 
+@pytest.fixture(autouse=True)
+def _regulated_manifest_boundary(monkeypatch):
+    """Keep existing manifest authorization cases explicitly regulated."""
+    from phlo_api import security_manifest
+
+    monkeypatch.setattr(security_manifest, "is_regulated", lambda: True)
+
+    def enforce_with_test_backend(*, principal, action, resource, context, **_kwargs):  # noqa: ANN001
+        backend = security_manifest.get_authorization_backend()
+        if backend is None:
+            return EnforcementResult.error(reason_code="backend_unavailable")
+        decision = backend.explain_decision(
+            Principal(
+                subject=principal.subject,
+                principal_type=principal.principal_type,
+                roles=principal.groups,
+            ),
+            action,
+            resource,
+            context,
+        )
+        if decision.allowed:
+            return EnforcementResult.allow()
+        return EnforcementResult.deny(reason_code=decision.reason_code)
+
+    monkeypatch.setattr(security_manifest, "enforce", enforce_with_test_backend)
+
+
 def test_http_route_manifest_covers_every_registered_route() -> None:
     resolved = validate_manifest(app)
     actual_operations = {
@@ -201,6 +229,7 @@ def test_manifest_supports_fastapi_lazy_included_routers(monkeypatch) -> None:
 def test_anonymous_protected_request_is_401_before_handler(monkeypatch, tmp_path) -> None:
     from phlo_api import main
 
+    monkeypatch.setattr("phlo_api.security_manifest.is_regulated", lambda: True)
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     called = False
 
@@ -216,6 +245,20 @@ def test_anonymous_protected_request_is_401_before_handler(monkeypatch, tmp_path
 
     assert response.status_code == 401
     assert called is False
+
+
+def test_unregulated_anonymous_non_public_request_reaches_handler(monkeypatch, tmp_path) -> None:
+    from phlo_api import main
+
+    monkeypatch.setattr("phlo_api.security_manifest.is_regulated", lambda: False)
+    monkeypatch.setattr("phlo_api.security_manifest.get_request_principal", lambda _request: None)
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    monkeypatch.setattr(main, "load_phlo_config", lambda: {"name": "development"})
+
+    response = TestClient(app).get("/api/config")
+
+    assert response.status_code == 200
+    assert response.json() == {"name": "development"}
 
 
 def test_detailed_health_summary_is_protected(monkeypatch) -> None:

--- a/src/phlo/identity/bridge.py
+++ b/src/phlo/identity/bridge.py
@@ -236,14 +236,14 @@ def create_regulated_bridge(
     enforcement enabled.
 
     Args:
-        group_role_mapping: Optional custom group-to-role mapping.
-            Uses DEFAULT_GROUP_ROLE_MAPPING if not provided.
+        group_role_mapping: Retained for API compatibility. Regulated bridges
+            never translate identity-provider groups into authorization roles.
 
     Returns:
         IdentityBridge configured for regulated mode.
     """
     config = IdentityBridgeConfig(
-        group_role_mapping=group_role_mapping or DEFAULT_GROUP_ROLE_MAPPING.copy(),
+        group_role_mapping={},
         enforce_approved_principal_types=True,
         propagate_idp_groups=True,
         canonical_rbac=canonical_rbac,

--- a/src/phlo/security/enforcement.py
+++ b/src/phlo/security/enforcement.py
@@ -118,8 +118,10 @@ class EnforcementContext:
     def _init_authorization_backend(self) -> None:
         """Initialize the authorization backend."""
         from phlo.capabilities import resolve_capability
+        from phlo.capabilities.discovery import discover_capabilities
         from phlo.infrastructure.config import get_configured_authorization_backend_name
 
+        discover_capabilities()
         configured_name = get_configured_authorization_backend_name() or ""
 
         result = resolve_capability(

--- a/tests/cli/test_cli_authorization.py
+++ b/tests/cli/test_cli_authorization.py
@@ -297,6 +297,58 @@ class TestResourceActionMapping:
 class TestAuthorizationWrappers:
     """Tests for CLI authorization wrappers."""
 
+    def test_regulated_services_start_discovers_configured_authorization_backend(
+        self, monkeypatch, tmp_path
+    ):
+        """The regulated services wrapper resolves the configured discovered backend."""
+        from phlo.capabilities import clear_all_capabilities
+        from phlo.cli.authorization_wrappers import require_mutation_authorization
+        from phlo.security.enforcement import EnforcementContext
+
+        auth_dir = tmp_path / ".phlo" / "authorization"
+        auth_dir.mkdir(parents=True)
+        (auth_dir / "roles.yaml").write_text(
+            """
+version: 1
+roles:
+  operator:
+    inherits: []
+subjects:
+  services:
+    proof-operator: [operator]
+""".lstrip()
+        )
+        (auth_dir / "policies.yaml").write_text(
+            """
+version: 1
+policies:
+  - policy_id: allow_services_start
+    effect: allow
+    principal:
+      roles: [operator]
+    action: infrastructure.start
+    resource:
+      type: infrastructure
+      id_pattern: cli:services.start
+""".lstrip()
+        )
+        monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+        monkeypatch.setenv("PHLO_REGULATED", "true")
+        monkeypatch.setenv("PHLO_AUTHORIZATION_BACKEND", "default")
+        monkeypatch.setenv("PHLO_SERVICE_ACCOUNT", "proof-operator")
+        clear_all_capabilities()
+        EnforcementContext.reset_instance()
+
+        @require_mutation_authorization("services.start")
+        def handler() -> str:
+            return "started"
+
+        try:
+            assert handler() == "started"
+        finally:
+            EnforcementContext.reset_instance()
+            clear_all_capabilities()
+
     def test_require_mutation_authorization_import(self):
         """Can import the wrapper module."""
         from phlo.cli import authorization_wrappers

--- a/tests/security/test_authorization_policy_backend.py
+++ b/tests/security/test_authorization_policy_backend.py
@@ -32,6 +32,37 @@ def teardown_function() -> None:
     reset_capability_test_state()
 
 
+def test_enforcement_fails_closed_for_missing_or_ambiguous_provider(monkeypatch) -> None:
+    """Discovery does not turn missing or ambiguous backend selection into access."""
+    from phlo.capabilities import clear_all_capabilities
+    from phlo.capabilities import discovery as capability_discovery
+    from phlo.security.enforcement import EnforcementContext
+
+    monkeypatch.setattr(capability_discovery, "discover_capabilities", lambda: None)
+    monkeypatch.setattr(
+        "phlo.infrastructure.config.get_configured_authorization_backend_name",
+        lambda: "missing",
+    )
+    clear_all_capabilities()
+    with pytest.raises(RuntimeError, match="Configured authorization_policy_backend"):
+        EnforcementContext()._init_authorization_backend()
+
+    monkeypatch.setattr(
+        "phlo.infrastructure.config.get_configured_authorization_backend_name",
+        lambda: None,
+    )
+    register_capability(
+        "authorization_policy_backend",
+        AuthorizationPolicyBackendSpec(name="one", provider=DefaultAuthorizationPolicyBackend()),
+    )
+    register_capability(
+        "authorization_policy_backend",
+        AuthorizationPolicyBackendSpec(name="two", provider=DefaultAuthorizationPolicyBackend()),
+    )
+    with pytest.raises(RuntimeError, match="No authorization_policy_backend"):
+        EnforcementContext()._init_authorization_backend()
+
+
 def test_registry_tracks_authorization_policy_backends() -> None:
     backend = DefaultAuthorizationPolicyBackend()
     register_capability(
@@ -130,11 +161,12 @@ def test_auth_principal_uses_canonical_subject_assignments_and_inheritance() -> 
         AuthPrincipal(
             subject="alice",
             principal_type="user",
-            groups=("untrusted-idp-group",),
+            groups=("admin",),
         )
     )
 
     assert set(principal.roles) == {"custom_analyst", "viewer"}
+    assert principal.attributes["idp_groups"] == "admin"
     assert backend.is_allowed(
         principal,
         "dataset.read",


### PR DESCRIPTION
## Summary

This closes the agreed v1 security boundary without turning development into a regulated deployment.

- Development remains open: anonymous Phlo API operations and Dagster GraphQL continue to work.
- Regulated mode remains authenticated and fail closed.
- Canonical Phlo role assignments are authoritative in regulated mode. Identity-provider group names remain available for audit, but no longer become authorization roles.
- A supplied run-scoped service token remains bound to its exact run report, even in development mode.

## Why

The regulated role-matrix proof found two concrete gaps:

1. Regulated CLI enforcement could start before the built-in authorization backend had been discovered.
2. An OpenID Connect token containing a group named `admin` could acquire regulated admin permissions despite lacking a canonical Phlo admin assignment.

The first implementation also exposed a release-golden-path regression: the development bypass skipped the existing run-scoped service-token check, so a token probing another run reached the handler and returned 404 instead of being refused with 403. The final implementation keeps anonymous development access open while applying that exact-resource check only when a run-scoped service principal is supplied.

## Changes

- Discover registered capabilities before resolving the configured regulated authorization backend.
- Disable identity-provider group-to-role translation in regulated identity bridges.
- Preserve identity-provider groups in the `idp_groups` audit attribute.
- Allow anonymous Phlo API reads and actions in development mode.
- Keep exact-resource enforcement for supplied run-scoped report tokens.
- Make API tests state explicitly whether they exercise development or regulated behavior.

No Dagster production code changes are included.

## Real-stack proof

A production-rendered regulated stack with a Transport Layer Security (TLS) OpenID Connect issuer proved:

- anonymous Phlo API and direct Dagster GraphQL requests return 401;
- viewer, operator, and admin positive paths succeed within their assigned roles;
- viewer and operator tokens containing `groups=admin` cannot acquire admin permissions;
- a legitimate operator reload succeeds; and
- a legitimate admin read succeeds.

A separate development stack proved anonymous Phlo API reads/actions and Dagster GraphQL remain open.

The exact release CI command, `python3 scripts/release_golden_path.py`, also passed locally from fresh wheels on a generated stack with owned cleanup. On head `a78af54815`, the remote release golden path passed in 5m34s and aggregate `ci / status` passed.

## Focused validation

- Runtime package suite: 309 passed, 37 deselected.
- Focused API and security suite: 136 passed.
- Development run-report regression: anonymous request 200, exact scoped token 200, mismatched scoped token 403.
- Ruff check, Ruff format check, and `git diff --check` passed.
- Every GitHub Actions check is green on `a78af54815`.

## Boundaries

The regulated proof stack had no active dataset, table, or run identifiers, so analyst query and operator retry/promotion were not exercised live; focused authorization tests cover those rules.

This PR does not add service coupling, backend-native access control, a policy redesign, or broader Dagster hardening. Deeper Dagster authorization remains future work unless a concrete bounded vulnerability requires it.

Scope: two packages, four production files, twelve tracked files, 257 additions and 15 deletions.
