### PR TITLE
ci: pin validation toolchain and partition core tests

### DIFF
--- a/.github/workflows/build-core-services.yml
+++ b/.github/workflows/build-core-services.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install workspace service plugins
         run: |
           uv python install 3.11
-          uv sync --python 3.11 --all-packages
+          uv sync --python 3.11 --all-packages --locked
 
       - name: Render every installed service through the public CLI
         id: matrix
@@ -68,16 +68,16 @@ jobs:
           project="$RUNNER_TEMP/generated-service-project"
           mkdir -p "$project"
           cd "$project"
-          uv --project "$GITHUB_WORKSPACE" run phlo services init --no-dev --force
+          uv --project "$GITHUB_WORKSPACE" run --locked phlo services init --no-dev --force
           mapfile -t services < <(
-            uv --project "$GITHUB_WORKSPACE" run phlo services list --all --json |
+            uv --project "$GITHUB_WORKSPACE" run --locked phlo services list --all --json |
               jq -r '.[].name'
           )
           add_args=()
           for service in "${services[@]}"; do
             add_args+=(--service "$service")
           done
-          uv --project "$GITHUB_WORKSPACE" run phlo services add "${add_args[@]}" --no-start
+          uv --project "$GITHUB_WORKSPACE" run --locked phlo services add "${add_args[@]}" --no-start
           docker compose \
             --profile '*' \
             -f "$project/.phlo/docker-compose.yml" \
@@ -88,7 +88,7 @@ jobs:
             matrix_args+=(--services "$PUBLISH_SERVICES")
           fi
           matrix="$(
-            uv --project "$GITHUB_WORKSPACE" run python \
+            uv --project "$GITHUB_WORKSPACE" run --locked python \
               "$GITHUB_WORKSPACE/scripts/generated_image_matrix.py" \
               "$RUNNER_TEMP/generated-compose.json" \
               "$project" \

--- a/.github/workflows/build-core-services.yml
+++ b/.github/workflows/build-core-services.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
           enable-cache: false
 
       - name: Install workspace service plugins

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Validate workflow YAML
         run: ruby -e 'Dir[".github/workflows/*.yml"].each { |file| YAML.load_file(file) }' -r yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Set up Python
         run: uv python install 3.11
@@ -155,7 +155,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
@@ -239,7 +239,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Set up Python
         run: uv python install 3.11
@@ -307,7 +307,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Run release artifact golden path
         run: python3 scripts/release_golden_path.py
@@ -324,7 +324,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Run owned backup and restore drill
         shell: bash
@@ -410,7 +410,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
           junit_path="cairn-artifacts/pytest-${{ matrix.python-version }}.xml"
 
           set +e
-          uv run --locked pytest tests -m "not integration" --tb=short --cov=phlo --cov-report=term-missing --junitxml "${junit_path}"
+          uv run --locked pytest tests -m "not integration and not core_regression" --tb=short --cov=phlo --cov-report=term-missing --junitxml "${junit_path}"
           pytest_exit=$?
           set -e
 

--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -20,7 +20,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
       - name: Validate waiver expiry
         run: uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py validate-waivers
       - name: Download latest published digest manifest

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -90,13 +90,13 @@ jobs:
         run: |
           set -euo pipefail
           uv python install 3.11
-          uv sync --python 3.11 --all-packages
+          uv sync --python 3.11 --all-packages --locked
           mapfile -t services < <(jq -r '.include[].service' <<< "$TARGETS")
           project="$RUNNER_TEMP/generated-service-project"
           mkdir -p "$project"
           cd "$project"
-          uv --project "$GITHUB_WORKSPACE" run phlo services init --no-dev --force
+          uv --project "$GITHUB_WORKSPACE" run --locked phlo services init --no-dev --force
           add_args=()
           for service in "${services[@]}"; do add_args+=(--service "$service"); done
-          uv --project "$GITHUB_WORKSPACE" run phlo services add "${add_args[@]}" --no-start
+          uv --project "$GITHUB_WORKSPACE" run --locked phlo services add "${add_args[@]}" --no-start
           docker compose --profile '*' -f "$project/.phlo/docker-compose.yml" --project-directory "$project/.phlo" config --format json > "$RUNNER_TEMP/generated-compose.json"

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
       - name: Validate register and generated report
         shell: bash
         run: |
@@ -44,7 +44,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
       - id: images
         name: Detect affected images
         env:
@@ -83,7 +83,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
       - name: Validate generated Dockerfiles and Compose configuration
         env:
           TARGETS: ${{ needs.affected.outputs.matrix }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Install pymdx
         run: uv tool install "pymdx==${PYMDX_VERSION}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
           enable-cache: false
 
       - uses: iamgp/ReleaseX@0f77cbd306b3e726e3a44d8546ae01548af40829
@@ -66,7 +66,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
           enable-cache: false
 
       - uses: iamgp/ReleaseX@0f77cbd306b3e726e3a44d8546ae01548af40829
@@ -123,7 +123,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
           enable-cache: false
 
       - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
           enable-cache: false
 
       - uses: iamgp/ReleaseX@0f77cbd306b3e726e3a44d8546ae01548af40829
@@ -66,7 +66,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
           enable-cache: false
 
       - uses: iamgp/ReleaseX@0f77cbd306b3e726e3a44d8546ae01548af40829
@@ -123,7 +123,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
           enable-cache: false
 
       - name: Set up Python

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,11 +25,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Audit Python dependencies
         shell: bash
-        run: uv --preview-features audit-command audit --locked
+        run: uv audit --locked
 
   observatory-dependencies:
     name: security / observatory dependencies
@@ -66,7 +66,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "0.10.10"
+          version: "0.12.1"
 
       - name: Install pymdx
         run: uv tool install "pymdx==0.1.4"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Audit Python dependencies
         shell: bash
@@ -66,7 +66,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
-          version: "latest"
+          version: "0.10.10"
 
       - name: Install pymdx
         run: uv tool install "pymdx==0.1.4"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,13 +16,6 @@ repos:
       - id: check-added-large-files
         args: ["--maxkb=1024"]
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.1
-    hooks:
-      - id: ruff
-        args: ["--fix"]
-      - id: ruff-format
-
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.37.1
     hooks:
@@ -56,6 +49,16 @@ repos:
 
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff (locked project tool)
+        entry: uv run --locked ruff check --fix
+        language: system
+        types_or: [python, pyi, jupyter]
+      - id: ruff-format
+        name: ruff format (locked project tool)
+        entry: uv run --locked ruff format
+        language: system
+        types_or: [python, pyi, jupyter]
       - id: prettier-observatory
         name: prettier (Observatory)
         entry: npx prettier --cache --write
@@ -68,24 +71,24 @@ repos:
         files: ^\.github/(workflows/.*\.(yml|yaml)|dependabot\.yml)$
       - id: sqlfluff-dbt
         name: sqlfluff (dbt models)
-        entry: uv run sqlfluff lint
+        entry: uv run --locked sqlfluff lint
         language: system
         files: ^workflows/transforms/dbt/.*\.sql$
       - id: sqlfluff-dbt-fix
         name: sqlfluff fix (dbt models)
-        entry: uv run sqlfluff fix workflows/transforms/dbt
+        entry: uv run --locked sqlfluff fix workflows/transforms/dbt
         language: system
         pass_filenames: false
         stages: [manual]
       - id: ty-check
         name: ty check (repo scope)
-        entry: uv run ty check src/phlo packages
+        entry: uv run --locked ty check src/phlo packages
         language: system
         pass_filenames: false
         stages: [pre-push]
       - id: pytest-unit
         name: pytest (not integration)
-        entry: uv run pytest -m "not integration"
+        entry: uv run --locked pytest -m "not integration"
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ TY_CHECK_SCOPE ?= src/phlo \
 	packages/phlo-trino/src
 CHECK_CMD := scripts/run-parallel \
 	"support manifest" "python3 scripts/validate_support_manifest.py" \
-	"py lint" "uv run ruff check ." \
-	"py format" "uv run ruff format --check ." \
-	"py typecheck" "uv run ty check $(TY_CHECK_SCOPE)" \
-	"py test" "uv run pytest -m 'not integration'" \
+	"py lint" "uv run --locked ruff check ." \
+	"py format" "uv run --locked ruff format --check ." \
+	"py typecheck" "uv run --locked ty check $(TY_CHECK_SCOPE)" \
+	"py test" "uv run --locked pytest -m 'not integration'" \
 	"ts lint" "$(NPM_OBSERVATORY) run lint" \
 	"ts format" "$(NPM_OBSERVATORY) run format -- --check ." \
 	"ts typecheck" "$(NPM_OBSERVATORY) exec tsc -- -p $(OBSERVATORY_DIR)/tsconfig.json --noEmit"
@@ -117,16 +117,16 @@ venv:
 	uv venv
 
 install:
-	uv sync
+	uv sync --locked
 
 test:
-	uv run pytest
+	uv run --locked pytest
 
 test-core-regression:
-	uv run pytest $(CORE_REGRESSION_TEST_PATHS) -m core_regression $(CORE_REGRESSION_PYTEST_ARGS)
+	uv run --locked pytest $(CORE_REGRESSION_TEST_PATHS) -m core_regression $(CORE_REGRESSION_PYTEST_ARGS)
 
 test-quickstart-smoke:
-	uv run pytest tests/cli/test_quickstart_smoke.py $(QUICKSTART_SMOKE_PYTEST_ARGS)
+	uv run --locked pytest tests/cli/test_quickstart_smoke.py $(QUICKSTART_SMOKE_PYTEST_ARGS)
 
 dagster:
 	@open http://localhost:$${DAGSTER_PORT:-10006}
@@ -197,18 +197,18 @@ up-all:
 	$(COMPOSE) up -d $(PROFILE_ALL)
 
 docs-generate:
-	uv run pymdx generate src/phlo --docs docs --output $(PYMDX_DOCS_DIR)
+	uv run --locked pymdx generate src/phlo --docs docs --output $(PYMDX_DOCS_DIR)
 
 docs-dev: docs-generate
-	uv run pymdx dev $(PYMDX_DOCS_DIR) --port $(PYMDX_DOCS_PORT)
+	uv run --locked pymdx dev $(PYMDX_DOCS_DIR) --port $(PYMDX_DOCS_PORT)
 
 docs-build: docs-generate
-	uv run pymdx build $(PYMDX_DOCS_DIR)
+	uv run --locked pymdx build $(PYMDX_DOCS_DIR)
 
 docs-serve: docs-dev
 
 docs-clean:
-	uv run pymdx clean $(PYMDX_DOCS_DIR)
+	uv run --locked pymdx clean $(PYMDX_DOCS_DIR)
 
 # Health check target
 health:
@@ -330,13 +330,13 @@ nessie-shell:
 lint: lint-python lint-sql
 
 lint-python:
-	uv run ruff check .
+	uv run --locked ruff check .
 
 format-python:
-	uv run ruff format --check .
+	uv run --locked ruff format --check .
 
 typecheck-python:
-	uv run ty check $(TY_CHECK_SCOPE)
+	uv run --locked ty check $(TY_CHECK_SCOPE)
 
 dependency-refresh:
 	python3 scripts/dependency_refresh_plan.py --lane $(LANE)
@@ -360,10 +360,10 @@ check:
 	@$(CHECK_CMD)
 
 lint-sql:
-	uv run sqlfluff lint workflows/transforms/dbt
+	uv run --locked sqlfluff lint workflows/transforms/dbt
 
 fix-sql:
-	uv run sqlfluff fix workflows/transforms/dbt
+	uv run --locked sqlfluff fix workflows/transforms/dbt
 
 prek-install:
 	uvx prek install

--- a/tests/tooling/test_ci_test_partition.py
+++ b/tests/tooling/test_ci_test_partition.py
@@ -1,0 +1,53 @@
+"""Contracts for the separately reported core-regression CI partition."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _collect_node_ids(marker: str) -> set[str]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "--quiet",
+            "--import-mode=importlib",
+            "tests",
+            "-m",
+            marker,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    return {
+        line.strip()
+        for line in result.stdout.splitlines()
+        if line.startswith("tests/") and "::" in line
+    }
+
+
+def test_ci_keeps_core_regression_attributable_and_disjoint() -> None:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "id: core_regression" in workflow
+    assert "make test-core-regression" in workflow
+    assert "id: core_tests" in workflow
+    assert 'uv run --locked pytest tests -m "not integration and not core_regression"' in workflow
+
+    core_regression = _collect_node_ids("core_regression")
+    remaining = _collect_node_ids("not integration and not core_regression")
+    intended = _collect_node_ids("not integration")
+
+    assert core_regression
+    assert not core_regression & remaining
+    assert core_regression | remaining == intended

--- a/tests/tooling/test_toolchain_pins.py
+++ b/tests/tooling/test_toolchain_pins.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_ROOT = REPO_ROOT / ".github" / "workflows"
-EXPECTED_UV_VERSION = "0.10.10"
+EXPECTED_UV_VERSION = "0.12.1"
 
 
 def _workflow_texts() -> list[str]:
@@ -72,3 +72,10 @@ def test_workflow_project_validation_commands_require_the_lockfile() -> None:
                 )
             else:
                 assert "--locked" in line, f"{workflow_path}: {line}"
+
+
+def test_security_audit_uses_the_stable_pinned_uv_command() -> None:
+    security = (WORKFLOW_ROOT / "security.yml").read_text(encoding="utf-8")
+
+    assert "run: uv audit --locked" in security
+    assert "--preview-features audit-command" not in security

--- a/tests/tooling/test_toolchain_pins.py
+++ b/tests/tooling/test_toolchain_pins.py
@@ -1,0 +1,74 @@
+"""Contracts for the repository's pinned validation toolchain."""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_ROOT = REPO_ROOT / ".github" / "workflows"
+EXPECTED_UV_VERSION = "0.10.10"
+
+
+def _workflow_texts() -> list[str]:
+    return [path.read_text(encoding="utf-8") for path in sorted(WORKFLOW_ROOT.glob("*.yml"))]
+
+
+def test_every_setup_uv_step_uses_the_repository_pin() -> None:
+    for workflow in _workflow_texts():
+        lines = workflow.splitlines()
+        for index, line in enumerate(lines):
+            if "uses: astral-sh/setup-uv@" not in line:
+                continue
+            setup_block = lines[index : index + 6]
+            assert any(
+                re.fullmatch(rf'\s+version: "{EXPECTED_UV_VERSION}"', block_line)
+                for block_line in setup_block
+            ), f"setup-uv step is not pinned to {EXPECTED_UV_VERSION}: {line}"
+            assert not any('version: "latest"' in block_line for block_line in setup_block)
+
+
+def test_makefile_project_commands_require_the_lockfile() -> None:
+    makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    uv_run_lines = [line for line in makefile.splitlines() if "uv run" in line]
+
+    assert uv_run_lines
+    assert all("uv run --locked" in line for line in uv_run_lines), uv_run_lines
+    assert "uv sync --locked" in makefile
+
+
+def test_pre_commit_uses_the_locked_project_ruff_and_tools() -> None:
+    pre_commit = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    lockfile = (REPO_ROOT / "uv.lock").read_text(encoding="utf-8")
+    ruff_version = re.search(
+        r'\[\[package\]\]\nname = "ruff"\nversion = "([^"]+)"',
+        lockfile,
+    )
+
+    assert ruff_version is not None
+    assert ruff_version.group(1) == "0.15.9"
+    assert "https://github.com/astral-sh/ruff-pre-commit" not in pre_commit
+    assert "entry: uv run --locked ruff check --fix" in pre_commit
+    assert "entry: uv run --locked ruff format" in pre_commit
+
+    for line in pre_commit.splitlines():
+        if "entry: uv run" in line:
+            assert "--locked" in line, line
+
+
+def test_workflow_project_validation_commands_require_the_lockfile() -> None:
+    for workflow_path in sorted(WORKFLOW_ROOT.glob("*.yml")):
+        lines = workflow_path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if "uv sync" in line and "--no-project" not in line:
+                assert "--locked" in line, f"{workflow_path}: {line}"
+            if "uv --project" in line and " run" in line and "--no-project" not in line:
+                assert "--locked" in line, f"{workflow_path}: {line}"
+            if "uv run" not in line:
+                continue
+            if "--no-project" in line:
+                continue
+            if 'uv run "${run_args[@]}"' in line:
+                assert any(
+                    "run_args=(--locked" in prior for prior in lines[max(0, index - 20) : index]
+                )
+            else:
+                assert "--locked" in line, f"{workflow_path}: {line}"


### PR DESCRIPTION
## Outcome

Use one pinned, locked uv toolchain across repository validation and run the core regression slice exactly once per Python CI job.

## Changes

- Pin every setup-uv workflow step to uv 0.12.1.
- Require --locked for owned Makefile, pre-commit, and project workflow validation commands.
- Run pre-commit Ruff from the locked project tool (Ruff 0.15.9).
- Exclude core_regression from the remaining non-integration CI selection while preserving the attributable step, Python 3.11/3.12 matrix, and Cairn artifacts.
- Add focused contracts for toolchain drift and disjoint/complete pytest collection.
- Use the stable `uv audit --locked` command for Python dependency auditing.

## Validation

- uv 0.12.1 `uv audit --locked` — no known vulnerabilities or adverse project statuses
- uv run --locked pytest --import-mode=importlib tests/tooling/test_toolchain_pins.py tests/tooling/test_ci_test_partition.py -q — 6 passed
- uv run --locked ruff check tests/tooling/test_toolchain_pins.py tests/tooling/test_ci_test_partition.py — passed
- make test-core-regression — 336 passed, 1 skipped
- make actionlint — passed
- make check — Python lanes passed; TypeScript lanes unavailable locally because eslint/prettier are absent and npm registry DNS is blocked.

No golden-path scheduling or trigger changes are included.

Closes #640
Closes #642