### PR TITLE
ci: require PostgreSQL concurrency gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,89 @@ jobs:
             exit 1
           fi
 
+  postgres-concurrency-gates:
+    name: postgres / concurrency gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: phlo_test
+          POSTGRES_PASSWORD: phlo_test
+          POSTGRES_USER: phlo_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U phlo_test -d phlo_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      PHLO_RUN_EVIDENCE_TEST_POSTGRES_DSN: postgresql://phlo_test:phlo_test@localhost:5432/phlo_test
+      PHLO_SERVICE_TOKEN_TEST_POSTGRES_DSN: postgresql://phlo_test:phlo_test@localhost:5432/phlo_test
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          version: "0.10.10"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --dev --locked
+
+      - name: Preflight PostgreSQL concurrency gates
+        shell: bash
+        run: |
+          set -euo pipefail
+          uv run --locked python - <<'PY'
+          import os
+          import psycopg2
+
+          dsn_names = (
+              "PHLO_SERVICE_TOKEN_TEST_POSTGRES_DSN",
+              "PHLO_RUN_EVIDENCE_TEST_POSTGRES_DSN",
+          )
+          dsns = [os.environ[name] for name in dsn_names]
+          if not all(dsns):
+              raise RuntimeError("PostgreSQL concurrency gate DSNs must be set")
+          if len(set(dsns)) != 1:
+              raise RuntimeError("PostgreSQL concurrency gate DSNs must target one database")
+          with psycopg2.connect(dsns[0]):
+              pass
+          PY
+
+      - name: Run PostgreSQL concurrency gates
+        shell: bash
+        run: |
+          set -euo pipefail
+          junit_path="${RUNNER_TEMP}/postgres-concurrency-gates.xml"
+          uv run --locked pytest --import-mode=importlib \
+            tests/unit/phlo/security/test_service_identity.py::test_postgres_nonce_store_rejects_one_of_two_simultaneous_consumers \
+            tests/observability/test_run_evidence.py::test_postgres_concurrent_duplicate_replay_does_not_apply_loser_run_metadata \
+            tests/observability/test_run_evidence.py::test_true_v2_to_v3_upgrade_is_idempotent_and_compatible_postgres \
+            -q --junitxml "${junit_path}"
+          uv run --locked python - "${junit_path}" <<'PY'
+          import sys
+          from xml.etree import ElementTree
+
+          root = ElementTree.parse(sys.argv[1]).getroot()
+          cases = root.findall(".//testcase")
+          skipped = root.findall(".//skipped")
+          failures = root.findall(".//failure")
+          errors = root.findall(".//error")
+          if len(cases) != 3 or skipped or failures or errors:
+              raise RuntimeError(
+                  "PostgreSQL concurrency gates must report exactly 3 passed, 0 skipped"
+              )
+          PY
+
   quickstart-smoke:
     name: python / quickstart smoke
     runs-on: ubuntu-latest

--- a/tests/observability/test_run_evidence.py
+++ b/tests/observability/test_run_evidence.py
@@ -2163,6 +2163,7 @@ def test_true_v2_to_v3_upgrade_is_idempotent_and_compatible_postgres() -> None:
                     "002_create_run_evidence.sql",
                     "003_reconcile_run_evidence.sql",
                     "004_run_evidence_instrumentation.sql",
+                    "005_run_evidence_resource_identity.sql",
                 )
             )
 
@@ -2182,6 +2183,11 @@ def test_true_v2_to_v3_upgrade_is_idempotent_and_compatible_postgres() -> None:
         store._initialize_schema()
         store._initialized = False
         store._initialize_schema()
+        with store._transaction() as (_, cursor):
+            cursor.execute(
+                'SELECT version FROM "' + schema + '".run_evidence_schema_version ORDER BY version'
+            )
+            assert [row[0] for row in cursor.fetchall()] == [1, 2, 3, 4]
         assert _fixture_checksums(store) == before_checksums
         assert store.list_events(fixture["project_id"], fixture["run_id"])[0]["payload"] == {
             "legacy": True

--- a/tests/tooling/test_postgres_concurrency_ci.py
+++ b/tests/tooling/test_postgres_concurrency_ci.py
@@ -1,0 +1,20 @@
+"""Contract for the required live PostgreSQL concurrency gate."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_ci_runs_the_three_postgres_concurrency_gates_without_skips() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+    assert "postgres-concurrency-gates:" in workflow
+    assert "name: postgres / concurrency gates" in workflow
+    assert "image: postgres:16-alpine" in workflow
+    assert "PHLO_SERVICE_TOKEN_TEST_POSTGRES_DSN" in workflow
+    assert "PHLO_RUN_EVIDENCE_TEST_POSTGRES_DSN" in workflow
+    assert "test_postgres_nonce_store_rejects_one_of_two_simultaneous_consumers" in workflow
+    assert "test_postgres_concurrent_duplicate_replay_does_not_apply_loser_run_metadata" in workflow
+    assert "test_true_v2_to_v3_upgrade_is_idempotent_and_compatible_postgres" in workflow
+    assert "PostgreSQL concurrency gate DSNs must be set" in workflow
+    assert "PostgreSQL concurrency gates must report exactly 3 passed, 0 skipped" in workflow


### PR DESCRIPTION
## Summary

- add an isolated PostgreSQL 16 CI job for the nonce replay, run-evidence linearizability, and migration gates
- fail before tests when either owned DSN, the PostgreSQL driver, or the database connection is unavailable
- require exactly three passing tests and reject a skipped, failed, or errored result
- add a focused workflow contract test

Closes #630

## Validation

- `uv run --locked pytest --import-mode=importlib tests/tooling/test_postgres_concurrency_ci.py -q`
- `uv run --locked ruff check tests/tooling/test_postgres_concurrency_ci.py`
- `uv run --locked ruff format --check tests/tooling/test_postgres_concurrency_ci.py`
- `make prek-validate`
- pre-commit hooks (including YAML, yamllint, and zizmor)

The live three-test PostgreSQL run is delegated to the new CI service because this workspace has no reachable local PostgreSQL/Docker daemon.