### PR TITLE
fix(services): harden custom image release validation

### DIFF
--- a/.github/workflows/build-core-services.yml
+++ b/.github/workflows/build-core-services.yml
@@ -78,6 +78,25 @@ jobs:
             add_args+=(--service "$service")
           done
           uv --project "$GITHUB_WORKSPACE" run --locked phlo services add "${add_args[@]}" --no-start
+          # Generated service images must embed the workspace packages from
+          # this revision.  Otherwise the runtime Dockerfiles resolve the
+          # last PyPI release (which can omit modules introduced by the image
+          # revision itself).
+          wheelhouse="$project/.phlo/wheelhouse"
+          uv --project "$GITHUB_WORKSPACE" build --all-packages --wheel --out-dir "$wheelhouse"
+          phlo_version="$(
+            uv --project "$GITHUB_WORKSPACE" run --locked python \
+              -c 'from importlib.metadata import version; print(version("phlo"))'
+          )"
+          dagster_version="$(
+            uv --project "$GITHUB_WORKSPACE" run --locked python \
+              -c 'from importlib.metadata import version; print(version("phlo-dagster"))'
+          )"
+          {
+            echo "PHLO_VERSION=$phlo_version"
+            echo "PHLO_DAGSTER_VERSION=$dagster_version"
+            echo "PHLO_WHEELHOUSE=wheelhouse"
+          } >> "$project/.phlo/.env.local"
           docker compose \
             --profile '*' \
             -f "$project/.phlo/docker-compose.yml" \

--- a/packages/phlo-alloy/src/phlo_alloy/service.yaml
+++ b/packages/phlo-alloy/src/phlo_alloy/service.yaml
@@ -18,6 +18,7 @@ compose:
   command:
     - run
     - --server.http.listen-addr=0.0.0.0:12345
+    - --storage.path=/tmp/alloy
     - /etc/alloy/config.alloy
   ports:
     - "${ALLOY_PORT:-12345}:12345"

--- a/packages/phlo-alloy/tests/test_alloy_plugin.py
+++ b/packages/phlo-alloy/tests/test_alloy_plugin.py
@@ -22,6 +22,13 @@ def test_alloy_service_builds_patched_release_image() -> None:
     assert definition["build"] == {"context": ".", "dockerfile": "alloy/Dockerfile"}
 
 
+def test_alloy_service_uses_writable_storage_for_the_non_root_runtime() -> None:
+    """Alloy must not use its default relative state directory under an unwritable cwd."""
+    definition = AlloyServicePlugin().service_definition
+
+    assert "--storage.path=/tmp/alloy" in definition["compose"]["command"]
+
+
 def test_alloy_runtime_image_sets_the_upstream_non_root_user() -> None:
     """The generated Dockerfile keeps Alloy's upstream runtime identity explicit."""
     dockerfile = resources.files("phlo_alloy").joinpath("Dockerfile").read_text()

--- a/packages/phlo-api/src/phlo_api/observatory_api/loki.py
+++ b/packages/phlo-api/src/phlo_api/observatory_api/loki.py
@@ -162,6 +162,7 @@ def build_log_query(
 
     """
     label_matchers = []
+    line_filters = []
     json_filters = []
 
     # Service filter - required by Loki
@@ -170,9 +171,11 @@ def build_log_query(
     else:
         label_matchers.append('container=~".+"')
 
-    # JSON filters for correlation
+    # Dagster's container logs include the execution run ID in their rendered
+    # message, whereas application logs may expose it as a JSON field.  Filter
+    # the raw line first so both log formats remain queryable.
     if run_id:
-        json_filters.append(f'run_id="{run_id}"')
+        line_filters.append(f'|= "{run_id}"')
     if asset_key:
         json_filters.append(f'asset_key="{asset_key}"')
     if job:
@@ -185,9 +188,10 @@ def build_log_query(
         json_filters.append(f'level="{level}"')
 
     label_selector = ", ".join(label_matchers)
+    line_pipeline = " " + " ".join(line_filters) if line_filters else ""
     json_pipeline = " | json | " + " | ".join(json_filters) if json_filters else " | json"
 
-    return "{" + label_selector + "}" + json_pipeline
+    return "{" + label_selector + "}" + line_pipeline + json_pipeline
 
 
 def parse_loki_response(response: dict[str, Any]) -> list[LogEntry]:

--- a/packages/phlo-api/tests/test_loki_api.py
+++ b/packages/phlo-api/tests/test_loki_api.py
@@ -8,10 +8,16 @@ import pytest
 from fastapi import HTTPException
 
 from phlo_api.observatory_api.loki import (
+    build_log_query,
     parse_loki_response,
     reject_request_loki_url,
     resolve_loki_url,
 )
+
+
+def test_build_log_query_matches_dagster_run_id_in_plain_container_logs() -> None:
+    """Run correlation must work before JSON parsing structured application logs."""
+    assert build_log_query(run_id="run-123") == ('{container=~".+"} |= "run-123" | json')
 
 
 def test_parse_loki_response_emits_function_and_legacy_fn_metadata() -> None:

--- a/packages/phlo-dagster/src/phlo_dagster/framework/__init__.py
+++ b/packages/phlo-dagster/src/phlo_dagster/framework/__init__.py
@@ -31,6 +31,19 @@ Usage:
         defs = build_definitions(workflows_path="custom_workflows")
 """
 
-from phlo_dagster.framework.definitions import build_definitions, defs
-
 __all__ = ["build_definitions", "defs"]
+
+
+def __getattr__(name: str):
+    """Load framework definitions only when the public facade is requested.
+
+    Adapter imports use framework submodules such as ``asset_diagnostics``.
+    Eagerly importing definitions here starts plugin discovery while the
+    adapter is still being imported, which makes its entry point partial.
+    """
+    if name not in __all__:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from phlo_dagster.framework.definitions import build_definitions, defs
+
+    return {"build_definitions": build_definitions, "defs": defs}[name]

--- a/packages/phlo-dagster/src/phlo_dagster/service.yaml
+++ b/packages/phlo-dagster/src/phlo_dagster/service.yaml
@@ -27,9 +27,9 @@ depends_on:
 
 compose:
   restart: unless-stopped
-  # Use the generated entrypoint from the bind-mounted Dagster directory so
-  # development stacks execute the checked-out bootstrap script.
-  entrypoint: ["/bin/bash", "/opt/dagster/entrypoint.sh"]
+  # Keep the image entrypoint outside the bind-mounted DAGSTER_HOME directory.
+  # That lets both development and released stacks use the same bootstrap script.
+  entrypoint: ["/usr/local/bin/phlo-dagster-entrypoint.sh"]
   healthcheck:
     test:
       [

--- a/packages/phlo-dagster/tests/test_asset_diagnostics.py
+++ b/packages/phlo-dagster/tests/test_asset_diagnostics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from typing import Any
 
 import dagster as dg
@@ -11,6 +13,25 @@ from phlo.capabilities import AssetSpec, MaterializeResult, RunSpec
 from phlo.exceptions import PhloDiscoveryError
 from phlo_dagster.adapter import DagsterOrchestratorAdapter
 from phlo_dagster.framework.asset_diagnostics import merge_definitions_with_duplicate_diagnostics
+
+
+def test_adapter_import_does_not_eagerly_build_framework_definitions() -> None:
+    """Adapter imports must not trigger plugin discovery through the facade."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; import phlo_dagster.adapter; "
+                "assert 'phlo_dagster.framework.definitions' not in sys.modules"
+            ),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def _run(_context: Any) -> list[MaterializeResult]:

--- a/packages/phlo-dagster/tests/test_runtime_image_contract.py
+++ b/packages/phlo-dagster/tests/test_runtime_image_contract.py
@@ -104,8 +104,8 @@ def test_dagster_runtime_entrypoint_installs_only_requested_dev_packages() -> No
     assert "phlo-testing" not in entrypoint
 
 
-def test_dagster_service_uses_the_generated_bootstrap_script() -> None:
-    """Generated stacks must use the checked-out entrypoint in dev mode."""
+def test_dagster_service_uses_the_image_bootstrap_script() -> None:
+    """The DAGSTER_HOME bind mount must not hide the image bootstrap script."""
     service = resources.files("phlo_dagster").joinpath("service.yaml").read_text()
 
-    assert 'entrypoint: ["/bin/bash", "/opt/dagster/entrypoint.sh"]' in service
+    assert 'entrypoint: ["/usr/local/bin/phlo-dagster-entrypoint.sh"]' in service

--- a/packages/phlo-loki/src/phlo_loki/Dockerfile
+++ b/packages/phlo-loki/src/phlo_loki/Dockerfile
@@ -11,9 +11,13 @@ RUN CGO_ENABLED=0 go build -mod=mod -trimpath -tags netgo \
         -X github.com/grafana/loki/v3/pkg/util/build.Version=3.7.4 \
         -X github.com/grafana/loki/v3/pkg/util/build.Revision=b318f2829f0ae2094ab3a1e90780450e9e4b03be" \
     -o /out/loki ./cmd/loki
+COPY loki/loki_healthcheck.go /tmp/loki_healthcheck.go
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" \
+    -o /out/loki-healthcheck /tmp/loki_healthcheck.go
 
 FROM grafana/loki:3.7.4@sha256:87f0a067673756a3cede1bcbf0c74875f7df9b09fddb53e399d0c576f756cfcc
 
 COPY --from=build /out/loki /usr/bin/loki
+COPY --from=build /out/loki-healthcheck /usr/bin/loki-healthcheck
 
 USER 10001

--- a/packages/phlo-loki/src/phlo_loki/loki_healthcheck.go
+++ b/packages/phlo-loki/src/phlo_loki/loki_healthcheck.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	client := &http.Client{Timeout: 3 * time.Second}
+	response, err := client.Get("http://127.0.0.1:3100/ready")
+	if err != nil {
+		os.Exit(1)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+}

--- a/packages/phlo-loki/src/phlo_loki/service.yaml
+++ b/packages/phlo-loki/src/phlo_loki/service.yaml
@@ -23,15 +23,7 @@ compose:
     - ./loki:/etc/loki:ro
     - loki-data:/loki
   healthcheck:
-    test:
-      [
-        "CMD",
-        "wget",
-        "--quiet",
-        "--tries=1",
-        "--spider",
-        "http://localhost:3100/ready",
-      ]
+    test: ["CMD", "/usr/bin/loki-healthcheck"]
     interval: 10s
     timeout: 5s
     retries: 5
@@ -50,5 +42,7 @@ env_vars:
 files:
   - source: Dockerfile
     dest: loki/Dockerfile
+  - source: loki_healthcheck.go
+    dest: loki/loki_healthcheck.go
   - source: loki-config.yml
     dest: loki/loki-config.yml

--- a/packages/phlo-loki/tests/test_loki_plugin.py
+++ b/packages/phlo-loki/tests/test_loki_plugin.py
@@ -24,6 +24,17 @@ def test_loki_service_builds_patched_release_image() -> None:
     assert "LOKI_VERSION" not in definition["env_vars"]
 
 
+def test_loki_uses_a_distroless_readiness_probe() -> None:
+    """The generated image must not depend on absent shell utilities."""
+    definition = LokiServicePlugin().service_definition
+
+    assert definition["compose"]["healthcheck"]["test"] == [
+        "CMD",
+        "/usr/bin/loki-healthcheck",
+    ]
+    assert any(file["dest"] == "loki/loki_healthcheck.go" for file in definition["files"])
+
+
 def test_loki_plugin_metadata():
     """Validate Loki plugin metadata tags and name."""
 

--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
@@ -8,9 +8,13 @@ RUN git clone https://github.com/oauth2-proxy/oauth2-proxy.git . && \
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v7.15.3" \
     -o /out/oauth2-proxy .
+COPY oauth2-proxy/oauth2_proxy_healthcheck.go /tmp/oauth2_proxy_healthcheck.go
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" \
+    -o /out/oauth2-proxy-healthcheck /tmp/oauth2_proxy_healthcheck.go
 
 FROM quay.io/oauth2-proxy/oauth2-proxy:v7.15.3@sha256:10a1165743a192e1940b4708fb9647027185ce11a681a1c5519b442ff7f1f561
 
 COPY --from=build /out/oauth2-proxy /bin/oauth2-proxy
+COPY --from=build /out/oauth2-proxy-healthcheck /bin/oauth2-proxy-healthcheck
 
 USER 65532

--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/oauth2_proxy_healthcheck.go
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/oauth2_proxy_healthcheck.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+	"os"
+	"time"
+)
+
+func main() {
+	client := &http.Client{Timeout: 3 * time.Second}
+	response, err := client.Get("http://127.0.0.1:4180/ping")
+	if err != nil {
+		os.Exit(1)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		os.Exit(1)
+	}
+}

--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/service.yaml
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/service.yaml
@@ -29,15 +29,7 @@ compose:
     OAUTH2_PROXY_UPSTREAMS: "static://202"
     OAUTH2_PROXY_SKIP_PROVIDER_BUTTON: "true"
   healthcheck:
-    test:
-      [
-        "CMD",
-        "wget",
-        "--quiet",
-        "--tries=1",
-        "--spider",
-        "http://127.0.0.1:4180/ping",
-      ]
+    test: ["CMD", "/bin/oauth2-proxy-healthcheck"]
     interval: 30s
     timeout: 5s
     retries: 3
@@ -68,3 +60,5 @@ env_vars:
 files:
   - source: Dockerfile
     dest: oauth2-proxy/Dockerfile
+  - source: oauth2_proxy_healthcheck.go
+    dest: oauth2-proxy/oauth2_proxy_healthcheck.go

--- a/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
+++ b/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
@@ -40,3 +40,16 @@ def test_oauth2_proxy_image_pinned():
 
     assert defn["image"] == "ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1"
     assert defn["build"]["dockerfile"] == "oauth2-proxy/Dockerfile"
+
+
+def test_oauth2_proxy_uses_a_distroless_readiness_probe():
+    """The generated image must not depend on absent shell utilities."""
+    definition = Oauth2ProxyServicePlugin().service_definition
+
+    assert definition["compose"]["healthcheck"]["test"] == [
+        "CMD",
+        "/bin/oauth2-proxy-healthcheck",
+    ]
+    assert any(
+        file["dest"] == "oauth2-proxy/oauth2_proxy_healthcheck.go" for file in definition["files"]
+    )

--- a/packages/phlo-postgrest/src/phlo_postgrest/service.yaml
+++ b/packages/phlo-postgrest/src/phlo_postgrest/service.yaml
@@ -16,6 +16,10 @@ compose:
   restart: unless-stopped
   labels:
     phlo.metrics.enabled: "false"
+  environment:
+    # Project initialization generates POSTGRES_PASSWORD.  Override the
+    # static template's development fallback so PostgREST uses that secret.
+    PGRST_DB_URI: postgresql://${POSTGRES_USER:-phlo}:${POSTGRES_PASSWORD:-phlo}@postgres:5432/${POSTGRES_DB:-phlo}
   command: ["/bin/postgrest", "/etc/postgrest/postgrest.conf"]
   volumes:
     - ./postgrest/conf:/etc/postgrest:ro

--- a/packages/phlo-postgrest/tests/test_postgrest_plugin.py
+++ b/packages/phlo-postgrest/tests/test_postgrest_plugin.py
@@ -13,6 +13,16 @@ def test_postgrest_builds_a_minimal_stable_runtime_image() -> None:
         "context": ".",
         "dockerfile": "postgrest/Dockerfile",
     }
+
+
+def test_postgrest_uses_the_project_postgres_credentials() -> None:
+    """Generated projects use a random database password, not the template fallback."""
+    definition = PostgrestServicePlugin().service_definition
+
+    assert definition["compose"]["environment"]["PGRST_DB_URI"] == (
+        "postgresql://${POSTGRES_USER:-phlo}:${POSTGRES_PASSWORD:-phlo}@postgres:5432/"
+        "${POSTGRES_DB:-phlo}"
+    )
     assert "POSTGREST_VERSION" not in definition["env_vars"]
     assert {"source": "Dockerfile", "dest": "postgrest/Dockerfile"} in definition["files"]
 


### PR DESCRIPTION
## Summary

Consolidates the reproducible custom-image defects found while starting every custom service in an isolated release-mode Lakehouse.

- Make Alloy runtime storage writable for its non-root user.
- Build and publish generated Dagster images from the checked-out workspace wheels, and preserve the generated-image entrypoint outside the mounted DAGSTER_HOME path.
- Use the generated PostgreSQL credential in PostgREST.
- Replace unavailable `wget` health checks in the distroless Loki and OAuth2 Proxy images with static in-image readiness probes.
- Query Dagster run IDs as LogQL line content before JSON parsing so completed run logs are discoverable through the API.

## Root causes

Generated service images could publish dependency wheels from PyPI instead of the workspace source; several minimal images exposed health checks that assumed shell utilities existed; PostgREST used a fixed development password; and the Loki API query treated plain Dagster container output as JSON.

## Validation

- Focused package tests for Alloy, Dagster, PostgREST, Loki, OAuth2 Proxy, and API Loki queries.
- Real isolated Lakehouse startup with Docker Compose `--no-build`, using retained cached release images.
- Every long-running custom service reached `running` and `healthy`; MinIO and OpenMetadata setup images exited successfully.
- A real `dlt_posts` Dagster materialization completed successfully through PostgreSQL, MinIO, Nessie, Trino, and Iceberg (100 rows).

## Follow-up validation

The retained fixture identified and includes the API Loki query fix. The final full feature contract must be rerun after publishing the consolidated generated images, using fresh public GHCR pulls.
