### PR TITLE
ci: run container security checks nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Validate v1 support boundary
         run: python3 scripts/validate_support_manifest.py
 
-      - name: Lint workflows with zizmor
-        run: make zizmor
-
       - name: Lint workflows with actionlint
         run: make actionlint
 

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -1,12 +1,12 @@
 name: Container Security
 
 on:
-  pull_request:
-    branches: [main]
   workflow_dispatch:
+  schedule:
+    - cron: "10 2 * * *"
 
 concurrency:
-  group: container-security-${{ github.event.pull_request.number || github.ref }}
+  group: container-security-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -46,13 +46,11 @@ jobs:
         with:
           version: "0.12.1"
       - id: images
-        name: Detect affected images
-        env:
-          BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+        name: Select generated service images
         shell: bash
         run: |
           set -euo pipefail
-          matrix="$(uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py affected-images --base "$BASE")"
+          matrix="$(uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py affected-images --all)"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           if [ "$(jq '.include | length' <<< "$matrix")" -gt 0 ]; then echo "has_images=true" >> "$GITHUB_OUTPUT"; else echo "has_images=false" >> "$GITHUB_OUTPUT"; fi
 
@@ -69,7 +67,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
-      - name: Lint changed Dockerfile
+      - name: Lint generated-service Dockerfile
         run: docker run --rm -i hadolint/hadolint@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e < "${{ matrix.target.package }}/${{ matrix.target.dockerfile }}"
 
   generated-files:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,17 @@ permissions:
   contents: read
 
 jobs:
+  workflow-hardening:
+    name: security / workflow hardening
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Audit workflow security with zizmor
+        run: make zizmor
+
   python-dependencies:
     name: security / python dependencies
     runs-on: ubuntu-latest

--- a/scripts/container_security.py
+++ b/scripts/container_security.py
@@ -243,7 +243,13 @@ def main() -> int:
     render.add_argument("--register", type=Path, default=Path("security/container-waivers.yml"))
     render.add_argument("--output", type=Path, default=Path("security/container-waivers.md"))
     affected = sub.add_parser("affected-images")
-    affected.add_argument("--base", required=True)
+    changed_scope = affected.add_mutually_exclusive_group(required=True)
+    changed_scope.add_argument("--base")
+    changed_scope.add_argument(
+        "--all",
+        action="store_true",
+        help="Return every generated service image for the nightly validation lane.",
+    )
     affected.add_argument("--head", default="HEAD")
     policy = sub.add_parser("apply-policy")
     policy.add_argument("--register", type=Path, default=Path("security/container-waivers.yml"))
@@ -251,9 +257,12 @@ def main() -> int:
     policy.add_argument("--report", type=Path, required=True)
     args = parser.parse_args()
     if args.command == "affected-images":
-        changed = subprocess.check_output(
-            ["git", "diff", "--name-only", f"{args.base}...{args.head}"], text=True
-        ).splitlines()
+        if args.all:
+            changed = ["pyproject.toml"]
+        else:
+            changed = subprocess.check_output(
+                ["git", "diff", "--name-only", f"{args.base}...{args.head}"], text=True
+            ).splitlines()
         print(json.dumps(affected_images(changed, Path.cwd()), separators=(",", ":")))
         return 0
     waivers = load_waivers(args.register)

--- a/tests/tooling/test_container_security_workflows.py
+++ b/tests/tooling/test_container_security_workflows.py
@@ -5,16 +5,27 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def test_container_workflows_use_pinned_tools_and_digest_rescans() -> None:
-    pr = (REPO_ROOT / ".github/workflows/container-security.yml").read_text()
+def test_container_workflows_run_validation_nightly_with_pinned_tools_and_digest_rescans() -> None:
+    validation = (REPO_ROOT / ".github/workflows/container-security.yml").read_text()
     nightly = (REPO_ROOT / ".github/workflows/container-rescan.yml").read_text()
-    assert "hadolint/hadolint@sha256:" in pr
-    assert "affected-images" in pr
-    assert "container-waivers.md" in pr
-    assert "docker build" not in pr
-    assert "aquasec/trivy" not in pr
+    assert "schedule:" in validation
+    assert "pull_request:" not in validation
+    assert "hadolint/hadolint@sha256:" in validation
+    assert "affected-images --all" in validation
+    assert "container-waivers.md" in validation
+    assert "docker build" not in validation
+    assert "aquasec/trivy" not in validation
     assert "generated-service-images" in nightly
     assert '"$image@$digest"' in nightly
     assert "--limit 100" in nightly
     assert "No successful image publication run with a digest manifest was found." in nightly
     assert "docker build" not in nightly
+
+
+def test_workflow_security_audit_is_nightly_not_a_pr_ci_gate() -> None:
+    ci = (REPO_ROOT / ".github/workflows/ci.yml").read_text()
+    security = (REPO_ROOT / ".github/workflows/security.yml").read_text()
+
+    assert "make zizmor" not in ci
+    assert "security / workflow hardening" in security
+    assert "make zizmor" in security


### PR DESCRIPTION
## What changed

Moves PR-triggered container security validation to a nightly schedule.

- The nightly lane validates the waiver register, runs Hadolint against every generated-service Dockerfile, and validates generated Compose configuration.
- Zizmor moves from generic PR CI to the nightly Security workflow.
- Post-merge immutable-image Trivy enforcement and the nightly published-digest rescan remain unchanged.

## Why

Container security and Dockerfile hardening are scheduled security audits, not per-pull-request gates.

## Validation

- Container-security workflow contracts: 2 passed.
- All generated service images selected successfully for the nightly matrix.
- Zizmor: no findings.
- Actionlint: passed.
