### PR TITLE
fix(oauth2-proxy): pin fixed xtext dependency

### DIFF
--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
@@ -4,7 +4,8 @@ RUN apk add --no-cache git=2.54.0-r0
 WORKDIR /src
 RUN git clone https://github.com/oauth2-proxy/oauth2-proxy.git . && \
     git checkout 66b3a17db09f0b51a4bc3159d4c7fe3fbeca1288 && \
-    go get google.golang.org/grpc@v1.82.1
+    go get google.golang.org/grpc@v1.82.1 \
+        google.golang.org/x/text@v0.39.0
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v7.15.3" \
     -o /out/oauth2-proxy .

--- a/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
+++ b/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
@@ -1,5 +1,7 @@
 """Tests for oauth2-proxy service plugin."""
 
+from importlib.resources import files
+
 from phlo_oauth2_proxy.plugin import Oauth2ProxyServicePlugin
 
 
@@ -40,6 +42,13 @@ def test_oauth2_proxy_image_pinned():
 
     assert defn["image"] == "ghcr.io/phlohouse/phlo-oauth2-proxy:v7.15.3-grpc1.82.1"
     assert defn["build"]["dockerfile"] == "oauth2-proxy/Dockerfile"
+
+
+def test_oauth2_proxy_image_pins_the_fixed_xtext_dependency() -> None:
+    """The generated image must contain the scanner-required x/text fix."""
+    dockerfile = files("phlo_oauth2_proxy").joinpath("Dockerfile").read_text()
+
+    assert "google.golang.org/x/text@v0.39.0" in dockerfile
 
 
 def test_oauth2_proxy_uses_a_distroless_readiness_probe():


### PR DESCRIPTION
## Summary

Pins `golang.org/x/text` to `v0.39.0` while building the custom OAuth2 Proxy image.

## Why

The merged release publication's immutable arm64 image scan found `CVE-2026-56852` in the transitive `x/text v0.37.0` dependency. The fixed version is `v0.39.0`.

## Validation

- `uv run pytest packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py -q` (6 passed)
- Pre-commit hooks, including Dockerfile lint, passed.
