### PR TITLE
chore(release): publish v1 support BOM

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,7 @@ name: Security
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: "0 6 * * 1"
 
@@ -27,9 +28,8 @@ jobs:
           version: "latest"
 
       - name: Audit Python dependencies
-        continue-on-error: true
         shell: bash
-        run: uv --preview-features audit audit --locked --all-groups --all-extras
+        run: uv --preview-features audit-command audit --locked
 
   observatory-dependencies:
     name: security / observatory dependencies
@@ -53,7 +53,6 @@ jobs:
         run: npm ci
 
       - name: Audit Observatory dependencies
-        continue-on-error: true
         run: npm audit --audit-level=high
 
   docs-dependencies:

--- a/docs/operations/operations-guide.md
+++ b/docs/operations/operations-guide.md
@@ -688,30 +688,7 @@ done
 
 ### Testing Recovery
 
-**Regular DR drills**:
-
-```bash
-#!/bin/bash
-# dr-test.sh
-
-# 1. Backup current state
-./backup-all.sh
-
-# 2. Destroy services
-phlo services stop --volumes
-
-# 3. Restore from backup
-./restore-all.sh
-
-# 4. Verify services
-phlo services status
-
-# 5. Test asset materialization
-phlo materialize --select "tag:critical" --partition $(date -d "yesterday" +%Y-%m-%d)
-
-# 6. Validate data
-./validate-data.sh
-```
+Automated upgrade and restore drills are deferred beyond v1; Phlo does not currently provide recovery scripts for those operations.
 
 ## Release Management
 

--- a/packages/phlo-minio/src/phlo_minio/minio-setup.yaml
+++ b/packages/phlo-minio/src/phlo_minio/minio-setup.yaml
@@ -4,7 +4,7 @@ description: Initialize MinIO buckets for data lake
 category: core
 default: true
 
-image: minio/mc:latest
+image: minio/mc:RELEASE.2025-08-13T08-35-41Z
 
 depends_on:
   - minio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Topic :: Database",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]

--- a/registry/support/schema/v1.json
+++ b/registry/support/schema/v1.json
@@ -18,6 +18,7 @@
     "current_release",
     "runtime",
     "production",
+    "release_set",
     "exclusions"
   ],
   "properties": {
@@ -46,6 +47,7 @@
     "current_release": { "$ref": "#/$defs/current_release" },
     "runtime": { "$ref": "#/$defs/runtime" },
     "production": { "$ref": "#/$defs/production" },
+    "release_set": { "$ref": "#/$defs/release_set" },
     "exclusions": {
       "type": "array",
       "items": { "$ref": "#/$defs/exclusion" }
@@ -266,6 +268,58 @@
         "status": { "const": "excluded" },
         "reason": { "type": "string", "minLength": 1 },
         "evidence": { "$ref": "#/$defs/evidence" }
+      }
+    },
+    "release_set": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["packages", "services", "schemas"],
+      "properties": {
+        "packages": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/release_package" }
+        },
+        "services": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/release_service" }
+        },
+        "schemas": { "$ref": "#/$defs/release_schemas" }
+      }
+    },
+    "release_package": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "type": "string", "minLength": 1 }
+      }
+    },
+    "release_service": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "image_reference"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "image_reference": { "type": "string", "minLength": 1 }
+      }
+    },
+    "release_schemas": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["configuration", "database"],
+      "properties": {
+        "configuration": { "$ref": "#/$defs/versioned_schema" },
+        "database": { "$ref": "#/$defs/versioned_schema" }
+      }
+    },
+    "versioned_schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["version", "source"],
+      "properties": {
+        "version": { "type": "string", "minLength": 1 },
+        "source": { "type": "string", "minLength": 1 }
       }
     }
   }

--- a/registry/support/v1.json
+++ b/registry/support/v1.json
@@ -9,6 +9,45 @@
     "maturity": "alpha",
     "production_ready": false
   },
+  "release_set": {
+    "packages": [
+      {"name": "phlo", "version": "0.12.1"},
+      {"name": "phlo-api", "version": "0.7.0"},
+      {"name": "phlo-core-plugins", "version": "0.3.0"},
+      {"name": "phlo-dagster", "version": "0.6.0"},
+      {"name": "phlo-dbt", "version": "0.6.1"},
+      {"name": "phlo-dlt", "version": "0.7.0"},
+      {"name": "phlo-iceberg", "version": "0.6.0"},
+      {"name": "phlo-minio", "version": "0.4.0"},
+      {"name": "phlo-nessie", "version": "0.5.0"},
+      {"name": "phlo-observatory", "version": "0.7.0"},
+      {"name": "phlo-pandera", "version": "0.6.0"},
+      {"name": "phlo-postgres", "version": "0.4.0"},
+      {"name": "phlo-trino", "version": "0.5.0"}
+    ],
+    "services": [
+      {"name": "dagster", "image_reference": "build:context=.;dockerfile=dagster/Dockerfile"},
+      {"name": "dagster-daemon", "image_reference": "build:context=.;dockerfile=dagster/Dockerfile"},
+      {"name": "postgres", "image_reference": "postgres:16-alpine"},
+      {"name": "postgres-volume-setup", "image_reference": "alpine:3.20"},
+      {"name": "minio", "image_reference": "minio/minio:RELEASE.2025-09-07T16-13-09Z"},
+      {"name": "minio-setup", "image_reference": "minio/mc:RELEASE.2025-08-13T08-35-41Z"},
+      {"name": "nessie", "image_reference": "ghcr.io/projectnessie/nessie:0.107.2"},
+      {"name": "trino", "image_reference": "trinodb/trino:467"},
+      {"name": "phlo-api", "image_reference": "build:context=.;dockerfile=phlo-api/Dockerfile"},
+      {"name": "observatory", "image_reference": "build:context=source;dockerfile=Dockerfile"}
+    ],
+    "schemas": {
+      "configuration": {
+        "version": "1",
+        "source": "src/phlo/config/settings.py"
+      },
+      "database": {
+        "version": "4",
+        "source": "src/phlo/run_evidence/models.py"
+      }
+    }
+  },
   "profiles": {
     "blessed_core": {
       "status": "scope-frozen",
@@ -1574,16 +1613,15 @@
         "3.12"
       ],
       "unverified": [
+        "3.13",
         "3.14+"
       ],
-      "reason": "Metadata advertises 3.11-3.13, but only 3.11 and 3.12 execute in the CI matrix.",
+      "reason": "Only 3.11 and 3.12 execute in the CI matrix.",
       "evidence": [
         "pyproject.toml",
         ".github/workflows/ci.yml"
       ],
-      "advertised_unverified": [
-        "3.13"
-      ]
+      "advertised_unverified": []
     },
     "os": {
       "supported": [

--- a/scripts/validate_support_manifest.py
+++ b/scripts/validate_support_manifest.py
@@ -142,6 +142,19 @@ def _top_level_yaml_name(path: Path) -> str | None:
     return None
 
 
+def _service_image_reference(path: Path) -> str | None:
+    """Return the literal image or build reference declared by a service definition."""
+    text = path.read_text(encoding="utf-8")
+    image = re.search(r"^image:\s*(\S+)\s*$", text, re.MULTILINE)
+    if image:
+        return re.sub(r"\$\{[^:}]+:-([^}]+)\}", r"\1", image.group(1))
+    context = re.search(r"^\s+context:\s*(\S+)\s*$", text, re.MULTILINE)
+    dockerfile = re.search(r"^\s+dockerfile:\s*(\S+)\s*$", text, re.MULTILINE)
+    if context and dockerfile:
+        return f"build:context={context.group(1)};dockerfile={dockerfile.group(1)}"
+    return None
+
+
 def _registered_service_plugins(pyproject_path: Path) -> dict[str, str]:
     with pyproject_path.open("rb") as handle:
         project = tomllib.load(handle)["project"]
@@ -475,6 +488,71 @@ def validate_manifest(manifest: dict[str, Any], *, repo_root: Path = ROOT) -> li
                 f"service {entry['name']!r}: package {entry['package']!r} is absent from the package manifest"
             )
 
+    release_set = manifest["release_set"]
+    release_package_names = [entry["name"] for entry in release_set["packages"]]
+    if len(release_package_names) != len(set(release_package_names)):
+        errors.append("release_set.packages contains duplicate package names")
+    release_packages = {entry["name"]: entry["version"] for entry in release_set["packages"]}
+    blessed_packages = {
+        _normalise_package_name(entry["name"])
+        for entry in package_entries
+        if entry["scope"] == "blessed_core"
+    }
+    if set(release_packages) != blessed_packages:
+        errors.append("release_set.packages must cover exactly the blessed_core packages")
+    for package, version in release_packages.items():
+        path = package_inventory.get(package)
+        if path is None:
+            continue
+        with path.open("rb") as handle:
+            declared_version = tomllib.load(handle)["project"]["version"]
+        if version != declared_version:
+            errors.append(
+                f"release_set package {package!r} version {version!r} does not match {path.relative_to(repo_root)}"
+            )
+
+    release_service_names = [entry["name"] for entry in release_set["services"]]
+    if len(release_service_names) != len(set(release_service_names)):
+        errors.append("release_set.services contains duplicate service names")
+    release_services = {
+        entry["name"]: entry["image_reference"] for entry in release_set["services"]
+    }
+    blessed_services = {
+        entry["name"] for entry in service_entries if entry["scope"] == "blessed_core"
+    }
+    if set(release_services) != blessed_services:
+        errors.append("release_set.services must cover exactly the blessed_core services")
+    for service, image_reference in release_services.items():
+        source = service_inventory.get(service)
+        if source is None:
+            continue
+        declared_reference = _service_image_reference(source)
+        if image_reference != declared_reference:
+            errors.append(
+                f"release_set service {service!r} image_reference does not match declared metadata"
+            )
+
+    config_schema = release_set["schemas"]["configuration"]
+    database_schema = release_set["schemas"]["database"]
+    config_source = repo_root / config_schema["source"]
+    database_source = repo_root / database_schema["source"]
+    if not config_source.is_file():
+        errors.append("release_set configuration source does not exist")
+    elif not re.search(
+        rf'^CONFIG_SCHEMA_VERSION\s*=\s*["\']{re.escape(config_schema["version"])}["\']\s*$',
+        config_source.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    ):
+        errors.append("release_set configuration version does not match CONFIG_SCHEMA_VERSION")
+    if not database_source.is_file():
+        errors.append("release_set database source does not exist")
+    elif not re.search(
+        rf"^RUN_EVIDENCE_SCHEMA_VERSION\s*=\s*{re.escape(database_schema['version'])}\s*$",
+        database_source.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    ):
+        errors.append("release_set database version does not match RUN_EVIDENCE_SCHEMA_VERSION")
+
     # Registry ``core`` marks discovery/defaulting roles, not release maturity.
     core_packages, core_services = _registry_core_claims(repo_root)
     for package in sorted(core_packages):
@@ -656,8 +734,19 @@ def validate_manifest(manifest: dict[str, Any], *, repo_root: Path = ROOT) -> li
             "runtime Python supported, advertised_unverified, and unverified sets must be disjoint"
         )
     classifiers = set(root_project["project"].get("classifiers", []))
+    classifier_prefix = "Programming Language :: Python :: "
+    advertised_python = {
+        classifier.removeprefix(classifier_prefix)
+        for classifier in classifiers
+        if classifier.startswith(classifier_prefix)
+        and classifier.removeprefix(classifier_prefix) != "3"
+    }
+    if advertised_python != supported_python | advertised_unverified:
+        errors.append(
+            "runtime Python supported and advertised_unverified claims must exactly match pyproject classifiers"
+        )
     for version in supported_python | advertised_unverified:
-        if f"Programming Language :: Python :: {version}" not in classifiers:
+        if f"{classifier_prefix}{version}" not in classifiers:
             errors.append(f"runtime Python claim {version!r} is absent from pyproject classifiers")
     ci_text = (repo_root / ".github/workflows/ci.yml").read_text(encoding="utf-8")
     for version in supported_python:

--- a/src/phlo/config/settings.py
+++ b/src/phlo/config/settings.py
@@ -15,6 +15,8 @@ from pydantic import AliasChoices, Field
 from phlo.config.base import BaseConfig
 from phlo.config.cache import project_root_cached
 
+CONFIG_SCHEMA_VERSION = "1"
+
 
 class Settings(BaseConfig):
     """Core configuration for Phlo.

--- a/tests/tooling/test_support_manifest.py
+++ b/tests/tooling/test_support_manifest.py
@@ -46,6 +46,37 @@ def test_checked_in_manifest_matches_schema_and_repository_inventory() -> None:
     assert validate_manifest(_manifest()) == []
 
 
+def test_release_set_package_versions_and_service_images_are_derived_from_metadata() -> None:
+    manifest = _manifest()
+    manifest["release_set"]["packages"][0]["version"] = "0.0.0"
+    manifest["release_set"]["services"][0]["image_reference"] = "example:latest"
+
+    errors = validate_manifest(manifest)
+
+    assert any("release_set package 'phlo' version" in error for error in errors)
+    assert any("release_set service 'dagster' image_reference" in error for error in errors)
+
+
+def test_release_set_rejects_duplicate_package_and_service_names() -> None:
+    manifest = _manifest()
+    manifest["release_set"]["packages"].append(manifest["release_set"]["packages"][0])
+    manifest["release_set"]["services"].append(manifest["release_set"]["services"][0])
+
+    errors = validate_manifest(manifest)
+
+    assert "release_set.packages contains duplicate package names" in errors
+    assert "release_set.services contains duplicate service names" in errors
+
+
+def test_release_set_configuration_schema_version_matches_source() -> None:
+    manifest = _manifest()
+    manifest["release_set"]["schemas"]["configuration"]["version"] = "2"
+
+    errors = validate_manifest(manifest)
+
+    assert "release_set configuration version does not match CONFIG_SCHEMA_VERSION" in errors
+
+
 def test_schema_version_is_compatible_only_at_v1() -> None:
     manifest = _manifest()
     manifest["schema_version"] = "2.0"
@@ -467,6 +498,15 @@ def test_runtime_claim_sets_must_be_disjoint() -> None:
     errors = validate_manifest(manifest)
 
     assert any("must be disjoint" in error for error in errors)
+
+
+def test_runtime_python_claims_must_match_advertised_classifiers() -> None:
+    manifest = _manifest()
+    manifest["runtime"]["python"]["advertised_unverified"] = ["3.13"]
+
+    errors = validate_manifest(manifest)
+
+    assert any("must exactly match pyproject classifiers" in error for error in errors)
 
 
 def test_runtime_supported_python_requires_ci_evidence() -> None:


### PR DESCRIPTION
## Summary

This finishes the bounded v1 release-hygiene work without adding more release-path testing.

- Publishes an exact support bill of materials for the blessed v1 package and service set.
- Records configuration schema version 1, run-evidence database schema version 4, and Python 3.11/3.12 as the supported runtime set.
- Removes the unverified Python 3.13 classifier.
- Pins the MinIO client image instead of using latest.
- Makes the existing Python and high-severity Observatory npm audits blocking on pull requests.
- Removes fictional disaster-recovery script commands from the operations guide and states the deferred recovery boundary plainly.

## Validation

- 42 support-manifest tests passed.
- The checked-in support manifest validator passed.
- Actionlint passed using the repository target.
- The exact Pymdx documentation generation and production build passed: 598 pages generated and 600 static pages built.
- Git diff checks passed, and the removed command names are absent from documentation.

## Boundaries

This does not add recovery scripts, upgrade or restore proofs, failure/restart cases, more golden-path runs, workshop changes, or changes to PR 574. Build-based Phlo services remain identified by their checked-in build context and Dockerfile because v1 images have not yet been published. The configuration schema version records the current settings contract; it does not introduce a migration system.
