### PR TITLE
fix: fetch history for generated image change detection

### DIFF
--- a/.github/workflows/build-core-services.yml
+++ b/.github/workflows/build-core-services.yml
@@ -33,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv

--- a/tests/tooling/test_generated_image_publication.py
+++ b/tests/tooling/test_generated_image_publication.py
@@ -37,6 +37,7 @@ def test_publication_workflow_publishes_attested_images_after_digest_scans() -> 
 
     assert "pull_request:" not in workflow
     assert "\n  push:" in workflow
+    assert "fetch-depth: 0" in workflow
     assert "workflow_dispatch:" in workflow
     assert "release:" in workflow
     assert "PUBLISH_SERVICES" in workflow


### PR DESCRIPTION
## Summary

- fetch full Git history in the generated-image preparation job
- add a regression assertion for the checkout depth

## Root cause

The workflow computes changed services with `git diff "$BEFORE...HEAD"` on pushes to `main`, but the default shallow checkout does not contain the previous push commit. The preparation job therefore failed before rendering any build contexts.

## Validation

- Full pre-commit suite passed, including YAML validation, Ruff, formatting, yamllint, and zizmor.
- `git diff --check` passed.
- Targeted workflow checkout contract passed.