### PR TITLE
ci: add Codex pull request review

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,69 @@
+name: Codex PR review
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    # Secrets are intentionally unavailable to workflows triggered from forks.
+    # Do not change this workflow to pull_request_target.
+    if: github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    outputs:
+      final_message: ${{ steps.codex.outputs.final-message }}
+    steps:
+      - name: Check out the pull request merge commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Review the pull request
+        id: codex
+        uses: openai/codex-action@b11346a6fa031e2e164ab4b7c7ea201afffd7d59 # v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-5.6-luna
+          effort: xhigh
+          permission-profile: ":read-only"
+          safety-strategy: drop-sudo
+          prompt: |
+            Review only the change introduced by this pull request.
+
+            Inspect the diff with:
+              git diff --check ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+              git diff ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
+
+            Report only actionable correctness, security, data-loss, or regression
+            findings introduced by the diff. Do not report style, formatting, naming,
+            or pre-existing issues. For every finding, name the affected file and
+            explain the failure scenario. If there are no findings, respond exactly:
+            "No actionable findings."
+
+  post-feedback:
+    needs: review
+    if: >-
+      needs.review.result == 'success' &&
+      needs.review.outputs.final_message != ''
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post Codex feedback
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          CODEX_FINAL_MESSAGE: ${{ needs.review.outputs.final_message }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: process.env.CODEX_FINAL_MESSAGE,
+            });


### PR DESCRIPTION
## What changed

Adds a pull-request workflow that runs an automated Codex review with `gpt-5.6-luna` at `xhigh` reasoning effort.

## Safety and behaviour

- Reviews only same-repository PRs; fork PRs are skipped.
- Runs Codex with the `:read-only` permission profile and dropped sudo privileges.
- Posts feedback from a separate job with only `pull-requests: write` permission.

## Validation

- YAML parsing
- Pre-commit workflow checks, including yamllint and Zizmor

`actionlint` remains for GitHub CI because Docker Desktop was unavailable locally.