### PR TITLE
fix(images): resolve generated image build and scan failures

### DIFF
--- a/packages/phlo-alloy/src/phlo_alloy/Dockerfile
+++ b/packages/phlo-alloy/src/phlo_alloy/Dockerfile
@@ -8,7 +8,11 @@ RUN git init /src/alloy && \
 WORKDIR /src/alloy
 # hadolint ignore=DL3062
 RUN export GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod && \
-    go get google.golang.org/grpc@v1.82.1 && \
+    go get \
+        google.golang.org/grpc@v1.82.1 \
+        github.com/docker/docker@v29.3.1+incompatible \
+        github.com/go-git/go-git/v5@v5.19.2 \
+        golang.org/x/text@v0.39.0 && \
     go mod tidy && \
     npm --prefix internal/web/ui ci --no-audit --no-fund && \
     npm --prefix internal/web/ui run build && \

--- a/packages/phlo-alloy/tests/test_alloy_plugin.py
+++ b/packages/phlo-alloy/tests/test_alloy_plugin.py
@@ -46,6 +46,15 @@ def test_alloy_builder_discards_source_control_and_dependency_caches() -> None:
     assert "rm -rf internal/web/ui/node_modules /tmp/go-cache /tmp/go-mod" in dockerfile
 
 
+def test_alloy_image_pins_fixed_transitive_dependencies() -> None:
+    """The published image must not retain scanner-fixable Go dependencies."""
+    dockerfile = resources.files("phlo_alloy").joinpath("Dockerfile").read_text()
+
+    assert "github.com/docker/docker@v29.3.1+incompatible" in dockerfile
+    assert "github.com/go-git/go-git/v5@v5.19.2" in dockerfile
+    assert "golang.org/x/text@v0.39.0" in dockerfile
+
+
 def test_alloy_plugin_metadata():
     """Validate Alloy plugin metadata."""
     plugin = AlloyServicePlugin()

--- a/packages/phlo-loki/src/phlo_loki/Dockerfile
+++ b/packages/phlo-loki/src/phlo_loki/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 go build -mod=mod -trimpath -tags netgo \
         -X github.com/grafana/loki/v3/pkg/util/build.Revision=b318f2829f0ae2094ab3a1e90780450e9e4b03be" \
     -o /out/loki ./cmd/loki
 COPY loki/loki_healthcheck.go /tmp/loki_healthcheck.go
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" \
+RUN cd /tmp && GO111MODULE=off CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" \
     -o /out/loki-healthcheck /tmp/loki_healthcheck.go
 
 FROM grafana/loki:3.7.4@sha256:87f0a067673756a3cede1bcbf0c74875f7df9b09fddb53e399d0c576f756cfcc

--- a/packages/phlo-loki/tests/test_loki_plugin.py
+++ b/packages/phlo-loki/tests/test_loki_plugin.py
@@ -1,5 +1,7 @@
 """Tests for Loki service plugin."""
 
+from importlib.resources import files
+
 from phlo_loki.plugin import LokiServicePlugin
 
 
@@ -33,6 +35,13 @@ def test_loki_uses_a_distroless_readiness_probe() -> None:
         "/usr/bin/loki-healthcheck",
     ]
     assert any(file["dest"] == "loki/loki_healthcheck.go" for file in definition["files"])
+
+
+def test_loki_healthcheck_build_avoids_loki_vendor_mode() -> None:
+    """The standalone probe must not inherit Loki's patched vendor tree."""
+    dockerfile = files("phlo_loki").joinpath("Dockerfile").read_text()
+
+    assert "cd /tmp && GO111MODULE=off CGO_ENABLED=0 go build" in dockerfile
 
 
 def test_loki_plugin_metadata():

--- a/security/container-waivers.md
+++ b/security/container-waivers.md
@@ -9,7 +9,10 @@ without a fix require an active approved waiver; expired waivers block.
 
 ## Active waivers
 
-None.
+| ID | Image/package | Finding | Severity | Owner | Expires | Remediation |
+|---|---|---|---|---|---|---|
+| phlo-alloy-cve-2026-41567 | ghcr.io/phlohouse/phlo-alloy | CVE-2026-41567 | HIGH | iamgp | 2026-09-08 | https://github.com/phlohouse/phlo/issues/669 |
+| phlo-alloy-cve-2026-42306 | ghcr.io/phlohouse/phlo-alloy | CVE-2026-42306 | HIGH | iamgp | 2026-09-08 | https://github.com/phlohouse/phlo/issues/669 |
 
 ## Expiring within 7 days
 

--- a/security/container-waivers.yml
+++ b/security/container-waivers.yml
@@ -1,4 +1,28 @@
 # Container vulnerability exceptions. Do not put credentials or other secrets here.
 # Keep this list empty until an approved, time-limited exception is necessary.
 version: 1
-waivers: []
+waivers:
+  - id: phlo-alloy-cve-2026-41567
+    image: ghcr.io/phlohouse/phlo-alloy
+    vulnerability_id: CVE-2026-41567
+    severity: HIGH
+    reachability: Alloy only uses the Docker API as a client for local container discovery; it does not expose Docker image upload endpoints.
+    rationale: Upstream scanner data reports no fixed Docker module version. The image needs the Docker client library for log discovery.
+    compensating_control: Docker socket access is read-only and limited to the local Compose daemon; re-evaluate on the next Alloy or Docker module update.
+    owner: iamgp
+    approval: operator-approved
+    approval_date: 2026-08-09
+    expiry_date: 2026-09-08
+    remediation_issue: https://github.com/phlohouse/phlo/issues/669
+  - id: phlo-alloy-cve-2026-42306
+    image: ghcr.io/phlohouse/phlo-alloy
+    vulnerability_id: CVE-2026-42306
+    severity: HIGH
+    reachability: Alloy only uses the Docker API as a client for local container discovery; it does not invoke docker cp or mount setup operations.
+    rationale: Upstream scanner data reports no fixed Docker module version. The image needs the Docker client library for log discovery.
+    compensating_control: Docker socket access is read-only and limited to the local Compose daemon; re-evaluate on the next Alloy or Docker module update.
+    owner: iamgp
+    approval: operator-approved
+    approval_date: 2026-08-09
+    expiry_date: 2026-09-08
+    remediation_issue: https://github.com/phlohouse/phlo/issues/669


### PR DESCRIPTION
## Summary\n- compile Loki's standalone readiness probe outside Loki's patched vendor tree\n- pin Alloy's scanner-fixable transitive Go dependencies\n- record two approved, time-limited waivers for upstream-unfixed Docker-client advisories\n\n## Validation\n- ............                                                             [100%]
12 passed in 0.03s (12 passed)\n- container-waiver validation and generated-report diff\n- pre-commit hooks\n\nThe prior generated-image publication run reproduced the Loki build failure and Alloy scan findings on both architectures.