### PR TITLE
fix: rebuild generated images with fixed x/text

### DIFF
--- a/packages/phlo-alloy/src/phlo_alloy/Dockerfile
+++ b/packages/phlo-alloy/src/phlo_alloy/Dockerfile
@@ -8,7 +8,7 @@ RUN git init /src/alloy && \
 WORKDIR /src/alloy
 # hadolint ignore=DL3062
 RUN export GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod && \
-    go get google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     go mod tidy && \
     npm --prefix internal/web/ui ci --no-audit --no-fund && \
     npm --prefix internal/web/ui run build && \

--- a/packages/phlo-alloy/src/phlo_alloy/service.yaml
+++ b/packages/phlo-alloy/src/phlo_alloy/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-alloy:v1.18.0-go1.26.5
+image: ghcr.io/phlohouse/phlo-alloy:v1.18.0-go1.26.5-xtext0.39.0
 build:
   context: .
   dockerfile: alloy/Dockerfile

--- a/packages/phlo-alloy/tests/test_alloy_plugin.py
+++ b/packages/phlo-alloy/tests/test_alloy_plugin.py
@@ -18,7 +18,7 @@ def test_alloy_service_builds_patched_release_image() -> None:
     """Generated Alloy uses the stable release with fixed embedded Go dependencies."""
     definition = AlloyServicePlugin().service_definition
 
-    assert definition["image"] == "ghcr.io/phlohouse/phlo-alloy:v1.18.0-go1.26.5"
+    assert definition["image"] == "ghcr.io/phlohouse/phlo-alloy:v1.18.0-go1.26.5-xtext0.39.0"
     assert definition["build"] == {"context": ".", "dockerfile": "alloy/Dockerfile"}
 
 

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -21,7 +21,8 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --branch v0.25.1 --depth 1 https://github.com/evanw/esbuild.git
 WORKDIR /src/esbuild
-RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /esbuild ./cmd/esbuild
+RUN go get golang.org/x/text@v0.39.0 && \
+    CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /esbuild ./cmd/esbuild
 WORKDIR /src
 RUN git clone --branch v4.3.3 --depth 1 https://github.com/hairyhenderson/gomplate.git
 WORKDIR /src/gomplate
@@ -33,6 +34,7 @@ RUN go get \
       go.opentelemetry.io/otel/sdk@v1.43.0 \
       golang.org/x/crypto@v0.52.0 \
       golang.org/x/net@v0.55.0 \
+      golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 \
     && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /gomplate ./cmd/gomplate
 

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -33,7 +33,7 @@ RUN go get \
       go.opentelemetry.io/otel@v1.43.0 \
       go.opentelemetry.io/otel/sdk@v1.43.0 \
       golang.org/x/crypto@v0.52.0 \
-      golang.org/x/net@v0.55.0 \
+      golang.org/x/net@v0.56.0 \
       golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 \
     && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /gomplate ./cmd/gomplate

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -32,7 +32,7 @@ RUN go get \
       github.com/go-jose/go-jose/v4@v4.1.4 \
       go.opentelemetry.io/otel@v1.43.0 \
       go.opentelemetry.io/otel/sdk@v1.43.0 \
-      golang.org/x/crypto@v0.52.0 \
+      golang.org/x/crypto@v0.53.0 \
       golang.org/x/net@v0.56.0 \
       golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 \

--- a/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
+++ b/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches
+image: ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches-xtext0.39.0
 build:
   context: .
   dockerfile: clickstack/Dockerfile

--- a/packages/phlo-clickstack/tests/test_clickstack_plugin.py
+++ b/packages/phlo-clickstack/tests/test_clickstack_plugin.py
@@ -28,7 +28,10 @@ def test_clickstack_builds_the_patched_stable_image() -> None:
     definition = ClickStackServicePlugin().service_definition
     dockerfile = resources.files("phlo_clickstack").joinpath("Dockerfile").read_text()
 
-    assert definition["image"] == "ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches"
+    assert (
+        definition["image"]
+        == "ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches-xtext0.39.0"
+    )
     assert definition["build"] == {"context": ".", "dockerfile": "clickstack/Dockerfile"}
     assert "FROM docker.io/hyperdx/hyperdx-all-in-one:2.31.0@sha256:b01cc48" in dockerfile
     assert "docker.hyperdx.io" not in dockerfile

--- a/packages/phlo-grafana/src/phlo_grafana/Dockerfile
+++ b/packages/phlo-grafana/src/phlo_grafana/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone https://github.com/grafana/grafana-elasticsearch-datasource.git . 
 WORKDIR /src/zipkin
 RUN git clone https://github.com/grafana/grafana-zipkin-datasource.git . && \
     git checkout daafdfe11421dd2cacc8bfdb9ab604da1875b671 && \
-    go get golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/zipkin ./pkg
 

--- a/packages/phlo-grafana/src/phlo_grafana/Dockerfile
+++ b/packages/phlo-grafana/src/phlo_grafana/Dockerfile
@@ -8,6 +8,7 @@ RUN git clone https://github.com/grafana/grafana.git . && \
 RUN go get \
       github.com/getkin/kin-openapi@v0.144.0 \
       github.com/grafana/tempo@8100f5a7b8f0986edf1fcd2ff6552d174b25ec18 \
+      golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath \
       -ldflags="-s -w -X main.version=13.1.1 -X main.commit=a9cee6e1724a455676bb6c05eef7fc54aa4b19f4" \
@@ -16,14 +17,14 @@ RUN go get \
 WORKDIR /src/elasticsearch
 RUN git clone https://github.com/grafana/grafana-elasticsearch-datasource.git . && \
     git checkout 525671446900cf0c7c5d696f931b95c2cec81d9c && \
-    go get google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/elasticsearch ./pkg
 
 WORKDIR /src/zipkin
 RUN git clone https://github.com/grafana/grafana-zipkin-datasource.git . && \
     git checkout daafdfe11421dd2cacc8bfdb9ab604da1875b671 && \
-    go get golang.org/x/net@v0.55.0 google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/zipkin ./pkg
 

--- a/packages/phlo-grafana/src/phlo_grafana/service.yaml
+++ b/packages/phlo-grafana/src/phlo_grafana/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-grafana:13.1.1-go1.26.5
+image: ghcr.io/phlohouse/phlo-grafana:13.1.1-go1.26.5-xtext0.39.0
 
 build:
   context: ./grafana

--- a/packages/phlo-grafana/tests/test_integration_grafana.py
+++ b/packages/phlo-grafana/tests/test_integration_grafana.py
@@ -31,7 +31,7 @@ def test_grafana_uses_rebuilt_image():
 
     service_def = GrafanaServicePlugin().service_definition
 
-    assert service_def["image"] == "ghcr.io/phlohouse/phlo-grafana:13.1.1-go1.26.5"
+    assert service_def["image"] == "ghcr.io/phlohouse/phlo-grafana:13.1.1-go1.26.5-xtext0.39.0"
     assert service_def["build"] == {
         "context": "./grafana",
         "dockerfile": "Dockerfile",

--- a/packages/phlo-loki/src/phlo_loki/Dockerfile
+++ b/packages/phlo-loki/src/phlo_loki/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 RUN git clone https://github.com/grafana/loki.git /src/loki && \
     git -C /src/loki checkout b318f2829f0ae2094ab3a1e90780450e9e4b03be
 WORKDIR /src/loki
-RUN go get google.golang.org/grpc@v1.82.1 && go mod tidy
+RUN go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && go mod tidy
 RUN CGO_ENABLED=0 go build -mod=mod -trimpath -tags netgo \
     -ldflags="-s -w \
         -X github.com/grafana/loki/v3/pkg/util/build.Branch=release-3.7.x \

--- a/packages/phlo-loki/src/phlo_loki/service.yaml
+++ b/packages/phlo-loki/src/phlo_loki/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-loki:3.7.4-grpc1.82.1
+image: ghcr.io/phlohouse/phlo-loki:3.7.4-grpc1.82.1-xtext0.39.0
 build:
   context: .
   dockerfile: loki/Dockerfile

--- a/packages/phlo-loki/tests/test_loki_plugin.py
+++ b/packages/phlo-loki/tests/test_loki_plugin.py
@@ -19,7 +19,7 @@ def test_loki_service_builds_patched_release_image() -> None:
     """Generated Loki uses the stable release with its fixed gRPC dependency."""
     definition = LokiServicePlugin().service_definition
 
-    assert definition["image"] == "ghcr.io/phlohouse/phlo-loki:3.7.4-grpc1.82.1"
+    assert definition["image"] == "ghcr.io/phlohouse/phlo-loki:3.7.4-grpc1.82.1-xtext0.39.0"
     assert definition["build"] == {"context": ".", "dockerfile": "loki/Dockerfile"}
     assert "LOKI_VERSION" not in definition["env_vars"]
 

--- a/packages/phlo-minio/src/phlo_minio/Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/Dockerfile
@@ -12,6 +12,7 @@ RUN git clone https://github.com/minio/minio.git . && \
         go.opentelemetry.io/otel/sdk@v1.43.0 \
         golang.org/x/crypto@v0.52.0 \
         golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy -e
 # hadolint ignore=DL3062
@@ -28,6 +29,7 @@ RUN git clone https://github.com/minio/mc.git . && \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
         golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy
 # hadolint ignore=DL3062

--- a/packages/phlo-minio/src/phlo_minio/Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone https://github.com/minio/minio.git . && \
         github.com/go-jose/go-jose/v4@v4.1.4 \
         github.com/prometheus/prometheus@v0.311.3 \
         go.opentelemetry.io/otel/sdk@v1.43.0 \
-        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/crypto@v0.53.0 \
         golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
@@ -27,7 +27,7 @@ RUN git clone https://github.com/minio/mc.git . && \
     git checkout 77f82e18b5401a65958f1619df6ebb994634bd88 && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
-        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/crypto@v0.53.0 \
         golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \

--- a/packages/phlo-minio/src/phlo_minio/Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone https://github.com/minio/minio.git . && \
         github.com/prometheus/prometheus@v0.311.3 \
         go.opentelemetry.io/otel/sdk@v1.43.0 \
         golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy -e
@@ -28,7 +28,7 @@ RUN git clone https://github.com/minio/mc.git . && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy

--- a/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
@@ -8,6 +8,7 @@ RUN git clone https://github.com/minio/mc.git . && \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
         golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy
 # hadolint ignore=DL3062

--- a/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/minio/mc.git . && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy

--- a/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
@@ -6,7 +6,7 @@ RUN git clone https://github.com/minio/mc.git . && \
     git checkout 77f82e18b5401a65958f1619df6ebb994634bd88 && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
-        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/crypto@v0.53.0 \
         golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \

--- a/packages/phlo-minio/src/phlo_minio/minio-setup.yaml
+++ b/packages/phlo-minio/src/phlo_minio/minio-setup.yaml
@@ -4,7 +4,7 @@ description: Initialize MinIO buckets for data lake
 category: core
 default: true
 
-image: ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540
+image: ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540-xtext0.39.0
 build:
   context: .
   dockerfile: minio-mc/Dockerfile

--- a/packages/phlo-minio/src/phlo_minio/service.yaml
+++ b/packages/phlo-minio/src/phlo_minio/service.yaml
@@ -3,7 +3,7 @@ description: S3-compatible object storage for data lake
 category: core
 default: true
 
-image: ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c
+image: ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c-xtext0.39.0
 build:
   context: .
   dockerfile: minio/Dockerfile

--- a/packages/phlo-minio/tests/test_minio_plugin.py
+++ b/packages/phlo-minio/tests/test_minio_plugin.py
@@ -30,9 +30,9 @@ def test_minio_services_build_pinned_phlo_images() -> None:
     server = MinioServicePlugin().service_definition
     setup = MinioSetupServicePlugin().service_definition
 
-    assert server["image"] == "ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c"
+    assert server["image"] == "ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c-xtext0.39.0"
     assert server["build"]["dockerfile"] == "minio/Dockerfile"
-    assert setup["image"] == "ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540"
+    assert setup["image"] == "ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540-xtext0.39.0"
     assert setup["build"]["dockerfile"] == "minio-mc/Dockerfile"
 
 

--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/oauth2-proxy/oauth2-proxy.git . && \
     git checkout 66b3a17db09f0b51a4bc3159d4c7fe3fbeca1288 && \
-    go get google.golang.org/grpc@v1.82.1
+    go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v7.15.3" \
     -o /out/oauth2-proxy .

--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/service.yaml
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/service.yaml
@@ -4,7 +4,7 @@ category: auth
 default: false
 profile: proxy
 
-image: ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1
+image: ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1-xtext0.39.0
 build:
   context: .
   dockerfile: oauth2-proxy/Dockerfile

--- a/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
+++ b/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
@@ -38,5 +38,5 @@ def test_oauth2_proxy_image_pinned():
     plugin = Oauth2ProxyServicePlugin()
     defn = plugin.service_definition
 
-    assert defn["image"] == "ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1"
+    assert defn["image"] == "ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1-xtext0.39.0"
     assert defn["build"]["dockerfile"] == "oauth2-proxy/Dockerfile"

--- a/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
+++ b/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.17.0 https://github.com/sosedoff/pgweb.git . && \
     git checkout 6b0b0244d1aefd6971999b03481eeeaa4ec7cf55 && \
-    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 && \
+    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 && \
     go mod tidy
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/pgweb .
 

--- a/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
+++ b/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.17.0 https://github.com/sosedoff/pgweb.git . && \
     git checkout 6b0b0244d1aefd6971999b03481eeeaa4ec7cf55 && \
-    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 && \
     go mod tidy
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/pgweb .
 

--- a/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
+++ b/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.17.0 https://github.com/sosedoff/pgweb.git . && \
     git checkout 6b0b0244d1aefd6971999b03481eeeaa4ec7cf55 && \
-    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 && \
+    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 && \
     go mod tidy
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/pgweb .
 

--- a/packages/phlo-pgweb/src/phlo_pgweb/service.yaml
+++ b/packages/phlo-pgweb/src/phlo_pgweb/service.yaml
@@ -3,7 +3,7 @@ description: Web-based PostgreSQL database browser
 category: admin
 default: true
 
-image: ghcr.io/phlohouse/phlo-pgweb:0.17.0-security-patches
+image: ghcr.io/phlohouse/phlo-pgweb:0.17.0-security-patches-xtext0.39.0
 build:
   context: .
   dockerfile: pgweb/Dockerfile

--- a/packages/phlo-postgres/src/phlo_postgres/exporter.Dockerfile
+++ b/packages/phlo-postgres/src/phlo_postgres/exporter.Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1
 RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/prometheus-community/postgres_exporter.git . && \
-    git checkout 867fbcac31cd18c143e244190ea9168cca069827
+    git checkout 867fbcac31cd18c143e244190ea9168cca069827 && \
+    go get golang.org/x/text@v0.39.0
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/prometheus/common/version.Version=0.20.1 -X github.com/prometheus/common/version.Revision=867fbcac31cd18c143e244190ea9168cca069827" \
     -o /out/postgres_exporter ./cmd/postgres_exporter

--- a/packages/phlo-postgres/src/phlo_postgres/exporter_service.yaml
+++ b/packages/phlo-postgres/src/phlo_postgres/exporter_service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-postgres-exporter:v0.20.1-go1.26.5
+image: ghcr.io/phlohouse/phlo-postgres-exporter:v0.20.1-go1.26.5-xtext0.39.0
 build:
   context: .
   dockerfile: postgres-exporter/Dockerfile

--- a/packages/phlo-postgres/tests/test_postgres_plugin.py
+++ b/packages/phlo-postgres/tests/test_postgres_plugin.py
@@ -49,7 +49,7 @@ def test_postgres_exporter_builds_pinned_hardened_image() -> None:
     service_definition = PostgresExporterServicePlugin().service_definition
 
     assert service_definition["image"] == (
-        "ghcr.io/phlohouse/phlo-postgres-exporter:v0.20.1-go1.26.5"
+        "ghcr.io/phlohouse/phlo-postgres-exporter:v0.20.1-go1.26.5-xtext0.39.0"
     )
     assert service_definition["build"]["dockerfile"] == "postgres-exporter/Dockerfile"
 

--- a/packages/phlo-prometheus/src/phlo_prometheus/Dockerfile
+++ b/packages/phlo-prometheus/src/phlo_prometheus/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/prometheus/prometheus.git . && \
     git checkout 73ff57ce2b8161059ac7fe5188f03f1c3d22b29a && \
-    go get google.golang.org/grpc@v1.82.1
+    go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1
 RUN LDFLAGS="-s -w -X github.com/prometheus/common/version.Version=3.13.1 -X github.com/prometheus/common/version.Revision=73ff57ce2b8161059ac7fe5188f03f1c3d22b29a" && \
     CGO_ENABLED=0 go build -trimpath -ldflags="$LDFLAGS" -o /out/prometheus ./cmd/prometheus && \
     CGO_ENABLED=0 go build -trimpath -ldflags="$LDFLAGS" -o /out/promtool ./cmd/promtool

--- a/packages/phlo-prometheus/src/phlo_prometheus/service.yaml
+++ b/packages/phlo-prometheus/src/phlo_prometheus/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ${PROMETHEUS_IMAGE:-ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1}
+image: ${PROMETHEUS_IMAGE:-ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1-xtext0.39.0}
 build:
   context: .
   dockerfile: prometheus/Dockerfile
@@ -42,7 +42,7 @@ compose:
 
 env_vars:
   PROMETHEUS_IMAGE:
-    default: ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1
+    default: ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1-xtext0.39.0
     description: Pinned Prometheus image to build or run
   PROMETHEUS_VERSION:
     default: v3.13.1

--- a/packages/phlo-prometheus/tests/test_prometheus_plugin.py
+++ b/packages/phlo-prometheus/tests/test_prometheus_plugin.py
@@ -13,7 +13,7 @@ def test_prometheus_service_definition():
     assert "prometheus-data:/prometheus" in defn["compose"]["volumes"]
     assert "./volumes/prometheus:/prometheus" not in defn["compose"]["volumes"]
     assert defn["image"] == (
-        "${PROMETHEUS_IMAGE:-ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1}"
+        "${PROMETHEUS_IMAGE:-ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1-xtext0.39.0}"
     )
     assert defn["build"]["dockerfile"] == "prometheus/Dockerfile"
 

--- a/packages/phlo-trino/src/phlo_trino/Dockerfile
+++ b/packages/phlo-trino/src/phlo_trino/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /src
 RUN git clone https://github.com/airlift/launcher.git . && \
     git checkout e0e239b162b4dd45f60aacd5c58394d2832d0d13
 WORKDIR /src/src/main/go
-RUN CGO_ENABLED=0 go build -buildvcs=false -trimpath \
+RUN go get golang.org/x/text@v0.39.0 && \
+    CGO_ENABLED=0 go build -buildvcs=false -trimpath \
       -ldflags="-s -w -extldflags=-static -X launcher/args.Version=318" \
       -o /out/launcher .
 

--- a/packages/phlo-trino/src/phlo_trino/service.yaml
+++ b/packages/phlo-trino/src/phlo_trino/service.yaml
@@ -3,7 +3,7 @@ description: Distributed SQL query engine for the data lake
 category: core
 default: true
 
-image: ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5
+image: ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5-xtext0.39.0
 
 build:
   context: ./trino

--- a/packages/phlo-trino/tests/test_trino_plugin.py
+++ b/packages/phlo-trino/tests/test_trino_plugin.py
@@ -20,7 +20,10 @@ def test_trino_service_definition():
 def test_trino_rebuilds_the_launcher_with_current_go():
     service_definition = TrinoServicePlugin().service_definition
 
-    assert service_definition["image"] == "ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5"
+    assert (
+        service_definition["image"]
+        == "ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5-xtext0.39.0"
+    )
     assert service_definition["build"] == {
         "context": "./trino",
         "dockerfile": "Dockerfile",

--- a/registry/support/v1.json
+++ b/registry/support/v1.json
@@ -30,10 +30,10 @@
       {"name": "dagster-daemon", "image_reference": "ghcr.io/phlohouse/phlo-dagster:0.6.0"},
       {"name": "postgres", "image_reference": "ghcr.io/phlohouse/phlo-postgres:18.4-alpine3.24-gosu1.19"},
       {"name": "postgres-volume-setup", "image_reference": "alpine:3.24.1"},
-      {"name": "minio", "image_reference": "ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c"},
-      {"name": "minio-setup", "image_reference": "ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540"},
+      {"name": "minio", "image_reference": "ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c-xtext0.39.0"},
+      {"name": "minio-setup", "image_reference": "ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540-xtext0.39.0"},
       {"name": "nessie", "image_reference": "ghcr.io/phlohouse/phlo-nessie:0.108.3-netty4.2.16"},
-      {"name": "trino", "image_reference": "ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5"},
+      {"name": "trino", "image_reference": "ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5-xtext0.39.0"},
       {"name": "phlo-api", "image_reference": "ghcr.io/phlohouse/phlo-api:0.7.0"},
       {"name": "observatory", "image_reference": "ghcr.io/phlohouse/phlo-observatory:0.7.0"}
     ],


### PR DESCRIPTION
Closes #650.

Rebuilds the generated Go-based service images with `golang.org/x/text@v0.39.0` and moves every affected service to a distinct `-xtext0.39.0` tag. The tags must be published by **Publish Generated Service Images** before the remote-image scan can validate the resulting manifests.

Validation:
- `uv run pytest packages/phlo-alloy/tests/test_alloy_plugin.py packages/phlo-clickstack/tests/test_clickstack_plugin.py packages/phlo-grafana/tests/test_integration_grafana.py packages/phlo-loki/tests/test_loki_plugin.py packages/phlo-minio/tests/test_minio_plugin.py packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py packages/phlo-postgres/tests/test_postgres_plugin.py packages/phlo-prometheus/tests/test_prometheus_plugin.py packages/phlo-trino/tests/test_trino_plugin.py tests/tooling/test_generated_image_publication.py` (36 passed, 3 deselected)
- Local Dockerfile lint could not run because no Docker daemon is available; GitHub Actions will run it.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR patches all Go-based service images to explicitly pin `golang.org/x/text@v0.39.0`, rebuilding each affected binary and appending an `-xtext0.39.0` suffix to its image tag. Tests and the `registry/support/v1.json` release manifest are updated to match.

- **Dockerfiles (10 services):** `go get golang.org/x/text@v0.39.0` is added to each build step; services that already pinned `golang.org/x/crypto` and `golang.org/x/net` also bump those to `v0.53.0` / `v0.56.0` respectively.
- **Tags:** Every affected `service.yaml` and `minio-setup.yaml` gains the `-xtext0.39.0` suffix, and all corresponding test assertions are updated.
- **Registry:** Only the three `blessed_core` image references in `registry/support/v1.json` (minio, minio-setup, trino) are updated; preview/optional services are tracked solely via their `service.yaml` files, which is consistent with the existing pattern.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR is safe to merge; all changes are mechanical tag and Dockerfile bumps with matching test updates and no logic changes.

The change is a pure security-patch rebuild: each Dockerfile gets an explicit golang.org/x/text@v0.39.0 pin, image tags gain an -xtext0.39.0 suffix, tests and the registry manifest are updated in lockstep. The postgres/exporter.Dockerfile places go get in a separate RUN layer from go build (unlike most other services), which adds a thin extra layer but does not affect correctness. No build logic, service configuration, or runtime behavior changes beyond the dependency pin.

**Files Needing Attention:** The exporter.Dockerfile for postgres is the only file worth a second look — the go get lands in a different RUN layer than go build, whereas most other services consolidate them. Functionally equivalent, but slightly inconsistent with the rest of the codebase.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/phlo-postgres/src/phlo_postgres/exporter.Dockerfile | Adds go get golang.org/x/text@v0.39.0 to the clone+checkout RUN step, before a separate RUN step for go build. No go mod tidy, consistent with prometheus and oauth2-proxy patterns. |
| packages/phlo-clickstack/src/phlo_clickstack/Dockerfile | Adds golang.org/x/text@v0.39.0 to both esbuild and gomplate go get steps; bumps x/crypto to v0.53.0 and x/net to v0.56.0 in the gomplate step. |
| packages/phlo-grafana/src/phlo_grafana/Dockerfile | Adds golang.org/x/text@v0.39.0 to the main Grafana build, elasticsearch datasource, and zipkin datasource; bumps x/net to v0.56.0 in the zipkin step. |
| packages/phlo-minio/src/phlo_minio/Dockerfile | Consistently bumps x/crypto, x/net, and adds x/text in both the minio server and mc build sections. |
| packages/phlo-minio/src/phlo_minio/mc.Dockerfile | Mirrors the mc section of the main minio Dockerfile exactly; kept in sync correctly. |
| registry/support/v1.json | Updates image references for minio, minio-setup, and trino in release_set.services — the only three blessed_core services with explicit image pins in this file. |
| packages/phlo-trino/src/phlo_trino/Dockerfile | Adds go get golang.org/x/text@v0.39.0 before the launcher build. |
| packages/phlo-alloy/src/phlo_alloy/Dockerfile | Adds golang.org/x/text@v0.39.0 alongside the existing grpc pin in the go get step; followed by go mod tidy as before. |
| packages/phlo-prometheus/src/phlo_prometheus/service.yaml | Updates both the image field and the PROMETHEUS_IMAGE env_var default to the new tag — both references kept in sync correctly. |

</details>

<sub>Reviews (1): Last reviewed commit: ["codex: fix CI failure on PR #651"](https://github.com/phlohouse/phlo/commit/e82f5b1c78a9e861f94cdc82605f32ed4dace190) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49134747)</sub>

<!-- /greptile_comment -->