### PR TITLE
ci: schedule release golden path nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,23 +295,6 @@ jobs:
             exit 1
           fi
 
-  release-golden-path:
-    name: python / release golden path
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
-        with:
-          version: "0.12.1"
-
-      - name: Run release artifact golden path
-        run: python3 scripts/release_golden_path.py
-
   recovery-continuity-drill:
     name: python / recovery continuity drill
     runs-on: ubuntu-latest
@@ -496,7 +479,6 @@ jobs:
       - python-quality
       - python-core-tests
       - quickstart-smoke
-      - release-golden-path
       - recovery-continuity-drill
       - windows-release-contract
       - python-package-tests
@@ -509,7 +491,6 @@ jobs:
           PYTHON_QUALITY: ${{ needs.python-quality.result }}
           PYTHON_CORE_TESTS: ${{ needs.python-core-tests.result }}
           QUICKSTART_SMOKE: ${{ needs.quickstart-smoke.result }}
-          RELEASE_GOLDEN_PATH: ${{ needs.release-golden-path.result }}
           RECOVERY_CONTINUITY_DRILL: ${{ needs.recovery-continuity-drill.result }}
           WINDOWS_RELEASE_CONTRACT: ${{ needs.windows-release-contract.result }}
           PYTHON_PACKAGE_TESTS: ${{ needs.python-package-tests.result }}
@@ -526,7 +507,6 @@ jobs:
             echo "| python / quality | ${PYTHON_QUALITY} |"
             echo "| python / core tests | ${PYTHON_CORE_TESTS} |"
             echo "| python / quickstart smoke | ${QUICKSTART_SMOKE} |"
-            echo "| python / release golden path | ${RELEASE_GOLDEN_PATH} |"
             echo "| python / recovery continuity drill | ${RECOVERY_CONTINUITY_DRILL} |"
             echo "| windows / release golden path contract | ${WINDOWS_RELEASE_CONTRACT} |"
             echo "| python / package tests | ${PYTHON_PACKAGE_TESTS} |"
@@ -538,7 +518,6 @@ jobs:
             "${PYTHON_QUALITY}" \
             "${PYTHON_CORE_TESTS}" \
             "${QUICKSTART_SMOKE}" \
-            "${RELEASE_GOLDEN_PATH}" \
             "${RECOVERY_CONTINUITY_DRILL}" \
             "${WINDOWS_RELEASE_CONTRACT}" \
             "${PYTHON_PACKAGE_TESTS}" \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,3 +39,20 @@ jobs:
           MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
           SUPERSET_ADMIN_PASSWORD: ${{ secrets.SUPERSET_ADMIN_PASSWORD }}
         run: uv run --locked pytest -m integration --tb=short tests packages/*/tests
+
+  release-golden-path:
+    name: python / release golden path
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          version: "0.12.1"
+
+      - name: Run release artifact golden path
+        run: python3 scripts/release_golden_path.py

--- a/tests/tooling/test_golden_path_scheduling.py
+++ b/tests/tooling/test_golden_path_scheduling.py
@@ -1,0 +1,45 @@
+"""Workflow contracts for the scheduled release golden path."""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_ROOT = REPO_ROOT / ".github" / "workflows"
+
+
+def test_release_golden_path_runs_only_in_nightly() -> None:
+    ci = yaml.safe_load((WORKFLOW_ROOT / "ci.yml").read_text(encoding="utf-8"))
+    nightly = yaml.safe_load((WORKFLOW_ROOT / "nightly.yml").read_text(encoding="utf-8"))
+
+    assert "release-golden-path" not in ci["jobs"]
+    assert ci["jobs"]["windows-release-contract"]["name"] == (
+        "windows / release golden path contract"
+    )
+    assert nightly["jobs"]["release-golden-path"] == {
+        "name": "python / release golden path",
+        "runs-on": "ubuntu-latest",
+        "timeout-minutes": 45,
+        "steps": [
+            {
+                "uses": "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd",
+                "with": {"persist-credentials": False},
+            },
+            {
+                "name": "Install uv",
+                "uses": "astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098",
+                "with": {"version": "0.12.1"},
+            },
+            {
+                "name": "Run release artifact golden path",
+                "run": "python3 scripts/release_golden_path.py",
+            },
+        ],
+    }
+
+
+def test_nightly_release_golden_path_keeps_dispatch_and_schedule() -> None:
+    nightly = (WORKFLOW_ROOT / "nightly.yml").read_text(encoding="utf-8")
+
+    assert "  workflow_dispatch:\n" in nightly
+    assert '    - cron: "0 3 * * *"' in nightly


### PR DESCRIPTION
## Outcome

Ordinary pull-request CI no longer runs `python / release golden path`; the existing Nightly workflow runs the same job at 03:00 UTC and on `workflow_dispatch`.

## Changes

- Move the unchanged `release-golden-path` job from `.github/workflows/ci.yml` to `.github/workflows/nightly.yml`.
- Remove its CI-status dependency, summary row, and result gate.
- Preserve the focused Windows release-golden-path contract in PR CI.
- Add workflow contracts proving CI absence, Nightly presence, unchanged job configuration, dispatch, and schedule.

## Validation

- `uv run --locked pytest --import-mode=importlib tests/tooling/test_golden_path_scheduling.py tests/scripts/test_release_golden_path.py -q` — 35 passed
- `uv run --locked ruff check tests/tooling/test_golden_path_scheduling.py` — passed
- `make actionlint` — passed
- Main branch protection check — no protection configured (HTTP 404: Branch not protected)
- Repository rulesets check — empty (`[]`)

No release-golden-path script, timeout, permissions, cache/uv configuration, artifact behavior, Windows contract, or unrelated policy was changed.

Supersedes #659; no source changes were made in the replacement.