### PR TITLE
fix: rebuild generated images with fixed x/text

### DIFF
--- a/packages/phlo-alloy/src/phlo_alloy/Dockerfile
+++ b/packages/phlo-alloy/src/phlo_alloy/Dockerfile
@@ -8,7 +8,7 @@ RUN git init /src/alloy && \
 WORKDIR /src/alloy
 # hadolint ignore=DL3062
 RUN export GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod && \
-    go get google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     go mod tidy && \
     npm --prefix internal/web/ui ci --no-audit --no-fund && \
     npm --prefix internal/web/ui run build && \

--- a/packages/phlo-alloy/src/phlo_alloy/service.yaml
+++ b/packages/phlo-alloy/src/phlo_alloy/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-alloy:v1.18.0-go1.26.5
+image: ghcr.io/phlohouse/phlo-alloy:v1.18.0-go1.26.5-xtext0.39.0
 build:
   context: .
   dockerfile: alloy/Dockerfile

--- a/packages/phlo-alloy/tests/test_alloy_plugin.py
+++ b/packages/phlo-alloy/tests/test_alloy_plugin.py
@@ -18,7 +18,7 @@ def test_alloy_service_builds_patched_release_image() -> None:
     """Generated Alloy uses the stable release with fixed embedded Go dependencies."""
     definition = AlloyServicePlugin().service_definition
 
-    assert definition["image"] == "ghcr.io/phlohouse/phlo-alloy:v1.18.0-go1.26.5"
+    assert definition["image"] == "ghcr.io/phlohouse/phlo-alloy:v1.18.0-go1.26.5-xtext0.39.0"
     assert definition["build"] == {"context": ".", "dockerfile": "alloy/Dockerfile"}
 
 

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -38,7 +38,7 @@ RUN go get \
       google.golang.org/grpc@v1.82.1 \
     && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /gomplate ./cmd/gomplate
 
-FROM docker.io/hyperdx/hyperdx-all-in-one:2.31.0@sha256:b01cc48cb5aaf30d630865a88217c826ab86fb9828374201f6cd7c539d5beed1
+FROM docker.io/hyperdx/hyperdx-all-in-one:2.32.0@sha256:54a0a805d761d6fef76122736a0d62400b78f69bd00394fe15086c8eda39b6c7
 
 RUN apk update \
     && apk upgrade --no-cache --available \

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -21,7 +21,8 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --branch v0.25.1 --depth 1 https://github.com/evanw/esbuild.git
 WORKDIR /src/esbuild
-RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /esbuild ./cmd/esbuild
+RUN go get golang.org/x/text@v0.39.0 && \
+    CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /esbuild ./cmd/esbuild
 WORKDIR /src
 RUN git clone --branch v4.3.3 --depth 1 https://github.com/hairyhenderson/gomplate.git
 WORKDIR /src/gomplate
@@ -33,6 +34,7 @@ RUN go get \
       go.opentelemetry.io/otel/sdk@v1.43.0 \
       golang.org/x/crypto@v0.52.0 \
       golang.org/x/net@v0.55.0 \
+      golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 \
     && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /gomplate ./cmd/gomplate
 

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -33,7 +33,7 @@ RUN go get \
       go.opentelemetry.io/otel@v1.43.0 \
       go.opentelemetry.io/otel/sdk@v1.43.0 \
       golang.org/x/crypto@v0.52.0 \
-      golang.org/x/net@v0.55.0 \
+      golang.org/x/net@v0.56.0 \
       golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 \
     && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /gomplate ./cmd/gomplate

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -64,6 +64,24 @@ RUN go get \
     go mod tidy && \
     CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /otelcontribcol .
 
+# The upstream all-in-one image also includes the OTel opamp supervisor. Rebuild
+# it from the matching collector release so its embedded Go modules match the
+# patched collector binary.
+FROM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS hyperdx-opamp-patches
+
+RUN apk add --no-cache git=2.54.0-r0
+WORKDIR /src
+RUN git clone --depth 1 --branch v0.155.0 https://github.com/open-telemetry/opentelemetry-collector-contrib.git collector && \
+    git -C collector checkout --detach aaf5045a24c0a6f000225c97ad5449e69aeb5835
+WORKDIR /src/collector/cmd/opampsupervisor
+RUN go get \
+      golang.org/x/crypto@v0.53.0 \
+      golang.org/x/net@v0.56.0 \
+      golang.org/x/text@v0.39.0 \
+      google.golang.org/grpc@v1.82.1 && \
+    go mod tidy && \
+    CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /opampsupervisor .
+
 FROM docker.io/hyperdx/hyperdx-all-in-one:2.32.0@sha256:54a0a805d761d6fef76122736a0d62400b78f69bd00394fe15086c8eda39b6c7
 
 RUN apk update \
@@ -73,6 +91,7 @@ RUN apk update \
 COPY --from=go-patches /esbuild /tmp/esbuild
 COPY --from=go-patches /gomplate /usr/local/bin/gomplate
 COPY --from=hyperdx-otel-patches /otelcontribcol /otelcontribcol
+COPY --from=hyperdx-opamp-patches /opampsupervisor /usr/local/bin/opampsupervisor
 RUN find /app/packages/app/node_modules/@esbuild -path '*/bin/esbuild' \
       -exec install -m 0755 /tmp/esbuild {} \; \
     && rm /tmp/esbuild

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -38,6 +38,32 @@ RUN go get \
       google.golang.org/grpc@v1.82.1 \
     && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /gomplate ./cmd/gomplate
 
+# HyperDX packages its OpenTelemetry collector inside the all-in-one image. Build
+# the exact collector source used by the 2.32.0 release with patched Go modules,
+# then replace only that embedded binary in the final image.
+FROM otel/opentelemetry-collector-builder:0.155.0 AS otel-builder
+
+FROM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS hyperdx-otel-patches
+
+RUN apk add --no-cache git=2.54.0-r0
+COPY --from=otel-builder /usr/local/bin/ocb /usr/local/bin/ocb
+WORKDIR /src
+RUN git clone --depth 1 https://github.com/hyperdxio/hyperdx.git hyperdx && \
+    git -C hyperdx fetch --depth 1 origin 31a461db46d23439c4b72c80be02d6991e924921 && \
+    git -C hyperdx checkout --detach 31a461db46d23439c4b72c80be02d6991e924921
+WORKDIR /build
+RUN cp /src/hyperdx/packages/otel-collector/builder-config.yaml . && \
+    sed -i 's/__OTEL_COLLECTOR_VERSION__/0.155.0/g; s/__OTEL_COLLECTOR_CORE_VERSION__/1.61.0/g' builder-config.yaml && \
+    CGO_ENABLED=0 ocb --config=builder-config.yaml && \
+    cd output && \
+    go get \
+      golang.org/x/crypto@v0.53.0 \
+      golang.org/x/net@v0.56.0 \
+      golang.org/x/text@v0.39.0 \
+      google.golang.org/grpc@v1.82.1 && \
+    go mod tidy && \
+    CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /otelcontribcol .
+
 FROM docker.io/hyperdx/hyperdx-all-in-one:2.32.0@sha256:54a0a805d761d6fef76122736a0d62400b78f69bd00394fe15086c8eda39b6c7
 
 RUN apk update \
@@ -46,6 +72,7 @@ RUN apk update \
 
 COPY --from=go-patches /esbuild /tmp/esbuild
 COPY --from=go-patches /gomplate /usr/local/bin/gomplate
+COPY --from=hyperdx-otel-patches /otelcontribcol /otelcontribcol
 RUN find /app/packages/app/node_modules/@esbuild -path '*/bin/esbuild' \
       -exec install -m 0755 /tmp/esbuild {} \; \
     && rm /tmp/esbuild

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -54,9 +54,9 @@ RUN git clone --depth 1 https://github.com/hyperdxio/hyperdx.git hyperdx && \
 WORKDIR /build
 RUN cp /src/hyperdx/packages/otel-collector/builder-config.yaml . && \
     sed -i 's/__OTEL_COLLECTOR_VERSION__/0.155.0/g; s/__OTEL_COLLECTOR_CORE_VERSION__/1.61.0/g' builder-config.yaml && \
-    CGO_ENABLED=0 ocb --config=builder-config.yaml && \
-    cd output && \
-    go get \
+    CGO_ENABLED=0 ocb --config=builder-config.yaml
+WORKDIR /build/output
+RUN go get \
       golang.org/x/crypto@v0.53.0 \
       golang.org/x/net@v0.56.0 \
       golang.org/x/text@v0.39.0 \

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -32,7 +32,7 @@ RUN go get \
       github.com/go-jose/go-jose/v4@v4.1.4 \
       go.opentelemetry.io/otel@v1.43.0 \
       go.opentelemetry.io/otel/sdk@v1.43.0 \
-      golang.org/x/crypto@v0.52.0 \
+      golang.org/x/crypto@v0.53.0 \
       golang.org/x/net@v0.56.0 \
       golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 \

--- a/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
+++ b/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches
+image: ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches-xtext0.39.0
 build:
   context: .
   dockerfile: clickstack/Dockerfile

--- a/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
+++ b/packages/phlo-clickstack/src/phlo_clickstack/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches-xtext0.39.0
+image: ghcr.io/phlohouse/phlo-clickstack:2.32.0-security-patches-xtext0.39.0
 build:
   context: .
   dockerfile: clickstack/Dockerfile

--- a/packages/phlo-clickstack/tests/test_clickstack_plugin.py
+++ b/packages/phlo-clickstack/tests/test_clickstack_plugin.py
@@ -30,10 +30,10 @@ def test_clickstack_builds_the_patched_stable_image() -> None:
 
     assert (
         definition["image"]
-        == "ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches-xtext0.39.0"
+        == "ghcr.io/phlohouse/phlo-clickstack:2.32.0-security-patches-xtext0.39.0"
     )
     assert definition["build"] == {"context": ".", "dockerfile": "clickstack/Dockerfile"}
-    assert "FROM docker.io/hyperdx/hyperdx-all-in-one:2.31.0@sha256:b01cc48" in dockerfile
+    assert "FROM docker.io/hyperdx/hyperdx-all-in-one:2.32.0@sha256:54a0a805" in dockerfile
     assert "docker.hyperdx.io" not in dockerfile
     assert "CLICKSTACK_IMAGE" not in definition["env_vars"]
 

--- a/packages/phlo-clickstack/tests/test_clickstack_plugin.py
+++ b/packages/phlo-clickstack/tests/test_clickstack_plugin.py
@@ -28,7 +28,10 @@ def test_clickstack_builds_the_patched_stable_image() -> None:
     definition = ClickStackServicePlugin().service_definition
     dockerfile = resources.files("phlo_clickstack").joinpath("Dockerfile").read_text()
 
-    assert definition["image"] == "ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches"
+    assert (
+        definition["image"]
+        == "ghcr.io/phlohouse/phlo-clickstack:2.31.0-security-patches-xtext0.39.0"
+    )
     assert definition["build"] == {"context": ".", "dockerfile": "clickstack/Dockerfile"}
     assert "FROM docker.io/hyperdx/hyperdx-all-in-one:2.31.0@sha256:b01cc48" in dockerfile
     assert "docker.hyperdx.io" not in dockerfile

--- a/packages/phlo-grafana/src/phlo_grafana/Dockerfile
+++ b/packages/phlo-grafana/src/phlo_grafana/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone https://github.com/grafana/grafana-elasticsearch-datasource.git . 
 WORKDIR /src/zipkin
 RUN git clone https://github.com/grafana/grafana-zipkin-datasource.git . && \
     git checkout daafdfe11421dd2cacc8bfdb9ab604da1875b671 && \
-    go get golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/zipkin ./pkg
 

--- a/packages/phlo-grafana/src/phlo_grafana/Dockerfile
+++ b/packages/phlo-grafana/src/phlo_grafana/Dockerfile
@@ -8,6 +8,7 @@ RUN git clone https://github.com/grafana/grafana.git . && \
 RUN go get \
       github.com/getkin/kin-openapi@v0.144.0 \
       github.com/grafana/tempo@8100f5a7b8f0986edf1fcd2ff6552d174b25ec18 \
+      golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath \
       -ldflags="-s -w -X main.version=13.1.1 -X main.commit=a9cee6e1724a455676bb6c05eef7fc54aa4b19f4" \
@@ -16,14 +17,14 @@ RUN go get \
 WORKDIR /src/elasticsearch
 RUN git clone https://github.com/grafana/grafana-elasticsearch-datasource.git . && \
     git checkout 525671446900cf0c7c5d696f931b95c2cec81d9c && \
-    go get google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/elasticsearch ./pkg
 
 WORKDIR /src/zipkin
 RUN git clone https://github.com/grafana/grafana-zipkin-datasource.git . && \
     git checkout daafdfe11421dd2cacc8bfdb9ab604da1875b671 && \
-    go get golang.org/x/net@v0.55.0 google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/zipkin ./pkg
 

--- a/packages/phlo-grafana/src/phlo_grafana/service.yaml
+++ b/packages/phlo-grafana/src/phlo_grafana/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-grafana:13.1.1-go1.26.5
+image: ghcr.io/phlohouse/phlo-grafana:13.1.1-go1.26.5-xtext0.39.0
 
 build:
   context: ./grafana

--- a/packages/phlo-grafana/tests/test_integration_grafana.py
+++ b/packages/phlo-grafana/tests/test_integration_grafana.py
@@ -31,7 +31,7 @@ def test_grafana_uses_rebuilt_image():
 
     service_def = GrafanaServicePlugin().service_definition
 
-    assert service_def["image"] == "ghcr.io/phlohouse/phlo-grafana:13.1.1-go1.26.5"
+    assert service_def["image"] == "ghcr.io/phlohouse/phlo-grafana:13.1.1-go1.26.5-xtext0.39.0"
     assert service_def["build"] == {
         "context": "./grafana",
         "dockerfile": "Dockerfile",

--- a/packages/phlo-loki/src/phlo_loki/Dockerfile
+++ b/packages/phlo-loki/src/phlo_loki/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 RUN git clone https://github.com/grafana/loki.git /src/loki && \
     git -C /src/loki checkout b318f2829f0ae2094ab3a1e90780450e9e4b03be
 WORKDIR /src/loki
-RUN go get google.golang.org/grpc@v1.82.1 && go mod tidy
+RUN go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && go mod tidy
 RUN CGO_ENABLED=0 go build -mod=mod -trimpath -tags netgo \
     -ldflags="-s -w \
         -X github.com/grafana/loki/v3/pkg/util/build.Branch=release-3.7.x \

--- a/packages/phlo-loki/src/phlo_loki/service.yaml
+++ b/packages/phlo-loki/src/phlo_loki/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-loki:3.7.4-grpc1.82.1
+image: ghcr.io/phlohouse/phlo-loki:3.7.4-grpc1.82.1-xtext0.39.0
 build:
   context: .
   dockerfile: loki/Dockerfile

--- a/packages/phlo-loki/tests/test_loki_plugin.py
+++ b/packages/phlo-loki/tests/test_loki_plugin.py
@@ -19,7 +19,7 @@ def test_loki_service_builds_patched_release_image() -> None:
     """Generated Loki uses the stable release with its fixed gRPC dependency."""
     definition = LokiServicePlugin().service_definition
 
-    assert definition["image"] == "ghcr.io/phlohouse/phlo-loki:3.7.4-grpc1.82.1"
+    assert definition["image"] == "ghcr.io/phlohouse/phlo-loki:3.7.4-grpc1.82.1-xtext0.39.0"
     assert definition["build"] == {"context": ".", "dockerfile": "loki/Dockerfile"}
     assert "LOKI_VERSION" not in definition["env_vars"]
 

--- a/packages/phlo-minio/src/phlo_minio/Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/Dockerfile
@@ -12,6 +12,7 @@ RUN git clone https://github.com/minio/minio.git . && \
         go.opentelemetry.io/otel/sdk@v1.43.0 \
         golang.org/x/crypto@v0.52.0 \
         golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy -e
 # hadolint ignore=DL3062
@@ -28,6 +29,7 @@ RUN git clone https://github.com/minio/mc.git . && \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
         golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy
 # hadolint ignore=DL3062

--- a/packages/phlo-minio/src/phlo_minio/Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/Dockerfile
@@ -10,7 +10,7 @@ RUN git clone https://github.com/minio/minio.git . && \
         github.com/go-jose/go-jose/v4@v4.1.4 \
         github.com/prometheus/prometheus@v0.311.3 \
         go.opentelemetry.io/otel/sdk@v1.43.0 \
-        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/crypto@v0.53.0 \
         golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
@@ -27,7 +27,7 @@ RUN git clone https://github.com/minio/mc.git . && \
     git checkout 77f82e18b5401a65958f1619df6ebb994634bd88 && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
-        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/crypto@v0.53.0 \
         golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \

--- a/packages/phlo-minio/src/phlo_minio/Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone https://github.com/minio/minio.git . && \
         github.com/prometheus/prometheus@v0.311.3 \
         go.opentelemetry.io/otel/sdk@v1.43.0 \
         golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy -e
@@ -28,7 +28,7 @@ RUN git clone https://github.com/minio/mc.git . && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy

--- a/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
@@ -8,6 +8,7 @@ RUN git clone https://github.com/minio/mc.git . && \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
         golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy
 # hadolint ignore=DL3062

--- a/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/minio/mc.git . && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy

--- a/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/mc.Dockerfile
@@ -6,7 +6,7 @@ RUN git clone https://github.com/minio/mc.git . && \
     git checkout 77f82e18b5401a65958f1619df6ebb994634bd88 && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
-        golang.org/x/crypto@v0.52.0 \
+        golang.org/x/crypto@v0.53.0 \
         golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \

--- a/packages/phlo-minio/src/phlo_minio/minio-setup.yaml
+++ b/packages/phlo-minio/src/phlo_minio/minio-setup.yaml
@@ -4,7 +4,7 @@ description: Initialize MinIO buckets for data lake
 category: core
 default: true
 
-image: ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540
+image: ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540-xtext0.39.0
 build:
   context: .
   dockerfile: minio-mc/Dockerfile

--- a/packages/phlo-minio/src/phlo_minio/service.yaml
+++ b/packages/phlo-minio/src/phlo_minio/service.yaml
@@ -3,7 +3,7 @@ description: S3-compatible object storage for data lake
 category: core
 default: true
 
-image: ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c
+image: ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c-xtext0.39.0
 build:
   context: .
   dockerfile: minio/Dockerfile

--- a/packages/phlo-minio/tests/test_minio_plugin.py
+++ b/packages/phlo-minio/tests/test_minio_plugin.py
@@ -30,9 +30,9 @@ def test_minio_services_build_pinned_phlo_images() -> None:
     server = MinioServicePlugin().service_definition
     setup = MinioSetupServicePlugin().service_definition
 
-    assert server["image"] == "ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c"
+    assert server["image"] == "ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c-xtext0.39.0"
     assert server["build"]["dockerfile"] == "minio/Dockerfile"
-    assert setup["image"] == "ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540"
+    assert setup["image"] == "ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540-xtext0.39.0"
     assert setup["build"]["dockerfile"] == "minio-mc/Dockerfile"
 
 

--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/oauth2-proxy/oauth2-proxy.git . && \
     git checkout 66b3a17db09f0b51a4bc3159d4c7fe3fbeca1288 && \
-    go get google.golang.org/grpc@v1.82.1
+    go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v7.15.3" \
     -o /out/oauth2-proxy .

--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/service.yaml
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/service.yaml
@@ -4,7 +4,7 @@ category: auth
 default: false
 profile: proxy
 
-image: ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1
+image: ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1-xtext0.39.0
 build:
   context: .
   dockerfile: oauth2-proxy/Dockerfile

--- a/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
+++ b/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
@@ -38,5 +38,5 @@ def test_oauth2_proxy_image_pinned():
     plugin = Oauth2ProxyServicePlugin()
     defn = plugin.service_definition
 
-    assert defn["image"] == "ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1"
+    assert defn["image"] == "ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1-xtext0.39.0"
     assert defn["build"]["dockerfile"] == "oauth2-proxy/Dockerfile"

--- a/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
+++ b/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.17.0 https://github.com/sosedoff/pgweb.git . && \
     git checkout 6b0b0244d1aefd6971999b03481eeeaa4ec7cf55 && \
-    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 && \
+    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 && \
     go mod tidy
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/pgweb .
 

--- a/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
+++ b/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.17.0 https://github.com/sosedoff/pgweb.git . && \
     git checkout 6b0b0244d1aefd6971999b03481eeeaa4ec7cf55 && \
-    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 && \
     go mod tidy
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/pgweb .
 

--- a/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
+++ b/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.17.0 https://github.com/sosedoff/pgweb.git . && \
     git checkout 6b0b0244d1aefd6971999b03481eeeaa4ec7cf55 && \
-    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 && \
+    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 && \
     go mod tidy
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/pgweb .
 

--- a/packages/phlo-pgweb/src/phlo_pgweb/service.yaml
+++ b/packages/phlo-pgweb/src/phlo_pgweb/service.yaml
@@ -3,7 +3,7 @@ description: Web-based PostgreSQL database browser
 category: admin
 default: true
 
-image: ghcr.io/phlohouse/phlo-pgweb:0.17.0-security-patches
+image: ghcr.io/phlohouse/phlo-pgweb:0.17.0-security-patches-xtext0.39.0
 build:
   context: .
   dockerfile: pgweb/Dockerfile

--- a/packages/phlo-postgres/src/phlo_postgres/exporter.Dockerfile
+++ b/packages/phlo-postgres/src/phlo_postgres/exporter.Dockerfile
@@ -3,7 +3,8 @@ FROM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1
 RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/prometheus-community/postgres_exporter.git . && \
-    git checkout 867fbcac31cd18c143e244190ea9168cca069827
+    git checkout 867fbcac31cd18c143e244190ea9168cca069827 && \
+    go get golang.org/x/text@v0.39.0
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/prometheus/common/version.Version=0.20.1 -X github.com/prometheus/common/version.Revision=867fbcac31cd18c143e244190ea9168cca069827" \
     -o /out/postgres_exporter ./cmd/postgres_exporter

--- a/packages/phlo-postgres/src/phlo_postgres/exporter_service.yaml
+++ b/packages/phlo-postgres/src/phlo_postgres/exporter_service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ghcr.io/phlohouse/phlo-postgres-exporter:v0.20.1-go1.26.5
+image: ghcr.io/phlohouse/phlo-postgres-exporter:v0.20.1-go1.26.5-xtext0.39.0
 build:
   context: .
   dockerfile: postgres-exporter/Dockerfile

--- a/packages/phlo-postgres/tests/test_postgres_plugin.py
+++ b/packages/phlo-postgres/tests/test_postgres_plugin.py
@@ -49,7 +49,7 @@ def test_postgres_exporter_builds_pinned_hardened_image() -> None:
     service_definition = PostgresExporterServicePlugin().service_definition
 
     assert service_definition["image"] == (
-        "ghcr.io/phlohouse/phlo-postgres-exporter:v0.20.1-go1.26.5"
+        "ghcr.io/phlohouse/phlo-postgres-exporter:v0.20.1-go1.26.5-xtext0.39.0"
     )
     assert service_definition["build"]["dockerfile"] == "postgres-exporter/Dockerfile"
 

--- a/packages/phlo-prometheus/src/phlo_prometheus/Dockerfile
+++ b/packages/phlo-prometheus/src/phlo_prometheus/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/prometheus/prometheus.git . && \
     git checkout 73ff57ce2b8161059ac7fe5188f03f1c3d22b29a && \
-    go get google.golang.org/grpc@v1.82.1
+    go get golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1
 RUN LDFLAGS="-s -w -X github.com/prometheus/common/version.Version=3.13.1 -X github.com/prometheus/common/version.Revision=73ff57ce2b8161059ac7fe5188f03f1c3d22b29a" && \
     CGO_ENABLED=0 go build -trimpath -ldflags="$LDFLAGS" -o /out/prometheus ./cmd/prometheus && \
     CGO_ENABLED=0 go build -trimpath -ldflags="$LDFLAGS" -o /out/promtool ./cmd/promtool

--- a/packages/phlo-prometheus/src/phlo_prometheus/service.yaml
+++ b/packages/phlo-prometheus/src/phlo_prometheus/service.yaml
@@ -4,7 +4,7 @@ category: observability
 default: false
 profile: observability
 
-image: ${PROMETHEUS_IMAGE:-ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1}
+image: ${PROMETHEUS_IMAGE:-ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1-xtext0.39.0}
 build:
   context: .
   dockerfile: prometheus/Dockerfile
@@ -42,7 +42,7 @@ compose:
 
 env_vars:
   PROMETHEUS_IMAGE:
-    default: ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1
+    default: ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1-xtext0.39.0
     description: Pinned Prometheus image to build or run
   PROMETHEUS_VERSION:
     default: v3.13.1

--- a/packages/phlo-prometheus/tests/test_prometheus_plugin.py
+++ b/packages/phlo-prometheus/tests/test_prometheus_plugin.py
@@ -13,7 +13,7 @@ def test_prometheus_service_definition():
     assert "prometheus-data:/prometheus" in defn["compose"]["volumes"]
     assert "./volumes/prometheus:/prometheus" not in defn["compose"]["volumes"]
     assert defn["image"] == (
-        "${PROMETHEUS_IMAGE:-ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1}"
+        "${PROMETHEUS_IMAGE:-ghcr.io/phlohouse/phlo-prometheus:v3.13.1-grpc1.82.1-xtext0.39.0}"
     )
     assert defn["build"]["dockerfile"] == "prometheus/Dockerfile"
 

--- a/packages/phlo-traefik/src/phlo_traefik/Dockerfile
+++ b/packages/phlo-traefik/src/phlo_traefik/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
+
+RUN apk add --no-cache git=2.54.0-r0
+WORKDIR /src
+RUN git clone --depth 1 --branch v3.7.10 https://github.com/traefik/traefik.git . && \
+    git checkout --detach 2a2349356c01b1b1f7ecddb0c17b30c97f5241e7 && \
+    CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /traefik ./cmd/traefik
+
+FROM alpine:3.24
+
+RUN apk add --no-cache --no-progress ca-certificates tzdata
+COPY --from=build /traefik /traefik
+
+EXPOSE 80
+VOLUME ["/tmp"]
+
+ENTRYPOINT ["/traefik"]

--- a/packages/phlo-traefik/src/phlo_traefik/service.yaml
+++ b/packages/phlo-traefik/src/phlo_traefik/service.yaml
@@ -4,7 +4,7 @@ category: networking
 default: false
 profile: proxy
 
-image: traefik:v3.7.9
+image: traefik:v3.7@sha256:652929a140a32d7cafafb13c6cdfab5376cfeff800f51397b87b524501ed02a8
 
 compose:
   restart: unless-stopped

--- a/packages/phlo-traefik/src/phlo_traefik/service.yaml
+++ b/packages/phlo-traefik/src/phlo_traefik/service.yaml
@@ -4,7 +4,13 @@ category: networking
 default: false
 profile: proxy
 
-image: traefik:v3.7@sha256:652929a140a32d7cafafb13c6cdfab5376cfeff800f51397b87b524501ed02a8
+image: ghcr.io/phlohouse/phlo-traefik:v3.7.10-xtext0.40.0
+build:
+  context: .
+  dockerfile: traefik/Dockerfile
+files:
+  - source: Dockerfile
+    dest: traefik/Dockerfile
 
 compose:
   restart: unless-stopped

--- a/packages/phlo-traefik/tests/test_traefik_plugin.py
+++ b/packages/phlo-traefik/tests/test_traefik_plugin.py
@@ -10,6 +10,8 @@ def test_traefik_service_definition():
 
     assert defn["name"] == "traefik"
     assert defn["profile"] == "proxy"
+    assert defn["image"] == "ghcr.io/phlohouse/phlo-traefik:v3.7.10-xtext0.40.0"
+    assert defn["build"] == {"context": ".", "dockerfile": "traefik/Dockerfile"}
 
 
 def test_traefik_plugin_metadata():

--- a/packages/phlo-trino/src/phlo_trino/Dockerfile
+++ b/packages/phlo-trino/src/phlo_trino/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /src
 RUN git clone https://github.com/airlift/launcher.git . && \
     git checkout e0e239b162b4dd45f60aacd5c58394d2832d0d13
 WORKDIR /src/src/main/go
-RUN CGO_ENABLED=0 go build -buildvcs=false -trimpath \
+RUN go get golang.org/x/text@v0.39.0 && \
+    CGO_ENABLED=0 go build -buildvcs=false -trimpath \
       -ldflags="-s -w -extldflags=-static -X launcher/args.Version=318" \
       -o /out/launcher .
 

--- a/packages/phlo-trino/src/phlo_trino/service.yaml
+++ b/packages/phlo-trino/src/phlo_trino/service.yaml
@@ -3,7 +3,7 @@ description: Distributed SQL query engine for the data lake
 category: core
 default: true
 
-image: ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5
+image: ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5-xtext0.39.0
 
 build:
   context: ./trino

--- a/packages/phlo-trino/tests/test_trino_plugin.py
+++ b/packages/phlo-trino/tests/test_trino_plugin.py
@@ -20,7 +20,10 @@ def test_trino_service_definition():
 def test_trino_rebuilds_the_launcher_with_current_go():
     service_definition = TrinoServicePlugin().service_definition
 
-    assert service_definition["image"] == "ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5"
+    assert (
+        service_definition["image"]
+        == "ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5-xtext0.39.0"
+    )
     assert service_definition["build"] == {
         "context": "./trino",
         "dockerfile": "Dockerfile",

--- a/registry/support/v1.json
+++ b/registry/support/v1.json
@@ -30,10 +30,10 @@
       {"name": "dagster-daemon", "image_reference": "ghcr.io/phlohouse/phlo-dagster:0.6.0"},
       {"name": "postgres", "image_reference": "ghcr.io/phlohouse/phlo-postgres:18.4-alpine3.24-gosu1.19"},
       {"name": "postgres-volume-setup", "image_reference": "alpine:3.24.1"},
-      {"name": "minio", "image_reference": "ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c"},
-      {"name": "minio-setup", "image_reference": "ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540"},
+      {"name": "minio", "image_reference": "ghcr.io/phlohouse/phlo-minio:7aac2a2c5b7c-xtext0.39.0"},
+      {"name": "minio-setup", "image_reference": "ghcr.io/phlohouse/phlo-minio-mc:77f82e18b540-xtext0.39.0"},
       {"name": "nessie", "image_reference": "ghcr.io/phlohouse/phlo-nessie:0.108.3-netty4.2.16"},
-      {"name": "trino", "image_reference": "ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5"},
+      {"name": "trino", "image_reference": "ghcr.io/phlohouse/phlo-trino:483-launcher318-go1.26.5-xtext0.39.0"},
       {"name": "phlo-api", "image_reference": "ghcr.io/phlohouse/phlo-api:0.7.0"},
       {"name": "observatory", "image_reference": "ghcr.io/phlohouse/phlo-observatory:0.7.0"}
     ],

--- a/src/phlo/cli/commands/plugin/check.py
+++ b/src/phlo/cli/commands/plugin/check.py
@@ -314,7 +314,7 @@ def _with_vulnerability_evidence_detail(detail: str, result: dict[str, Any]) -> 
     findings = sorted(
         {
             f"{finding['vulnerability_id']} ({finding['component']})"
-            for finding in result["vulnerable_components"]
+            for finding in result.get("vulnerable_components", [])
         }
     )
     return _join_failure_details(

--- a/src/phlo/cli/commands/plugin/check.py
+++ b/src/phlo/cli/commands/plugin/check.py
@@ -302,6 +302,17 @@ def _vulnerability_evidence_sha256(evidence: dict[str, Any]) -> str:
     return hashlib.sha256(payload).hexdigest()
 
 
+def _with_vulnerability_evidence_detail(detail: str, result: dict[str, Any]) -> str:
+    """Attach the exact waiver fingerprint to a failed eligible image scan."""
+    evidence_sha256 = result.get("vulnerability_evidence_sha256")
+    if not evidence_sha256:
+        return detail
+    return _join_failure_details(
+        detail,
+        f"vulnerability evidence sha256: {evidence_sha256}",
+    )
+
+
 def _run_trivy_image_scan(
     command: list[str],
     *,
@@ -531,7 +542,7 @@ def _check_remote_service_images(
             result["status"] = "failed" if trivy_failure else "passed"
             result["image_scan"] = "failed" if trivy_failure else "passed"
             if trivy_failure:
-                result["detail"] = trivy_failure
+                result["detail"] = _with_vulnerability_evidence_detail(trivy_failure, result)
                 if waiver and waiver_eligible and not waiver_matches:
                     result["detail"] = _join_failure_details(
                         result["detail"],
@@ -937,6 +948,9 @@ def check_generated_containers(
                     if trivy_image_failure:
                         result["detail"] = _join_failure_details(
                             result.get("detail"), trivy_image_failure
+                        )
+                        result["detail"] = _with_vulnerability_evidence_detail(
+                            result["detail"], result
                         )
                         if waiver and waiver_eligible and not waiver_matches:
                             result["detail"] = _join_failure_details(

--- a/src/phlo/cli/commands/plugin/check.py
+++ b/src/phlo/cli/commands/plugin/check.py
@@ -303,13 +303,23 @@ def _vulnerability_evidence_sha256(evidence: dict[str, Any]) -> str:
 
 
 def _with_vulnerability_evidence_detail(detail: str, result: dict[str, Any]) -> str:
-    """Attach the exact waiver fingerprint to a failed eligible image scan."""
+    """Attach a compact, exact finding summary to a failed eligible image scan."""
     evidence_sha256 = result.get("vulnerability_evidence_sha256")
     if not evidence_sha256:
         return detail
-    return _join_failure_details(
+    detail = _join_failure_details(
         detail,
         f"vulnerability evidence sha256: {evidence_sha256}",
+    )
+    findings = sorted(
+        {
+            f"{finding['vulnerability_id']} ({finding['component']})"
+            for finding in result["vulnerable_components"]
+        }
+    )
+    return _join_failure_details(
+        detail,
+        f"vulnerability evidence findings: {', '.join(findings)}",
     )
 
 

--- a/tests/cli/test_cli_plugin.py
+++ b/tests/cli/test_cli_plugin.py
@@ -1173,7 +1173,9 @@ def test_plugin_check_containers_reports_evidence_hash_without_waiver() -> None:
     )
 
     assert detail == (
-        f"trivy image sha256:one failed with exit code 1\nvulnerability evidence sha256: {'a' * 64}"
+        "trivy image sha256:one failed with exit code 1\n"
+        f"vulnerability evidence sha256: {'a' * 64}\n"
+        "vulnerability evidence findings: CVE-TEST (example/component)"
     )
 
 

--- a/tests/cli/test_cli_plugin.py
+++ b/tests/cli/test_cli_plugin.py
@@ -1163,6 +1163,20 @@ def test_plugin_check_containers_reports_exact_image_vulnerability_waiver(monkey
     ]
 
 
+def test_plugin_check_containers_reports_evidence_hash_without_waiver() -> None:
+    """A failed scan exposes its exact evidence fingerprint for safe remediation."""
+    from phlo.cli.commands.plugin import check as check_module
+
+    detail = check_module._with_vulnerability_evidence_detail(
+        "trivy image sha256:one failed with exit code 1",
+        {"vulnerability_evidence_sha256": "a" * 64},
+    )
+
+    assert detail == (
+        f"trivy image sha256:one failed with exit code 1\nvulnerability evidence sha256: {'a' * 64}"
+    )
+
+
 def test_plugin_check_rejects_ambiguous_vulnerability_waiver() -> None:
     """Waivers must bind a service and image to exact vulnerability evidence."""
     from phlo.cli.commands.plugin import check as check_module

--- a/tests/cli/test_cli_plugin.py
+++ b/tests/cli/test_cli_plugin.py
@@ -1169,7 +1169,12 @@ def test_plugin_check_containers_reports_evidence_hash_without_waiver() -> None:
 
     detail = check_module._with_vulnerability_evidence_detail(
         "trivy image sha256:one failed with exit code 1",
-        {"vulnerability_evidence_sha256": "a" * 64},
+        {
+            "vulnerability_evidence_sha256": "a" * 64,
+            "vulnerable_components": [
+                {"vulnerability_id": "CVE-TEST", "component": "example/component"}
+            ],
+        },
     )
 
     assert detail == (


### PR DESCRIPTION
Closes #650.

Replacement for #651 after the branch was renamed to remove the `codex/` prefix. Rebuilds generated Go-based service images with `golang.org/x/text@v0.39.0`, aligns the compatible `x/net` and `x/crypto` versions, updates HyperDX to 2.32.0, and pins Traefik to the current 3.7 manifest.

Published images:
- all targeted generated service images at `-xtext0.39.0`
- ClickStack 2.32.0 artifact

The remote container scan will refresh the remaining exact waiver fingerprints.