### PR TITLE
fix: prevent quoted-empty MinIO OIDC configuration

### DIFF
--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -377,7 +377,11 @@ class ComposeGenerator:
             return
         environment = config.get("environment")
         for trigger, entries in conditional_environment.items():
-            if not str(env_values.get(str(trigger), "")).strip() or not isinstance(entries, dict):
+            trigger_name = str(trigger)
+            trigger_value = str(env_values.get(trigger_name, "")).strip()
+            if trigger_value in {'""', "''"}:
+                trigger_value = ""
+            if not trigger_value or not isinstance(entries, dict):
                 continue
             if environment is None:
                 environment = {}

--- a/src/phlo/plugins/compose/generator.py
+++ b/src/phlo/plugins/compose/generator.py
@@ -6,6 +6,7 @@ Generates docker-compose.yml and .env/.env.local files from service definitions.
 
 import os
 import platform
+import re
 import shutil
 from collections.abc import Mapping
 from pathlib import Path
@@ -37,6 +38,7 @@ _PRODUCTION_CREDENTIAL_DEFAULTS = {
     "MINIO_ROOT_USER": "minio",
     "MINIO_ROOT_PASSWORD": "minio123",
 }
+_EMPTY_DEFAULT_ENVIRONMENT_EXPRESSION = re.compile(r"^\$\{([A-Za-z_][A-Za-z0-9_]*):-\}$")
 
 
 class ComposeGenerator:
@@ -359,6 +361,7 @@ class ComposeGenerator:
                 config["depends_on"] = depends_config
 
         self._apply_conditional_environment(config, compose, env_values or {})
+        self._remove_windows_quoted_empty_environment_values(config, env_values or {})
 
         # Apply user overrides from phlo.yaml last, so they take precedence.
         self._apply_user_overrides(config, user_override)
@@ -378,9 +381,9 @@ class ComposeGenerator:
         environment = config.get("environment")
         for trigger, entries in conditional_environment.items():
             trigger_name = str(trigger)
-            trigger_value = str(env_values.get(trigger_name, "")).strip()
-            if trigger_value in {'""', "''"}:
-                trigger_value = ""
+            trigger_value = self._normalise_optional_environment_value(
+                env_values.get(trigger_name, "")
+            )
             if not trigger_value or not isinstance(entries, dict):
                 continue
             if environment is None:
@@ -390,6 +393,59 @@ class ComposeGenerator:
                 environment.update(entries)
             elif isinstance(environment, list):
                 environment.extend(f"{key}={value}" for key, value in entries.items())
+
+    @staticmethod
+    def _normalise_optional_environment_value(value: Any) -> str:
+        """Treat CMD's literal quoted-empty values as an unset optional value."""
+        normalised = str(value).strip()
+        return "" if normalised in {'""', "''"} else normalised
+
+    @staticmethod
+    def _is_windows_quoted_empty(value: Any) -> bool:
+        """Return whether a value is CMD's literal quoted-empty representation."""
+        return str(value).strip() in {'""', "''"}
+
+    def _remove_windows_quoted_empty_environment_values(
+        self, config: dict[str, Any], env_values: Mapping[str, Any]
+    ) -> None:
+        """Omit optional `${NAME:-}` entries set as `""` by Windows CMD.
+
+        In CMD, `set NAME=""` stores the quote characters rather than an empty
+        value. Docker Compose would otherwise pass those characters through to
+        services, which makes optional integrations look partially configured.
+        Only expressions with an explicitly empty fallback are removed; required
+        values and non-empty defaults preserve their existing Compose behavior.
+        """
+        environment = config.get("environment")
+        if isinstance(environment, dict):
+            for key, value in list(environment.items()):
+                variable = self._empty_default_variable(value)
+                if (
+                    variable
+                    and variable in env_values
+                    and self._is_windows_quoted_empty(env_values[variable])
+                ):
+                    del environment[key]
+        elif isinstance(environment, list):
+            config["environment"] = [
+                entry
+                for entry in environment
+                if not (
+                    isinstance(entry, str)
+                    and "=" in entry
+                    and (variable := self._empty_default_variable(entry.split("=", 1)[1]))
+                    and variable in env_values
+                    and self._is_windows_quoted_empty(env_values[variable])
+                )
+            ]
+
+    @staticmethod
+    def _empty_default_variable(value: Any) -> str | None:
+        """Return the variable referenced by an exact `${NAME:-}` expression."""
+        if not isinstance(value, str):
+            return None
+        match = _EMPTY_DEFAULT_ENVIRONMENT_EXPRESSION.fullmatch(value)
+        return match.group(1) if match else None
 
     def _apply_user_overrides(
         self,

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -65,6 +65,10 @@ def test_production_credentials_allow_generated_passwords_and_safe_usernames() -
     ("env_values", "expected_openid"),
     (
         ({}, {}),
+        ({"MINIO_OIDC_CONFIG_URL": ""}, {}),
+        ({"MINIO_OIDC_CONFIG_URL": "   \t"}, {}),
+        ({"MINIO_OIDC_CONFIG_URL": '""'}, {}),
+        ({"MINIO_OIDC_CONFIG_URL": "''"}, {}),
         (
             {"MINIO_OIDC_CONFIG_URL": "https://identity.example/.well-known/openid-configuration"},
             {

--- a/tests/cli/test_cli_services_init.py
+++ b/tests/cli/test_cli_services_init.py
@@ -100,6 +100,61 @@ def test_minio_compose_only_includes_openid_settings_with_a_discovery_url(
     } == expected_openid
 
 
+@pytest.mark.parametrize("quoted_empty", ('""', "''"))
+def test_compose_omits_optional_environment_values_set_to_windows_quoted_empty(
+    tmp_path, quoted_empty
+) -> None:
+    discovery = ServiceDiscovery()
+    services = [
+        service
+        for name in ("minio", "dagster", "clickstack")
+        if (service := discovery.get_service(name)) is not None
+    ]
+
+    rendered = yaml.safe_load(
+        ComposeGenerator(discovery).generate_compose(
+            services,
+            output_dir=tmp_path,
+            env_values={
+                "MINIO_SERVER_URL": quoted_empty,
+                "MINIO_LDAP_SERVER": quoted_empty,
+                "MINIO_LDAP_BIND_DN": quoted_empty,
+                "MINIO_LDAP_BIND_PASSWORD": quoted_empty,
+                "MINIO_LDAP_USER_BASE_DN": quoted_empty,
+                "MINIO_LDAP_USER_FILTER": quoted_empty,
+                "MINIO_AUDIT_ENDPOINT": quoted_empty,
+                "PHLO_DAGSTER_OIDC_ISSUER": quoted_empty,
+                "PHLO_DAGSTER_OIDC_AUDIENCE": quoted_empty,
+                "PHLO_DAGSTER_OIDC_JWKS_URL": quoted_empty,
+                "PHLO_DAGSTER_OIDC_CA_FILE": quoted_empty,
+                "CLICKSTACK_QUERY_URL": quoted_empty,
+            },
+        )
+    )
+
+    minio_environment = rendered["services"]["minio"]["environment"]
+    assert not {
+        "MINIO_SERVER_URL",
+        "MINIO_IDENTITY_LDAP_SERVER_ADDR",
+        "MINIO_IDENTITY_LDAP_LOOKUP_BIND_DN",
+        "MINIO_IDENTITY_LDAP_LOOKUP_BIND_PASSWORD",
+        "MINIO_IDENTITY_LDAP_USER_DN_SEARCH_BASE_DN",
+        "MINIO_IDENTITY_LDAP_USER_DN_SEARCH_FILTER",
+        "MINIO_AUDIT_WEBHOOK_ENDPOINT",
+    }.intersection(minio_environment)
+
+    dagster_environment = rendered["services"]["dagster"]["environment"]
+    assert not {
+        "PHLO_DAGSTER_OIDC_ISSUER",
+        "PHLO_DAGSTER_OIDC_AUDIENCE",
+        "PHLO_DAGSTER_OIDC_JWKS_URL",
+        "PHLO_DAGSTER_OIDC_CA_FILE",
+    }.intersection(dagster_environment)
+
+    clickstack_environment = rendered["services"]["clickstack"]["environment"]
+    assert "CLICKSTACK_QUERY_URL" not in clickstack_environment
+
+
 def test_conditional_environment_creates_an_absent_environment(tmp_path) -> None:
     service = ServiceDefinition(
         name="conditional",


### PR DESCRIPTION
## Summary
- treat quoted-empty conditional environment values as unset
- prevent Windows CMD `MINIO_OIDC_CONFIG_URL=""` from enabling MinIO OpenID
- cover unset, empty, whitespace, single-quoted-empty, double-quoted-empty, and valid HTTPS OIDC URLs

## Root cause
Windows CMD can pass `""` as a literal value. The Compose generator treated that string as enabled and emitted MinIO OpenID configuration; MinIO then rejected the invalid discovery URL because it has no scheme.

## Validation
- `make check`
- focused Compose-generator regression: 6 cases passed

## Review
- standards and spec review completed; the core generator keeps provider-neutral behavior.