### PR TITLE
fix(dagster): avoid framework import cycle

### DIFF
--- a/packages/phlo-dagster/src/phlo_dagster/framework/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/framework/__init__.py
@@ -31,6 +31,19 @@ Usage:
         defs = build_definitions(workflows_path="custom_workflows")
 """
 
-from phlo_dagster.framework.definitions import build_definitions, defs
-
 __all__ = ["build_definitions", "defs"]
+
+
+def __getattr__(name: str):
+    """Load framework definitions only when the public facade is requested.
+
+    Adapter imports use framework submodules such as ``asset_diagnostics``.
+    Eagerly importing definitions here starts plugin discovery while the
+    adapter is still being imported, which makes its entry point partial.
+    """
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from phlo_dagster.framework.definitions import build_definitions, defs
+
+    return {"build_definitions": build_definitions, "defs": defs}[name]

--- a/packages/phlo-dagster/tests/test_asset_diagnostics.py
+++ b/packages/phlo-dagster/tests/test_asset_diagnostics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from typing import Any
 
 import dagster as dg
@@ -11,6 +13,25 @@ from phlo.capabilities import AssetSpec, MaterializeResult, RunSpec
 from phlo.exceptions import PhloDiscoveryError
 from phlo_dagster.adapter import DagsterOrchestratorAdapter
 from phlo_dagster.framework.asset_diagnostics import merge_definitions_with_duplicate_diagnostics
+
+
+def test_adapter_import_does_not_eagerly_build_framework_definitions() -> None:
+    """Adapter imports must not trigger plugin discovery through the facade."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; import phlo_dagster.adapter; "
+                "assert 'phlo_dagster.framework.definitions' not in sys.modules"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def _run(_context: Any) -> list[MaterializeResult]:


### PR DESCRIPTION
## Summary
- make the framework package facade lazy so adapter imports do not start definition discovery
- prevent plugin loading from observing a partially initialized Dagster adapter
- cover the adapter-import regression in a fresh Python process

## Validation
- ....                                                                     [100%]
4 passed in 1.18s (4 passed)
- All checks passed!
- fresh-process adapter import assertion