### PR TITLE
fix: remediate all Python type diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ TY_CHECK_SCOPE ?= src/phlo \
 	packages/phlo-iceberg/src \
 	packages/phlo-lineage/src \
 	packages/phlo-loki/src \
+	packages/phlo-mcp/src \
 	packages/phlo-minio/src \
 	packages/phlo-nessie/src \
 	packages/phlo-oauth2-proxy/src \

--- a/packages/phlo-alerting/src/phlo_alerting/authorization.py
+++ b/packages/phlo-alerting/src/phlo_alerting/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-alerting"
 FRAMEWORK_TYPE = "cli"
@@ -23,5 +23,5 @@ AlertingSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_alerting_adapter() -> AlertingSurfaceAdapter:
+def get_alerting_adapter() -> CliSurfaceAdapter:
     return AlertingSurfaceAdapter.get_instance()

--- a/packages/phlo-alerting/src/phlo_alerting/destinations/slack.py
+++ b/packages/phlo-alerting/src/phlo_alerting/destinations/slack.py
@@ -31,7 +31,7 @@ See Also:
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 import requests
 
@@ -222,7 +222,7 @@ class SlackAlertDestination(AlertDestination):
             "fields": fields,
         }
 
-        payload = {
+        payload: dict[str, Any] = {
             "attachments": [attachment],
         }
 

--- a/packages/phlo-api/src/phlo_api/observatory_api/contributing.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/contributing.py
@@ -447,7 +447,7 @@ async def resolve_iceberg_table(
     }
 
     return ResolveTableResult(
-        schema_name=schema,
+        schema=schema,
         table=table_name,
         full_name=".".join(
             [quote_identifier(catalog), quote_identifier(schema), quote_identifier(table_name)]
@@ -512,7 +512,7 @@ async def get_contributing_rows_query(
 
     return ContributingRowsQueryResponse(
         query=query,
-        upstream=UpstreamTableRef(schema_name=upstream.schema_name, table=upstream.table),
+        upstream=UpstreamTableRef(schema=upstream.schema_name, table=upstream.table),
     )
 
 
@@ -586,7 +586,7 @@ async def get_contributing_rows_page(
         page_size=page_size,
         has_more=has_more,
         query=query_or_error,
-        upstream=UpstreamTableRef(schema_name=upstream.schema_name, table=upstream.table),
+        upstream=UpstreamTableRef(schema=upstream.schema_name, table=upstream.table),
         columns=columns,
         column_types=column_types,
         rows=rows,

--- a/packages/phlo-api/src/phlo_api/observatory_api/lineage.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/lineage.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import os
 from collections import deque
+from collections.abc import Iterable
 from typing import Any
 
 from fastapi import APIRouter, Query
@@ -127,6 +128,16 @@ def _row_to_lineage_info(row: dict[str, Any] | None) -> RowLineageInfo | None:
         if created_at
         else None,
     )
+
+
+def _rows_to_lineage_info(rows: Iterable[dict[str, Any]]) -> list[RowLineageInfo]:
+    """Convert provider rows while dropping malformed or absent entries."""
+    result: list[RowLineageInfo] = []
+    for row in rows:
+        info = _row_to_lineage_info(row)
+        if info is not None:
+            result.append(info)
+    return result
 
 
 def _coerce_asset_node(name: str, payload: Any) -> AssetNode:
@@ -309,7 +320,7 @@ async def get_row_ancestors(
     """
     try:
         journey = _resolve_lineage_sink().get_row_journey(row_id=row_id, depth=max_depth)
-        return [_row_to_lineage_info(row) for row in journey.get("ancestors", []) if row]
+        return _rows_to_lineage_info(journey.get("ancestors", []))
     except RuntimeError as exc:
         return {"error": str(exc)}
     except Exception as exc:
@@ -337,7 +348,7 @@ async def get_row_descendants(
     """
     try:
         journey = _resolve_lineage_sink().get_row_journey(row_id=row_id, depth=max_depth)
-        return [_row_to_lineage_info(row) for row in journey.get("descendants", []) if row]
+        return _rows_to_lineage_info(journey.get("descendants", []))
     except RuntimeError as exc:
         return {"error": str(exc)}
     except Exception as exc:
@@ -363,10 +374,8 @@ async def get_row_journey(row_id: str) -> LineageJourney | dict[str, str]:
         journey = _resolve_lineage_sink().get_row_journey(row_id=row_id, depth=10)
         return LineageJourney(
             current=_row_to_lineage_info(journey.get("current")),
-            ancestors=[_row_to_lineage_info(row) for row in journey.get("ancestors", []) if row],
-            descendants=[
-                _row_to_lineage_info(row) for row in journey.get("descendants", []) if row
-            ],
+            ancestors=_rows_to_lineage_info(journey.get("ancestors", [])),
+            descendants=_rows_to_lineage_info(journey.get("descendants", [])),
         )
     except RuntimeError as exc:
         return {"error": str(exc)}

--- a/packages/phlo-api/src/phlo_api/observatory_api/observatory.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/observatory.py
@@ -21,11 +21,6 @@ from typing import Any, cast
 from urllib.parse import quote
 from uuid import uuid4
 
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - POSIX is used in production
-    fcntl = None  # type: ignore[assignment]
-
 from fastapi import APIRouter, BackgroundTasks, Body, Query, Request
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
@@ -35,6 +30,7 @@ from phlo_api.observatory_api.observatory_actions import execute_observatory_act
 from phlo_api.observatory_api.observatory_cache import ReadModelCache
 from phlo_api.observatory_api.observatory_capabilities import build_capability_inventory
 from phlo_api.observatory_api.observatory_models import (
+    ControlStatus,
     HealthState,
     ObservatoryAction,
     ObservatoryActionRequest,
@@ -163,6 +159,15 @@ from phlo_api.api.operation_controls import (
     require_scope,
 )
 from phlo_api.pagination import paginate_items
+from types import ModuleType
+
+fcntl: ModuleType | None
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - POSIX is used in production
+    fcntl = None
+else:
+    fcntl = _fcntl
 
 router = APIRouter(tags=["observatory"])
 
@@ -382,15 +387,19 @@ def _dataset_workflow_config() -> ObservatoryDatasetWorkflowConfig:
 
 
 def _workflow_dataset_overlay(dataset_id: str) -> Mapping[str, Any]:
-    state = _load_dataset_workflow_state()
-    datasets = state.get("datasets") if isinstance(state.get("datasets"), Mapping) else {}
+    raw_state = _load_dataset_workflow_state()
+    state: dict[str, Any] = raw_state if isinstance(raw_state, dict) else {}
+    raw_datasets = state.get("datasets")
+    datasets = raw_datasets if isinstance(raw_datasets, Mapping) else {}
     overlay = datasets.get(dataset_id)
     return overlay if isinstance(overlay, Mapping) else {}
 
 
 def _workflow_candidate_overlay(table_id: str) -> Mapping[str, Any]:
-    state = _load_dataset_workflow_state()
-    candidates = state.get("candidates") if isinstance(state.get("candidates"), Mapping) else {}
+    raw_state = _load_dataset_workflow_state()
+    state: dict[str, Any] = raw_state if isinstance(raw_state, dict) else {}
+    raw_candidates = state.get("candidates")
+    candidates = raw_candidates if isinstance(raw_candidates, Mapping) else {}
     overlay = candidates.get(table_id)
     return overlay if isinstance(overlay, Mapping) else {}
 
@@ -1357,7 +1366,13 @@ def _load_governance_matrix() -> ObservatoryGovernanceMatrix:
     )
 
 
-CONTROL_STATUSES = ("pass", "fail", "warning", "unknown", "not_applicable")
+CONTROL_STATUSES: tuple[ControlStatus, ...] = (
+    "pass",
+    "fail",
+    "warning",
+    "unknown",
+    "not_applicable",
+)
 
 
 def _governance_row_for_dataset(
@@ -1447,7 +1462,7 @@ def _governance_controls_for_dataset(
 def _quality_control_status(
     dataset: ObservatoryDataset,
     quality: Sequence[ObservatoryQualityCheck],
-) -> str:
+) -> ControlStatus:
     if dataset.candidate:
         return "not_applicable"
     if not quality:
@@ -1480,7 +1495,7 @@ def _quality_control_message(
     return "Blocking quality checks are clear."
 
 
-def _aggregate_control_status(controls: Sequence[ObservatoryDatasetControl]) -> str:
+def _aggregate_control_status(controls: Sequence[ObservatoryDatasetControl]) -> ControlStatus:
     statuses = [control.status for control in controls]
     for status in ("fail", "warning", "unknown", "not_applicable"):
         if status in statuses:
@@ -2876,20 +2891,22 @@ async def _contributing_rows_query(
 ) -> ObservatoryContributingRowsQueryResponse | dict[str, str]:
     from phlo_api.observatory_api.contributing import (
         ContributingRowsQueryRequest,
+        ContributingRowsQueryResponse,
         get_contributing_rows_query,
     )
 
     result = await get_contributing_rows_query(
         ContributingRowsQueryRequest.model_validate(request.model_dump())
     )
-    if isinstance(result, Mapping):
+    if not isinstance(result, ContributingRowsQueryResponse):
         error = result.get("error")
         if isinstance(error, str):
             return {"error": error}
+        return {"error": "Unable to build contributing rows query."}
     return ObservatoryContributingRowsQueryResponse(
         query=result.query,
         upstream=ObservatoryUpstreamTableRef(
-            schema_name=result.upstream.schema_name,
+            schema=result.upstream.schema_name,
             table=result.upstream.table,
         ),
     )
@@ -2900,16 +2917,18 @@ async def _contributing_rows_page(
 ) -> ObservatoryContributingRowsPageResponse | dict[str, str]:
     from phlo_api.observatory_api.contributing import (
         ContributingRowsPageRequest,
+        ContributingRowsPageResponse,
         get_contributing_rows_page,
     )
 
     result = await get_contributing_rows_page(
         ContributingRowsPageRequest.model_validate(request.model_dump())
     )
-    if isinstance(result, Mapping):
+    if not isinstance(result, ContributingRowsPageResponse):
         error = result.get("error")
         if isinstance(error, str):
             return {"error": error}
+        return {"error": "Unable to build contributing rows page."}
     return ObservatoryContributingRowsPageResponse(
         mode=result.mode,
         page=result.page,
@@ -2917,7 +2936,7 @@ async def _contributing_rows_page(
         has_more=result.has_more,
         query=result.query,
         upstream=ObservatoryUpstreamTableRef(
-            schema_name=result.upstream.schema_name,
+            schema=result.upstream.schema_name,
             table=result.upstream.table,
         ),
         columns=result.columns,

--- a/packages/phlo-api/src/phlo_api/observatory_api/search.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/search.py
@@ -152,6 +152,8 @@ async def get_search_index(
             return {"error": f"Failed to fetch assets: {assets_result['error']}"}
         if isinstance(tables_result, dict) and "error" in tables_result:
             return {"error": f"Failed to fetch tables: {tables_result['error']}"}
+        if not isinstance(assets_result, list) or not isinstance(tables_result, list):
+            return {"error": "Failed to fetch search index data."}
 
         # Convert assets
         assets = [

--- a/packages/phlo-api/src/phlo_api/security_manifest.py
+++ b/packages/phlo-api/src/phlo_api/security_manifest.py
@@ -12,7 +12,7 @@ import json
 import os
 from uuid import uuid4
 from dataclasses import dataclass, replace
-from typing import Any, Iterable
+from typing import Any, Iterable, NoReturn
 
 from fastapi import HTTPException, Request
 from starlette.routing import Match
@@ -545,12 +545,10 @@ def validate_manifest(app: Any) -> tuple[OperationSpec, ...]:
                     f"Duplicate HTTP security manifest operation for {method} {path}"
                 )
             seen_routes.add(key)
-            resolved_spec = OperationSpec(
-                **{
-                    **spec.__dict__,
-                    "methods": tuple(sorted(route.methods)),
-                    "path": path,
-                }
+            resolved_spec = replace(
+                spec,
+                methods=tuple(sorted(route.methods)),
+                path=path,
             )
             route_key_manifest[key] = resolved_spec
             resolved.append(resolved_spec)
@@ -668,7 +666,7 @@ async def resolve_resource(
     )
 
 
-def _raise_unauthorized() -> None:
+def _raise_unauthorized() -> NoReturn:
     raise HTTPException(
         status_code=401,
         detail={"error": "unauthorized", "reason": "authentication_required"},

--- a/packages/phlo-clickhouse/src/phlo_clickhouse/authorization.py
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-clickhouse"
 FRAMEWORK_TYPE = "cli"
@@ -23,5 +23,5 @@ ClickHouseSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_adapter() -> ClickHouseSurfaceAdapter:
+def get_adapter() -> CliSurfaceAdapter:
     return ClickHouseSurfaceAdapter.get_instance()

--- a/packages/phlo-clickhouse/src/phlo_clickhouse/resource.py
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/resource.py
@@ -124,7 +124,7 @@ class ClickHouseResource:
         client = self.get_client()
         try:
             result = client.query(sql, parameters=list(params or []))
-            return result.result_rows
+            return [list(row) for row in result.result_rows]
         finally:
             client.close()
 

--- a/packages/phlo-clickstack/src/phlo_clickstack/authorization.py
+++ b/packages/phlo-clickstack/src/phlo_clickstack/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-clickstack"
 FRAMEWORK_TYPE = "cli"
@@ -23,5 +23,5 @@ ClickStackSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_adapter() -> ClickStackSurfaceAdapter:
+def get_adapter() -> CliSurfaceAdapter:
     return ClickStackSurfaceAdapter.get_instance()

--- a/packages/phlo-core-plugins/src/phlo_core/quality/freshness_check.py
+++ b/packages/phlo-core-plugins/src/phlo_core/quality/freshness_check.py
@@ -98,9 +98,8 @@ class FreshnessCheckPlugin(QualityCheckPlugin[Any]):
 
     def create_check(
         self,
-        timestamp_column: str,
-        max_age_hours: float,
-        reference_time: datetime | None = None,
+        *args: Any,
+        **kwargs: Any,
     ) -> Any:
         """Create a freshness check instance.
 
@@ -146,6 +145,16 @@ class FreshnessCheckPlugin(QualityCheckPlugin[Any]):
                 )
 
         """
+        if len(args) > 3 or set(kwargs) - {"timestamp_column", "max_age_hours", "reference_time"}:
+            raise TypeError("create_check accepts timestamp_column, max_age_hours, reference_time")
+        timestamp_column = kwargs.get("timestamp_column", args[0] if args else None)
+        max_age_hours = kwargs.get("max_age_hours", args[1] if len(args) > 1 else None)
+        reference_time = kwargs.get("reference_time", args[2] if len(args) > 2 else None)
+        if not isinstance(timestamp_column, str) or not isinstance(max_age_hours, (int, float)):
+            raise TypeError("timestamp_column and max_age_hours are required")
+        if reference_time is not None and not isinstance(reference_time, datetime):
+            raise TypeError("reference_time must be a datetime or None")
+
         from phlo_pandera.checks import FreshnessCheck
 
         return FreshnessCheck(

--- a/packages/phlo-core-plugins/src/phlo_core/quality/null_check.py
+++ b/packages/phlo-core-plugins/src/phlo_core/quality/null_check.py
@@ -104,7 +104,7 @@ class NullCheckPlugin(QualityCheckPlugin[Any]):
             tags=["quality", "nulls"],
         )
 
-    def create_check(self, columns: list[str], allow_threshold: float = 0.0) -> Any:
+    def create_check(self, *args: Any, **kwargs: Any) -> Any:
         """Create a null check instance.
 
         Creates and returns a configured NullCheck instance from phlo_pandera
@@ -150,6 +150,15 @@ class NullCheckPlugin(QualityCheckPlugin[Any]):
                 result = check.validate(df)
 
         """
+        if len(args) > 2 or set(kwargs) - {"columns", "allow_threshold"}:
+            raise TypeError("create_check accepts columns and allow_threshold")
+        columns = kwargs.get("columns", args[0] if args else None)
+        allow_threshold = kwargs.get("allow_threshold", args[1] if len(args) > 1 else 0.0)
+        if not isinstance(columns, list) or not all(isinstance(column, str) for column in columns):
+            raise TypeError("columns must be a list of strings")
+        if not isinstance(allow_threshold, (int, float)):
+            raise TypeError("allow_threshold must be numeric")
+
         from phlo_pandera.checks import NullCheck
 
         return NullCheck(columns=columns, allow_threshold=allow_threshold)

--- a/packages/phlo-core-plugins/src/phlo_core/quality/schema_check.py
+++ b/packages/phlo-core-plugins/src/phlo_core/quality/schema_check.py
@@ -85,7 +85,7 @@ class SchemaCheckPlugin(QualityCheckPlugin[Any]):
             tags=["quality", "schema"],
         )
 
-    def create_check(self, schema: Any, lazy: bool = True) -> Any:
+    def create_check(self, *args: Any, **kwargs: Any) -> Any:
         """Create a schema check instance.
 
         Creates and returns a configured SchemaCheck instance from phlo_pandera
@@ -125,6 +125,13 @@ class SchemaCheckPlugin(QualityCheckPlugin[Any]):
                 strict_check = plugin.create_check(schema=schema, lazy=False)
 
         """
+        if len(args) > 2 or set(kwargs) - {"schema", "lazy"}:
+            raise TypeError("create_check accepts schema and lazy")
+        schema = kwargs.get("schema", args[0] if args else None)
+        lazy = kwargs.get("lazy", args[1] if len(args) > 1 else True)
+        if schema is None or not isinstance(lazy, bool):
+            raise TypeError("schema is required and lazy must be boolean")
+
         from phlo_pandera.checks_extra import SchemaCheck
 
         return SchemaCheck(schema=schema, lazy=lazy)

--- a/packages/phlo-core-plugins/src/phlo_core/quality/uniqueness_check.py
+++ b/packages/phlo-core-plugins/src/phlo_core/quality/uniqueness_check.py
@@ -101,7 +101,7 @@ class UniquenessCheckPlugin(QualityCheckPlugin[Any]):
             tags=["quality", "uniqueness"],
         )
 
-    def create_check(self, columns: list[str], allow_threshold: float = 0.0) -> Any:
+    def create_check(self, *args: Any, **kwargs: Any) -> Any:
         """Create a uniqueness check instance.
 
         Creates and returns a configured UniqueCheck instance from phlo_pandera
@@ -151,6 +151,15 @@ class UniquenessCheckPlugin(QualityCheckPlugin[Any]):
                 )
 
         """
+        if len(args) > 2 or set(kwargs) - {"columns", "allow_threshold"}:
+            raise TypeError("create_check accepts columns and allow_threshold")
+        columns = kwargs.get("columns", args[0] if args else None)
+        allow_threshold = kwargs.get("allow_threshold", args[1] if len(args) > 1 else 0.0)
+        if not isinstance(columns, list) or not all(isinstance(column, str) for column in columns):
+            raise TypeError("columns must be a list of strings")
+        if not isinstance(allow_threshold, (int, float)):
+            raise TypeError("allow_threshold must be numeric")
+
         from phlo_pandera.checks import UniqueCheck
 
         return UniqueCheck(columns=columns, allow_threshold=allow_threshold)

--- a/packages/phlo-dagster/src/phlo_dagster/authorization.py
+++ b/packages/phlo-dagster/src/phlo_dagster/authorization.py
@@ -27,6 +27,8 @@ from dataclasses import dataclass
 import re
 from typing import Any
 
+from graphql import GraphQLObjectType
+
 from phlo.capabilities import (
     RegulatedSurfaceSpec,
     register_capability,
@@ -509,7 +511,7 @@ def validate_graphql_schema(schema: Any | None = None) -> None:
 
     for operation in ("query", "mutation", "subscription"):
         root = schema.get_type(operation.capitalize())
-        if root is None:
+        if not isinstance(root, GraphQLObjectType):
             continue
         actual_fields = set(root.fields)
         classified = {field for kind, field in _GRAPHQL_OPERATION_INDEX if kind == operation}

--- a/packages/phlo-dagster/src/phlo_dagster/daemon_identity.py
+++ b/packages/phlo-dagster/src/phlo_dagster/daemon_identity.py
@@ -17,6 +17,7 @@ Run Tag Propagation:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dagster._core.run_coordinator import QueuedRunCoordinator, SubmitRunContext
 from dagster._core.storage.tags import (
     AUTOMATION_CONDITION_TAG,
@@ -186,7 +187,7 @@ def authorize_daemon_run(
     )
 
 
-def _infer_daemon_trigger(run_tags: dict[str, str]) -> tuple[str, str] | None:
+def _infer_daemon_trigger(run_tags: Mapping[str, str]) -> tuple[str, str] | None:
     """Infer daemon trigger kind and name from Dagster run tags."""
     if schedule_name := run_tags.get(SCHEDULE_NAME_TAG):
         return "schedule", schedule_name

--- a/packages/phlo-dagster/src/phlo_dagster/maintenance_sensor.py
+++ b/packages/phlo-dagster/src/phlo_dagster/maintenance_sensor.py
@@ -46,6 +46,7 @@ import os
 import re
 import time
 from datetime import datetime, timezone
+from importlib import import_module
 from typing import Any
 
 import dagster as dg
@@ -290,10 +291,15 @@ def optimize_tables_job():
     optimize_table_files()
 
 
+expire_snapshots_job: dg.JobDefinition | None = None
 try:
-    from phlo_dagster.iceberg_maintenance import expire_snapshots_job
+    candidate_job = getattr(
+        import_module("phlo_dagster.iceberg_maintenance"), "expire_snapshots_job", None
+    )
+    if isinstance(candidate_job, dg.JobDefinition):
+        expire_snapshots_job = candidate_job
 except Exception:  # noqa: BLE001 - optional dependency integration
-    expire_snapshots_job = None
+    pass
 
 _SENSOR_TARGET_JOBS: list[dg.JobDefinition] = [optimize_tables_job]
 if expire_snapshots_job is not None:

--- a/packages/phlo-dagster/src/phlo_dagster/oidc_identity.py
+++ b/packages/phlo-dagster/src/phlo_dagster/oidc_identity.py
@@ -12,6 +12,8 @@ from urllib.parse import urlparse
 
 import httpx
 import jwt
+from jwt.algorithms import RSAAlgorithm
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from phlo.capabilities import AuthPrincipal
 from phlo.logging import get_logger
@@ -117,9 +119,12 @@ class OIDCIdentityValidator:
             key = self._key_for_kid(str(header["kid"]))
             if key is None:
                 return None
+            public_key = RSAAlgorithm.from_jwk(json.dumps(key))
+            if not isinstance(public_key, RSAPublicKey):
+                return None
             claims = jwt.decode(
                 token,
-                key=jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key)),
+                key=public_key,
                 algorithms=["RS256"],
                 audience=self.audience,
                 issuer=self.issuer,
@@ -129,11 +134,11 @@ class OIDCIdentityValidator:
             subject = claims.get("sub")
             if not isinstance(subject, str) or not subject:
                 return None
-            groups = claims.get(self.groups_claim, ())
-            if isinstance(groups, str):
-                groups = tuple(value.strip() for value in groups.split(",") if value.strip())
-            elif isinstance(groups, list):
-                groups = tuple(value for value in groups if isinstance(value, str) and value)
+            groups_claim = claims.get(self.groups_claim, ())
+            if isinstance(groups_claim, str):
+                groups = tuple(value.strip() for value in groups_claim.split(",") if value.strip())
+            elif isinstance(groups_claim, list):
+                groups = tuple(value for value in groups_claim if isinstance(value, str) and value)
             else:
                 groups = ()
             return AuthPrincipal(
@@ -237,7 +242,7 @@ class OIDCIdentityValidator:
                         raise ValueError("OIDC JWKS contains duplicate signing kid values")
                     if key.get("kty") != "RSA":
                         raise ValueError("OIDC JWKS signing key is not RSA")
-                    public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+                    public_key = RSAAlgorithm.from_jwk(json.dumps(key))
                     if public_key.key_size < 2048:
                         raise ValueError("OIDC JWKS RSA key is smaller than 2048 bits")
                     parsed_keys[kid] = key

--- a/packages/phlo-dagster/src/phlo_dagster/operations.py
+++ b/packages/phlo-dagster/src/phlo_dagster/operations.py
@@ -233,7 +233,8 @@ async def terminate(
     result = await _graphql(dagster_url, TERMINATE_RUN_MUTATION, {"runId": run_id})
     payload = result.get("data", {}).get("terminateRun", {})
     typename = str(payload.get("__typename") or "TerminateRunResult")
-    run = payload.get("run") if isinstance(payload.get("run"), dict) else {}
+    raw_run = payload.get("run")
+    run: dict[str, Any] = raw_run if isinstance(raw_run, dict) else {}
     accepted = typename == "TerminateRunSuccess"
     return DagsterOperationResult(
         operation="cancel_run",
@@ -354,7 +355,8 @@ def _launch_result(
     fallback_run_id: str | None = None,
 ) -> DagsterOperationResult:
     typename = str(payload.get("__typename") or "DagsterLaunchResult")
-    run = payload.get("run") if isinstance(payload.get("run"), dict) else {}
+    raw_run = payload.get("run")
+    run: dict[str, Any] = raw_run if isinstance(raw_run, dict) else {}
     accepted = typename in {"LaunchRunSuccess", "LaunchPipelineRunSuccess"} and bool(run)
     return DagsterOperationResult(
         operation=operation,

--- a/packages/phlo-dagster/src/phlo_dagster/run_evidence.py
+++ b/packages/phlo-dagster/src/phlo_dagster/run_evidence.py
@@ -131,10 +131,21 @@ def _stage_id(
     check_identity: str | None,
     storage_id: Any,
 ) -> str:
-    identity = (logical_run_id, attempt, stage_type, step_key, asset, partition, check_identity)
+    identity = [
+        str(value)
+        for value in (
+            logical_run_id,
+            attempt,
+            stage_type,
+            step_key,
+            asset,
+            partition,
+            check_identity,
+        )
+    ]
     if stage_type == "materialization":
-        identity += (storage_id,)
-    return hashlib.sha256("\0".join(map(str, identity)).encode()).hexdigest()[:32]
+        identity.append(str(storage_id))
+    return hashlib.sha256("\0".join(identity).encode()).hexdigest()[:32]
 
 
 class DagsterRunEvidenceSource:
@@ -391,7 +402,7 @@ class DagsterRunEvidenceSource:
                     resource_ref=run_resource_ref,
                 )
             )
-            if stage_id is not None:
+            if stage_id is not None and stage_type is not None:
                 stages.append(
                     RunStage(
                         project_id=project_id,

--- a/packages/phlo-dagster/src/phlo_dagster/webserver.py
+++ b/packages/phlo-dagster/src/phlo_dagster/webserver.py
@@ -373,7 +373,8 @@ class GraphQLWebSocketAuthenticationASGI:
         payload = envelope.get("payload") if isinstance(envelope, dict) else None
         token = payload.get("access_token") if isinstance(payload, dict) else None
         if (
-            envelope.get("type") != "connection_init"
+            not isinstance(envelope, dict)
+            or envelope.get("type") != "connection_init"
             or not isinstance(payload, dict)
             or set(payload) != {"access_token"}
             or not isinstance(token, str)
@@ -465,7 +466,7 @@ class PhloDagsterWebserver(DagsterWebserver):
             operations = [
                 definition
                 for definition in document.definitions
-                if getattr(definition, "operation", None).value == "subscription"
+                if getattr(getattr(definition, "operation", None), "value", None) == "subscription"
                 and (
                     operation_name is None
                     or getattr(getattr(definition, "name", None), "value", None) == operation_name
@@ -474,7 +475,10 @@ class PhloDagsterWebserver(DagsterWebserver):
             if len(operations) != 1:
                 raise GraphQLError("Unclassified GraphQL operation")
             operation = operations[0]
-            for selection in operation.selection_set.selections:
+            selection_set = getattr(operation, "selection_set", None)
+            if selection_set is None:
+                raise GraphQLError("GraphQL operation has no selection set")
+            for selection in selection_set.selections:
                 field_name = selection.name.value
                 kwargs = {}
                 for argument in selection.arguments:
@@ -523,7 +527,7 @@ class PhloDagsterWebserver(DagsterWebserver):
 # Dagster's CLI factory resolves this class from dagster_webserver.app, so the
 # normal CLI options and workspace lifecycle remain unchanged while the shipped
 # entrypoint uses the secured subclass.
-dagster_app.DagsterWebserver = PhloDagsterWebserver
+setattr(dagster_app, "DagsterWebserver", PhloDagsterWebserver)
 
 
 if __name__ == "__main__":

--- a/packages/phlo-dbt/src/phlo_dbt/authorization.py
+++ b/packages/phlo-dbt/src/phlo_dbt/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-dbt"
 FRAMEWORK_TYPE = "cli"
@@ -26,5 +26,5 @@ DbtSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_dbt_adapter() -> DbtSurfaceAdapter:
+def get_dbt_adapter() -> CliSurfaceAdapter:
     return DbtSurfaceAdapter.get_instance()

--- a/packages/phlo-dlt/src/phlo_dlt/authorization.py
+++ b/packages/phlo-dlt/src/phlo_dlt/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-dlt"
 FRAMEWORK_TYPE = "cli"
@@ -23,5 +23,5 @@ DltSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_dlt_adapter() -> DltSurfaceAdapter:
+def get_dlt_adapter() -> CliSurfaceAdapter:
     return DltSurfaceAdapter.get_instance()

--- a/packages/phlo-dlt/src/phlo_dlt/executor.py
+++ b/packages/phlo-dlt/src/phlo_dlt/executor.py
@@ -202,7 +202,9 @@ class DltIngester(BaseIngester):
         self.merge_config = merge_config or {}
 
     def run_ingestion(
-        self, partition_key: str, parameters: Dict[str, Any] | None = None
+        self,
+        partition_key: str | None,
+        parameters: Dict[str, Any] | None = None,
     ) -> IngestionResult:
         """Run the full DLT -> Parquet -> table_store flow.
 
@@ -259,7 +261,8 @@ class DltIngester(BaseIngester):
             attempt = None
         correlation_attempt = attempt if attempt is not None else 1
 
-        pipeline_name = f"{self.table_config.table_name}_{partition_key.replace('-', '_')}"
+        partition_date = partition_key or "unpartitioned"
+        pipeline_name = f"{self.table_config.table_name}_{partition_date.replace('-', '_')}"
         group_name = self.table_config.group_name
 
         # Emission Setup
@@ -343,7 +346,7 @@ class DltIngester(BaseIngester):
                                     or self.table_config.full_table_name,
                                     attributes={
                                         "table_name": self.table_config.full_table_name,
-                                        "partition_key": partition_key,
+                                        "partition_key": partition_date,
                                     },
                                 ),
                                 "ref_name": branch_name,
@@ -402,7 +405,7 @@ class DltIngester(BaseIngester):
                 for parquet_path in parquet_paths:
                     inject_metadata_columns(
                         parquet_path=parquet_path,
-                        partition_date=partition_key,
+                        partition_date=partition_date,
                         run_id=run_id,
                         context=shim,
                     )
@@ -439,7 +442,7 @@ class DltIngester(BaseIngester):
                         resource_id=source_identity or self.table_config.full_table_name,
                         attributes={
                             "table_name": self.table_config.full_table_name,
-                            "partition_key": partition_key,
+                            "partition_key": partition_date,
                         },
                     ),
                     "ref_name": branch_name,
@@ -469,7 +472,7 @@ class DltIngester(BaseIngester):
                         or self.table_config.full_table_name,
                         attributes={
                             "table_name": self.table_config.full_table_name,
-                            "partition_key": partition_key,
+                            "partition_key": partition_date,
                         },
                     ),
                     "ref_name": branch_name,

--- a/packages/phlo-hasura/src/phlo_hasura/client.py
+++ b/packages/phlo-hasura/src/phlo_hasura/client.py
@@ -118,14 +118,15 @@ class HasuraClient:
         """
         raw_url = hasura_url or "http://hasura:8080"
         self.hasura_url = _resolve_hasura_url(raw_url)
-        self.admin_secret = admin_secret or os.environ.get("HASURA_ADMIN_SECRET")
-        if not self.admin_secret:
-            self.admin_secret = get_settings().hasura_admin_secret
-        if not self.admin_secret:
+        resolved_admin_secret = admin_secret or os.environ.get("HASURA_ADMIN_SECRET")
+        if not resolved_admin_secret:
+            resolved_admin_secret = get_settings().hasura_admin_secret
+        if not resolved_admin_secret:
             raise ValueError(
                 "Hasura admin secret must be provided via the 'admin_secret' argument "
                 "or the HASURA_ADMIN_SECRET environment/.phlo config."
             )
+        self.admin_secret = resolved_admin_secret
         if self.admin_secret == "phlo-hasura-admin-secret":
             logger.warning(
                 "hasura_using_generated_default_admin_secret",

--- a/packages/phlo-iceberg/src/phlo_iceberg/evidence.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/evidence.py
@@ -35,9 +35,15 @@ def table_state(catalog: Any, table_name: str) -> dict[str, Any]:
         try:
             from pyiceberg.exceptions import NoSuchTableError
         except ImportError:
-            NoSuchTableError = ()  # type: ignore[assignment]
-        if NoSuchTableError and isinstance(exc, NoSuchTableError):
-            return {"state": "absent", "snapshot_id": None, "schema_hash": None, "metadata": {}}
+            pass
+        else:
+            if isinstance(exc, NoSuchTableError):
+                return {
+                    "state": "absent",
+                    "snapshot_id": None,
+                    "schema_hash": None,
+                    "metadata": {},
+                }
         return {
             "state": "unavailable",
             "snapshot_id": None,

--- a/packages/phlo-iceberg/src/phlo_iceberg/resource.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/resource.py
@@ -90,6 +90,16 @@ from phlo_iceberg.evidence import emit_mutation, table_state, unavailable_table_
 
 logger = get_logger(__name__)
 
+
+def _as_int(value: object) -> int:
+    """Convert supported numeric evidence values to an integer."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float, str)):
+        return int(value)
+    return 0
+
+
 _COMPACTION_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 DEFAULT_MAX_AFFECTED_OBJECTS = 1_000
 DEFAULT_MAX_AFFECTED_BYTES = 10 * 1024 * 1024 * 1024
@@ -1962,6 +1972,8 @@ class IcebergResource:
             ).to_dict()
 
         after = _retention_state_evidence(after_plan)
+        after_snapshot_id = after_plan.get("before_snapshot_id")
+        after_revision = after_snapshot_id if isinstance(after_snapshot_id, (str, int)) else None
         return MaintenanceOperationResult(
             operation="expire_snapshots",
             table_name=table_name,
@@ -1971,7 +1983,7 @@ class IcebergResource:
             accepted=True,
             executed=True,
             before_revision=expected_snapshot_id,
-            after_revision=after_plan.get("before_snapshot_id"),
+            after_revision=after_revision,
             planned={
                 **plan,
                 "trino_boundary": "executed",
@@ -1982,7 +1994,7 @@ class IcebergResource:
                 "planned_candidate_snapshots": len(plan["candidate_snapshots"]),
                 "observed_snapshot_count_reduction": max(
                     0,
-                    int(before.get("snapshot_count") or 0) - int(after.get("snapshot_count") or 0),
+                    _as_int(before.get("snapshot_count")) - _as_int(after.get("snapshot_count")),
                 ),
                 "exact_deleted_snapshot_set": "unavailable",
                 "provider_deletion_surface": "threshold_not_bound_to_plan",

--- a/packages/phlo-iceberg/src/phlo_iceberg/settings.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/settings.py
@@ -105,7 +105,7 @@ class IcebergSettings(BaseConfig):
     iceberg_default_ref: str = Field(
         default="main", description="Default catalog ref/branch for Iceberg operations"
     )
-    iceberg_s3_endpoint: str | None = Field(
+    iceberg_s3_endpoint: str = Field(
         default="http://minio:10001",
         validation_alias=AliasChoices(
             "iceberg_s3_endpoint", "PHLO_ICEBERG_S3_ENDPOINT", "ICEBERG_S3_ENDPOINT"

--- a/packages/phlo-iceberg/src/phlo_iceberg/tables.py
+++ b/packages/phlo-iceberg/src/phlo_iceberg/tables.py
@@ -449,9 +449,9 @@ def merge_to_table(
 
         for i in range(0, len(unique_values_list), batch_size):
             batch = unique_values_list[i : i + batch_size]
-            from pyiceberg.expressions import In
+            from pyiceberg.expressions import In, Reference
 
-            delete_expr = In(unique_key, literals=batch)  # type: ignore[arg-type]
+            delete_expr = In(term=Reference(unique_key), values=set(batch))
             try:
                 table.delete(delete_expr)
                 rows_deleted += len(batch)  # Approximation

--- a/packages/phlo-lineage/src/phlo_lineage/authorization.py
+++ b/packages/phlo-lineage/src/phlo_lineage/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-lineage"
 FRAMEWORK_TYPE = "cli"
@@ -32,5 +32,5 @@ LineageSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_lineage_adapter() -> LineageSurfaceAdapter:
+def get_lineage_adapter() -> CliSurfaceAdapter:
     return LineageSurfaceAdapter.get_instance()

--- a/packages/phlo-mcp/src/phlo_mcp/api_client.py
+++ b/packages/phlo-mcp/src/phlo_mcp/api_client.py
@@ -32,7 +32,7 @@ class PhloApiClient:
         return {}
 
     def get_platform_health(self) -> dict[str, Any]:
-        return self._get_json("/api/observability/health")
+        return self._get_object("/api/observability/health")
 
     def get_config(self) -> dict[str, Any] | list[dict[str, Any]]:
         return self._get_json("/api/config")
@@ -349,7 +349,7 @@ class PhloApiClient:
 
     def get_logs_query_link(self, service: str | None = None) -> dict[str, Any]:
         params = {"service": service} if service else None
-        return self._get_json("/api/observability/links/logs", params=params)
+        return self._get_object("/api/observability/links/logs", params=params)
 
     def get_trace_spans(
         self,
@@ -386,7 +386,7 @@ class PhloApiClient:
 
     def get_metrics_query_link(self, metric: str | None = None) -> dict[str, Any]:
         params = {"metric": metric} if metric else None
-        return self._get_json("/api/observability/links/metrics", params=params)
+        return self._get_object("/api/observability/links/metrics", params=params)
 
     def materialize_asset(
         self,
@@ -513,6 +513,18 @@ class PhloApiClient:
                 return response.json()
             except httpx.HTTPError as exc:
                 return {"error": map_httpx_error(exc).to_payload()}
+
+    def _get_object(
+        self,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Fetch an endpoint whose response contract is a JSON object."""
+        payload = self._get_json(path, params=params)
+        if not isinstance(payload, dict):
+            raise TypeError(f"Expected JSON object from {path}, got {type(payload).__name__}")
+        return payload
 
     def _post_json(
         self,

--- a/packages/phlo-mcp/src/phlo_mcp/cli.py
+++ b/packages/phlo-mcp/src/phlo_mcp/cli.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from phlo_mcp.config import McpConfig, config_from_env
+from phlo_mcp.config import McpConfig, config_from_env, parse_transport
 from phlo_mcp.server import create_server
 
 
@@ -38,7 +38,7 @@ def parse_args() -> McpConfig:
         api_token=args.api_token if args.api_token is not None else env_config.api_token,
         enable_write_tools=args.enable_write_tools or env_config.enable_write_tools,
         trace_file=args.trace_file if args.trace_file is not None else env_config.trace_file,
-        transport=args.transport or env_config.transport,
+        transport=parse_transport(args.transport or env_config.transport),
         host=args.host or env_config.host,
         port=args.port if args.port is not None else env_config.port,
         streamable_http_path=args.path or env_config.streamable_http_path,

--- a/packages/phlo-mcp/src/phlo_mcp/config.py
+++ b/packages/phlo-mcp/src/phlo_mcp/config.py
@@ -4,8 +4,22 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from typing import Literal
 
 _DEFAULT_API_BASE_URL = "http://127.0.0.1:4000"
+Transport = Literal["stdio", "sse", "streamable-http"]
+_TRANSPORTS = {"stdio", "sse", "streamable-http"}
+
+
+def parse_transport(value: str) -> Transport:
+    """Validate and narrow an MCP transport name."""
+    if value not in _TRANSPORTS:
+        raise ValueError(f"Unsupported MCP transport: {value}")
+    if value == "stdio":
+        return "stdio"
+    if value == "sse":
+        return "sse"
+    return "streamable-http"
 
 
 @dataclass(frozen=True, slots=True)
@@ -16,7 +30,7 @@ class McpConfig:
     api_token: str | None = None
     enable_write_tools: bool = False
     trace_file: str | None = None
-    transport: str = "stdio"
+    transport: Transport = "stdio"
     host: str = "127.0.0.1"
     port: int = 8000
     streamable_http_path: str = "/mcp"
@@ -29,12 +43,13 @@ def _truthy_env(name: str) -> bool:
 def config_from_env() -> McpConfig:
     """Load MCP configuration from environment variables."""
     port = int(os.environ.get("PHLO_MCP_PORT", "8000"))
+    transport = parse_transport(os.environ.get("PHLO_MCP_TRANSPORT", "stdio"))
     return McpConfig(
         api_base_url=os.environ.get("PHLO_MCP_API_BASE_URL", _DEFAULT_API_BASE_URL).rstrip("/"),
         api_token=os.environ.get("PHLO_MCP_API_TOKEN") or None,
         enable_write_tools=_truthy_env("PHLO_MCP_ENABLE_WRITE_TOOLS"),
         trace_file=os.environ.get("PHLO_MCP_TRACE_FILE") or None,
-        transport=os.environ.get("PHLO_MCP_TRANSPORT", "stdio"),
+        transport=transport,
         host=os.environ.get("PHLO_MCP_HOST", "127.0.0.1"),
         port=port,
         streamable_http_path=os.environ.get("PHLO_MCP_HTTP_PATH", "/mcp"),

--- a/packages/phlo-mcp/src/phlo_mcp/tracing.py
+++ b/packages/phlo-mcp/src/phlo_mcp/tracing.py
@@ -6,6 +6,7 @@ import json
 import os
 from collections import defaultdict
 from pathlib import Path
+from collections.abc import Sequence
 from typing import Any
 
 from opentelemetry import trace
@@ -24,7 +25,7 @@ class JsonLineSpanExporter(SpanExporter):
         self._path = Path(path)
         self._path.parent.mkdir(parents=True, exist_ok=True)
 
-    def export(self, spans: list[ReadableSpan]) -> SpanExportResult:
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         with self._path.open("a", encoding="utf-8") as handle:
             for span in spans:
                 parent_id = None
@@ -39,7 +40,7 @@ class JsonLineSpanExporter(SpanExporter):
                     },
                     "start_time_ns": span.start_time,
                     "end_time_ns": span.end_time,
-                    "attributes": dict(span.attributes),
+                    "attributes": {key: value for key, value in (span.attributes or {}).items()},
                     "status": {
                         "code": getattr(
                             span.status.status_code, "name", str(span.status.status_code)

--- a/packages/phlo-minio/src/phlo_minio/authorization.py
+++ b/packages/phlo-minio/src/phlo_minio/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-minio-cli"
 FRAMEWORK_TYPE = "cli"
@@ -31,5 +31,5 @@ MinioCliSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_minio_cli_adapter() -> MinioCliSurfaceAdapter:
+def get_minio_cli_adapter() -> CliSurfaceAdapter:
     return MinioCliSurfaceAdapter.get_instance()

--- a/packages/phlo-nessie/src/phlo_nessie/authorization.py
+++ b/packages/phlo-nessie/src/phlo_nessie/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-nessie-cli"
 FRAMEWORK_TYPE = "cli"
@@ -43,5 +43,5 @@ NessieCliSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_nessie_cli_adapter() -> NessieCliSurfaceAdapter:
+def get_nessie_cli_adapter() -> CliSurfaceAdapter:
     return NessieCliSurfaceAdapter.get_instance()

--- a/packages/phlo-nessie/src/phlo_nessie/cli_branch.py
+++ b/packages/phlo-nessie/src/phlo_nessie/cli_branch.py
@@ -722,7 +722,7 @@ def diff(source_branch: str, target_branch: str, format: str):
 
         console.print(f"\n[bold]Differences: {source_branch} -> {target_branch}[/bold]")
 
-        differences: dict[str, list[str]] = {
+        differences: dict[str, builtins.list[str]] = {
             "added_tables": [],
             "modified_tables": [],
             "deleted_tables": [],

--- a/packages/phlo-nessie/src/phlo_nessie/resource.py
+++ b/packages/phlo-nessie/src/phlo_nessie/resource.py
@@ -110,6 +110,13 @@ class NessieResource:
         """
         return f"{self.base_url}{path}"
 
+    @staticmethod
+    def _status_code(response: requests.Response) -> int:
+        """Return an HTTP status code, rejecting an incomplete response."""
+        if response.status_code is None:
+            raise RuntimeError("Nessie response did not include an HTTP status code")
+        return response.status_code
+
     def _request(
         self,
         method: str,
@@ -163,7 +170,9 @@ class NessieResource:
                     time.sleep(_BACKOFF_SCHEDULE[attempt - 1])
                     continue
                 raise
-        raise last_exc  # type: ignore[misc]
+        if last_exc is None:
+            raise RuntimeError("Nessie request retries exhausted without an exception")
+        raise last_exc
 
     def list_branches(self) -> list[BranchInfo]:
         """List all branch references from Nessie.
@@ -248,11 +257,12 @@ class NessieResource:
             base_url=self.base_url,
         )
         response = self._request("GET", self._url(f"/api/v1/trees/tree/{name}"), timeout=10)
-        if response.status_code >= 400:
+        status_code = self._status_code(response)
+        if status_code >= 400:
             logger.info(
                 "nessie_resource_get_branch_hash_missing",
                 branch_name=name,
-                status_code=response.status_code,
+                status_code=status_code,
             )
             return None
         data = response.json() or {}
@@ -296,11 +306,12 @@ class NessieResource:
             params={"expectedHash": branch_hash},
             timeout=10,
         )
-        deleted = response.status_code < 300
+        status_code = self._status_code(response)
+        deleted = status_code < 300
         logger.info(
             "nessie_resource_delete_branch_completed",
             branch_name=name,
-            status_code=response.status_code,
+            status_code=status_code,
             deleted=deleted,
         )
         return deleted
@@ -340,12 +351,13 @@ class NessieResource:
             json={"name": name, "type": "BRANCH", "hash": source_hash},
             timeout=10,
         )
-        if response.status_code >= 400:
+        status_code = self._status_code(response)
+        if status_code >= 400:
             logger.warning(
                 "nessie_resource_create_branch_failed",
                 branch_name=name,
                 from_ref=from_ref,
-                status_code=response.status_code,
+                status_code=status_code,
                 body=response.text[:200],
             )
             return None
@@ -400,13 +412,14 @@ class NessieResource:
             },
             timeout=30,
         )
-        merged = response.status_code < 300
+        status_code = self._status_code(response)
+        merged = status_code < 300
         logger.info(
             "nessie_resource_merge_branch_completed",
             source=source,
             target=target,
-            status_code=response.status_code,
-            body=response.text[:200] if response.status_code >= 400 else None,
+            status_code=status_code,
+            body=response.text[:200] if status_code >= 400 else None,
             merged=merged,
         )
         return merged

--- a/packages/phlo-openmetadata/src/phlo_openmetadata/authorization.py
+++ b/packages/phlo-openmetadata/src/phlo_openmetadata/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-openmetadata"
 FRAMEWORK_TYPE = "cli"
@@ -23,5 +23,5 @@ OpenMetadataSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_openmetadata_adapter() -> OpenMetadataSurfaceAdapter:
+def get_openmetadata_adapter() -> CliSurfaceAdapter:
     return OpenMetadataSurfaceAdapter.get_instance()

--- a/packages/phlo-openmetadata/src/phlo_openmetadata/dbt_sync.py
+++ b/packages/phlo-openmetadata/src/phlo_openmetadata/dbt_sync.py
@@ -334,6 +334,8 @@ class DbtManifestParser:
         models = self.get_models(manifest)
         for unique_id, model in models.items():
             model_name = model.get("name")
+            if not isinstance(model_name, str) or not model_name:
+                continue
             if model_filter and model_name not in model_filter:
                 continue
 

--- a/packages/phlo-pandera/src/phlo_pandera/authorization.py
+++ b/packages/phlo-pandera/src/phlo_pandera/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-pandera"
 FRAMEWORK_TYPE = "cli"
@@ -33,5 +33,5 @@ PanderaSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_pandera_adapter() -> PanderaSurfaceAdapter:
+def get_pandera_adapter() -> CliSurfaceAdapter:
     return PanderaSurfaceAdapter.get_instance()

--- a/packages/phlo-pandera/src/phlo_pandera/cli_schema_codegen.py
+++ b/packages/phlo-pandera/src/phlo_pandera/cli_schema_codegen.py
@@ -298,14 +298,10 @@ def _ensure_imports_in_module(content: str, import_lines: list[str]) -> str:
         return "\n".join(import_lines) + "\n" + content
 
     insert_after = 0
-    if (
-        tree.body
-        and isinstance(tree.body[0], ast.Expr)
-        and isinstance(getattr(tree.body[0], "value", None), ast.Constant)
-        and isinstance(tree.body[0].value.value, str)
-        and getattr(tree.body[0], "end_lineno", None)
-    ):
-        insert_after = tree.body[0].end_lineno
+    first_node = tree.body[0] if tree.body else None
+    if isinstance(first_node, ast.Expr) and isinstance(first_node.value, ast.Constant):
+        if isinstance(first_node.value.value, str) and first_node.end_lineno is not None:
+            insert_after = first_node.end_lineno
 
     lines = content.splitlines()
     existing = set(lines)

--- a/packages/phlo-postgres/src/phlo_postgres/authorization.py
+++ b/packages/phlo-postgres/src/phlo_postgres/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-postgres-cli"
 FRAMEWORK_TYPE = "cli"
@@ -37,5 +37,5 @@ PostgresCliSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_postgres_cli_adapter() -> PostgresCliSurfaceAdapter:
+def get_postgres_cli_adapter() -> CliSurfaceAdapter:
     return PostgresCliSurfaceAdapter.get_instance()

--- a/packages/phlo-sling/src/phlo_sling/authorization.py
+++ b/packages/phlo-sling/src/phlo_sling/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-sling"
 FRAMEWORK_TYPE = "cli"
@@ -23,5 +23,5 @@ SlingSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_adapter() -> SlingSurfaceAdapter:
+def get_adapter() -> CliSurfaceAdapter:
     return SlingSurfaceAdapter.get_instance()

--- a/packages/phlo-sling/src/phlo_sling/executor.py
+++ b/packages/phlo-sling/src/phlo_sling/executor.py
@@ -80,7 +80,7 @@ class SlingIngester(BaseIngester):
         self.overrides = overrides or {}
 
     def run_ingestion(
-        self, partition_key: str, parameters: Dict[str, Any] | None = None
+        self, partition_key: str | None, parameters: Dict[str, Any]
     ) -> IngestionResult:
         """Run the Sling replication flow.
 
@@ -209,7 +209,7 @@ class SlingIngester(BaseIngester):
             )
             raise
 
-    def _build_sling_kwargs(self, partition_key: str) -> dict[str, Any]:
+    def _build_sling_kwargs(self, partition_key: str | None) -> dict[str, Any]:
         """Build keyword arguments for the Sling constructor.
 
         Merges static configuration from the ReplicationConfig with runtime

--- a/packages/phlo-sling/src/phlo_sling/helpers.py
+++ b/packages/phlo-sling/src/phlo_sling/helpers.py
@@ -16,6 +16,30 @@ from phlo_sling.registry import SlingReplication
 SECRET_KEY_PARTS = ("password", "secret", "token", "key")
 
 
+def _coerce_replication_mode(
+    value: object,
+) -> Literal["full-refresh", "incremental", "snapshot", "backfill"] | None:
+    """Validate and narrow a replication mode from a dynamic mapping."""
+    if value is None:
+        return None
+    if value not in {"full-refresh", "incremental", "snapshot", "backfill"}:
+        raise ValueError(f"Unsupported replication mode: {value}")
+    if value == "full-refresh":
+        return "full-refresh"
+    if value == "incremental":
+        return "incremental"
+    if value == "snapshot":
+        return "snapshot"
+    return "backfill"
+
+
+def _mapping_value(value: object) -> dict[str, Any]:
+    """Return a string-keyed mapping from dynamic configuration data."""
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in value.items()}
+
+
 @dataclass(frozen=True)
 class ReplicationPlan:
     """A lightweight collection of Sling replication definitions."""
@@ -88,7 +112,11 @@ def build_replication_plan(
             replications.append(stream)
             continue
 
-        stream_config = {"stream_name": stream} if isinstance(stream, str) else dict(stream)
+        stream_config = (
+            {"stream_name": stream}
+            if isinstance(stream, str)
+            else {str(key): value for key, value in stream.items()}
+        )
         stream_name = str(stream_config["stream_name"])
         table_name = str(stream_config.get("table_name") or table_name_from_stream(stream_name))
         replications.append(
@@ -97,19 +125,19 @@ def build_replication_plan(
                 table_name=table_name,
                 source_conn=str(stream_config.get("source_conn") or source_conn),
                 target_conn=_coalesce_str(stream_config.get("target_conn"), target_conn),
-                mode=stream_config.get("mode") or mode,
+                mode=_coerce_replication_mode(stream_config.get("mode") or mode),
                 primary_key=stream_config.get("primary_key", primary_key),
                 update_key=_coalesce_str(stream_config.get("update_key"), update_key),
                 group_name=_coalesce_str(stream_config.get("group_name"), group_name),
                 object=_coalesce_str(stream_config.get("object"), None),
                 select=list(stream_config.get("select") or []),
                 where=_coalesce_str(stream_config.get("where"), where),
-                source_options=dict(stream_config.get("source_options") or {}),
-                target_options=dict(stream_config.get("target_options") or {}),
+                source_options=_mapping_value(stream_config.get("source_options")),
+                target_options=_mapping_value(stream_config.get("target_options")),
                 description=_coalesce_str(stream_config.get("description"), None),
                 owner=_coalesce_str(stream_config.get("owner"), None),
-                metadata=dict(stream_config.get("metadata") or {}),
-                tags={str(k): str(v) for k, v in dict(stream_config.get("tags") or {}).items()},
+                metadata=_mapping_value(stream_config.get("metadata")),
+                tags={str(k): str(v) for k, v in _mapping_value(stream_config.get("tags")).items()},
             )
         )
     return ReplicationPlan(replications=replications)

--- a/packages/phlo-testing/src/phlo_testing/mock_trino.py
+++ b/packages/phlo-testing/src/phlo_testing/mock_trino.py
@@ -85,7 +85,7 @@ class MockCursor:
             # Get column names and types
             try:
                 # Try to get columns from result
-                cols = result.columns
+                cols = getattr(result, "columns", None)
                 if cols:
                     self._description = [
                         (name, "VARCHAR")  # Simplified type mapping

--- a/packages/phlo-testing/src/phlo_testing/profile_harness.py
+++ b/packages/phlo-testing/src/phlo_testing/profile_harness.py
@@ -33,6 +33,7 @@ import sys
 import time
 import urllib.parse
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -678,7 +679,7 @@ class BundledStackHarness:
         return _load_golden_path_module()
 
     @contextlib.contextmanager
-    def _temporary_env(self, updates: dict[str, str | None]) -> Any:
+    def _temporary_env(self, updates: Mapping[str, str | None]) -> Any:
         """Temporarily update environment variables.
 
         Args:

--- a/packages/phlo-trino/src/phlo_trino/authorization.py
+++ b/packages/phlo-trino/src/phlo_trino/authorization.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from phlo.cli.authorization import cli_surface_adapter_class
+from phlo.cli.authorization import CliSurfaceAdapter, cli_surface_adapter_class
 
 SURFACE_NAME = "phlo-trino-cli"
 FRAMEWORK_TYPE = "cli"
@@ -23,5 +23,5 @@ TrinoCliSurfaceAdapter = cli_surface_adapter_class(
 )
 
 
-def get_trino_cli_adapter() -> TrinoCliSurfaceAdapter:
+def get_trino_cli_adapter() -> CliSurfaceAdapter:
     return TrinoCliSurfaceAdapter.get_instance()

--- a/packages/phlo-trino/src/phlo_trino/publishing.py
+++ b/packages/phlo-trino/src/phlo_trino/publishing.py
@@ -47,11 +47,6 @@ from typing import Any
 from psycopg2 import sql
 from psycopg2.extras import execute_values
 
-try:
-    from trino.exceptions import TrinoUserError
-except Exception:  # noqa: BLE001 - optional dependency in lightweight test envs
-    TrinoUserError = None  # type: ignore[assignment]
-
 from phlo.hooks import (
     HookCorrelation,
     LineageEventContext,
@@ -612,7 +607,7 @@ def _is_retryable_introspection_error(exc: Exception) -> bool:
     retryable_error_types = {"external", "internal_error", "insufficient_resources"}
 
     for error in iter_exception_chain(exc):
-        if TrinoUserError is not None and isinstance(error, TrinoUserError):
+        if _is_trino_user_error(error):
             error_name = getattr(error, "error_name", None)
             if error_name and str(error_name).lower() in retryable_error_names:
                 return True
@@ -637,6 +632,15 @@ def _is_retryable_introspection_error(exc: Exception) -> bool:
         "timed out",
     )
     return any(snippet in message for snippet in retryable_snippets)
+
+
+def _is_trino_user_error(error: BaseException) -> bool:
+    """Return whether an optional Trino client exception is present."""
+    try:
+        from trino.exceptions import TrinoUserError
+    except Exception:  # noqa: BLE001 - optional dependency
+        return False
+    return isinstance(error, TrinoUserError)
 
 
 _TRINO_TO_PG_SIMPLE: dict[str, str] = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,18 +228,19 @@ python-version = "3.11"
 root = ["./src"]
 
 [tool.ty.rules]
-invalid-argument-type = "warn"
-invalid-assignment = "warn"
-invalid-method-override = "warn"
-invalid-raise = "warn"
-invalid-return-type = "warn"
-invalid-type-form = "warn"
-missing-argument = "warn"
-no-matching-overload = "warn"
-too-many-positional-arguments = "warn"
-unknown-argument = "warn"
-unresolved-attribute = "warn"
-unsupported-operator = "warn"
+invalid-argument-type = "error"
+invalid-assignment = "error"
+invalid-method-override = "error"
+invalid-raise = "error"
+invalid-return-type = "error"
+invalid-type-form = "error"
+missing-argument = "error"
+no-matching-overload = "error"
+possibly-missing-submodule = "error"
+too-many-positional-arguments = "error"
+unknown-argument = "error"
+unresolved-attribute = "error"
+unsupported-operator = "error"
 
 [tool.ty.src]
 exclude = ["**/testing/**"]

--- a/src/phlo/_flow_authoring.py
+++ b/src/phlo/_flow_authoring.py
@@ -65,8 +65,11 @@ def _call_with_optional_context(fn: Callable[..., Any], context: RuntimeContext)
         in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
     ]
     if unsupported_parameters or len(required_parameters) > 1:
+        function_name = getattr(fn, "__qualname__", None)
+        if not isinstance(function_name, str):
+            function_name = repr(fn)
         raise TypeError(
-            f"Decorated function {fn.__qualname__}{signature} must accept either "
+            f"Decorated function {function_name}{signature} must accept either "
             "no parameters or one context parameter."
         )
     if required_parameters:

--- a/src/phlo/capabilities/interfaces.py
+++ b/src/phlo/capabilities/interfaces.py
@@ -742,7 +742,7 @@ class AuthPrincipal:
     issuer: str | None = None
     email: str | None = None
     groups: tuple[str, ...] = ()
-    claims: dict[str, str] = field(default_factory=dict)
+    claims: dict[str, Any] = field(default_factory=dict)
     attributes: dict[str, str] = field(default_factory=dict)
 
 

--- a/src/phlo/cli/commands/plugin/check.py
+++ b/src/phlo/cli/commands/plugin/check.py
@@ -14,7 +14,7 @@ import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import click
 from rich.text import Text
@@ -22,6 +22,7 @@ from rich.text import Text
 from phlo.cli.commands.plugin.utils import console
 from phlo.logging import get_logger
 from phlo.plugins import discover_plugins, validate_plugins
+from phlo.plugins.base.service import ServicePlugin
 from phlo.plugins.discovery import ServiceDiscovery
 from phlo.plugins.discovery._service_loading import resolve_plugin_source_path
 
@@ -64,7 +65,15 @@ def _service_inventory() -> tuple[dict[str, str], list[str]]:
     service_names: list[str] = []
     package_roots: dict[Path, str] = {}
     discovered = discover_plugins(plugin_type="service", auto_register=True)
-    for plugin in discovered.get("service", []):
+    for discovered_plugin in discovered.get("service", []):
+        if isinstance(discovered_plugin, ServicePlugin):
+            plugin = discovered_plugin
+        elif not hasattr(discovered_plugin, "service_definition") or not callable(
+            getattr(discovered_plugin, "get_files", None)
+        ):
+            continue
+        else:
+            plugin = cast(ServicePlugin, discovered_plugin)
         package = _plugin_package(plugin)
         source_path = resolve_plugin_source_path(plugin)
         if source_path:
@@ -1144,7 +1153,7 @@ def check_cmd(
         discover_plugins(auto_register=True)
 
         # Then validate
-        validation_results = validate_plugins()
+        validation_results: dict[str, Any] = {**validate_plugins()}
 
         if containers:
             validation_results["containers"] = check_generated_containers(
@@ -1180,7 +1189,9 @@ def check_cmd(
         else:
             console.print("\n[green]All plugins are valid![/green]")
             if containers:
-                checked = validation_results["containers"]
+                checked = validation_results.get("containers")
+                if not isinstance(checked, dict):
+                    raise RuntimeError("Container validation did not return a result mapping")
                 console.print(
                     f"\n[green]Generated container checks passed:[/green] "
                     f"{len(checked['dockerfiles'])} Dockerfile(s)"

--- a/src/phlo/cli/commands/services/remove.py
+++ b/src/phlo/cli/commands/services/remove.py
@@ -1,5 +1,6 @@
 """Remove command for removing services from the project."""
 
+from collections.abc import Mapping
 from pathlib import Path
 from subprocess import TimeoutExpired
 
@@ -24,7 +25,7 @@ logger = get_logger(__name__)
 
 
 def _dependent_closure(
-    all_services: dict[str, object],
+    all_services: Mapping[str, object],
     service_name: str,
 ) -> list[str]:
     """Return services that directly or transitively depend on a service."""

--- a/src/phlo/compliance/governance/break_glass.py
+++ b/src/phlo/compliance/governance/break_glass.py
@@ -145,14 +145,15 @@ class BreakGlassManager:
         expires_at = datetime.now(UTC) + timedelta(hours=hours)
 
         object.__setattr__(request, "status", BreakGlassStatus.APPROVED)
-        object.__setattr__(request, "approved_at", datetime.now(UTC).isoformat())
+        approved_at = datetime.now(UTC).isoformat()
+        object.__setattr__(request, "approved_at", approved_at)
         object.__setattr__(request, "approved_by", approved_by)
         object.__setattr__(request, "expires_at", expires_at.isoformat())
 
         return BreakGlassApproval(
             request_id=request_id,
             approved_by=approved_by,
-            approved_at=request.approved_at,
+            approved_at=approved_at,
             validity_hours=hours,
             conditions=conditions,
         )

--- a/src/phlo/logging.py
+++ b/src/phlo/logging.py
@@ -465,13 +465,13 @@ def _extract_message_and_extra(
 
     event_dict: dict[str, Any] | None = None
     if isinstance(record.msg, Mapping):
-        event_dict = dict(record.msg)
+        event_dict = {str(key): value for key, value in record.msg.items()}
     elif (
         isinstance(record.msg, (list, tuple))
         and len(record.msg) == 1
         and isinstance(record.msg[0], Mapping)
     ):
-        event_dict = dict(record.msg[0])
+        event_dict = {str(key): value for key, value in record.msg[0].items()}
 
     if event_dict:
         extra.update(event_dict)

--- a/src/phlo/plugins/base/quality.py
+++ b/src/phlo/plugins/base/quality.py
@@ -6,7 +6,7 @@ This module defines plugin types for custom data quality validation.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from phlo.plugins.base.plugin import Plugin
 
@@ -59,7 +59,7 @@ class QualityCheckPlugin(Plugin, ABC, Generic[TQualityCheck]):
     """
 
     @abstractmethod
-    def create_check(self, **kwargs) -> TQualityCheck:
+    def create_check(self, *args: Any, **kwargs: Any) -> TQualityCheck:
         """Create a quality check instance.
 
         This factory method creates instances of quality checks

--- a/src/phlo/run_evidence/store.py
+++ b/src/phlo/run_evidence/store.py
@@ -1224,7 +1224,7 @@ class _SqlRunEvidenceStore:
     def _insert_stage(self, cursor: Any, stage: RunStage) -> None:
         self._require_id("stage_id", stage.stage_id)
         self._validate_stage_write_references(cursor, stage)
-        immutable_payload = {
+        immutable_payload: dict[str, Any] = {
             "stage_id": stage.stage_id,
             "project_id": stage.project_id,
             "run_id": stage.run_id,

--- a/src/phlo/security/enforcement.py
+++ b/src/phlo/security/enforcement.py
@@ -152,7 +152,10 @@ class EnforcementContext:
                     if self._authorization_backend is None:
                         self._init_authorization_backend()
                     self._init_identity_bridge()
-        return self._identity_bridge
+        bridge = self._identity_bridge
+        if bridge is None:
+            raise RuntimeError("Identity bridge initialization did not produce a bridge")
+        return bridge
 
     @property
     def authorization_backend(self) -> AuthorizationPolicyBackend:
@@ -161,7 +164,10 @@ class EnforcementContext:
             with self._init_lock:
                 if self._authorization_backend is None:
                     self._init_authorization_backend()
-        return self._authorization_backend
+        backend = self._authorization_backend
+        if backend is None:
+            raise RuntimeError("Authorization backend initialization did not produce a backend")
+        return backend
 
     @property
     def audit_emitter(self) -> Any:


### PR DESCRIPTION
## Summary

Refs #633. This comprehensive remediation fixes all 136 current production `ty` diagnostics, including `packages/phlo-mcp/src`, across the full configured production scope.

- Corrected the underlying type/API mismatches while preserving behavior.
- Promoted every observed diagnostic rule from warning to error, including `possibly-missing-submodule`.
- Added `packages/phlo-mcp/src` to the normal `make typecheck-python` scope.
- No baseline, waiver, suppression, ignore, warning downgrade, or ratchet.
- PR #664 was closed unmerged as superseded.

## Validation

- `UV_CACHE_DIR=/tmp/phlo-uv-cache-all-633 make typecheck-python` — passed; all checks passed.
- Full-scope GitLab proof using the Makefile scope plus `packages/phlo-mcp/src` — `ty_exit=0 total_diagnostics=0`.
- `UV_CACHE_DIR=/tmp/phlo-uv-cache-all-633 uv run --locked ruff check .` — passed.
- `UV_CACHE_DIR=/tmp/phlo-uv-cache-all-633 uv run --locked ruff format --check .` — 981 files already formatted.
- `UV_CACHE_DIR=/tmp/phlo-uv-cache-all-633 uv run --locked pytest --import-mode=importlib -q` — 3271 passed, 5 skipped, 500 deselected.
- Focused production-package tests — 1464 passed, 1 skipped, 315 deselected.
- Commit hooks — passed, including locked Ruff and Ruff format.

A bounded review found and corrected one claim-shape preservation issue before publication.