### PR TITLE
fix(images): scan generated images by architecture

### DIFF
--- a/.github/workflows/build-core-services.yml
+++ b/.github/workflows/build-core-services.yml
@@ -206,12 +206,13 @@ jobs:
         env:
           IMAGE: ${{ steps.image.outputs.repository }}
           DIGEST: ${{ steps.build.outputs.digest }}
+          PLATFORM: ${{ matrix.architecture.platform }}
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p security-reports
           docker run --rm -v "$PWD:/work" -w /work aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
-            image --format json --output "/work/security-reports/${{ matrix.target.service }}-${{ matrix.architecture.name }}.json" --scanners vuln "$IMAGE@$DIGEST"
+            image --platform "$PLATFORM" --format json --output "/work/security-reports/${{ matrix.target.service }}-${{ matrix.architecture.name }}.json" --scanners vuln "$IMAGE@$DIGEST"
           uv --project source run --no-project --with pyyaml==6.0.3 python source/scripts/container_security.py \
             apply-policy --register source/security/container-waivers.yml --image "$IMAGE@$DIGEST" --report "security-reports/${{ matrix.target.service }}-${{ matrix.architecture.name }}.json"
 

--- a/tests/tooling/test_generated_image_publication.py
+++ b/tests/tooling/test_generated_image_publication.py
@@ -65,6 +65,8 @@ def test_publication_workflow_publishes_attested_images_after_digest_scans() -> 
         '"/work/security-reports/${{ matrix.target.service }}-${{ matrix.architecture.name }}.json"'
         in workflow
     )
+    assert "PLATFORM: ${{ matrix.architecture.platform }}" in workflow
+    assert 'image --platform "$PLATFORM"' in workflow
 
 
 def test_container_security_replaces_legacy_remote_image_scan() -> None:


### PR DESCRIPTION
Fixes the second generated-image publication failure.

Trivy now receives the matrix platform while scanning each immutable architecture digest, avoiding its amd64 default when scanning arm64 images.

Validation: `uv run --locked pytest tests/tooling/test_generated_image_publication.py -q`.