### PR TITLE
fix(ci): install uv before generated image scans

### DIFF
--- a/.github/workflows/build-core-services.yml
+++ b/.github/workflows/build-core-services.yml
@@ -133,6 +133,12 @@ jobs:
           path: source
           persist-credentials: false
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          version: "0.12.1"
+          enable-cache: false
+
       - name: Download generated build contexts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:


### PR DESCRIPTION
Fixes the generated-image publication scan jobs, which reproducibly failed after Trivy completed because the build runners did not install uv before invoking the policy script.\n\nValidation: pre-commit hooks passed, including YAML, yamllint, and zizmor.