### PR TITLE
Fix project-configured WAP launches and Dagster bootstrap

### DIFF
--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -91,16 +91,14 @@ flowchart LR
 **Implementation**
 
 ```python
-# Automatic ref creation on job start
-# packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
-@sensor(name="branch_creation_sensor")
-def branch_creation_sensor(context):
-    # Creates isolated run ref when a VersionedCatalog is available
+# `phlo materialize` and `phlo backfill` create the isolated ref before
+# submitting the Dagster run. The launch manifest binds the branch to the run.
+# packages/phlo-dagster/src/phlo_dagster/wap_launch.py
+prepare_wap_launch(logical_run_id="...")
 
-# Automatic promotion when checks pass
-@sensor(name="auto_promotion_sensor")
-def auto_promotion_sensor(context):
-    # Promotes to the durable target ref if all checks pass
+# Dagster promotes only a run whose immutable tags match that manifest.
+# packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+wap_auto_promotion_sensor
 
 # Cleanup old branches
 @sensor(name="branch_cleanup_sensor")
@@ -464,7 +462,7 @@ branch = get_branch_from_context(context)
 # Write to branch-specific reference
 table.write(
     data,
-    override_ref=branch  # e.g., "pipeline/run-abc123"
+    override_ref=branch  # e.g., "pipeline-run-abc123"
 )
 
 # Query from specific branch
@@ -553,7 +551,7 @@ Complete end-to-end flow:
 flowchart LR
     source[API source]
     ingest["@phlo.ingest.dlt"]
-    branch["Iceberg table on<br/>pipeline/run-abc123"]
+    branch["Iceberg table on<br/>pipeline-run-abc123"]
     quality["@phlo.quality.rules checks"]
     promote[Auto-promotion sensor]
     dbt[dbt transformations]

--- a/docs/packages/phlo-dagster.md
+++ b/docs/packages/phlo-dagster.md
@@ -66,8 +66,9 @@ hard-wiring Dagster to a specific catalog implementation.
 In the bundled stack, Nessie is the versioned catalog provider. In profiles
 without versioning, the same Dagster adapter still works, but WAP branch
 creation/promotion/cleanup is not enabled.
-Set `PHLO_WAP_ENABLED=false` to keep WAP off even when a versioned catalog is
-available. WAP executions write `.phlo/wap-reports/<run_id>.json`, and
+Set `wap.enabled: false` in the project `phlo.yaml` to keep WAP off even when a
+versioned catalog is available. WAP executions write
+`.phlo/wap-reports/<logical-run-id>.json`, and
 Observatory exposes those reports in the operations and branch history views.
 
 ## Usage

--- a/docs/packages/phlo-nessie.md
+++ b/docs/packages/phlo-nessie.md
@@ -88,7 +88,7 @@ Phlo uses Nessie branches for the Write-Audit-Publish (WAP) pattern:
 
 ```
 1. Write Phase
-   └── Data lands on isolated branch: pipeline/run-{run_id}
+   └── Data lands on isolated branch: pipeline-run-{logical_run_id}
 
 2. Audit Phase
    └── Quality checks validate data on the branch
@@ -121,7 +121,7 @@ nessie.delete_branch("feature/new-data")
 | ------------------- | ------------------------------------ |
 | `main`              | Production data (read-only for most) |
 | `dev`               | Development workspace                |
-| `pipeline/run-{id}` | Isolated pipeline execution          |
+| `pipeline-run-{id}` | Isolated pipeline execution          |
 | `feature/*`         | Feature development                  |
 
 ## Endpoints

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1202,14 +1202,18 @@ When enabled, every `phlo materialize ASSET_NAME` creates a fresh
 start the asset. Phlo applies the `phlo/wap_branch` and `phlo/ref` tags to bind
 the run to that immutable ref. A configured `PHLO_DAGSTER_ACCESS_TOKEN` is sent
 as a bearer token but never appears in process arguments or shell history.
+For a remote endpoint, the token and HTTPS are required; plaintext HTTP is
+accepted only for the default local endpoint.
 
 ```bash
 phlo materialize dlt_events
 ```
 
-If Dagster rejects a launch, the run fails checks, or transport is ambiguous,
-Phlo retains the branch and WAP report for audit. With WAP disabled, this command
-retains its legacy direct `dagster asset materialize` behavior.
+Before GraphQL submission, Phlo writes an immutable launch manifest that binds
+the logical run ID, branch, tags, and catalog hashes. If Dagster rejects a
+launch, the run fails checks, or transport is ambiguous, Phlo retains that
+branch and report for audit. With WAP disabled, this command retains its legacy
+direct `dagster asset materialize` behavior.
 
 **Selection Syntax**:
 

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1210,6 +1210,9 @@ phlo materialize dlt_events --wap --job-name __ASSET_JOB \
   --repository-location-name phlo_dagster --repository-name phlo_dagster
 ```
 
+The direct `dagster asset materialize` command bypasses Phlo's WAP lifecycle;
+use the Phlo WAP launch path when writes must be isolated before execution.
+
 **Selection Syntax**:
 
 ```bash

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -1196,22 +1196,20 @@ for the structured failure details.
 
 **Write-audit-publish (WAP) launch**:
 
-WAP creates or reuses a `pipeline-run-<logical-run-id>` catalog branch before
-asking Dagster to start exactly one asset. It requires the Dagster job and
-repository selector plus a verified user access token. Set the repository with
-the shown options or `PHLO_DAGSTER_REPOSITORY_*` environment variables. The
-token is accepted only through `PHLO_DAGSTER_ACCESS_TOKEN`, so it doesn't appear
-in process arguments or shell history. If the launch response is ambiguous,
-Phlo retains a newly created branch so the caller can reconcile or retry with
-the same `--wap-run-id`; a retry reuses the run Dagster already accepted.
+WAP is a project policy configured in `phlo.yaml`, not a command-line option.
+When enabled, every `phlo materialize ASSET_NAME` creates a fresh
+`pipeline-run-<logical-run-id>` catalog branch before asking Dagster GraphQL to
+start the asset. Phlo applies the `phlo/wap_branch` and `phlo/ref` tags to bind
+the run to that immutable ref. A configured `PHLO_DAGSTER_ACCESS_TOKEN` is sent
+as a bearer token but never appears in process arguments or shell history.
 
 ```bash
-phlo materialize dlt_events --wap --job-name __ASSET_JOB \
-  --repository-location-name phlo_dagster --repository-name phlo_dagster
+phlo materialize dlt_events
 ```
 
-The direct `dagster asset materialize` command bypasses Phlo's WAP lifecycle;
-use the Phlo WAP launch path when writes must be isolated before execution.
+If Dagster rejects a launch, the run fails checks, or transport is ambiguous,
+Phlo retains the branch and WAP report for audit. With WAP disabled, this command
+retains its legacy direct `dagster asset materialize` behavior.
 
 **Selection Syntax**:
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -526,6 +526,11 @@ through Dagster GraphQL after creating a fresh WAP branch. Do not pass WAP
 command-line flags: the configuration is intentionally project-wide. Disabled
 or absent configuration keeps the direct CLI execution path.
 
+WAP configuration is fail-closed: unknown `wap` keys and insecure non-local
+`http://` endpoints are rejected. Remote Dagster endpoints must use HTTPS and
+require `PHLO_DAGSTER_ACCESS_TOKEN`; plaintext HTTP is allowed only for the
+local default endpoint.
+
 Dagster WAP sensor intervals:
 
 ```bash
@@ -537,9 +542,11 @@ PHLO_WAP_CLEANUP_INTERVAL_SECONDS=3600
 These settings only matter when the active profile includes a versioned catalog
 capability.
 The project-level `wap.enabled` setting controls whether these sensors are
-loaded. Each WAP run writes `.phlo/wap-reports/<run_id>.json`
-with the branch, source hash, target hash before/after promotion, and cleanup
-result.
+loaded. Each WAP launch first writes `.phlo/wap-reports/<logical-run-id>.json`.
+The immutable launch manifest binds the logical ID, Dagster run ID, branch,
+ref tags, and source/target hashes. It is retained when launch outcome is
+rejected or ambiguous, and is verified again before promotion or retention
+cleanup.
 
 ### Validation Configuration
 
@@ -1024,7 +1031,7 @@ Dagster run configuration for asset execution:
     "resources": {
         "iceberg": {
             "config": {
-                "ref": "pipeline/run-abc123"
+                "ref": "pipeline-run-abc123"
             }
         }
     }

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -508,10 +508,27 @@ BRANCH_CLEANUP_ENABLED=false
 
 ### WAP Sensor Configuration
 
+Enable the branch-first WAP policy at project scope in `phlo.yaml`:
+
+```yaml
+wap:
+  enabled: true
+  # These defaults target the standard generated Dagster asset job.
+  job_name: __ASSET_JOB
+  # Optional selectors for projects with more than one Dagster code location.
+  repository_location_name: user_code
+  repository_name: user_repository
+  dagster_url: http://localhost:10006/graphql
+```
+
+When `enabled` is true, `phlo materialize` and `phlo backfill` always launch
+through Dagster GraphQL after creating a fresh WAP branch. Do not pass WAP
+command-line flags: the configuration is intentionally project-wide. Disabled
+or absent configuration keeps the direct CLI execution path.
+
 Dagster WAP sensor intervals:
 
 ```bash
-PHLO_WAP_ENABLED=true
 PHLO_WAP_BRANCH_CREATION_INTERVAL_SECONDS=30
 PHLO_WAP_PROMOTION_INTERVAL_SECONDS=60
 PHLO_WAP_CLEANUP_INTERVAL_SECONDS=3600
@@ -519,8 +536,8 @@ PHLO_WAP_CLEANUP_INTERVAL_SECONDS=3600
 
 These settings only matter when the active profile includes a versioned catalog
 capability.
-Set `PHLO_WAP_ENABLED=false` to disable WAP sensors even when Nessie/Iceberg
-branching is available. Each WAP run writes `.phlo/wap-reports/<run_id>.json`
+The project-level `wap.enabled` setting controls whether these sensors are
+loaded. Each WAP run writes `.phlo/wap-reports/<run_id>.json`
 with the branch, source hash, target hash before/after promotion, and cleanup
 result.
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -894,9 +894,19 @@ infrastructure:
       internal_host: postgres
 ```
 
-Service enablement, Compose port replacement, environment, volume, dependency,
+Service enablement, Compose port replacement, environment, volume, `extra_hosts`, dependency,
 command, and healthcheck overrides live in the top-level `services:` section, not
 under `infrastructure.services`.
+
+Use `extra_hosts` when a generated service must resolve a host-private dependency from
+inside Docker. Values use Docker Compose host mappings and replace any package default:
+
+```yaml
+services:
+  dagster:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+```
 
 Service packages own their default ports. When a package is selected by
 `phlo services init`, its non-secret defaults are materialized into `.phlo/.env`;

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -518,13 +518,18 @@ wap:
   # Optional selectors for projects with more than one Dagster code location.
   repository_location_name: user_code
   repository_name: user_repository
-  dagster_url: http://localhost:10006/graphql
+  # Optional only when Dagster is remote; local Dagster is resolved by Phlo.
+  dagster_url: https://dagster.example.com/graphql
 ```
 
 When `enabled` is true, `phlo materialize` and `phlo backfill` always launch
 through Dagster GraphQL after creating a fresh WAP branch. Do not pass WAP
 command-line flags: the configuration is intentionally project-wide. Disabled
 or absent configuration keeps the direct CLI execution path.
+
+For a standard local Phlo stack, only `wap.enabled: true` is needed. Phlo uses
+`resolve_host` and the project's `DAGSTER_PORT` to find local Dagster; do not
+duplicate its URL in `phlo.yaml`.
 
 WAP configuration is fail-closed: unknown `wap` keys and insecure non-local
 `http://` endpoints are rejected. Remote Dagster endpoints must use HTTPS and

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -531,6 +531,18 @@ WAP configuration is fail-closed: unknown `wap` keys and insecure non-local
 require `PHLO_DAGSTER_ACCESS_TOKEN`; plaintext HTTP is allowed only for the
 local default endpoint.
 
+Service-specific Docker settings such as `extra_hosts` belong under
+`infrastructure.services` (the legacy top-level `services` form remains
+supported):
+
+```yaml
+infrastructure:
+  services:
+    dagster:
+      extra_hosts:
+        - host.docker.internal:host-gateway
+```
+
 Dagster WAP sensor intervals:
 
 ```bash

--- a/packages/phlo-dagster/src/phlo_dagster/Dockerfile
+++ b/packages/phlo-dagster/src/phlo_dagster/Dockerfile
@@ -51,7 +51,9 @@ RUN \
     fi; \
     else \
         uv pip install --system "phlo[defaults]" "$PHLO_DBT_REQUIREMENT" dagster-webserver dagster-postgres "psycopg[binary]"; \
-    fi && apk del .build-deps
+    fi \
+    && uv pip install --system "PyJWT[crypto]>=2.13.0" "cryptography>=48.0.1" \
+    && apk del .build-deps
 
 # Build caches contain package manifests that vulnerability scanners treat as runtime
 # dependencies. They are unnecessary after installation and must not ship in the image.

--- a/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
@@ -264,6 +264,10 @@ def backfill(
 
     if wap_config.enabled:
         access_token = os.environ.get("PHLO_DAGSTER_ACCESS_TOKEN")
+        if getattr(wap_config, "requires_access_token", False) and not access_token:
+            raise click.ClickException(
+                "PHLO_DAGSTER_ACCESS_TOKEN is required for a non-local WAP Dagster endpoint."
+            )
         discover_capabilities()
         _run_wap_backfill(
             asset_name,
@@ -301,21 +305,35 @@ def _run_wap_backfill(
     for partition_date in partition_dates:
         logical_run_id = f"backfill-{uuid.uuid4().hex}"
         launch = prepare_wap_launch(logical_run_id=logical_run_id)
-        result = asyncio.run(
-            launch_materialize(
-                dagster_url=dagster_url,
-                asset_key_path=asset_name,
-                job_name=job_name,
-                repository_location_name=repository_location_name,
-                repository_name=repository_name,
-                access_token=access_token,
-                partition_key=partition_date,
-                idempotency_key=logical_run_id,
-                tags=launch.tags,
+        try:
+            result = asyncio.run(
+                launch_materialize(
+                    dagster_url=dagster_url,
+                    asset_key_path=asset_name,
+                    job_name=job_name,
+                    repository_location_name=repository_location_name,
+                    repository_name=repository_name,
+                    access_token=access_token,
+                    partition_key=partition_date,
+                    idempotency_key=logical_run_id,
+                    tags=launch.tags,
+                )
             )
-        )
+        except Exception as exc:
+            launch.record_launch_result(status="launch_ambiguous", error=str(exc))
+            raise click.ClickException(
+                f"WAP launch outcome is ambiguous for {partition_date}: {exc}"
+            ) from exc
         if not result.accepted:
+            launch.record_launch_result(status="launch_rejected", error=result.message)
             raise click.ClickException(result.message)
+        if not launch.record_launch_result(
+            status="launched", dagster_run_id=getattr(result, "run_id", None)
+        ):
+            raise click.ClickException(
+                "Dagster accepted the WAP run, but its immutable launch manifest could not be stored. "
+                "The branch was retained."
+            )
         console.print(f"Launched WAP backfill for {partition_date} on {launch.branch}")
 
 

--- a/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
@@ -57,6 +57,8 @@ from phlo.cli.infrastructure.container_backend import (
 )
 from phlo.cli.infrastructure.utils import get_project_name
 from phlo.cli.output import service_unavailable_error
+from phlo.capabilities.discovery import discover_capabilities
+from phlo.infrastructure import load_wap_config
 from phlo.logging import get_logger
 from phlo_dagster.cli_materialize import wait_for_dagster_runtime
 from phlo_dagster.containers import find_dagster_container
@@ -109,13 +111,6 @@ BACKFILL_STATE_FILE = Path(".phlo/backfill_state.json")
     default=0.0,
     help="Delay between parallel executions in seconds (rate limiting)",
 )
-@click.option("--wap", is_flag=True, help="Launch partitions on isolated WAP branches.")
-@click.option("--job-name", help="Dagster job name for a WAP backfill launch.")
-@click.option("--repository-location-name", envvar="PHLO_DAGSTER_REPOSITORY_LOCATION_NAME")
-@click.option("--repository-name", envvar="PHLO_DAGSTER_REPOSITORY_NAME")
-@click.option(
-    "--dagster-url", envvar="DAGSTER_GRAPHQL_URL", default="http://localhost:3000/graphql"
-)
 def backfill(
     asset_name: str | None,
     start_date: str | None,
@@ -125,11 +120,6 @@ def backfill(
     resume: bool,
     dry_run: bool,
     delay: float,
-    wap: bool,
-    job_name: str | None,
-    repository_location_name: str | None,
-    repository_name: str | None,
-    dagster_url: str,
 ):
     """Run asset materialization across a date range with parallel execution.
 
@@ -245,6 +235,8 @@ def backfill(
         console.print(f"[yellow]Already completed:[/yellow] {len(completed_partitions)}")
         console.print(f"[yellow]Remaining:[/yellow] {len(partition_dates)}")
 
+    wap_config = load_wap_config()
+
     if dry_run:
         logger.info(
             "dagster_backfill_dry_run",
@@ -253,8 +245,14 @@ def backfill(
         )
         console.print("\n[yellow]Dry run - showing first 5 commands:[/yellow]\n")
         for date in partition_dates[:5]:
-            cmd = _build_materialize_command(asset_name, date, container_name="dagster")
-            console.print(f"[dim]{' '.join(cmd)}[/dim]")
+            if wap_config.enabled:
+                console.print(
+                    f"[dim]GraphQL WAP launch {asset_name} partition {date} "
+                    f"through {wap_config.dagster_url}[/dim]"
+                )
+            else:
+                cmd = _build_materialize_command(asset_name, date, container_name="dagster")
+                console.print(f"[dim]{' '.join(cmd)}[/dim]")
         if len(partition_dates) > 5:
             console.print(f"[dim]... and {len(partition_dates) - 5} more[/dim]")
         return
@@ -264,19 +262,16 @@ def backfill(
         console.print("[yellow]No partitions to backfill[/yellow]")
         return
 
-    if wap:
+    if wap_config.enabled:
         access_token = os.environ.get("PHLO_DAGSTER_ACCESS_TOKEN")
-        if not job_name or not repository_location_name or not repository_name or not access_token:
-            raise click.UsageError(
-                "WAP backfill requires --job-name, repository selectors, and PHLO_DAGSTER_ACCESS_TOKEN."
-            )
+        discover_capabilities()
         _run_wap_backfill(
             asset_name,
             partition_dates,
-            dagster_url=dagster_url,
-            job_name=job_name,
-            repository_location_name=repository_location_name,
-            repository_name=repository_name,
+            dagster_url=wap_config.dagster_url,
+            job_name=wap_config.job_name,
+            repository_location_name=wap_config.repository_location_name,
+            repository_name=wap_config.repository_name,
             access_token=access_token,
         )
         return
@@ -298,9 +293,9 @@ def _run_wap_backfill(
     *,
     dagster_url: str,
     job_name: str,
-    repository_location_name: str,
-    repository_name: str,
-    access_token: str,
+    repository_location_name: str | None,
+    repository_name: str | None,
+    access_token: str | None,
 ) -> None:
     """Create a WAP branch before submitting each partitioned asset run."""
     for partition_date in partition_dates:
@@ -320,7 +315,6 @@ def _run_wap_backfill(
             )
         )
         if not result.accepted:
-            launch.cleanup_if_created()
             raise click.ClickException(result.message)
         console.print(f"Launched WAP backfill for {partition_date} on {launch.branch}")
 

--- a/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
@@ -63,6 +63,7 @@ from phlo.logging import get_logger
 from phlo_dagster.cli_materialize import wait_for_dagster_runtime
 from phlo_dagster.containers import find_dagster_container
 from phlo_dagster.operations import launch_materialize
+from phlo_dagster.wap_endpoint import resolve_wap_dagster_url
 from phlo_dagster.wap_launch import prepare_wap_launch
 
 console = Console()
@@ -244,11 +245,12 @@ def backfill(
             partition_count=len(partition_dates),
         )
         console.print("\n[yellow]Dry run - showing first 5 commands:[/yellow]\n")
+        dagster_url = resolve_wap_dagster_url(wap_config) if wap_config.enabled else None
         for date in partition_dates[:5]:
             if wap_config.enabled:
                 console.print(
                     f"[dim]GraphQL WAP launch {asset_name} partition {date} "
-                    f"through {wap_config.dagster_url}[/dim]"
+                    f"through {dagster_url}[/dim]"
                 )
             else:
                 cmd = _build_materialize_command(asset_name, date, container_name="dagster")
@@ -263,6 +265,7 @@ def backfill(
         return
 
     if wap_config.enabled:
+        dagster_url = resolve_wap_dagster_url(wap_config)
         access_token = os.environ.get("PHLO_DAGSTER_ACCESS_TOKEN")
         if getattr(wap_config, "requires_access_token", False) and not access_token:
             raise click.ClickException(
@@ -272,7 +275,7 @@ def backfill(
         _run_wap_backfill(
             asset_name,
             partition_dates,
-            dagster_url=wap_config.dagster_url,
+            dagster_url=dagster_url,
             job_name=wap_config.job_name,
             repository_location_name=wap_config.repository_location_name,
             repository_name=wap_config.repository_name,

--- a/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_backfill.py
@@ -35,9 +35,12 @@ Example:
 """
 
 import json
+import asyncio
+import os
 import re
 import subprocess
 import sys
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -57,6 +60,8 @@ from phlo.cli.output import service_unavailable_error
 from phlo.logging import get_logger
 from phlo_dagster.cli_materialize import wait_for_dagster_runtime
 from phlo_dagster.containers import find_dagster_container
+from phlo_dagster.operations import launch_materialize
+from phlo_dagster.wap_launch import prepare_wap_launch
 
 console = Console()
 logger = get_logger(__name__)
@@ -104,6 +109,13 @@ BACKFILL_STATE_FILE = Path(".phlo/backfill_state.json")
     default=0.0,
     help="Delay between parallel executions in seconds (rate limiting)",
 )
+@click.option("--wap", is_flag=True, help="Launch partitions on isolated WAP branches.")
+@click.option("--job-name", help="Dagster job name for a WAP backfill launch.")
+@click.option("--repository-location-name", envvar="PHLO_DAGSTER_REPOSITORY_LOCATION_NAME")
+@click.option("--repository-name", envvar="PHLO_DAGSTER_REPOSITORY_NAME")
+@click.option(
+    "--dagster-url", envvar="DAGSTER_GRAPHQL_URL", default="http://localhost:3000/graphql"
+)
 def backfill(
     asset_name: str | None,
     start_date: str | None,
@@ -113,6 +125,11 @@ def backfill(
     resume: bool,
     dry_run: bool,
     delay: float,
+    wap: bool,
+    job_name: str | None,
+    repository_location_name: str | None,
+    repository_name: str | None,
+    dagster_url: str,
 ):
     """Run asset materialization across a date range with parallel execution.
 
@@ -247,6 +264,23 @@ def backfill(
         console.print("[yellow]No partitions to backfill[/yellow]")
         return
 
+    if wap:
+        access_token = os.environ.get("PHLO_DAGSTER_ACCESS_TOKEN")
+        if not job_name or not repository_location_name or not repository_name or not access_token:
+            raise click.UsageError(
+                "WAP backfill requires --job-name, repository selectors, and PHLO_DAGSTER_ACCESS_TOKEN."
+            )
+        _run_wap_backfill(
+            asset_name,
+            partition_dates,
+            dagster_url=dagster_url,
+            job_name=job_name,
+            repository_location_name=repository_location_name,
+            repository_name=repository_name,
+            access_token=access_token,
+        )
+        return
+
     # Run backfill with progress tracking
     console.print()
     _run_backfill(
@@ -256,6 +290,39 @@ def backfill(
         delay=delay,
         completed_partitions=completed_partitions,
     )
+
+
+def _run_wap_backfill(
+    asset_name: str,
+    partition_dates: list[str],
+    *,
+    dagster_url: str,
+    job_name: str,
+    repository_location_name: str,
+    repository_name: str,
+    access_token: str,
+) -> None:
+    """Create a WAP branch before submitting each partitioned asset run."""
+    for partition_date in partition_dates:
+        logical_run_id = f"backfill-{uuid.uuid4().hex}"
+        launch = prepare_wap_launch(logical_run_id=logical_run_id)
+        result = asyncio.run(
+            launch_materialize(
+                dagster_url=dagster_url,
+                asset_key_path=asset_name,
+                job_name=job_name,
+                repository_location_name=repository_location_name,
+                repository_name=repository_name,
+                access_token=access_token,
+                partition_key=partition_date,
+                idempotency_key=logical_run_id,
+                tags=launch.tags,
+            )
+        )
+        if not result.accepted:
+            launch.cleanup_if_created()
+            raise click.ClickException(result.message)
+        console.print(f"Launched WAP backfill for {partition_date} on {launch.branch}")
 
 
 def _generate_partition_dates(start_date: str, end_date: str) -> list[str]:

--- a/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
@@ -150,6 +150,10 @@ def materialize(
                 "WAP is enabled in phlo.yaml and requires one ASSET_NAME; --select is not supported."
             )
         access_token = os.environ.get("PHLO_DAGSTER_ACCESS_TOKEN")
+        if getattr(wap_config, "requires_access_token", False) and not access_token:
+            raise click.ClickException(
+                "PHLO_DAGSTER_ACCESS_TOKEN is required for a non-local WAP Dagster endpoint."
+            )
         logical_run_id = uuid.uuid4().hex
         if dry_run:
             click.echo(
@@ -160,21 +164,32 @@ def materialize(
 
         discover_capabilities()
         wap_launch = prepare_wap_launch(logical_run_id=logical_run_id)
-        result = asyncio.run(
-            launch_materialize(
-                dagster_url=wap_config.dagster_url,
-                asset_key_path=asset_name,
-                job_name=wap_config.job_name,
-                repository_location_name=wap_config.repository_location_name,
-                repository_name=wap_config.repository_name,
-                access_token=access_token,
-                partition_key=partition,
-                idempotency_key=logical_run_id,
-                tags=wap_launch.tags,
+        try:
+            result = asyncio.run(
+                launch_materialize(
+                    dagster_url=wap_config.dagster_url,
+                    asset_key_path=asset_name,
+                    job_name=wap_config.job_name,
+                    repository_location_name=wap_config.repository_location_name,
+                    repository_name=wap_config.repository_name,
+                    access_token=access_token,
+                    partition_key=partition,
+                    idempotency_key=logical_run_id,
+                    tags=wap_launch.tags,
+                )
             )
-        )
+        except Exception as exc:
+            wap_launch.record_launch_result(status="launch_ambiguous", error=str(exc))
+            raise click.ClickException(f"WAP launch outcome is ambiguous: {exc}") from exc
         if not result.accepted:
+            wap_launch.record_launch_result(status="launch_rejected", error=result.message)
             raise click.ClickException(result.message)
+
+        if not wap_launch.record_launch_result(status="launched", dagster_run_id=result.run_id):
+            raise click.ClickException(
+                "Dagster accepted the WAP run, but its immutable launch manifest could not be stored. "
+                "The branch was retained."
+            )
 
         click.echo(
             f"Launched WAP materialization for {asset_name} on {wap_launch.branch} "

--- a/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
@@ -59,6 +59,7 @@ from phlo.cli.infrastructure.container_backend import (
 )
 from phlo.cli.infrastructure.utils import get_project_name
 from phlo.cli.output import command_failed_error, service_unavailable_error
+from phlo.infrastructure import load_wap_config
 from phlo_dagster.containers import find_dagster_container
 from phlo_dagster.operations import launch_materialize
 from phlo_dagster.wap_launch import prepare_wap_launch
@@ -111,26 +112,6 @@ def wait_for_dagster_runtime(
 @click.argument("asset_name", required=False)
 @click.option("-p", "--partition", help="Partition date (YYYY-MM-DD)")
 @click.option("--select", help="Asset selector expression")
-@click.option("--wap", is_flag=True, help="Launch one asset through the WAP branch lifecycle")
-@click.option("--wap-run-id", help="Reuse this logical run identity for a WAP retry")
-@click.option("--job-name", help="Dagster job name required for a WAP launch")
-@click.option(
-    "--repository-location-name",
-    envvar="PHLO_DAGSTER_REPOSITORY_LOCATION_NAME",
-    help="Dagster repository location for a WAP launch",
-)
-@click.option(
-    "--repository-name",
-    envvar="PHLO_DAGSTER_REPOSITORY_NAME",
-    help="Dagster repository name for a WAP launch",
-)
-@click.option(
-    "--dagster-url",
-    envvar="DAGSTER_GRAPHQL_URL",
-    default="http://localhost:3000/graphql",
-    show_default=True,
-    help="Dagster GraphQL endpoint for a WAP launch",
-)
 @click.option(
     "--no-contract-refresh",
     is_flag=True,
@@ -141,12 +122,6 @@ def materialize(
     asset_name: str | None,
     partition: Optional[str],
     select: Optional[str],
-    wap: bool,
-    wap_run_id: str | None,
-    job_name: str | None,
-    repository_location_name: str | None,
-    repository_name: str | None,
-    dagster_url: str,
     no_contract_refresh: bool,
     dry_run: bool,
 ) -> None:
@@ -168,54 +143,37 @@ def materialize(
     """
     if not asset_name and not select:
         raise click.UsageError("Provide ASSET_NAME or --select.")
-    if wap:
+    wap_config = load_wap_config()
+    if wap_config.enabled:
         if not asset_name or select:
             raise click.UsageError(
-                "WAP materialization requires one ASSET_NAME and does not support --select."
-            )
-        if not job_name:
-            raise click.UsageError("WAP materialization requires --job-name.")
-        if not repository_location_name or not repository_name:
-            raise click.UsageError(
-                "WAP materialization requires --repository-location-name and --repository-name "
-                "(or PHLO_DAGSTER_REPOSITORY_LOCATION_NAME and PHLO_DAGSTER_REPOSITORY_NAME)."
+                "WAP is enabled in phlo.yaml and requires one ASSET_NAME; --select is not supported."
             )
         access_token = os.environ.get("PHLO_DAGSTER_ACCESS_TOKEN")
-        if not access_token:
-            raise click.UsageError("WAP materialization requires PHLO_DAGSTER_ACCESS_TOKEN.")
-
-        logical_run_id = wap_run_id or uuid.uuid4().hex
+        logical_run_id = uuid.uuid4().hex
         if dry_run:
             click.echo(
                 "WAP dry run - would launch "
-                f"{asset_name} with logical run ID {logical_run_id} through {dagster_url}"
+                f"{asset_name} with logical run ID {logical_run_id} through {wap_config.dagster_url}"
             )
             return
 
         discover_capabilities()
         wap_launch = prepare_wap_launch(logical_run_id=logical_run_id)
-        try:
-            result = asyncio.run(
-                launch_materialize(
-                    dagster_url=dagster_url,
-                    asset_key_path=asset_name,
-                    job_name=job_name,
-                    repository_location_name=repository_location_name,
-                    repository_name=repository_name,
-                    access_token=access_token,
-                    partition_key=partition,
-                    idempotency_key=logical_run_id,
-                    tags=wap_launch.tags,
-                )
+        result = asyncio.run(
+            launch_materialize(
+                dagster_url=wap_config.dagster_url,
+                asset_key_path=asset_name,
+                job_name=wap_config.job_name,
+                repository_location_name=wap_config.repository_location_name,
+                repository_name=wap_config.repository_name,
+                access_token=access_token,
+                partition_key=partition,
+                idempotency_key=logical_run_id,
+                tags=wap_launch.tags,
             )
-        except Exception:
-            # A timeout or transport failure can occur after Dagster accepts the
-            # mutation. Retain a branch we created so the run can be reconciled
-            # or retried with the same logical run ID.
-            raise
-
+        )
         if not result.accepted:
-            wap_launch.cleanup_if_created()
             raise click.ClickException(result.message)
 
         click.echo(

--- a/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
+++ b/packages/phlo-dagster/src/phlo_dagster/cli_materialize.py
@@ -62,6 +62,7 @@ from phlo.cli.output import command_failed_error, service_unavailable_error
 from phlo.infrastructure import load_wap_config
 from phlo_dagster.containers import find_dagster_container
 from phlo_dagster.operations import launch_materialize
+from phlo_dagster.wap_endpoint import resolve_wap_dagster_url
 from phlo_dagster.wap_launch import prepare_wap_launch
 from phlo.logging import get_logger
 
@@ -149,6 +150,7 @@ def materialize(
             raise click.UsageError(
                 "WAP is enabled in phlo.yaml and requires one ASSET_NAME; --select is not supported."
             )
+        dagster_url = resolve_wap_dagster_url(wap_config)
         access_token = os.environ.get("PHLO_DAGSTER_ACCESS_TOKEN")
         if getattr(wap_config, "requires_access_token", False) and not access_token:
             raise click.ClickException(
@@ -158,7 +160,7 @@ def materialize(
         if dry_run:
             click.echo(
                 "WAP dry run - would launch "
-                f"{asset_name} with logical run ID {logical_run_id} through {wap_config.dagster_url}"
+                f"{asset_name} with logical run ID {logical_run_id} through {dagster_url}"
             )
             return
 
@@ -167,7 +169,7 @@ def materialize(
         try:
             result = asyncio.run(
                 launch_materialize(
-                    dagster_url=wap_config.dagster_url,
+                    dagster_url=dagster_url,
                     asset_key_path=asset_name,
                     job_name=wap_config.job_name,
                     repository_location_name=wap_config.repository_location_name,

--- a/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
+++ b/packages/phlo-dagster/src/phlo_dagster/entrypoint.sh
@@ -94,6 +94,17 @@ else
     echo "Non-root mode: using mounted project directly"
 fi
 
+# Development stacks mount the complete repository. Make every source package
+# importable even when the pinned runtime image runs as the unprivileged user
+# and therefore cannot perform a system-wide editable install.
+if [ "$PHLO_DEV_MODE" = "true" ] && [ -d /opt/phlo-dev ]; then
+    for source_dir in /opt/phlo-dev/src /opt/phlo-dev/packages/*/src; do
+        if [ -d "$source_dir" ]; then
+            export PYTHONPATH="$source_dir${PYTHONPATH:+:$PYTHONPATH}"
+        fi
+    done
+fi
+
 # Execute Dagster from the mounted project root when available. User workflows
 # often read local files relative to the project (for example data/*.csv), while
 # DAGSTER_HOME intentionally remains /opt/dagster for instance state.

--- a/packages/phlo-dagster/src/phlo_dagster/framework/definitions.py
+++ b/packages/phlo-dagster/src/phlo_dagster/framework/definitions.py
@@ -55,7 +55,6 @@ Example:
 
 from __future__ import annotations
 
-import os
 import platform
 from pathlib import Path
 from typing import Any
@@ -65,6 +64,7 @@ import dagster as dg
 from phlo.capabilities.interfaces import VersionedCatalog
 from phlo.capabilities.resolver import resolve_capability
 from phlo.exceptions import PhloCapabilitySetupError
+from phlo.infrastructure import load_wap_config
 from phlo_dagster.framework.discovery import (
     _collect_dagster_extension_definitions,
     _ensure_core_resources,
@@ -91,14 +91,8 @@ def _collect_wap_definitions() -> dg.Definitions | None:
         No explicit exceptions raised. Logs warnings for incompatible providers.
 
     """
-    if not get_settings().phlo_wap_enabled:
-        logger.info("dagster_wap_definitions_disabled")
-        return None
-
-    wap_sensors_raw = os.getenv("PHLO_WAP_SENSORS_ENABLED", "")
-    wap_sensors_enabled = wap_sensors_raw.lower() in {"1", "true", "yes"}
-    if os.getenv("PHLO_DAGSTER_DEV") == "1" and not wap_sensors_enabled:
-        logger.info("dagster_wap_definitions_skipped_in_local_dev")
+    if not load_wap_config().enabled:
+        logger.info("dagster_wap_definitions_disabled_by_project_policy")
         return None
 
     resolution = resolve_capability("catalog")

--- a/packages/phlo-dagster/src/phlo_dagster/operations.py
+++ b/packages/phlo-dagster/src/phlo_dagster/operations.py
@@ -163,17 +163,21 @@ async def launch_materialize(
                 message="Dagster previously accepted materialize_asset.",
                 details={"typename": "LaunchRunSuccess", "reconciled": True},
             )
+    selector: dict[str, Any] = {
+        "pipelineName": job_name,
+        "assetSelection": [{"path": asset_key_path.split("/")}],
+    }
+    if repository_location_name:
+        selector["repositoryLocationName"] = repository_location_name
+    if repository_name:
+        selector["repositoryName"] = repository_name
+
     result = await _graphql(
         dagster_url,
         LAUNCH_PIPELINE_EXECUTION_MUTATION,
         {
             "executionParams": {
-                "selector": {
-                    "pipelineName": job_name,
-                    "repositoryLocationName": repository_location_name,
-                    "repositoryName": repository_name,
-                    "assetSelection": [{"path": asset_key_path.split("/")}],
-                },
+                "selector": selector,
                 "runConfigData": run_config or {},
                 "mode": "default",
                 "executionMetadata": {"tags": _tags_for_execution(execution_tags)},

--- a/packages/phlo-dagster/src/phlo_dagster/service.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/service.yaml
@@ -26,6 +26,9 @@ depends_on:
 
 compose:
   restart: unless-stopped
+  # Use the generated entrypoint from the bind-mounted Dagster directory so
+  # development stacks execute the checked-out bootstrap script.
+  entrypoint: ["/bin/bash", "/opt/dagster/entrypoint.sh"]
   healthcheck:
     test:
       [

--- a/packages/phlo-dagster/src/phlo_dagster/service.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/service.yaml
@@ -37,7 +37,9 @@ compose:
     interval: 30s
     timeout: 5s
     retries: 3
-    start_period: 15s
+    # Editable project installs and Dagster definition loading can exceed the
+    # short Docker default on a cold bundled-stack boot.
+    start_period: 120s
   labels:
     phlo.metrics.enabled: "true"
     phlo.metrics.port: "dagster:3000"

--- a/packages/phlo-dagster/src/phlo_dagster/settings.py
+++ b/packages/phlo-dagster/src/phlo_dagster/settings.py
@@ -70,10 +70,6 @@ class DagsterSettings(BaseConfig):
         description="Host platform for executor selection (Darwin/Linux/Windows). "
         "Auto-detected in CLI; set explicitly for daemon/webserver on macOS.",
     )
-    phlo_wap_enabled: bool = Field(
-        default=True,
-        description="Enable Write-Audit-Publish lifecycle sensors when a versioned catalog exists.",
-    )
 
     @model_validator(mode="after")
     def validate_executor_flags(self) -> "DagsterSettings":

--- a/packages/phlo-dagster/src/phlo_dagster/wap_endpoint.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_endpoint.py
@@ -1,0 +1,25 @@
+"""Resolve the Dagster endpoint for project-policy WAP launches."""
+
+from __future__ import annotations
+
+from phlo.config.network import resolve_host
+from phlo.config_schema import WapConfig
+
+from phlo_dagster.settings import get_settings
+
+
+def resolve_wap_dagster_url(config: WapConfig) -> str:
+    """Return an explicit remote endpoint or resolve the local Dagster service.
+
+    Local WAP must follow the same host and port resolution as other Phlo
+    services.  ``dagster_url`` is therefore reserved for an intentionally
+    remote GraphQL endpoint.
+    """
+    if config.dagster_url:
+        return config.dagster_url
+    host, port = resolve_host(
+        "dagster",
+        get_settings().dagster_port,
+        port_env_var="DAGSTER_PORT",
+    )
+    return f"http://{host}:{port}/graphql"

--- a/packages/phlo-dagster/src/phlo_dagster/wap_launch.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_launch.py
@@ -10,6 +10,7 @@ from phlo.capabilities.resolver import resolve_capability
 from phlo.exceptions import PhloConfigError
 
 WAP_BRANCH_TAG = "phlo/wap_branch"
+WAP_REF_TAG = "phlo/ref"
 WAP_RUN_ID_TAG = "phlo/run_id"
 WAP_BRANCH_PREFIX = "pipeline-run-"
 
@@ -26,7 +27,11 @@ class WapLaunch:
     @property
     def tags(self) -> dict[str, str]:
         """Return the Dagster tags that bind stages to this WAP branch."""
-        return {WAP_RUN_ID_TAG: self.logical_run_id, WAP_BRANCH_TAG: self.branch}
+        return {
+            WAP_RUN_ID_TAG: self.logical_run_id,
+            WAP_BRANCH_TAG: self.branch,
+            WAP_REF_TAG: self.branch,
+        }
 
     def cleanup_if_created(self) -> None:
         """Remove only the branch created by this launch attempt."""

--- a/packages/phlo-dagster/src/phlo_dagster/wap_launch.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_launch.py
@@ -34,20 +34,24 @@ class WapLaunch:
         }
 
     def cleanup_if_created(self) -> None:
-        """Remove only the branch created by this launch attempt."""
+        """Remove only the branch created by this launch attempt.
+
+        Normal WAP callers intentionally do not invoke this method: retained
+        refs and their reports are the audit trail for failed checks.
+        """
         if self.created_branch:
             self.catalog.delete_branch(self.branch)
 
 
 def prepare_wap_launch(*, logical_run_id: str) -> WapLaunch:
-    """Ensure a WAP branch and tags exist before asking Dagster to start work."""
+    """Create a WAP branch and tags before asking Dagster to start work."""
     resolution = resolve_capability("catalog")
     if resolution is None or not (
         resolution.support.supports_refs and resolution.support.supports_promote
     ):
         raise PhloConfigError(
             message="WAP materialization requires a catalog with refs and promotion support.",
-            suggestions=["Configure a versioned catalog such as phlo-nessie before using --wap."],
+            suggestions=["Configure a versioned catalog such as phlo-nessie before enabling wap."],
         )
 
     catalog: Any = resolution.provider
@@ -59,11 +63,9 @@ def prepare_wap_launch(*, logical_run_id: str) -> WapLaunch:
 
     branch = f"{WAP_BRANCH_PREFIX}{logical_run_id}"
     if catalog.get_branch_hash(branch):
-        return WapLaunch(
-            logical_run_id=logical_run_id,
-            branch=branch,
-            catalog=catalog,
-            created_branch=False,
+        raise PhloConfigError(
+            message=f"WAP branch {branch!r} already exists; refusing to reuse it for a new run.",
+            suggestions=["Retry the command to create a new WAP branch."],
         )
 
     if catalog.create_branch(branch, from_ref="main") is None:

--- a/packages/phlo-dagster/src/phlo_dagster/wap_launch.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_launch.py
@@ -3,16 +3,129 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from phlo.capabilities.interfaces import VersionedCatalog
 from phlo.capabilities.resolver import resolve_capability
 from phlo.exceptions import PhloConfigError
+from phlo.logging import get_logger
 
 WAP_BRANCH_TAG = "phlo/wap_branch"
 WAP_REF_TAG = "phlo/ref"
 WAP_RUN_ID_TAG = "phlo/run_id"
 WAP_BRANCH_PREFIX = "pipeline-run-"
+logger = get_logger(__name__)
+
+
+def _report_path(logical_run_id: str) -> Path:
+    root = Path(os.getenv("PHLO_PROJECT_PATH", "."))
+    return root / ".phlo" / "wap-reports" / f"{logical_run_id}.json"
+
+
+def _report_snapshot_path(logical_run_id: str, checksum: str) -> Path:
+    root = Path(os.getenv("PHLO_PROJECT_PATH", ".")) / ".phlo" / "wap-reports" / "evidence"
+    run_key = hashlib.sha256(logical_run_id.encode("utf-8")).hexdigest()[:24]
+    return root / f"{run_key}.{checksum}.json"
+
+
+def _launch_manifest_path(logical_run_id: str, checksum: str) -> Path:
+    root = Path(os.getenv("PHLO_PROJECT_PATH", ".")) / ".phlo" / "wap-reports" / "launches"
+    run_key = hashlib.sha256(logical_run_id.encode("utf-8")).hexdigest()[:24]
+    return root / f"{run_key}.{checksum}.json"
+
+
+def _write_launch_manifest(
+    *,
+    logical_run_id: str,
+    dagster_run_id: str,
+    branch: str,
+    tags: dict[str, str],
+    source_hash: str | None,
+    target_hash_before: str | None,
+) -> str | None:
+    """Write the immutable, content-addressed binding used for promotion."""
+    payload = {
+        "schema_version": "phlo.wap_launch_manifest.v1",
+        "logical_run_id": logical_run_id,
+        "dagster_run_id": dagster_run_id,
+        "branch": branch,
+        "tags": tags,
+        "source_hash": source_hash,
+        "target_branch": "main",
+        "target_hash_before": target_hash_before,
+    }
+    serialized = json.dumps(payload, indent=2, sort_keys=True)
+    checksum = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    path = _launch_manifest_path(logical_run_id, checksum)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            path.write_text(serialized, encoding="utf-8")
+            path.chmod(0o444)
+    except OSError:
+        logger.warning(
+            "wap_launch_manifest_write_failed",
+            logical_run_id=logical_run_id,
+            path=str(path),
+            exc_info=True,
+        )
+        return None
+    return checksum
+
+
+def read_wap_launch_manifest(logical_run_id: str, checksum: str) -> dict[str, Any] | None:
+    """Read a launch binding only when its content matches the recorded digest."""
+    try:
+        raw = _launch_manifest_path(logical_run_id, checksum).read_bytes()
+        if hashlib.sha256(raw).hexdigest() != checksum:
+            return None
+        payload = json.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def write_wap_report(logical_run_id: str, **updates: Any) -> bool:
+    """Persist the durable WAP launch manifest and lifecycle audit record.
+
+    The logical ID is created before GraphQL submission, so this record exists
+    even when Dagster rejects a run or a response is lost in transit.
+    """
+    path = _report_path(logical_run_id)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        payload = {}
+    now = datetime.now(timezone.utc).isoformat()
+    payload.update(updates)
+    payload.update(
+        {
+            "created_at": payload.get("created_at", now),
+            "schema_version": "phlo.wap_report.v2",
+            "run_id": logical_run_id,
+            "updated_at": now,
+        }
+    )
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        serialized = json.dumps(payload, indent=2, sort_keys=True)
+        path.write_text(serialized, encoding="utf-8")
+        raw = serialized.encode("utf-8")
+        snapshot_path = _report_snapshot_path(logical_run_id, hashlib.sha256(raw).hexdigest())
+        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+        if not snapshot_path.exists():
+            snapshot_path.write_bytes(raw)
+    except OSError:
+        logger.warning(
+            "wap_report_write_failed", path=str(path), logical_run_id=logical_run_id, exc_info=True
+        )
+        return False
+    return True
 
 
 @dataclass(frozen=True)
@@ -23,6 +136,8 @@ class WapLaunch:
     branch: str
     catalog: VersionedCatalog
     created_branch: bool
+    source_hash: str | None
+    target_hash_before: str | None
 
     @property
     def tags(self) -> dict[str, str]:
@@ -41,6 +156,40 @@ class WapLaunch:
         """
         if self.created_branch:
             self.catalog.delete_branch(self.branch)
+
+    def record_launch_result(
+        self,
+        *,
+        status: str,
+        dagster_run_id: str | None = None,
+        error: str | None = None,
+    ) -> bool:
+        """Update the pre-created manifest without changing its branch binding."""
+        updates: dict[str, Any] = {
+            "status": status,
+            "branch": self.branch,
+            "launch_tags": self.tags,
+            "source_hash": self.source_hash,
+            "target_branch": "main",
+            "target_hash_before": self.target_hash_before,
+        }
+        if dagster_run_id is not None:
+            updates["dagster_run_id"] = dagster_run_id
+        if error is not None:
+            updates["launch_error"] = error
+        if status == "launched" and dagster_run_id is not None:
+            checksum = _write_launch_manifest(
+                logical_run_id=self.logical_run_id,
+                dagster_run_id=dagster_run_id,
+                branch=self.branch,
+                tags=self.tags,
+                source_hash=self.source_hash,
+                target_hash_before=self.target_hash_before,
+            )
+            if checksum is None:
+                return False
+            updates["launch_manifest_checksum"] = checksum
+        return write_wap_report(self.logical_run_id, **updates)
 
 
 def prepare_wap_launch(*, logical_run_id: str) -> WapLaunch:
@@ -68,15 +217,27 @@ def prepare_wap_launch(*, logical_run_id: str) -> WapLaunch:
             suggestions=["Retry the command to create a new WAP branch."],
         )
 
+    target_hash_before = catalog.get_branch_hash("main")
     if catalog.create_branch(branch, from_ref="main") is None:
         raise PhloConfigError(
             message=f"Could not create WAP branch {branch!r} from main.",
             suggestions=["Confirm the configured catalog can create branches from main."],
         )
 
-    return WapLaunch(
+    source_hash = catalog.get_branch_hash(branch)
+    launch = WapLaunch(
         logical_run_id=logical_run_id,
         branch=branch,
         catalog=catalog,
         created_branch=True,
+        source_hash=source_hash,
+        target_hash_before=target_hash_before,
     )
+    if not launch.record_launch_result(status="branch_created"):
+        raise PhloConfigError(
+            message=f"Could not persist the WAP launch report for branch {branch!r}.",
+            suggestions=[
+                "Repair .phlo/wap-reports storage before retrying; the branch was retained."
+            ],
+        )
+    return launch

--- a/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
@@ -45,11 +45,10 @@ Example:
 
 from __future__ import annotations
 
-import json
 import hashlib
+import json
 import os
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any
 
 import dagster as dg
@@ -68,12 +67,21 @@ from phlo.run_evidence import (
     emit_observation,
 )
 from phlo_dagster.run_evidence import DagsterRunEvidenceSource
+from phlo_dagster.wap_launch import (
+    WAP_BRANCH_TAG,
+    WAP_REF_TAG,
+    WAP_RUN_ID_TAG,
+    _report_path,
+    _report_snapshot_path,
+    read_wap_launch_manifest,
+    write_wap_report,
+)
 
 logger = get_logger(__name__)
 
 WAP_BRANCH_PREFIX = "pipeline-"
 OWNED_WAP_BRANCH_PREFIX = "pipeline-run-"
-WAP_TAG_KEY = "phlo/wap_branch"
+WAP_TAG_KEY = WAP_BRANCH_TAG
 DEFAULT_RETENTION_HOURS = 24
 DEFAULT_CLEANUP_INTERVAL_SECONDS = int(os.getenv("PHLO_WAP_CLEANUP_INTERVAL_SECONDS", "3600"))
 DEFAULT_PROMOTION_INTERVAL_SECONDS = int(os.getenv("PHLO_WAP_PROMOTION_INTERVAL_SECONDS", "60"))
@@ -82,17 +90,6 @@ WAP_EVIDENCE_PROFILE = RequiredEvidenceProfile(
     version="1",
     provider="dagster",
 )
-
-
-def _report_path(run_id: str) -> Path:
-    root = Path(os.getenv("PHLO_PROJECT_PATH", "."))
-    return root / ".phlo" / "wap-reports" / f"{run_id}.json"
-
-
-def _report_snapshot_path(run_id: str, checksum: str) -> Path:
-    root = Path(os.getenv("PHLO_PROJECT_PATH", ".")) / ".phlo" / "wap-reports" / "evidence"
-    run_key = hashlib.sha256(run_id.encode("utf-8")).hexdigest()[:24]
-    return root / f"{run_key}.{checksum}.json"
 
 
 def _branch_hash(catalog: VersionedCatalog, branch: str) -> str | None:
@@ -105,35 +102,6 @@ def _branch_hash(catalog: VersionedCatalog, branch: str) -> str | None:
         logger.warning("wap_report_branch_hash_failed", branch_name=branch, exc_info=True)
         return None
     return str(value) if value else None
-
-
-def write_wap_report(run_id: str, **updates: Any) -> None:
-    path = _report_path(run_id)
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8")) if path.exists() else {}
-    except (OSError, json.JSONDecodeError):
-        payload = {}
-    now = datetime.now(timezone.utc).isoformat()
-    payload.update(updates)
-    payload.update(
-        {
-            "created_at": payload.get("created_at", now),
-            "schema_version": "phlo.wap_report.v1",
-            "run_id": run_id,
-            "updated_at": now,
-        }
-    )
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        serialized = json.dumps(payload, indent=2, sort_keys=True)
-        path.write_text(serialized, encoding="utf-8")
-        raw = serialized.encode("utf-8")
-        snapshot_path = _report_snapshot_path(run_id, hashlib.sha256(raw).hexdigest())
-        snapshot_path.parent.mkdir(parents=True, exist_ok=True)
-        if not snapshot_path.exists():
-            snapshot_path.write_bytes(raw)
-    except OSError:
-        logger.warning("wap_report_write_failed", path=str(path), run_id=run_id, exc_info=True)
 
 
 def _load_versioned_catalog() -> VersionedCatalog:
@@ -442,6 +410,50 @@ def _logical_run_id(run: Any) -> str:
     return str(logical_run_id or dagster_run_id)
 
 
+def _verify_wap_launch_manifest(run: Any, branch_name: str) -> tuple[str, dict[str, Any]] | None:
+    """Fail closed unless the run still matches its pre-launch WAP manifest."""
+    logical_run_id = _logical_run_id(run)
+    dagster_run_id = str(getattr(run, "run_id", "") or "")
+    tags = getattr(run, "tags", {}) or {}
+    expected_tags = {
+        WAP_RUN_ID_TAG: logical_run_id,
+        WAP_BRANCH_TAG: branch_name,
+        WAP_REF_TAG: branch_name,
+    }
+    if (
+        not logical_run_id
+        or not dagster_run_id
+        or any(tags.get(key) != value for key, value in expected_tags.items())
+    ):
+        return None
+    manifest = _read_wap_report(logical_run_id)
+    checksum = manifest.get("launch_manifest_checksum") if manifest else None
+    binding = read_wap_launch_manifest(logical_run_id, str(checksum)) if checksum else None
+    if (
+        not manifest
+        or not binding
+        or (
+            manifest.get("run_id") != logical_run_id
+            or manifest.get("branch") != branch_name
+            or manifest.get("dagster_run_id") != dagster_run_id
+            or manifest.get("launch_tags") != expected_tags
+            or binding
+            != {
+                "schema_version": "phlo.wap_launch_manifest.v1",
+                "logical_run_id": logical_run_id,
+                "dagster_run_id": dagster_run_id,
+                "branch": branch_name,
+                "tags": expected_tags,
+                "source_hash": manifest.get("source_hash"),
+                "target_branch": "main",
+                "target_hash_before": manifest.get("target_hash_before"),
+            }
+        )
+    ):
+        return None
+    return logical_run_id, manifest
+
+
 def _reconcile_promoted_wap_run(run: Any, instance: Any) -> None:
     """Persist Dagster's authoritative history under the WAP logical identity."""
     dagster_run_id = getattr(run, "run_id", None)
@@ -604,6 +616,24 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
         if run_tags.get("phlo/wap_promoted"):
             continue
 
+        manifest = _verify_wap_launch_manifest(run, branch_name)
+        if manifest is None:
+            logical_run_id = _logical_run_id(run)
+            if logical_run_id:
+                write_wap_report(
+                    logical_run_id,
+                    status="promotion_blocked",
+                    branch=branch_name,
+                    failure_reason="launch_manifest_or_immutable_tags_invalid",
+                )
+            logger.warning(
+                "wap_promotion_blocked_launch_manifest_invalid",
+                run_id=run.run_id,
+                branch_name=branch_name,
+            )
+            blocked += 1
+            continue
+
         if not _all_checks_passed(instance, run.run_id):
             quality_decision_id, quality_metadata = _quality_evidence(
                 run.run_id,
@@ -614,7 +644,7 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
             )
             if quality_decision_id is None:
                 write_wap_report(
-                    run.run_id,
+                    _logical_run_id(run),
                     status="promotion_blocked",
                     branch=branch_name,
                     target_branch="main",
@@ -637,7 +667,7 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
                 blocked += 1
                 continue
             write_wap_report(
-                run.run_id,
+                _logical_run_id(run),
                 status="promotion_blocked",
                 branch=branch_name,
                 source_hash=_branch_hash(catalog, branch_name),
@@ -677,7 +707,7 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
         )
         if quality_decision_id is None:
             write_wap_report(
-                run.run_id,
+                _logical_run_id(run),
                 status="promotion_blocked",
                 branch=branch_name,
                 target_branch="main",
@@ -702,7 +732,7 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
         merged = catalog.merge_branch(source=branch_name, target="main")
         if not merged:
             write_wap_report(
-                run.run_id,
+                _logical_run_id(run),
                 status="promotion_failed",
                 branch=branch_name,
                 source_hash=source_hash,
@@ -747,7 +777,7 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
         )
         instance.add_run_tags(run.run_id, {"phlo/wap_promoted": "true"})
         write_wap_report(
-            run.run_id,
+            _logical_run_id(run),
             status="promoted",
             branch=branch_name,
             source_hash=source_hash,
@@ -883,17 +913,19 @@ def wap_branch_cleanup_sensor(context: dg.SensorEvaluationContext):
             skipped += 1
             continue
 
-        run_id = branch.name.removeprefix(OWNED_WAP_BRANCH_PREFIX)
-        report = _read_wap_report(run_id)
+        logical_run_id = branch.name.removeprefix(OWNED_WAP_BRANCH_PREFIX)
+        report = _read_wap_report(logical_run_id)
         if report and (
-            report.get("run_id") != run_id or report.get("branch") not in (None, branch.name)
+            report.get("run_id") != logical_run_id
+            or report.get("branch") not in (None, branch.name)
         ):
             report = None
+        dagster_run_id = report.get("dagster_run_id") if report else None
         dagster_run = None
         run_status = None
         get_run_by_id = getattr(context.instance, "get_run_by_id", None)
-        if callable(get_run_by_id):
-            dagster_run = get_run_by_id(run_id)
+        if callable(get_run_by_id) and dagster_run_id:
+            dagster_run = get_run_by_id(dagster_run_id)
             if dagster_run is not None:
                 run_status = _normalized_dagster_status(dagster_run)
         report_status = report.get("run_status") if report else None
@@ -901,9 +933,11 @@ def wap_branch_cleanup_sensor(context: dg.SensorEvaluationContext):
             run_status = report_status
         elif report and report.get("status") == "promoted":
             run_status = "success"
+        elif report and report.get("status") == "launch_rejected":
+            run_status = "failed"
         if run_status is None:
             _record_uncorrelated_gap(
-                run_id,
+                logical_run_id,
                 branch=branch.name,
                 missing=["run_status"],
                 reason="cleanup_authoritative_status_missing",
@@ -915,7 +949,7 @@ def wap_branch_cleanup_sensor(context: dg.SensorEvaluationContext):
         tagged_project = tags.get("phlo/project_id")
         if report_project and tagged_project and report_project != tagged_project:
             _record_uncorrelated_gap(
-                run_id,
+                logical_run_id,
                 branch=branch.name,
                 missing=["project_id"],
                 reason="cleanup_project_conflict",
@@ -925,12 +959,12 @@ def wap_branch_cleanup_sensor(context: dg.SensorEvaluationContext):
             tags["phlo/project_id"] = report_project
         if "phlo/attempt" not in tags and report:
             tags["phlo/attempt"] = str(report.get("attempt", ""))
-        cleanup_run = type("CleanupRun", (), {"run_id": run_id, "tags": tags})()
+        cleanup_run = type("CleanupRun", (), {"run_id": logical_run_id, "tags": tags})()
         project_id = _project_id_for_run(cleanup_run)
         attempt = _attempt_for_run(cleanup_run)
         if not project_id or attempt is None:
             _record_uncorrelated_gap(
-                run_id,
+                logical_run_id,
                 branch=branch.name,
                 missing=[
                     field
@@ -947,7 +981,7 @@ def wap_branch_cleanup_sensor(context: dg.SensorEvaluationContext):
             query_catalog_manager,
         )
         write_wap_report(
-            run_id,
+            logical_run_id,
             status="cleanup_complete" if cleanup_complete else "cleanup_incomplete",
             branch=branch.name,
             cleanup_complete=cleanup_complete,

--- a/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
+++ b/packages/phlo-dagster/src/phlo_dagster/wap_sensors.py
@@ -660,32 +660,9 @@ def wap_auto_promotion_sensor(context: dg.SensorEvaluationContext):
                     "changed_content_keys": {"status": "unavailable"},
                 },
             )
-            cleanup_complete = _cleanup_owned_wap_branch(
-                catalog,
-                branch_name,
-                query_catalog_manager,
-            )
-            write_wap_report(
-                run.run_id,
-                status="rejected" if cleanup_complete else "rejected_cleanup_incomplete",
-                branch=branch_name,
-                source_hash=_branch_hash(catalog, branch_name),
-                cleanup_complete=cleanup_complete,
-                failure_reason=None if cleanup_complete else "branch_cleanup_incomplete",
-            )
-            _emit_wap_observation(
-                run=run,
-                status="success" if cleanup_complete else "incomplete",
-                run_status="success",
-                operation="cleanup",
-                catalog_ref=branch_name,
-                source_hash=_branch_hash(catalog, branch_name),
-                merge_outcome="deleted" if cleanup_complete else "failed",
-                metadata={"target_ref": "main", "reason": "rejected_quality"},
-            )
             blocked += 1
             logger.info(
-                "wap_promotion_blocked_quality",
+                "wap_promotion_blocked_quality_branch_retained",
                 run_id=run.run_id,
                 branch_name=branch_name,
             )

--- a/packages/phlo-dagster/tests/test_cli_backfill.py
+++ b/packages/phlo-dagster/tests/test_cli_backfill.py
@@ -86,6 +86,57 @@ def test_wap_backfill_creates_branch_before_each_partition(monkeypatch):
     )
 
 
+def test_enabled_project_wap_backfill_uses_graphql_without_cli_flags(monkeypatch) -> None:
+    """The project policy selects the WAP path for every partition."""
+    launches: list[tuple[str, list[str]]] = []
+    discovery_calls: list[bool] = []
+    monkeypatch.setattr(
+        "phlo_dagster.cli_backfill.load_wap_config",
+        lambda: SimpleNamespace(
+            enabled=True,
+            dagster_url="http://dagster/graphql",
+            job_name="__ASSET_JOB",
+            repository_location_name=None,
+            repository_name=None,
+        ),
+    )
+    monkeypatch.setattr(
+        "phlo_dagster.cli_backfill._run_wap_backfill",
+        lambda asset_name, partitions, **_kwargs: launches.append((asset_name, partitions)),
+    )
+    monkeypatch.setattr(
+        "phlo_dagster.cli_backfill.discover_capabilities",
+        lambda: discovery_calls.append(True),
+    )
+
+    result = CliRunner().invoke(
+        backfill,
+        ["dlt_events", "--partitions", "2024-01-01,2024-01-02"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert launches == [("dlt_events", ["2024-01-01", "2024-01-02"])]
+    assert discovery_calls == [True]
+
+
+def test_disabled_project_wap_backfill_retains_direct_path(monkeypatch) -> None:
+    """Disabled WAP keeps the established container-exec implementation."""
+    direct_calls: list[tuple[str, list[str]]] = []
+    monkeypatch.setattr(
+        "phlo_dagster.cli_backfill.load_wap_config",
+        lambda: SimpleNamespace(enabled=False),
+    )
+    monkeypatch.setattr(
+        "phlo_dagster.cli_backfill._run_backfill",
+        lambda asset_name, partitions, **_kwargs: direct_calls.append((asset_name, partitions)),
+    )
+
+    result = CliRunner().invoke(backfill, ["dlt_events", "--partitions", "2024-01-01"])
+
+    assert result.exit_code == 0, result.output
+    assert direct_calls == [("dlt_events", ["2024-01-01"])]
+
+
 class TestBackfillValidation:
     """Test partition date validation."""
 

--- a/packages/phlo-dagster/tests/test_cli_backfill.py
+++ b/packages/phlo-dagster/tests/test_cli_backfill.py
@@ -1,6 +1,7 @@
 """Tests for the phlo backfill CLI command."""
 
 import json
+from types import SimpleNamespace
 from datetime import datetime
 from unittest.mock import ANY, patch
 
@@ -50,6 +51,39 @@ class TestBackfillDateGeneration:
         )
         assert result.exit_code == 1
         assert "Start date must be before end date" in result.output
+
+
+def test_wap_backfill_creates_branch_before_each_partition(monkeypatch):
+    from phlo_dagster.cli_backfill import _run_wap_backfill
+
+    launched: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "phlo_dagster.cli_backfill.prepare_wap_launch",
+        lambda **kwargs: SimpleNamespace(
+            branch=f"pipeline-run-{kwargs['logical_run_id']}",
+            tags={"phlo/wap_branch": "branch", "phlo/ref": "branch"},
+            cleanup_if_created=lambda: None,
+        ),
+    )
+
+    async def launch(**kwargs):
+        launched.append(kwargs)
+        return SimpleNamespace(accepted=True, message="ok")
+
+    monkeypatch.setattr("phlo_dagster.cli_backfill.launch_materialize", launch)
+    _run_wap_backfill(
+        "dlt_events",
+        ["2024-01-01", "2024-01-02"],
+        dagster_url="http://dagster",
+        job_name="__ASSET_JOB",
+        repository_location_name="phlo_dagster",
+        repository_name="phlo_dagster",
+        access_token="token",
+    )
+    assert [call["partition_key"] for call in launched] == ["2024-01-01", "2024-01-02"]
+    assert all(
+        call["tags"] == {"phlo/wap_branch": "branch", "phlo/ref": "branch"} for call in launched
+    )
 
 
 class TestBackfillValidation:

--- a/packages/phlo-dagster/tests/test_cli_backfill.py
+++ b/packages/phlo-dagster/tests/test_cli_backfill.py
@@ -63,6 +63,7 @@ def test_wap_backfill_creates_branch_before_each_partition(monkeypatch):
             branch=f"pipeline-run-{kwargs['logical_run_id']}",
             tags={"phlo/wap_branch": "branch", "phlo/ref": "branch"},
             cleanup_if_created=lambda: None,
+            record_launch_result=lambda **_kwargs: True,
         ),
     )
 

--- a/packages/phlo-dagster/tests/test_cli_materialize.py
+++ b/packages/phlo-dagster/tests/test_cli_materialize.py
@@ -128,6 +128,7 @@ def test_enabled_wap_materialize_uses_graphql_launch_and_retains_a_rejected_bran
     monkeypatch,
 ) -> None:
     cleaned: list[bool] = []
+    records: list[dict[str, str | None]] = []
 
     class Launch:
         logical_run_id = "request-42"
@@ -140,6 +141,10 @@ def test_enabled_wap_materialize_uses_graphql_launch_and_retains_a_rejected_bran
 
         def cleanup_if_created(self) -> None:
             cleaned.append(True)
+
+        def record_launch_result(self, **kwargs) -> bool:
+            records.append(kwargs)
+            return True
 
     async def rejected_launch(**kwargs):
         assert kwargs["asset_key_path"] == "dlt_orders"
@@ -185,12 +190,14 @@ def test_enabled_wap_materialize_uses_graphql_launch_and_retains_a_rejected_bran
     assert result.exit_code != 0
     assert "Dagster rejected run" in result.output
     assert cleaned == []
+    assert records == [{"status": "launch_rejected", "error": "Dagster rejected run"}]
 
 
 def test_enabled_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
     monkeypatch,
 ) -> None:
     cleaned: list[bool] = []
+    records: list[dict[str, str | None]] = []
 
     class Launch:
         logical_run_id = "request-42"
@@ -203,6 +210,10 @@ def test_enabled_wap_materialize_retains_new_branch_after_ambiguous_transport_fa
 
         def cleanup_if_created(self) -> None:
             cleaned.append(True)
+
+        def record_launch_result(self, **kwargs) -> bool:
+            records.append(kwargs)
+            return True
 
     async def timeout_launch(**_kwargs):
         raise httpx.ReadTimeout("response lost")
@@ -234,6 +245,8 @@ def test_enabled_wap_materialize_retains_new_branch_after_ambiguous_transport_fa
 
     assert result.exit_code != 0
     assert cleaned == []
+    assert records[0]["status"] == "launch_ambiguous"
+    assert "response lost" in str(records[0]["error"])
 
 
 def test_enabled_wap_materialize_requires_one_explicit_asset(monkeypatch) -> None:
@@ -273,6 +286,9 @@ def test_enabled_wap_materialize_uses_project_configuration(
 
         def cleanup_if_created(self) -> None:
             raise AssertionError("accepted launches retain their branch")
+
+        def record_launch_result(self, **_kwargs) -> bool:
+            return True
 
     async def accepted_launch(**kwargs):
         captured.update(

--- a/packages/phlo-dagster/tests/test_cli_materialize.py
+++ b/packages/phlo-dagster/tests/test_cli_materialize.py
@@ -124,7 +124,7 @@ def test_materialize_can_disable_contract_refresh(mock_project, mock_container) 
     assert "PHLO_AUTO_REFRESH_CONTRACTS=0" in result.output
 
 
-def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
+def test_enabled_wap_materialize_uses_graphql_launch_and_retains_a_rejected_branch(
     monkeypatch,
 ) -> None:
     cleaned: list[bool] = []
@@ -132,7 +132,11 @@ def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
     class Launch:
         logical_run_id = "request-42"
         branch = "pipeline-run-request-42"
-        tags = {"phlo/run_id": logical_run_id, "phlo/wap_branch": branch}
+        tags = {
+            "phlo/run_id": logical_run_id,
+            "phlo/wap_branch": branch,
+            "phlo/ref": branch,
+        }
 
         def cleanup_if_created(self) -> None:
             cleaned.append(True)
@@ -149,6 +153,24 @@ def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
             "Result", (), {"accepted": False, "message": "Dagster rejected run", "run_id": None}
         )()
 
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.load_wap_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "enabled": True,
+                "dagster_url": "http://dagster/graphql",
+                "job_name": "__ASSET_JOB",
+                "repository_location_name": "phlo_dagster",
+                "repository_name": "phlo_dagster",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.uuid.uuid4",
+        lambda: type("ID", (), {"hex": "request-42"})(),
+    )
     monkeypatch.setattr("phlo_dagster.cli_materialize.prepare_wap_launch", lambda **_: Launch())
     monkeypatch.setattr("phlo_dagster.cli_materialize.launch_materialize", rejected_launch)
     monkeypatch.setenv("PHLO_DAGSTER_ACCESS_TOKEN", "user-access-token")
@@ -157,24 +179,15 @@ def test_wap_materialize_uses_graphql_launch_and_cleans_a_rejected_new_branch(
         materialize,
         [
             "dlt_orders",
-            "--wap",
-            "--wap-run-id",
-            "request-42",
-            "--job-name",
-            "__ASSET_JOB",
-            "--repository-location-name",
-            "phlo_dagster",
-            "--repository-name",
-            "phlo_dagster",
         ],
     )
 
     assert result.exit_code != 0
     assert "Dagster rejected run" in result.output
-    assert cleaned == [True]
+    assert cleaned == []
 
 
-def test_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
+def test_enabled_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
     monkeypatch,
 ) -> None:
     cleaned: list[bool] = []
@@ -182,7 +195,11 @@ def test_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
     class Launch:
         logical_run_id = "request-42"
         branch = "pipeline-run-request-42"
-        tags = {"phlo/run_id": logical_run_id, "phlo/wap_branch": branch}
+        tags = {
+            "phlo/run_id": logical_run_id,
+            "phlo/wap_branch": branch,
+            "phlo/ref": branch,
+        }
 
         def cleanup_if_created(self) -> None:
             cleaned.append(True)
@@ -190,6 +207,20 @@ def test_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
     async def timeout_launch(**_kwargs):
         raise httpx.ReadTimeout("response lost")
 
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.load_wap_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "enabled": True,
+                "dagster_url": "http://dagster/graphql",
+                "job_name": "__ASSET_JOB",
+                "repository_location_name": None,
+                "repository_name": None,
+            },
+        )(),
+    )
     monkeypatch.setattr("phlo_dagster.cli_materialize.prepare_wap_launch", lambda **_: Launch())
     monkeypatch.setattr("phlo_dagster.cli_materialize.launch_materialize", timeout_launch)
     monkeypatch.setenv("PHLO_DAGSTER_ACCESS_TOKEN", "user-access-token")
@@ -198,13 +229,6 @@ def test_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
         materialize,
         [
             "dlt_orders",
-            "--wap",
-            "--job-name",
-            "__ASSET_JOB",
-            "--repository-location-name",
-            "phlo_dagster",
-            "--repository-name",
-            "phlo_dagster",
         ],
     )
 
@@ -212,43 +236,27 @@ def test_wap_materialize_retains_new_branch_after_ambiguous_transport_failure(
     assert cleaned == []
 
 
-def test_wap_materialize_requires_a_complete_selector_and_user_credential(monkeypatch) -> None:
+def test_enabled_wap_materialize_requires_one_explicit_asset(monkeypatch) -> None:
     monkeypatch.setattr(
         "phlo_dagster.cli_materialize.prepare_wap_launch",
         lambda **_: (_ for _ in ()).throw(AssertionError("must not create a branch")),
     )
     runner = CliRunner()
 
-    monkeypatch.setenv("PHLO_DAGSTER_ACCESS_TOKEN", "user-access-token")
-    incomplete_selector = runner.invoke(
-        materialize,
-        ["dlt_orders", "--wap", "--job-name", "__ASSET_JOB"],
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.load_wap_config",
+        lambda: type("Config", (), {"enabled": True})(),
     )
-    monkeypatch.delenv("PHLO_DAGSTER_ACCESS_TOKEN")
-    missing_credential = runner.invoke(
-        materialize,
-        [
-            "dlt_orders",
-            "--wap",
-            "--job-name",
-            "__ASSET_JOB",
-            "--repository-location-name",
-            "phlo_dagster",
-            "--repository-name",
-            "phlo_dagster",
-        ],
-    )
+    incomplete_selector = runner.invoke(materialize, ["dlt_orders", "--select", "dlt_orders"])
 
     assert incomplete_selector.exit_code != 0
-    assert "requires --repository-location-name and --repository-name" in incomplete_selector.output
-    assert missing_credential.exit_code != 0
-    assert "requires PHLO_DAGSTER_ACCESS_TOKEN" in missing_credential.output
+    assert "requires one ASSET_NAME" in incomplete_selector.output
 
     help_result = runner.invoke(materialize, ["--help"])
-    assert "--access-token" not in help_result.output
+    assert "--wap" not in help_result.output
 
 
-def test_wap_materialize_resolves_the_required_selector_and_credential_from_environment(
+def test_enabled_wap_materialize_uses_project_configuration(
     monkeypatch,
 ) -> None:
     captured: dict[str, str] = {}
@@ -257,7 +265,11 @@ def test_wap_materialize_resolves_the_required_selector_and_credential_from_envi
     class Launch:
         logical_run_id = "request-42"
         branch = "pipeline-run-request-42"
-        tags = {"phlo/run_id": logical_run_id, "phlo/wap_branch": branch}
+        tags = {
+            "phlo/run_id": logical_run_id,
+            "phlo/wap_branch": branch,
+            "phlo/ref": branch,
+        }
 
         def cleanup_if_created(self) -> None:
             raise AssertionError("accepted launches retain their branch")
@@ -277,9 +289,25 @@ def test_wap_materialize_resolves_the_required_selector_and_credential_from_envi
         assert discovery_calls == [True]
         return Launch()
 
-    monkeypatch.setenv("PHLO_DAGSTER_REPOSITORY_LOCATION_NAME", "phlo_dagster")
-    monkeypatch.setenv("PHLO_DAGSTER_REPOSITORY_NAME", "phlo_dagster")
     monkeypatch.setenv("PHLO_DAGSTER_ACCESS_TOKEN", "verified-user-token")
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.load_wap_config",
+        lambda: type(
+            "Config",
+            (),
+            {
+                "enabled": True,
+                "dagster_url": "http://dagster/graphql",
+                "job_name": "__ASSET_JOB",
+                "repository_location_name": "phlo_dagster",
+                "repository_name": "phlo_dagster",
+            },
+        )(),
+    )
+    monkeypatch.setattr(
+        "phlo_dagster.cli_materialize.uuid.uuid4",
+        lambda: type("ID", (), {"hex": "request-42"})(),
+    )
     monkeypatch.setattr(
         "phlo_dagster.cli_materialize.discover_capabilities", lambda: discovery_calls.append(True)
     )
@@ -288,7 +316,7 @@ def test_wap_materialize_resolves_the_required_selector_and_credential_from_envi
 
     result = CliRunner().invoke(
         materialize,
-        ["dlt_orders", "--wap", "--job-name", "__ASSET_JOB", "--wap-run-id", "request-42"],
+        ["dlt_orders"],
     )
 
     assert result.exit_code == 0, result.output
@@ -296,7 +324,11 @@ def test_wap_materialize_resolves_the_required_selector_and_credential_from_envi
         "repository_location_name": "phlo_dagster",
         "repository_name": "phlo_dagster",
         "access_token": "verified-user-token",
-        "tags": {"phlo/run_id": "request-42", "phlo/wap_branch": "pipeline-run-request-42"},
+        "tags": {
+            "phlo/run_id": "request-42",
+            "phlo/wap_branch": "pipeline-run-request-42",
+            "phlo/ref": "pipeline-run-request-42",
+        },
     }
     assert discovery_calls == [True]
 

--- a/packages/phlo-dagster/tests/test_cli_status.py
+++ b/packages/phlo-dagster/tests/test_cli_status.py
@@ -318,8 +318,13 @@ class TestStatusCLI:
 class TestStatusOutput:
     """Tests for status output formatting."""
 
-    def test_asset_status_empty_when_disconnected(self):
+    def test_asset_status_empty_when_disconnected(self, monkeypatch: pytest.MonkeyPatch):
         """Test that asset status shows empty state when services disconnected."""
+
+        def disconnected(*_args, **_kwargs):
+            raise status_module.requests_exceptions.ConnectionError("Dagster is disconnected")
+
+        monkeypatch.setattr(status_module.http_requests, "post", disconnected)
         runner = CliRunner()
         result = runner.invoke(status, ["--assets"])
 

--- a/packages/phlo-dagster/tests/test_operations.py
+++ b/packages/phlo-dagster/tests/test_operations.py
@@ -47,6 +47,8 @@ def test_launch_materialize_posts_asset_selection(monkeypatch) -> None:
     selector = variables["executionParams"]["selector"]
     assert selector["pipelineName"] == "orders_job"
     assert selector["assetSelection"] == [{"path": ["silver", "orders"]}]
+    assert "repositoryLocationName" not in selector
+    assert "repositoryName" not in selector
 
 
 def test_launch_materialize_uses_the_explicit_user_access_token(monkeypatch) -> None:

--- a/packages/phlo-dagster/tests/test_runtime_image_contract.py
+++ b/packages/phlo-dagster/tests/test_runtime_image_contract.py
@@ -18,6 +18,7 @@ def test_dagster_runtime_image_installs_prerelease_phlo_with_postgres_driver() -
     )
     assert 'uv pip install --system --prerelease explicit "${base_requirements[@]}"' in dockerfile
     assert 'dagster-postgres "psycopg[binary]"' in dockerfile
+    assert 'uv pip install --system "PyJWT[crypto]>=2.13.0" "cryptography>=48.0.1"' in dockerfile
 
 
 def test_dagster_runtime_image_pins_dbt_when_the_provider_version_is_populated() -> None:
@@ -64,3 +65,18 @@ def test_dagster_runtime_entrypoint_installs_mounted_project() -> None:
     assert non_root_message in entrypoint
     assert entrypoint.index("uv pip install --system -e /app") < entrypoint.index(non_root_message)
     assert entrypoint.index("fi\n\n# Execute Dagster") > entrypoint.index(non_root_message)
+
+
+def test_dagster_runtime_entrypoint_exposes_mounted_dev_sources_to_python() -> None:
+    """The unprivileged runtime can import local adapters without installing them."""
+    entrypoint = resources.files("phlo_dagster").joinpath("entrypoint.sh").read_text()
+
+    assert "for source_dir in /opt/phlo-dev/src /opt/phlo-dev/packages/*/src; do" in entrypoint
+    assert 'export PYTHONPATH="$source_dir${PYTHONPATH:+:$PYTHONPATH}"' in entrypoint
+
+
+def test_dagster_service_uses_the_generated_bootstrap_script() -> None:
+    """Generated stacks must use the checked-out entrypoint in dev mode."""
+    service = resources.files("phlo_dagster").joinpath("service.yaml").read_text()
+
+    assert 'entrypoint: ["/bin/bash", "/opt/dagster/entrypoint.sh"]' in service

--- a/packages/phlo-dagster/tests/test_wap_endpoint.py
+++ b/packages/phlo-dagster/tests/test_wap_endpoint.py
@@ -1,0 +1,33 @@
+"""WAP endpoint resolution follows normal Phlo host resolution."""
+
+from types import SimpleNamespace
+
+from phlo.config_schema import WapConfig
+from phlo_dagster.wap_endpoint import resolve_wap_dagster_url
+
+
+def test_local_wap_resolves_dagster_host_and_project_port(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "phlo_dagster.wap_endpoint.resolve_host",
+        lambda host, port, *, port_env_var: ("localhost", 18443),
+    )
+    monkeypatch.setattr(
+        "phlo_dagster.wap_endpoint.get_settings",
+        lambda: SimpleNamespace(dagster_port=10006),
+    )
+
+    assert resolve_wap_dagster_url(WapConfig(enabled=True)) == "http://localhost:18443/graphql"
+
+
+def test_remote_wap_uses_the_explicit_configured_endpoint(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "phlo_dagster.wap_endpoint.resolve_host",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must not resolve remote")),
+    )
+
+    assert (
+        resolve_wap_dagster_url(
+            WapConfig(enabled=True, dagster_url="https://dagster.example.com/graphql")
+        )
+        == "https://dagster.example.com/graphql"
+    )

--- a/packages/phlo-dagster/tests/test_wap_launch.py
+++ b/packages/phlo-dagster/tests/test_wap_launch.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from phlo_dagster.wap_launch import WAP_BRANCH_TAG, WAP_RUN_ID_TAG, prepare_wap_launch
+from phlo_dagster.wap_launch import WAP_BRANCH_TAG, WAP_REF_TAG, WAP_RUN_ID_TAG, prepare_wap_launch
 
 
 class _Catalog:
@@ -49,6 +49,7 @@ def test_prepare_wap_launch_creates_deterministic_branch_and_tags(monkeypatch) -
     assert launch.tags == {
         WAP_RUN_ID_TAG: "request-42",
         WAP_BRANCH_TAG: "pipeline-run-request-42",
+        WAP_REF_TAG: "pipeline-run-request-42",
     }
     assert catalog.created == [("pipeline-run-request-42", "main")]
 

--- a/packages/phlo-dagster/tests/test_wap_launch.py
+++ b/packages/phlo-dagster/tests/test_wap_launch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 from phlo_dagster.wap_launch import WAP_BRANCH_TAG, WAP_REF_TAG, WAP_RUN_ID_TAG, prepare_wap_launch
@@ -32,8 +33,11 @@ class _Catalog:
         return False
 
 
-def test_prepare_wap_launch_creates_deterministic_branch_and_tags(monkeypatch) -> None:
+def test_prepare_wap_launch_creates_deterministic_branch_tags_and_manifest(
+    monkeypatch, tmp_path
+) -> None:
     catalog = _Catalog()
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     monkeypatch.setattr(
         "phlo_dagster.wap_launch.resolve_capability",
         lambda _: SimpleNamespace(
@@ -52,6 +56,19 @@ def test_prepare_wap_launch_creates_deterministic_branch_and_tags(monkeypatch) -
         WAP_REF_TAG: "pipeline-run-request-42",
     }
     assert catalog.created == [("pipeline-run-request-42", "main")]
+    report = json.loads(
+        (tmp_path / ".phlo" / "wap-reports" / "request-42.json").read_text(encoding="utf-8")
+    )
+    assert report["status"] == "branch_created"
+    assert report["branch"] == "pipeline-run-request-42"
+    assert report["launch_tags"] == launch.tags
+
+    launch.record_launch_result(status="launch_ambiguous", error="response lost")
+    updated = json.loads(
+        (tmp_path / ".phlo" / "wap-reports" / "request-42.json").read_text(encoding="utf-8")
+    )
+    assert updated["status"] == "launch_ambiguous"
+    assert updated["launch_error"] == "response lost"
 
 
 def test_prepare_wap_launch_refuses_to_reuse_an_existing_branch(monkeypatch) -> None:

--- a/packages/phlo-dagster/tests/test_wap_launch.py
+++ b/packages/phlo-dagster/tests/test_wap_launch.py
@@ -54,7 +54,7 @@ def test_prepare_wap_launch_creates_deterministic_branch_and_tags(monkeypatch) -
     assert catalog.created == [("pipeline-run-request-42", "main")]
 
 
-def test_prepare_wap_launch_reuses_existing_branch_for_retry(monkeypatch) -> None:
+def test_prepare_wap_launch_refuses_to_reuse_an_existing_branch(monkeypatch) -> None:
     catalog = _Catalog({"main": "main-hash", "pipeline-run-request-42": "old-hash"})
     monkeypatch.setattr(
         "phlo_dagster.wap_launch.resolve_capability",
@@ -64,9 +64,10 @@ def test_prepare_wap_launch_reuses_existing_branch_for_retry(monkeypatch) -> Non
         ),
     )
 
-    launch = prepare_wap_launch(logical_run_id="request-42")
-    launch.cleanup_if_created()
+    import pytest
 
-    assert launch.created_branch is False
+    with pytest.raises(Exception, match="refusing to reuse"):
+        prepare_wap_launch(logical_run_id="request-42")
+
     assert catalog.created == []
     assert catalog.deleted == []

--- a/packages/phlo-dagster/tests/test_wap_sensors.py
+++ b/packages/phlo-dagster/tests/test_wap_sensors.py
@@ -20,6 +20,7 @@ from phlo_dagster.wap_sensors import (
     wap_branch_cleanup_sensor,
     write_wap_report,
 )
+from phlo_dagster.wap_launch import _write_launch_manifest as _write_immutable_launch_manifest
 from phlo.hooks import HookBus
 from phlo.run_evidence import SQLiteRunEvidenceStore
 from phlo.run_evidence.hooks import CoreRunEvidenceHookProvider
@@ -28,6 +29,31 @@ from phlo.run_evidence.hooks import CoreRunEvidenceHookProvider
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _write_launch_manifest(logical_run_id: str, dagster_run_id: str, branch: str) -> None:
+    tags = {
+        "phlo/run_id": logical_run_id,
+        "phlo/wap_branch": branch,
+        "phlo/ref": branch,
+    }
+    checksum = _write_immutable_launch_manifest(
+        logical_run_id=logical_run_id,
+        dagster_run_id=dagster_run_id,
+        branch=branch,
+        tags=tags,
+        source_hash=None,
+        target_hash_before=None,
+    )
+    assert checksum is not None
+    write_wap_report(
+        logical_run_id,
+        status="launched",
+        branch=branch,
+        dagster_run_id=dagster_run_id,
+        launch_tags=tags,
+        launch_manifest_checksum=checksum,
+    )
 
 
 def test_wap_branch_name():
@@ -75,7 +101,7 @@ def test_write_wap_report_keeps_identity_fields_and_ignores_write_failure(
 
     payload = json.loads((tmp_path / ".phlo" / "wap-reports" / "run-1.json").read_text())
     assert payload["run_id"] == "run-1"
-    assert payload["schema_version"] == "phlo.wap_report.v1"
+    assert payload["schema_version"] == "phlo.wap_report.v2"
     assert payload["updated_at"] != "wrong"
 
     def raise_write_error(*args, **kwargs):
@@ -299,14 +325,8 @@ def test_wap_successful_promotion_uses_recorded_check_event_identity(monkeypatch
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     dagster_run_id = "run-promote"
     logical_run_id = "logical-promote"
-    branch = _wap_branch_name(dagster_run_id)
-    write_wap_report(
-        dagster_run_id,
-        status="branch_created",
-        branch=branch,
-        project_id="project-promote",
-        attempt=1,
-    )
+    branch = _wap_branch_name(logical_run_id)
+    _write_launch_manifest(logical_run_id, dagster_run_id, branch)
 
     check_record = SimpleNamespace(
         storage_id=42,
@@ -321,6 +341,7 @@ def test_wap_successful_promotion_uses_recorded_check_event_identity(monkeypatch
             tags={
                 "phlo/wap_branch": branch,
                 "phlo/run_id": logical_run_id,
+                "phlo/ref": branch,
                 "phlo/project_id": "project-promote",
                 "phlo/attempt": "1",
             },
@@ -357,6 +378,11 @@ def test_wap_successful_promotion_uses_recorded_check_event_identity(monkeypatch
     catalog.merge_branch.assert_called_once_with(source=branch, target="main")
     query_catalog_manager.drop_ref_query_catalog.assert_called_once_with(branch)
     catalog.delete_branch.assert_called_once_with(branch)
+    manifest = json.loads(
+        (tmp_path / ".phlo" / "wap-reports" / f"{logical_run_id}.json").read_text()
+    )
+    assert manifest["status"] == "promoted"
+    assert not (tmp_path / ".phlo" / "wap-reports" / f"{dagster_run_id}.json").exists()
     quality_rows = store.list_quality_results("project-promote", logical_run_id, attempt=1)
     quality_id = next(row["quality_result_id"] for row in quality_rows)
     assert quality_id in {row["quality_result_id"] for row in quality_rows}
@@ -381,10 +407,13 @@ def test_wap_quality_rejection_retains_owned_query_catalog_and_branch(monkeypatc
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     run_id = "run-rejected"
     branch = _wap_branch_name(run_id)
+    _write_launch_manifest(run_id, run_id, branch)
     run = SimpleNamespace(
         run_id=run_id,
         tags={
             "phlo/wap_branch": branch,
+            "phlo/run_id": run_id,
+            "phlo/ref": branch,
             "phlo/project_id": "project-rejected",
             "phlo/attempt": "1",
         },
@@ -416,15 +445,46 @@ def test_wap_quality_rejection_retains_owned_query_catalog_and_branch(monkeypatc
     assert payload["failure_reason"] == "asset_checks_failed"
 
 
+def test_wap_promotion_rejects_mutated_ref_tag(monkeypatch, tmp_path):
+    """A run may promote only the exact branch recorded before GraphQL submission."""
+    monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
+    logical_run_id = "logical-mutated"
+    dagster_run_id = "run-mutated"
+    branch = _wap_branch_name(logical_run_id)
+    _write_launch_manifest(logical_run_id, dagster_run_id, branch)
+    run = SimpleNamespace(
+        run_id=dagster_run_id,
+        tags={
+            "phlo/run_id": logical_run_id,
+            "phlo/wap_branch": branch,
+            "phlo/ref": "pipeline-run-other",
+        },
+    )
+    instance = MagicMock()
+    instance.get_runs.return_value = [run]
+    catalog = MagicMock()
+    monkeypatch.setattr("phlo_dagster.wap_sensors._load_versioned_catalog", lambda: catalog)
+    context = MagicMock(instance=instance, cursor=None)
+
+    wap_auto_promotion_sensor._raw_fn(context)
+
+    catalog.merge_branch.assert_not_called()
+    report = json.loads((tmp_path / ".phlo" / "wap-reports" / f"{logical_run_id}.json").read_text())
+    assert report["failure_reason"] == "launch_manifest_or_immutable_tags_invalid"
+
+
 def test_wap_cleanup_keeps_branch_when_query_catalog_cleanup_fails(monkeypatch, tmp_path):
     """A manager failure does not report or perform completed branch cleanup."""
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     run_id = "run-catalog-failure"
     branch = _wap_branch_name(run_id)
+    _write_launch_manifest(run_id, run_id, branch)
     run = SimpleNamespace(
         run_id=run_id,
         tags={
             "phlo/wap_branch": branch,
+            "phlo/run_id": run_id,
+            "phlo/ref": branch,
             "phlo/project_id": "project-catalog-failure",
             "phlo/attempt": "1",
         },
@@ -599,11 +659,13 @@ def test_wap_merge_failure_preserves_successful_dagster_run_status(monkeypatch, 
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     run_id = "run-merge-failure"
     branch = _wap_branch_name(run_id)
-    write_wap_report(run_id, status="branch_created", branch=branch)
+    _write_launch_manifest(run_id, run_id, branch)
     run = SimpleNamespace(
         run_id=run_id,
         tags={
             "phlo/wap_branch": branch,
+            "phlo/run_id": run_id,
+            "phlo/ref": branch,
             "phlo/project_id": "project-merge-failure",
             "phlo/attempt": "1",
         },
@@ -672,7 +734,8 @@ def test_wap_project_identity_requires_authoritative_agreement(
 
 def test_wap_cleanup_uses_authoritative_terminated_run_status(monkeypatch, tmp_path):
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
-    branch_name = _wap_branch_name("run-cleanup")
+    logical_run_id = "logical-cleanup"
+    branch_name = _wap_branch_name(logical_run_id)
     branch = SimpleNamespace(
         name=branch_name,
         created_at=datetime.now(timezone.utc) - timedelta(hours=25),
@@ -683,6 +746,7 @@ def test_wap_cleanup_uses_authoritative_terminated_run_status(monkeypatch, tmp_p
         status=dg.DagsterRunStatus.SUCCESS,
         tags={"phlo/project_id": "project-cleanup", "phlo/attempt": "2"},
     )
+    _write_launch_manifest(logical_run_id, dagster_run.run_id, branch_name)
     instance = MagicMock()
     instance.get_run_by_id.return_value = dagster_run
     catalog = MagicMock()

--- a/packages/phlo-dagster/tests/test_wap_sensors.py
+++ b/packages/phlo-dagster/tests/test_wap_sensors.py
@@ -376,8 +376,8 @@ def test_wap_successful_promotion_uses_recorded_check_event_identity(monkeypatch
     )
 
 
-def test_wap_quality_rejection_cleans_owned_query_catalog_before_branch(monkeypatch, tmp_path):
-    """A rejected quality decision removes the WAP ref and its owned catalog."""
+def test_wap_quality_rejection_retains_owned_query_catalog_and_branch(monkeypatch, tmp_path):
+    """A rejected quality decision retains the WAP ref for audit."""
     monkeypatch.setenv("PHLO_PROJECT_PATH", str(tmp_path))
     run_id = "run-rejected"
     branch = _wap_branch_name(run_id)
@@ -393,7 +393,6 @@ def test_wap_quality_rejection_cleans_owned_query_catalog_before_branch(monkeypa
     instance.get_runs.return_value = [run]
     instance.get_records_for_run.return_value = SimpleNamespace(records=[_FakeRecord(passed=False)])
     catalog = MagicMock()
-    catalog.delete_branch.return_value = True
     query_catalog_manager = MagicMock()
     monkeypatch.setattr("phlo_dagster.wap_sensors._load_versioned_catalog", lambda: catalog)
     monkeypatch.setattr(
@@ -410,11 +409,11 @@ def test_wap_quality_rejection_cleans_owned_query_catalog_before_branch(monkeypa
     wap_auto_promotion_sensor._raw_fn(context)
 
     catalog.merge_branch.assert_not_called()
-    query_catalog_manager.drop_ref_query_catalog.assert_called_once_with(branch)
-    catalog.delete_branch.assert_called_once_with(branch)
+    query_catalog_manager.drop_ref_query_catalog.assert_not_called()
+    catalog.delete_branch.assert_not_called()
     payload = json.loads((tmp_path / ".phlo" / "wap-reports" / f"{run_id}.json").read_text())
-    assert payload["status"] == "rejected"
-    assert payload["cleanup_complete"] is True
+    assert payload["status"] == "promotion_blocked"
+    assert payload["failure_reason"] == "asset_checks_failed"
 
 
 def test_wap_cleanup_keeps_branch_when_query_catalog_cleanup_fails(monkeypatch, tmp_path):

--- a/packages/phlo-testing/src/phlo_testing/profile_harness.py
+++ b/packages/phlo-testing/src/phlo_testing/profile_harness.py
@@ -1408,6 +1408,7 @@ QualityResultEventEmitter(
 
         tags: dict[str, str] = {
             "phlo/wap_branch": branch_name,
+            "phlo/ref": branch_name,
             "phlo/run_id": logical_run_id,
             "phlo/project_id": self.project_dir.name,
             "phlo/attempt": "1",

--- a/src/phlo/cli/commands/services/init.py
+++ b/src/phlo/cli/commands/services/init.py
@@ -77,6 +77,41 @@ def _load_existing_project_config(config_file: Path) -> dict:
     return project_config
 
 
+def _get_service_overrides(project_config: dict) -> dict[str, dict]:
+    """Read service overrides from the canonical infrastructure block.
+
+    ``services`` at the top level predates ``infrastructure.services`` and is
+    retained for compatibility.  The infrastructure form is authoritative when
+    both configure the same service, which lets operators keep all container
+    configuration in one block.
+    """
+    legacy = project_config.get("services", {})
+    infrastructure = project_config.get("infrastructure", {})
+    canonical = infrastructure.get("services", {}) if isinstance(infrastructure, dict) else {}
+    if not isinstance(legacy, dict) or not isinstance(canonical, dict):
+        raise user_error(
+            "invalid phlo.yaml",
+            details={"services": "must be a mapping"},
+        )
+
+    overrides: dict[str, dict] = {}
+    for service_name in set(legacy) | set(canonical):
+        if not isinstance(service_name, str) or not service_name:
+            raise user_error(
+                "invalid phlo.yaml",
+                details={"services": "service names must be non-empty strings"},
+            )
+        legacy_value = legacy.get(service_name, {})
+        canonical_value = canonical.get(service_name, {})
+        if not isinstance(legacy_value, dict) or not isinstance(canonical_value, dict):
+            raise user_error(
+                "invalid phlo.yaml",
+                details={"services": f"{service_name} must be a mapping"},
+            )
+        overrides[service_name] = {**legacy_value, **canonical_value}
+    return overrides
+
+
 def _validate_production_credentials(
     env_overrides: dict,
     existing_local_values: dict[str, str],
@@ -286,7 +321,10 @@ def init_cmd(
     existing_config = {}
     if config_file.exists():
         existing_config = _load_existing_project_config(config_file)
-    user_overrides = existing_config.get("services", {})
+    user_overrides = _get_service_overrides(existing_config)
+    # Service selection and inline-service discovery use the same effective
+    # overrides as Compose generation.
+    existing_config["services"] = user_overrides
     env_overrides = _get_env_overrides(existing_config)
     existing_env_local = parse_env_file(phlo_dir / ".env.local")
     if production:

--- a/src/phlo/config_schema.py
+++ b/src/phlo/config_schema.py
@@ -55,6 +55,46 @@ class ApiConfig(BaseModel):
     )
 
 
+class WapConfig(BaseModel):
+    """Project-level Write-Audit-Publish launch configuration.
+
+    WAP is deliberately a project policy rather than a per-invocation switch:
+    enabling it makes every Phlo materialize or backfill launch branch-first.
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Launch materialize and backfill runs through the WAP GraphQL lifecycle.",
+    )
+    job_name: str = Field(
+        default="__ASSET_JOB",
+        description="Dagster asset job used for WAP launches.",
+    )
+    repository_location_name: str | None = Field(
+        default=None,
+        description="Optional Dagster code-location selector for WAP launches.",
+    )
+    repository_name: str | None = Field(
+        default=None,
+        description="Optional Dagster repository selector for WAP launches.",
+    )
+    dagster_url: str = Field(
+        default="http://localhost:10006/graphql",
+        description="Dagster GraphQL endpoint used for WAP launches.",
+    )
+
+    @field_validator("job_name", "repository_location_name", "repository_name", "dagster_url")
+    @classmethod
+    def validate_nonblank(cls, value: str | None) -> str | None:
+        """Normalize optional selectors and reject empty required settings."""
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("WAP string settings cannot be empty")
+        return normalized
+
+
 class ServiceOverride(BaseModel):
     """User overrides for a service in phlo.yaml.
 

--- a/src/phlo/config_schema.py
+++ b/src/phlo/config_schema.py
@@ -7,8 +7,9 @@ Pydantic models for phlo.yaml infrastructure section.
 from __future__ import annotations
 
 from typing import Any, Literal
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ApiAuthorizationConfig(BaseModel):
@@ -62,6 +63,8 @@ class WapConfig(BaseModel):
     enabling it makes every Phlo materialize or backfill launch branch-first.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     enabled: bool = Field(
         default=False,
         description="Launch materialize and backfill runs through the WAP GraphQL lifecycle.",
@@ -83,7 +86,7 @@ class WapConfig(BaseModel):
         description="Dagster GraphQL endpoint used for WAP launches.",
     )
 
-    @field_validator("job_name", "repository_location_name", "repository_name", "dagster_url")
+    @field_validator("job_name", "repository_location_name", "repository_name")
     @classmethod
     def validate_nonblank(cls, value: str | None) -> str | None:
         """Normalize optional selectors and reject empty required settings."""
@@ -93,6 +96,31 @@ class WapConfig(BaseModel):
         if not normalized:
             raise ValueError("WAP string settings cannot be empty")
         return normalized
+
+    @field_validator("dagster_url")
+    @classmethod
+    def validate_dagster_url(cls, value: str) -> str:
+        """Allow plaintext GraphQL only for local development endpoints."""
+        normalized = value.strip()
+        parsed = urlparse(normalized)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+            or parsed.path.rstrip("/") != "/graphql"
+        ):
+            raise ValueError("dagster_url must be an absolute HTTP(S) GraphQL endpoint")
+        if parsed.scheme == "http" and parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
+            raise ValueError("dagster_url must use HTTPS unless it targets localhost")
+        return normalized
+
+    @property
+    def requires_access_token(self) -> bool:
+        """Whether this endpoint is remote and must use explicit bearer authentication."""
+        return urlparse(self.dagster_url).hostname not in {"localhost", "127.0.0.1", "::1"}
 
 
 class ServiceOverride(BaseModel):

--- a/src/phlo/config_schema.py
+++ b/src/phlo/config_schema.py
@@ -81,9 +81,9 @@ class WapConfig(BaseModel):
         default=None,
         description="Optional Dagster repository selector for WAP launches.",
     )
-    dagster_url: str = Field(
-        default="http://localhost:10006/graphql",
-        description="Dagster GraphQL endpoint used for WAP launches.",
+    dagster_url: str | None = Field(
+        default=None,
+        description="Optional remote Dagster GraphQL endpoint used for WAP launches.",
     )
 
     @field_validator("job_name", "repository_location_name", "repository_name")
@@ -99,8 +99,10 @@ class WapConfig(BaseModel):
 
     @field_validator("dagster_url")
     @classmethod
-    def validate_dagster_url(cls, value: str) -> str:
+    def validate_dagster_url(cls, value: str | None) -> str | None:
         """Allow plaintext GraphQL only for local development endpoints."""
+        if value is None:
+            return None
         normalized = value.strip()
         parsed = urlparse(normalized)
         if (
@@ -120,7 +122,11 @@ class WapConfig(BaseModel):
     @property
     def requires_access_token(self) -> bool:
         """Whether this endpoint is remote and must use explicit bearer authentication."""
-        return urlparse(self.dagster_url).hostname not in {"localhost", "127.0.0.1", "::1"}
+        return self.dagster_url is not None and urlparse(self.dagster_url).hostname not in {
+            "localhost",
+            "127.0.0.1",
+            "::1",
+        }
 
 
 class ServiceOverride(BaseModel):

--- a/src/phlo/config_schema.py
+++ b/src/phlo/config_schema.py
@@ -89,6 +89,10 @@ class ServiceOverride(BaseModel):
         default=None,
         description="Volume mounts to add (appended to package defaults).",
     )
+    extra_hosts: list[str] | None = Field(
+        default=None,
+        description="Compose host mappings to add or replace for this service.",
+    )
     depends_on: list[str] | None = Field(
         default=None,
         description="Service dependencies to override (replaces package defaults).",
@@ -119,6 +123,22 @@ class ServiceOverride(BaseModel):
         default=None,
         description="Healthcheck configuration for inline services.",
     )
+
+    @field_validator("extra_hosts")
+    @classmethod
+    def validate_extra_hosts(cls, value: list[str] | None) -> list[str] | None:
+        """Require non-empty Docker Compose host-to-address mappings."""
+        if value is None:
+            return value
+        for mapping in value:
+            if not isinstance(mapping, str) or not mapping.strip():
+                raise ValueError("extra_hosts mappings must be non-empty")
+            host, separator, address = mapping.strip().partition("=")
+            if not separator:
+                host, separator, address = mapping.strip().partition(":")
+            if not separator or not host.strip() or not address.strip():
+                raise ValueError("extra_hosts entries must be Compose host mappings")
+        return [mapping.strip() for mapping in value]
 
 
 class ServiceConfig(BaseModel):

--- a/src/phlo/infrastructure/__init__.py
+++ b/src/phlo/infrastructure/__init__.py
@@ -16,6 +16,7 @@ from phlo.infrastructure.config import (
     get_service_config,
     load_infrastructure_config,
     load_project_config,
+    load_wap_config,
 )
 from phlo.infrastructure.containers import (
     find_service_container,
@@ -36,6 +37,7 @@ __all__ = [
     "get_regulated_mode_config",
     "clear_config_cache",
     "load_project_config",
+    "load_wap_config",
     "resolve_container_name",
     "list_running_containers",
     "select_first_existing",

--- a/src/phlo/infrastructure/config.py
+++ b/src/phlo/infrastructure/config.py
@@ -20,6 +20,7 @@ from phlo.config_schema import (
     ApiConfig,
     InfrastructureConfig,
     ServiceConfig,
+    WapConfig,
 )
 from phlo.logging import get_logger
 
@@ -132,6 +133,21 @@ def load_infrastructure_config(project_root: Path) -> InfrastructureConfig:
             error=str(exc),
         )
         raise
+
+
+@project_root_cached
+def load_wap_config(project_root: Path | None = None) -> WapConfig:
+    """Load the project-level WAP policy from ``phlo.yaml``.
+
+    Keeping this separate from infrastructure configuration makes the policy
+    available to both the host CLI and the Dagster process running in ``/app``.
+    """
+    root = project_root or _default_project_root()
+    project_config = load_project_config(root)
+    wap_config = project_config.get("wap", {}) if project_config else {}
+    if wap_config is None:
+        wap_config = {}
+    return WapConfig(**wap_config)
 
 
 def get_project_name_from_config(project_root: Path | None = None) -> str | None:
@@ -379,3 +395,4 @@ def clear_config_cache() -> None:
     """Clear the configuration cache."""
     load_project_config.cache_clear()
     load_infrastructure_config.cache_clear()
+    load_wap_config.cache_clear()

--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -287,6 +287,11 @@ class ComposeGenerator:
             # `phlo_src_path` points at `.../src/phlo`, so `../..` is the repo root.
             project_mount = f"{phlo_src_path}/../..:/opt/phlo-dev:rw"
             config["volumes"].append(project_mount)
+            # Do not silently reuse a published service image in a development
+            # stack: it cannot include the checked-out adapter's runtime
+            # dependencies. With no explicit image Compose builds the generated
+            # Dockerfile before starting the mounted source tree.
+            config.pop("image", None)
             # Add environment variable to enable dev mode sync
             if "environment" not in config:
                 config["environment"] = {}

--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -13,6 +13,7 @@ from typing import Any, Literal
 
 import yaml
 
+from phlo.config_schema import ServiceOverride
 from phlo.logging import get_logger
 from phlo.plugins.compose.env import (
     generate_env as _generate_env,
@@ -398,6 +399,10 @@ class ComposeGenerator:
         if not user_override:
             return
 
+        # `services init` reads raw project YAML, so validate it here as well as
+        # in `phlo config validate` before it reaches Docker Compose.
+        user_override = ServiceOverride.model_validate(user_override).model_dump(exclude_none=True)
+
         # Ports: replace
         if user_override.get("ports"):
             config["ports"] = user_override["ports"]
@@ -416,6 +421,10 @@ class ComposeGenerator:
         if user_override.get("volumes"):
             config.setdefault("volumes", [])
             config["volumes"].extend(user_override["volumes"])
+
+        # Extra hosts: replace package defaults with explicit project routing.
+        if "extra_hosts" in user_override:
+            config["extra_hosts"] = list(user_override["extra_hosts"])
 
         # Depends on: replace
         if user_override.get("depends_on"):

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -234,6 +234,31 @@ def test_service_override_renders_valid_extra_hosts_and_rejects_blank_mappings(t
     )
 
 
+def test_infrastructure_service_overrides_are_used_for_compose_generation() -> None:
+    """The documented infrastructure.services path reaches the Compose generator."""
+    from phlo.cli.commands.services.init import _get_service_overrides
+
+    overrides = _get_service_overrides(
+        {
+            "services": {"dagster": {"environment": {"LEGACY": "true"}}},
+            "infrastructure": {
+                "services": {
+                    "dagster": {
+                        "extra_hosts": ["host.docker.internal:host-gateway"],
+                    }
+                }
+            },
+        }
+    )
+
+    assert overrides == {
+        "dagster": {
+            "environment": {"LEGACY": "true"},
+            "extra_hosts": ["host.docker.internal:host-gateway"],
+        }
+    }
+
+
 def test_nessie_compose_uses_project_warehouse_location(tmp_path) -> None:
     discovery = ServiceDiscovery()
     nessie = discovery.get_service("nessie")

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -388,6 +388,33 @@ def test_compose_generator_injects_phlo_dev_mounts(tmp_path) -> None:
     assert "PHLO_DEV_MODE" in compose
 
 
+def test_compose_generator_dev_mode_builds_phlo_services_from_source(tmp_path) -> None:
+    """Dev stacks must not start an incomplete published Dagster image."""
+    service = ServiceDefinition(
+        name="dagster",
+        description="dagster",
+        category="orchestration",
+        default=True,
+        phlo_dev=True,
+        image="ghcr.io/phlohouse/phlo-dagster:0.6.0",
+        build={"context": ".", "dockerfile": "dagster/Dockerfile"},
+        compose={},
+    )
+
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery()))
+    compose = yaml.safe_load(
+        generator.generate_compose(
+            services=[service],
+            output_dir=tmp_path,
+            dev_mode=True,
+            phlo_src_path="../phlo/src/phlo",
+        )
+    )
+
+    assert "image" not in compose["services"]["dagster"]
+    assert compose["services"]["dagster"]["build"]["dockerfile"] == "dagster/Dockerfile"
+
+
 @pytest.mark.parametrize("service_name", ["dagster", "dagster-daemon"])
 @pytest.mark.parametrize(
     ("host_platform", "expected_user", "expected_home"),

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -9,9 +9,11 @@ import click
 import pytest
 import yaml
 from click.testing import CliRunner
+from pydantic import ValidationError
 
 from phlo.cli.commands.services.utils import detect_phlo_source_path
 from phlo.cli.infrastructure.selection import select_services_to_install
+from phlo.config_schema import ServiceOverride
 from phlo.plugins.compose import generator as generator_module
 from phlo.plugins.compose.env import generate_env, generate_env_local
 from phlo.plugins.compose.generator import ComposeGenerator
@@ -200,6 +202,36 @@ def test_conditional_environment_list_is_not_mutated_between_renders(tmp_path) -
         "EXISTING=value",
         "CONDITIONAL_VALUE=enabled",
     ]
+
+
+def test_service_override_renders_valid_extra_hosts_and_rejects_blank_mappings(tmp_path) -> None:
+    """A service can reach a host-only dependency through Compose host-gateway mapping."""
+    service = _service("dagster", default=True)
+    generator = ComposeGenerator(cast(ServiceDiscovery, FakeDiscovery({service.name: service})))
+
+    rendered = yaml.safe_load(
+        generator.generate_compose(
+            [service],
+            output_dir=tmp_path,
+            user_overrides={"dagster": {"extra_hosts": ["host.docker.internal:host-gateway"]}},
+        )
+    )
+
+    assert rendered["services"]["dagster"]["extra_hosts"] == ["host.docker.internal:host-gateway"]
+    with pytest.raises(ValidationError, match="extra_hosts mappings must be non-empty"):
+        ServiceOverride(extra_hosts=["  "])
+    with pytest.raises(ValidationError, match="extra_hosts mappings must be non-empty"):
+        generator.generate_compose(
+            [service],
+            output_dir=tmp_path,
+            user_overrides={"dagster": {"extra_hosts": ["  "]}},
+        )
+    assert (
+        "extra_hosts"
+        not in yaml.safe_load(generator.generate_compose([service], output_dir=tmp_path))[
+            "services"
+        ]["dagster"]
+    )
 
 
 def test_nessie_compose_uses_project_warehouse_location(tmp_path) -> None:

--- a/tests/contracts/test_bundled_stack_versioned_contract.py
+++ b/tests/contracts/test_bundled_stack_versioned_contract.py
@@ -28,6 +28,7 @@ def test_bundled_stack_versioned_flow_uses_isolated_branch_then_promotes(
 
     run_tags = bundled_stack_harness.get_run_tags(run_id)
     assert run_tags.get("phlo/wap_branch") == branch_name
+    assert run_tags.get("phlo/ref") == branch_name
     assert run_tags.get("phlo/project_id") == bundled_stack_harness.project_dir.name
     assert run_tags.get("phlo/run_id") == branch_name.removeprefix("pipeline-run-")
     assert run_tags.get("phlo/attempt") == "1"

--- a/tests/runtime/test_definitions.py
+++ b/tests/runtime/test_definitions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import dagster as dg
@@ -129,22 +130,28 @@ def test_build_definitions_merges_wap_sensors_when_versioned_catalog_present() -
 
 
 def test_wap_sensors_dev_flag_requires_truthy_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Falsy PHLO_WAP_SENSORS_ENABLED values should still skip WAP sensors in dev."""
+    """An absent project WAP policy skips sensors even in dev."""
     monkeypatch.setenv("PHLO_DAGSTER_DEV", "1")
     monkeypatch.setenv("PHLO_WAP_SENSORS_ENABLED", "false")
 
-    with patch("phlo_dagster.framework.definitions.resolve_capability") as resolve_capability:
+    with (
+        patch(
+            "phlo_dagster.framework.definitions.load_wap_config",
+            return_value=SimpleNamespace(enabled=False),
+        ),
+        patch("phlo_dagster.framework.definitions.resolve_capability") as resolve_capability,
+    ):
         from phlo_dagster.framework.definitions import _collect_wap_definitions
 
         assert _collect_wap_definitions() is None
         resolve_capability.assert_not_called()
 
 
-def test_wap_sensors_can_be_disabled_in_config() -> None:
+def test_wap_sensors_can_be_disabled_in_project_config() -> None:
     with (
         patch(
-            "phlo_dagster.framework.definitions.get_settings",
-            return_value=_Settings(phlo_wap_enabled=False),
+            "phlo_dagster.framework.definitions.load_wap_config",
+            return_value=SimpleNamespace(enabled=False),
         ),
         patch("phlo_dagster.framework.definitions.resolve_capability") as resolve_capability,
     ):

--- a/tests/runtime/test_infrastructure_config.py
+++ b/tests/runtime/test_infrastructure_config.py
@@ -329,7 +329,7 @@ wap:
   job_name: project_asset_job
   repository_location_name: user_code
   repository_name: user_repository
-  dagster_url: http://dagster.internal/graphql
+  dagster_url: https://dagster.internal/graphql
 """,
         encoding="utf-8",
     )
@@ -340,7 +340,25 @@ wap:
     assert config.job_name == "project_asset_job"
     assert config.repository_location_name == "user_code"
     assert config.repository_name == "user_repository"
-    assert config.dagster_url == "http://dagster.internal/graphql"
+    assert config.dagster_url == "https://dagster.internal/graphql"
+    assert config.requires_access_token is True
+
+
+def test_load_wap_config_fails_closed_for_typos_and_insecure_remote_endpoints(
+    tmp_path: Path,
+) -> None:
+    """A typo must not silently disable the WAP policy or downgrade transport security."""
+    (tmp_path / "phlo.yaml").write_text(
+        """\
+wap:
+  enabledd: true
+  dagster_url: http://dagster.internal/graphql
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValidationError):
+        load_wap_config(tmp_path)
 
 
 def test_load_infrastructure_config_empty_file_returns_defaults(tmp_path: Path):

--- a/tests/runtime/test_infrastructure_config.py
+++ b/tests/runtime/test_infrastructure_config.py
@@ -19,6 +19,7 @@ from phlo.infrastructure import (
     get_service_config,
     load_infrastructure_config,
     load_project_config,
+    load_wap_config,
 )
 from phlo.infrastructure.config import get_api_authorization_config
 from phlo.security.mode import is_regulated, is_regulated_mode_enabled
@@ -317,6 +318,29 @@ def test_load_infrastructure_config_missing_file_returns_defaults(tmp_path: Path
     assert config.container_naming_pattern == "{project}-{service}-1"
     assert config.services == {}
     assert config.network.driver == "bridge"
+
+
+def test_load_wap_config_reads_the_project_policy(tmp_path: Path) -> None:
+    """WAP launch selection is an explicit project-level phlo.yaml setting."""
+    (tmp_path / "phlo.yaml").write_text(
+        """\
+wap:
+  enabled: true
+  job_name: project_asset_job
+  repository_location_name: user_code
+  repository_name: user_repository
+  dagster_url: http://dagster.internal/graphql
+""",
+        encoding="utf-8",
+    )
+
+    config = load_wap_config(tmp_path)
+
+    assert config.enabled is True
+    assert config.job_name == "project_asset_job"
+    assert config.repository_location_name == "user_code"
+    assert config.repository_name == "user_repository"
+    assert config.dagster_url == "http://dagster.internal/graphql"
 
 
 def test_load_infrastructure_config_empty_file_returns_defaults(tmp_path: Path):

--- a/tests/runtime/test_infrastructure_config.py
+++ b/tests/runtime/test_infrastructure_config.py
@@ -361,6 +361,16 @@ wap:
         load_wap_config(tmp_path)
 
 
+def test_load_wap_config_uses_service_resolution_when_no_remote_url_is_set(tmp_path: Path) -> None:
+    (tmp_path / "phlo.yaml").write_text("wap:\n  enabled: true\n", encoding="utf-8")
+
+    config = load_wap_config(tmp_path)
+
+    assert config.enabled is True
+    assert config.dagster_url is None
+    assert config.requires_access_token is False
+
+
 def test_load_infrastructure_config_empty_file_returns_defaults(tmp_path: Path):
     """Empty phlo.yaml should return default infrastructure config."""
     config_path = tmp_path / "phlo.yaml"


### PR DESCRIPTION
## Summary

- Adds Docker Compose `extra_hosts` service overrides, including the documented `infrastructure.services` configuration path.
- Makes WAP an explicit project-level `phlo.yaml` policy for both materialization and partition backfill.
- Resolves local Dagster through Phlo service resolution; `dagster_url` is reserved for explicit remote endpoints.
- Creates a fresh WAP branch before each GraphQL launch, records immutable branch/ref metadata, and retains audit evidence for rejected, ambiguous, or failed outcomes.
- Builds the development Dagster image with the dependencies needed for bootstrap.

## Validation

- Python typecheck passed.
- Focused WAP, materialize, backfill, configuration, and service-override tests passed.
- Docker Compose host-mapping acceptance test passed.
- The disconnected-status regression now explicitly isolates its Dagster request and passes.

Full-suite CI remains the final green gate.
