### PR TITLE
fix(api): mount release state directories writable

### DIFF
--- a/packages/phlo-api/src/phlo_api/service.yaml
+++ b/packages/phlo-api/src/phlo_api/service.yaml
@@ -34,6 +34,10 @@ compose:
     volumes:
         - ../:/app:ro
         - ./logs:/app/.phlo/logs
+        # API-managed state must remain writable while the project definition
+        # itself stays immutable inside a release container.
+        - ../.phlo/observatory:/app/.phlo/observatory
+        - ../.phlo/state:/app/.phlo/state
     healthcheck:
         test:
             [

--- a/packages/phlo-api/tests/test_service_url_resolution.py
+++ b/packages/phlo-api/tests/test_service_url_resolution.py
@@ -202,3 +202,9 @@ def test_non_dev_api_profile_compose_is_reachable_without_dev_mounts(tmp_path) -
     assert "depends_on" not in service
     assert "PHLO_DEV_MODE" not in service["environment"]
     assert "/opt/phlo-dev:rw" not in "\n".join(service.get("volumes", []))
+    assert service["volumes"] == [
+        "../:/app:ro",
+        "./logs:/app/.phlo/logs",
+        "../.phlo/observatory:/app/.phlo/observatory",
+        "../.phlo/state:/app/.phlo/state",
+    ]


### PR DESCRIPTION
## Summary

- retain the read-only project mount for the release API container
- mount only Observatory and idempotency state directories writable
- cover the generated non-dev Compose volume contract

## Validation

- uv run pytest packages/phlo-api/tests/test_service_url_resolution.py -q (8 passed)
- reproduced release-mode public-image startup failure: API attempted to write Observatory state under the read-only project mount

The complete no-build Lakehouse acceptance remains blocked until this published API image is available; no source-image build was used in the reproduction.