### PR TITLE
ci: validate dependency remediation nightly

### DIFF
--- a/.github/workflows/dependency-validation.yml
+++ b/.github/workflows/dependency-validation.yml
@@ -1,0 +1,27 @@
+name: Dependency Validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - uv.lock
+      - packages/phlo-observatory/src/phlo_observatory/package-lock.json
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  nightly:
+    name: dependency / nightly validation
+    # The nightly suite requires service credentials, so only trusted in-repository
+    # dependency remediation PRs receive this extra validation.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/nightly.yml
+    secrets:
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
+      SUPERSET_ADMIN_PASSWORD: ${{ secrets.SUPERSET_ADMIN_PASSWORD }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,14 @@ name: Nightly
 
 on:
   workflow_dispatch:
+  workflow_call:
+    secrets:
+      POSTGRES_PASSWORD:
+        required: true
+      MINIO_ROOT_PASSWORD:
+        required: true
+      SUPERSET_ADMIN_PASSWORD:
+        required: true
   schedule:
     - cron: "0 3 * * *"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,9 +2,8 @@ name: Security
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "0 1 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/docs/operations/release-management.md
+++ b/docs/operations/release-management.md
@@ -42,7 +42,13 @@ relx status --channel
 ### Dependency Refresh Lane
 
 Run dependency refreshes only as an explicit release-maintenance task. They are
-not part of normal pull-request CI.
+not part of normal pull-request CI. GitHub Actions audits the locked Python and
+Observatory dependencies every day; Renovate opens dependency remediation PRs
+for available vulnerability fixes. A remediation PR runs the normal CI suite
+and the full nightly workflow before merge review. Do not merge a remediation
+PR until those checks have passed. The nightly workflow deliberately runs only
+for trusted in-repository PRs because it needs service credentials; forked PRs
+retain normal CI without those secrets.
 
 ```bash
 gh workflow run "Dependency Refresh" --ref main -f lane=all

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,17 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["every weekend"],
+  "schedule": ["before 3am every day"],
   "prHourlyLimit": 2,
   "prConcurrentLimit": 4,
   "labels": ["dependencies"],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["security"],
+    "groupName": "security dependency remediation",
+    "rangeStrategy": "update-lockfile",
+    "vulnerabilityFixStrategy": "lowest"
+  },
   "packageRules": [
     {
       "description": "Group GitHub Actions updates.",


### PR DESCRIPTION
## Summary

- run Python and Observatory vulnerability audits daily, outside ordinary pull-request checks
- let Renovate create daily, lockfile-only security remediation PRs
- run the reusable full nightly suite for trusted PRs that change `uv.lock` or the Observatory lockfile

## Why

Live advisory databases should not make unrelated feature PRs fail after their code is unchanged. Vulnerability remediation instead receives dedicated PR validation: normal CI plus full integration and the release golden-path nightly jobs.

## Validation

- `make check`
- `make actionlint`
- `make zizmor`
- `make dependency-refresh-check`
- `git diff --check`

## Operational note

`main` currently has no branch-protection rule or ruleset. Reviewers should merge remediation PRs only after normal CI and `dependency / nightly validation` are green.
