### PR TITLE
fix(images): remove Dagster Cargo build cache

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/Dockerfile
+++ b/packages/phlo-dagster/src/phlo_dagster/Dockerfile
@@ -65,7 +65,7 @@ RUN \
 
 # Build caches contain package manifests that vulnerability scanners treat as runtime
 # dependencies. They are unnecessary after installation and must not ship in the image.
-RUN rm -rf /root/.cache/uv /root/.cache/puccinialin
+RUN rm -rf /root/.cache/uv /root/.cache/puccinialin /root/.cargo/registry
 
 # Keep entrypoint outside /opt/dagster so dev volume mounts never hide it.
 COPY dagster/entrypoint.sh /usr/local/bin/phlo-dagster-entrypoint.sh


### PR DESCRIPTION
## Summary
- remove the non-runtime Cargo registry left by native dependency builds from the Dagster image
- retain runtime binaries and Python packages; no vulnerability waiver or policy change

## Validation
- rendered the Dagster context through `phlo services init` and `phlo services add --service dagster --no-start`
- confirmed the generated Dockerfile contains the cleanup
- pulled the exact rejected arm64 digest `sha256:de7b3bbc0bf9bf63bc8e1aab79b062345e7dcbd9882f0f0d7a9c2955f74a6642`; deleting only `/root/.cargo/registry` in an isolated disposable copy produced 0 HIGH/CRITICAL Trivy findings and passed `scripts/container_security.py apply-policy` unchanged
- `scripts/container_security.py validate-waivers`
- direct pinned Hadolint container check passed at error threshold (the local pre-commit Hadolint binary crashed before opening the existing Dockerfile)

Closes #669