### PR TITLE
fix(oauth2-proxy): correct xtext module path

### DIFF
--- a/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
+++ b/packages/phlo-oauth2-proxy/src/phlo_oauth2_proxy/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /src
 RUN git clone https://github.com/oauth2-proxy/oauth2-proxy.git . && \
     git checkout 66b3a17db09f0b51a4bc3159d4c7fe3fbeca1288 && \
     go get google.golang.org/grpc@v1.82.1 \
-        google.golang.org/x/text@v0.39.0
+        golang.org/x/text@v0.39.0
 RUN CGO_ENABLED=0 go build -trimpath \
     -ldflags="-s -w -X github.com/oauth2-proxy/oauth2-proxy/v7/pkg/version.VERSION=v7.15.3" \
     -o /out/oauth2-proxy .

--- a/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
+++ b/packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py
@@ -48,7 +48,7 @@ def test_oauth2_proxy_image_pins_the_fixed_xtext_dependency() -> None:
     """The generated image must contain the scanner-required x/text fix."""
     dockerfile = files("phlo_oauth2_proxy").joinpath("Dockerfile").read_text()
 
-    assert "google.golang.org/x/text@v0.39.0" in dockerfile
+    assert "golang.org/x/text@v0.39.0" in dockerfile
 
 
 def test_oauth2_proxy_uses_a_distroless_readiness_probe():


### PR DESCRIPTION
## Summary
- use the valid golang.org/x/text module path for the scanner-required dependency pin
- cover the exact module path in the plugin test

## Validation
- uv run pytest packages/phlo-oauth2-proxy/tests/test_oauth2_proxy_plugin.py -q (6 passed)
- pre-commit hooks

This corrects the deterministic publication error in run 31324095498: the previous google.golang.org/x/text import path returns 404.