### PR TITLE
fix: remediate generated image x/text vulnerabilities

### DIFF
--- a/packages/phlo-alloy/src/phlo_alloy/Dockerfile
+++ b/packages/phlo-alloy/src/phlo_alloy/Dockerfile
@@ -8,7 +8,7 @@ RUN git init /src/alloy && \
 WORKDIR /src/alloy
 # hadolint ignore=DL3062
 RUN export GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod && \
-    go get google.golang.org/grpc@v1.82.1 && \
+    go get google.golang.org/grpc@v1.82.1 golang.org/x/text@v0.39.0 && \
     go mod tidy && \
     npm --prefix internal/web/ui ci --no-audit --no-fund && \
     npm --prefix internal/web/ui run build && \

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -33,6 +33,7 @@ RUN go get \
       go.opentelemetry.io/otel/sdk@v1.43.0 \
       golang.org/x/crypto@v0.52.0 \
       golang.org/x/net@v0.55.0 \
+      golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 \
     && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /gomplate ./cmd/gomplate
 

--- a/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
+++ b/packages/phlo-clickstack/src/phlo_clickstack/Dockerfile
@@ -31,8 +31,8 @@ RUN go get \
       github.com/go-jose/go-jose/v4@v4.1.4 \
       go.opentelemetry.io/otel@v1.43.0 \
       go.opentelemetry.io/otel/sdk@v1.43.0 \
-      golang.org/x/crypto@v0.52.0 \
-      golang.org/x/net@v0.55.0 \
+      golang.org/x/crypto@v0.53.0 \
+      golang.org/x/net@v0.56.0 \
       golang.org/x/text@v0.39.0 \
       google.golang.org/grpc@v1.82.1 \
     && CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o /gomplate ./cmd/gomplate

--- a/packages/phlo-grafana/src/phlo_grafana/Dockerfile
+++ b/packages/phlo-grafana/src/phlo_grafana/Dockerfile
@@ -24,7 +24,7 @@ RUN git clone https://github.com/grafana/grafana-elasticsearch-datasource.git . 
 WORKDIR /src/zipkin
 RUN git clone https://github.com/grafana/grafana-zipkin-datasource.git . && \
     git checkout daafdfe11421dd2cacc8bfdb9ab604da1875b671 && \
-    go get golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/zipkin ./pkg
 

--- a/packages/phlo-grafana/src/phlo_grafana/Dockerfile
+++ b/packages/phlo-grafana/src/phlo_grafana/Dockerfile
@@ -8,7 +8,8 @@ RUN git clone https://github.com/grafana/grafana.git . && \
 RUN go get \
       github.com/getkin/kin-openapi@v0.144.0 \
       github.com/grafana/tempo@8100f5a7b8f0986edf1fcd2ff6552d174b25ec18 \
-      google.golang.org/grpc@v1.82.1 && \
+      google.golang.org/grpc@v1.82.1 \
+      golang.org/x/text@v0.39.0 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath \
       -ldflags="-s -w -X main.version=13.1.1 -X main.commit=a9cee6e1724a455676bb6c05eef7fc54aa4b19f4" \
       -o /out/grafana ./pkg/cmd/grafana
@@ -16,14 +17,14 @@ RUN go get \
 WORKDIR /src/elasticsearch
 RUN git clone https://github.com/grafana/grafana-elasticsearch-datasource.git . && \
     git checkout 525671446900cf0c7c5d696f931b95c2cec81d9c && \
-    go get google.golang.org/grpc@v1.82.1 && \
+    go get google.golang.org/grpc@v1.82.1 golang.org/x/text@v0.39.0 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/elasticsearch ./pkg
 
 WORKDIR /src/zipkin
 RUN git clone https://github.com/grafana/grafana-zipkin-datasource.git . && \
     git checkout daafdfe11421dd2cacc8bfdb9ab604da1875b671 && \
-    go get golang.org/x/net@v0.55.0 google.golang.org/grpc@v1.82.1 && \
+    go get golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 google.golang.org/grpc@v1.82.1 && \
     CGO_ENABLED=0 go build -buildvcs=false -trimpath -ldflags="-s -w" \
       -o /out/zipkin ./pkg
 

--- a/packages/phlo-loki/src/phlo_loki/Dockerfile
+++ b/packages/phlo-loki/src/phlo_loki/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 RUN git clone https://github.com/grafana/loki.git /src/loki && \
     git -C /src/loki checkout b318f2829f0ae2094ab3a1e90780450e9e4b03be
 WORKDIR /src/loki
-RUN go get google.golang.org/grpc@v1.82.1 && go mod tidy
+RUN go get google.golang.org/grpc@v1.82.1 golang.org/x/text@v0.39.0 && go mod tidy
 RUN CGO_ENABLED=0 go build -mod=mod -trimpath -tags netgo \
     -ldflags="-s -w \
         -X github.com/grafana/loki/v3/pkg/util/build.Branch=release-3.7.x \

--- a/packages/phlo-minio/src/phlo_minio/Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/Dockerfile
@@ -12,6 +12,7 @@ RUN git clone https://github.com/minio/minio.git . && \
         go.opentelemetry.io/otel/sdk@v1.43.0 \
         golang.org/x/crypto@v0.52.0 \
         golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy -e
 # hadolint ignore=DL3062
@@ -28,6 +29,7 @@ RUN git clone https://github.com/minio/mc.git . && \
         github.com/prometheus/prometheus@v0.311.3 \
         golang.org/x/crypto@v0.52.0 \
         golang.org/x/net@v0.55.0 \
+        golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy
 # hadolint ignore=DL3062

--- a/packages/phlo-minio/src/phlo_minio/Dockerfile
+++ b/packages/phlo-minio/src/phlo_minio/Dockerfile
@@ -10,8 +10,8 @@ RUN git clone https://github.com/minio/minio.git . && \
         github.com/go-jose/go-jose/v4@v4.1.4 \
         github.com/prometheus/prometheus@v0.311.3 \
         go.opentelemetry.io/otel/sdk@v1.43.0 \
-        golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/crypto@v0.53.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy -e
@@ -27,8 +27,8 @@ RUN git clone https://github.com/minio/mc.git . && \
     git checkout 77f82e18b5401a65958f1619df6ebb994634bd88 && \
     go get \
         github.com/prometheus/prometheus@v0.311.3 \
-        golang.org/x/crypto@v0.52.0 \
-        golang.org/x/net@v0.55.0 \
+        golang.org/x/crypto@v0.53.0 \
+        golang.org/x/net@v0.56.0 \
         golang.org/x/text@v0.39.0 \
         google.golang.org/grpc@v1.82.1 && \
     go mod tidy

--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/oauth2-proxy/oauth2-proxy.git . && \
     git checkout 66b3a17db09f0b51a4bc3159d4c7fe3fbeca1288 && \
-    go get google.golang.org/grpc@v1.82.1
+    go get google.golang.org/grpc@v1.82.1 golang.org/x/text@v0.39.0
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v7.15.3" \
     -o /out/oauth2-proxy .

--- a/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
+++ b/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.17.0 https://github.com/sosedoff/pgweb.git . && \
     git checkout 6b0b0244d1aefd6971999b03481eeeaa4ec7cf55 && \
-    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 && \
+    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.53.0 golang.org/x/net@v0.56.0 golang.org/x/text@v0.39.0 && \
     go mod tidy
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/pgweb .
 

--- a/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
+++ b/packages/phlo-pgweb/src/phlo_pgweb/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone --depth 1 --branch v0.17.0 https://github.com/sosedoff/pgweb.git . && \
     git checkout 6b0b0244d1aefd6971999b03481eeeaa4ec7cf55 && \
-    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 && \
+    go get github.com/sirupsen/logrus@v1.9.3 golang.org/x/crypto@v0.52.0 golang.org/x/net@v0.55.0 golang.org/x/text@v0.39.0 && \
     go mod tidy
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/pgweb .
 

--- a/packages/phlo-postgres/src/phlo_postgres/exporter.Dockerfile
+++ b/packages/phlo-postgres/src/phlo_postgres/exporter.Dockerfile
@@ -4,7 +4,8 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/prometheus-community/postgres_exporter.git . && \
     git checkout 867fbcac31cd18c143e244190ea9168cca069827
-RUN CGO_ENABLED=0 go build -trimpath \
+RUN go get golang.org/x/text@v0.39.0 && \
+    CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/prometheus/common/version.Version=0.20.1 -X github.com/prometheus/common/version.Revision=867fbcac31cd18c143e244190ea9168cca069827" \
     -o /out/postgres_exporter ./cmd/postgres_exporter
 

--- a/packages/phlo-prometheus/src/phlo_prometheus/Dockerfile
+++ b/packages/phlo-prometheus/src/phlo_prometheus/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/prometheus/prometheus.git . && \
     git checkout 73ff57ce2b8161059ac7fe5188f03f1c3d22b29a && \
-    go get google.golang.org/grpc@v1.82.1
+    go get google.golang.org/grpc@v1.82.1 golang.org/x/text@v0.39.0
 RUN LDFLAGS="-s -w -X github.com/prometheus/common/version.Version=3.13.1 -X github.com/prometheus/common/version.Revision=73ff57ce2b8161059ac7fe5188f03f1c3d22b29a" && \
     CGO_ENABLED=0 go build -trimpath -ldflags="$LDFLAGS" -o /out/prometheus ./cmd/prometheus && \
     CGO_ENABLED=0 go build -trimpath -ldflags="$LDFLAGS" -o /out/promtool ./cmd/promtool

--- a/packages/phlo-traefik/src/phlo_traefik/service.yaml
+++ b/packages/phlo-traefik/src/phlo_traefik/service.yaml
@@ -4,7 +4,7 @@ category: networking
 default: false
 profile: proxy
 
-image: traefik:v3.7.9
+image: traefik:v3.7.10
 
 compose:
   restart: unless-stopped

--- a/packages/phlo-traefik/tests/test_traefik_plugin.py
+++ b/packages/phlo-traefik/tests/test_traefik_plugin.py
@@ -10,6 +10,7 @@ def test_traefik_service_definition():
 
     assert defn["name"] == "traefik"
     assert defn["profile"] == "proxy"
+    assert defn["image"] == "traefik:v3.7.10"
 
 
 def test_traefik_plugin_metadata():

--- a/packages/phlo-trino/src/phlo_trino/Dockerfile
+++ b/packages/phlo-trino/src/phlo_trino/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /src
 RUN git clone https://github.com/airlift/launcher.git . && \
     git checkout e0e239b162b4dd45f60aacd5c58394d2832d0d13
 WORKDIR /src/src/main/go
+RUN go get golang.org/x/text@v0.39.0
 RUN CGO_ENABLED=0 go build -buildvcs=false -trimpath \
       -ldflags="-s -w -extldflags=-static -X launcher/args.Version=318" \
       -o /out/launcher .

--- a/tests/tooling/test_generated_image_publication.py
+++ b/tests/tooling/test_generated_image_publication.py
@@ -9,6 +9,19 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
+GO_TEXT_PATCHED_DOCKERFILES = (
+    "packages/phlo-alloy/src/phlo_alloy/Dockerfile",
+    "packages/phlo-clickstack/src/phlo_clickstack/Dockerfile",
+    "packages/phlo-grafana/src/phlo_grafana/Dockerfile",
+    "packages/phlo-loki/src/phlo_loki/Dockerfile",
+    "packages/phlo-minio/src/phlo_minio/Dockerfile",
+    "packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile",
+    "packages/phlo-pgweb/src/phlo_pgweb/Dockerfile",
+    "packages/phlo-postgres/src/phlo_postgres/exporter.Dockerfile",
+    "packages/phlo-prometheus/src/phlo_prometheus/Dockerfile",
+    "packages/phlo-trino/src/phlo_trino/Dockerfile",
+)
+
 
 def _published_image(raw_image: str) -> str:
     match = re.fullmatch(r"\$\{[^:}]+:-(.+)}", raw_image)
@@ -76,3 +89,9 @@ def test_ci_scans_published_images_remotely() -> None:
         "adc46e9eb99e4f3c0ea11a6cab55ebf0d720c844128a33b5bb8c7c7efae79224"
     )
     assert clickstack_waiver in workflow
+
+
+def test_rebuilt_go_images_pin_the_fixed_x_text_version() -> None:
+    for relative_path in GO_TEXT_PATCHED_DOCKERFILES:
+        dockerfile = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert "golang.org/x/text@v0.39.0" in dockerfile, relative_path


### PR DESCRIPTION
## Summary

- Pin `golang.org/x/text@v0.39.0` in every affected custom Go-generated service image, including the Trino launcher.
- Upgrade the unowned Traefik image from `v3.7.9` to `v3.7.10`, whose release updates `x/text` beyond the vulnerable range.
- Add contract coverage for the fixed Go dependency and Traefik image version.

Closes #650

## Root cause

Trivy began reporting CVE-2026-56852 in the published generated-service images because their rebuilt Go binaries still carried pre-`v0.39.0` versions of `golang.org/x/text`. Trino 483 also retains a Jetty 11 component affected by CVE-2026-2332; the available fixed versions are Jetty 12, which is not a compatible drop-in for Trino 483 and remains covered by its existing evidence-bound waiver. ClickStack's embedded upstream OCB binaries likewise remain covered by its existing waiver.

## Validation

- `uv run --locked pytest --import-mode=importlib -q` — 3254 passed, 5 skipped, 500 deselected
- Focused generated-image and Traefik tests — 6 passed
- Ruff check and format checks — passed
- Hadolint v2.14.0 against all ten changed Dockerfiles via OrbStack — passed (one informational DL3059 only)

The full generated-container matrix is intentionally left to CI rather than cold-building every unrelated service locally. That lane scans published GHCR images remotely; the affected tags need to be republished through the existing image publication workflow before that scan can observe these source-build fixes.