### PR TITLE
fix: generated image scan report persistence

### DIFF
--- a/.github/workflows/build-core-services.yml
+++ b/.github/workflows/build-core-services.yml
@@ -210,11 +210,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p security-reports
-          docker run --rm aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
-            image --format json --output /tmp/trivy.json --scanners vuln "$IMAGE@$DIGEST"
-          cp /tmp/trivy.json "security-reports/${{ matrix.target.service }}-${{ matrix.architecture.name }}.json"
+          docker run --rm -v "$PWD:/work" -w /work aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
+            image --format json --output "/work/security-reports/${{ matrix.target.service }}-${{ matrix.architecture.name }}.json" --scanners vuln "$IMAGE@$DIGEST"
           uv --project source run --no-project --with pyyaml==6.0.3 python source/scripts/container_security.py \
-            apply-policy --register source/security/container-waivers.yml --image "$IMAGE@$DIGEST" --report /tmp/trivy.json
+            apply-policy --register source/security/container-waivers.yml --image "$IMAGE@$DIGEST" --report "security-reports/${{ matrix.target.service }}-${{ matrix.architecture.name }}.json"
 
       - name: Upload immutable digest scan report
         if: always()

--- a/tests/tooling/test_generated_image_publication.py
+++ b/tests/tooling/test_generated_image_publication.py
@@ -60,6 +60,11 @@ def test_publication_workflow_publishes_attested_images_after_digest_scans() -> 
     assert "org.opencontainers.image.source=https://github.com/${{ github.repository }}" in workflow
     assert "Scan immutable architecture digest" in workflow
     assert "apply-policy" in workflow
+    assert '-v "$PWD:/work" -w /work' in workflow
+    assert (
+        '"/work/security-reports/${{ matrix.target.service }}-${{ matrix.architecture.name }}.json"'
+        in workflow
+    )
 
 
 def test_container_security_replaces_legacy_remote_image_scan() -> None:


### PR DESCRIPTION
Fixes the post-merge custom image publication failure.

Trivy runs in a container, so its report is now written to the mounted workspace for policy evaluation and artifact upload.

Validation: `uv run --locked pytest tests/tooling/test_generated_image_publication.py -q` (3 passed).