### PR TITLE
feat(security): harden container image governance

### DIFF
--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -21,33 +21,39 @@ jobs:
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
           version: "0.12.1"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate waiver expiry
         run: uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py validate-waivers
-      - name: Download latest published digest manifest
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Resolve the complete current published fleet
         shell: bash
         run: |
           set -euo pipefail
-          manifest=""
-          mapfile -t run_ids < <(
-            gh run list --workflow build-core-services.yml --status success --limit 100 \
-              --json databaseId --jq '.[].databaseId'
-          )
-          for run_id in "${run_ids[@]}"; do
-            candidate="$RUNNER_TEMP/published-$run_id/generated-service-images.json"
-            if gh run download "$run_id" --name generated-service-images \
-              --dir "$RUNNER_TEMP/published-$run_id" && test -s "$candidate"; then
-              manifest="$candidate"
-              break
-            fi
+          mkdir -p published resolved
+          uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py \
+            published-fleet > "$RUNNER_TEMP/expected-fleet.json"
+          jq -c '.[]' "$RUNNER_TEMP/expected-fleet.json" | while read -r target; do
+            image="$(jq -r .image <<< "$target")"
+            services="$(jq -c .services <<< "$target")"
+            digest="$(
+              docker buildx imagetools inspect \
+                --format '{{json .Manifest.Digest}}' "$image" | jq -r .
+            )"
+            [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            safe="$(tr -d '\n' <<< "$image" | tr '/:@' '___')"
+            jq -n --arg image "$image" --arg digest "$digest" --argjson services "$services" \
+              '{image: $image, digest: $digest, services: $services}' > "resolved/${safe}.json"
           done
-          test -n "$manifest" || {
-            echo "No successful image publication run with a digest manifest was found." >&2
-            exit 1
-          }
-          mkdir -p published
-          cp "$manifest" published/generated-service-images.json
+          jq -s '.' resolved/*.json > "$RUNNER_TEMP/resolved-fleet.json"
+          uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py \
+            assemble-rescan-manifest --records "$RUNNER_TEMP/resolved-fleet.json" \
+            --output published/generated-service-images.json
       - name: Rescan immutable images with fresh Trivy data
         shell: bash
         run: |
@@ -56,15 +62,19 @@ jobs:
           jq -c '.[]' published/generated-service-images.json | while read -r target; do
             image="$(jq -r .image <<< "$target")"
             digest="$(jq -r .digest <<< "$target")"
-            safe="$(tr '/:@' '___' <<< "$image")"
-            docker run --rm aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f image --format json --output "/tmp/trivy.json" --scanners vuln "$image@$digest"
-            cp /tmp/trivy.json "reports/${safe}.json"
-            uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py apply-policy --image "$image@$digest" --report "/tmp/trivy.json"
+            safe="$(tr -d '\n' <<< "$image" | tr '/:@' '___')"
+            report="reports/${safe}.json"
+            docker run --rm -v "$PWD:/work" -w /work aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
+              image --format json --output "/work/$report" --scanners vuln "$image@$digest"
+            uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py \
+              apply-policy --image "$image@$digest" --report "$report"
           done
       - name: Upload rescan reports
         if: always()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: container-rescan-${{ github.run_id }}
-          path: reports
+          path: |
+            published/generated-service-images.json
+            reports
           if-no-files-found: warn

--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -1,6 +1,18 @@
 name: Container Security
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "packages/**"
+      - "scripts/container_security.py"
+      - "scripts/generated_image_matrix.py"
+      - "security/**"
+      - ".github/workflows/build-core-services.yml"
+      - ".github/workflows/container-rescan.yml"
+      - ".github/workflows/container-security.yml"
+      - "pyproject.toml"
+      - "uv.lock"
   workflow_dispatch:
   schedule:
     - cron: "10 2 * * *"
@@ -15,11 +27,13 @@ permissions:
 jobs:
   waivers:
     name: containers / waiver register
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
           version: "0.12.1"
@@ -42,15 +56,26 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
           version: "0.12.1"
       - id: images
         name: Select generated service images
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         shell: bash
         run: |
           set -euo pipefail
-          matrix="$(uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py affected-images --all)"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git cat-file -e "$BASE_SHA^{commit}"
+            git cat-file -e "$HEAD_SHA^{commit}"
+            matrix="$(uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py affected-images --base "$BASE_SHA" --head "$HEAD_SHA")"
+          else
+            matrix="$(uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py affected-images --all)"
+          fi
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
           if [ "$(jq '.include | length' <<< "$matrix")" -gt 0 ]; then echo "has_images=true" >> "$GITHUB_OUTPUT"; else echo "has_images=false" >> "$GITHUB_OUTPUT"; fi
 
@@ -67,6 +92,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Lint generated-service Dockerfile
         run: docker run --rm -i hadolint/hadolint@sha256:27086352fd5e1907ea2b934eb1023f217c5ae087992eb59fde121dce9c9ff21e < "${{ matrix.target.package }}/${{ matrix.target.dockerfile }}"
 
@@ -79,6 +105,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
         with:
           version: "0.12.1"

--- a/docs/operations/container-image-security.md
+++ b/docs/operations/container-image-security.md
@@ -6,13 +6,22 @@ build or scan images; documentation-only changes do not trigger container work.
 Build, exact-digest vulnerability scanning, SBOM/provenance, and publication
 run only after a merge to `main`.
 
-Published image digests are collected as workflow artifacts. The nightly
-container scan downloads that manifest from the most recent successful image
-publication run and rescans immutable `image@digest` references with current
-Trivy data; it does not rebuild images. This repository has no safely
-configured issue token or issue-routing convention, so nightly failures are
-intentionally surfaced through workflow summaries and retained artifacts rather
-than creating issues automatically.
+Publication runs collect the digests changed by that run as workflow artifacts.
+Those artifacts are publication evidence and may intentionally describe only a
+subset of the fleet; they are not the nightly rescan inventory.
+
+The nightly container scan derives the complete three-image fleet from the
+current service definitions, including the shared image used by `dagster` and
+`dagster-daemon`. It resolves every current versioned GHCR tag from the registry
+to an immutable digest, rejects an incomplete, duplicate, conflicting, or
+unexpected fleet, writes a deterministic `generated-service-images.json`, and
+rescans every `image@digest` with current Trivy data. The scan does not rebuild
+or republish images. The generated full-fleet manifest and scan reports are
+retained together as the nightly workflow artifact.
+
+This repository has no safely configured issue token or issue-routing
+convention, so nightly failures are intentionally surfaced through workflow
+summaries and retained artifacts rather than creating issues automatically.
 
 ## Base-image refresh
 

--- a/docs/packages/phlo-hasura.md
+++ b/docs/packages/phlo-hasura.md
@@ -23,7 +23,7 @@ Part of the `api` profile.
 | Variable              | Default                    | Description             |
 | --------------------- | -------------------------- | ----------------------- |
 | `HASURA_PORT`         | `8082`                     | Hasura console/API port |
-| `HASURA_VERSION`      | `v2.46.0`                  | Hasura version          |
+| `HASURA_IMAGE`        | `hasura/graphql-engine:v2.49.5@sha256:...` | Complete immutable Hasura image reference |
 | `HASURA_ADMIN_SECRET` | `phlo-hasura-admin-secret` | Admin secret            |
 
 ## Features

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -355,8 +355,8 @@ trino://localhost:10005/iceberg_dev
 ClickHouse analytical database for data plane:
 
 ```bash
-# Version and connectivity
-CLICKHOUSE_VERSION=latest
+# Image and connectivity
+CLICKHOUSE_IMAGE=clickhouse/clickhouse-server:26.5.6.64-alpine@sha256:446c9d82443b926a5aacb952448dd632672606acc691ce1b3c2292b68a1197c2
 CLICKHOUSE_HTTP_PORT=8123
 CLICKHOUSE_NATIVE_PORT=19000
 CLICKHOUSE_HOST=clickhouse
@@ -648,6 +648,7 @@ JWT_EXPIRATION_HOURS=24
 #### Hasura GraphQL
 
 ```bash
+HASURA_IMAGE=hasura/graphql-engine:v2.49.5@sha256:a9f427a9078b75c5f43ea40abd4ba4e426f45777f862eff7265f411a5ac96086
 HASURA_GRAPHQL_PORT=10012
 HASURA_GRAPHQL_ADMIN_SECRET=hasura-admin-secret
 HASURA_GRAPHQL_ENABLE_CONSOLE=true

--- a/packages/phlo-clickhouse/README.md
+++ b/packages/phlo-clickhouse/README.md
@@ -41,7 +41,7 @@ The following environment variables can be used to configure ClickHouse:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CLICKHOUSE_VERSION` | `26.5.6.64-alpine` | ClickHouse server version tag |
+| `CLICKHOUSE_IMAGE` | `clickhouse/clickhouse-server:26.5.6.64-alpine@sha256:...` | Complete immutable ClickHouse image reference |
 | `CLICKHOUSE_HTTP_PORT` | `8123` | ClickHouse HTTP interface port |
 | `CLICKHOUSE_NATIVE_PORT` | `19000` | ClickHouse native protocol port |
 | `CLICKHOUSE_METRICS_PORT` | `9363` | ClickHouse Prometheus metrics port |

--- a/packages/phlo-clickhouse/src/phlo_clickhouse/clickhouse-setup.yaml
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/clickhouse-setup.yaml
@@ -4,7 +4,7 @@ description: Initialize ClickHouse databases for data plane
 category: data
 default: false
 
-image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-26.5.6.64-alpine}
+image: ${CLICKHOUSE_IMAGE:-clickhouse/clickhouse-server:26.5.6.64-alpine@sha256:446c9d82443b926a5aacb952448dd632672606acc691ce1b3c2292b68a1197c2}
 
 depends_on:
   - clickhouse

--- a/packages/phlo-clickhouse/src/phlo_clickhouse/service.yaml
+++ b/packages/phlo-clickhouse/src/phlo_clickhouse/service.yaml
@@ -3,7 +3,7 @@ description: ClickHouse analytical database for data plane
 category: data
 default: false
 
-image: clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-26.5.6.64-alpine}
+image: ${CLICKHOUSE_IMAGE:-clickhouse/clickhouse-server:26.5.6.64-alpine@sha256:446c9d82443b926a5aacb952448dd632672606acc691ce1b3c2292b68a1197c2}
 
 compose:
   restart: unless-stopped
@@ -43,9 +43,9 @@ compose:
       hard: 262144
 
 env_vars:
-  CLICKHOUSE_VERSION:
-    default: "26.5.6.64-alpine"
-    description: ClickHouse server version tag
+  CLICKHOUSE_IMAGE:
+    default: "clickhouse/clickhouse-server:26.5.6.64-alpine@sha256:446c9d82443b926a5aacb952448dd632672606acc691ce1b3c2292b68a1197c2"
+    description: Complete ClickHouse server image reference
   CLICKHOUSE_HTTP_PORT:
     default: 8123
     description: ClickHouse HTTP interface port

--- a/packages/phlo-clickhouse/tests/test_clickhouse_plugin.py
+++ b/packages/phlo-clickhouse/tests/test_clickhouse_plugin.py
@@ -19,14 +19,18 @@ def test_clickhouse_service_definition():
     assert "clickhouse-logs:/var/log/clickhouse-server" in service_definition["compose"]["volumes"]
 
 
-def test_clickhouse_service_pins_generated_image_version() -> None:
-    """The generated environment must not replace the pinned image tag with latest."""
+def test_clickhouse_service_pins_generated_image_digest() -> None:
+    """The generated environment defaults to an immutable image reference."""
     service_definition = ClickHouseServicePlugin().service_definition
 
     assert service_definition["image"] == (
-        "clickhouse/clickhouse-server:${CLICKHOUSE_VERSION:-26.5.6.64-alpine}"
+        "${CLICKHOUSE_IMAGE:-clickhouse/clickhouse-server:26.5.6.64-alpine@"
+        "sha256:446c9d82443b926a5aacb952448dd632672606acc691ce1b3c2292b68a1197c2}"
     )
-    assert service_definition["env_vars"]["CLICKHOUSE_VERSION"]["default"] == ("26.5.6.64-alpine")
+    assert service_definition["env_vars"]["CLICKHOUSE_IMAGE"]["default"] == (
+        "clickhouse/clickhouse-server:26.5.6.64-alpine@"
+        "sha256:446c9d82443b926a5aacb952448dd632672606acc691ce1b3c2292b68a1197c2"
+    )
 
 
 def test_clickhouse_service_metadata():

--- a/packages/phlo-dagster/src/phlo_dagster/Dockerfile
+++ b/packages/phlo-dagster/src/phlo_dagster/Dockerfile
@@ -81,6 +81,7 @@ COPY dagster/dagster.yaml /opt/dagster/dagster.yaml
 # The entrypoint installs the mounted project, then drops to the phlo account.
 # Keep the image startup user explicit so a base-image change cannot bypass that
 # bootstrap phase.
+# hadolint ignore=DL3002
 USER root
 
 EXPOSE 3000

--- a/packages/phlo-hasura/README.md
+++ b/packages/phlo-hasura/README.md
@@ -23,7 +23,7 @@ Part of the `api` profile.
 | Variable              | Default                    | Description             |
 | --------------------- | -------------------------- | ----------------------- |
 | `HASURA_PORT`         | `8082`                     | Hasura console/API port |
-| `HASURA_VERSION`      | `v2.49.5`                  | Hasura version          |
+| `HASURA_IMAGE`        | `hasura/graphql-engine:v2.49.5@sha256:...` | Complete immutable Hasura image reference |
 | `HASURA_ADMIN_SECRET` | `phlo-hasura-admin-secret` | Admin secret            |
 
 ## Auto-Configuration

--- a/packages/phlo-hasura/src/phlo_hasura/service.yaml
+++ b/packages/phlo-hasura/src/phlo_hasura/service.yaml
@@ -4,7 +4,7 @@ category: api
 default: false
 profile: api
 
-image: hasura/graphql-engine:${HASURA_VERSION:-v2.49.5}
+image: ${HASURA_IMAGE:-hasura/graphql-engine:v2.49.5@sha256:a9f427a9078b75c5f43ea40abd4ba4e426f45777f862eff7265f411a5ac96086}
 
 depends_on:
   - postgres
@@ -31,9 +31,9 @@ compose:
     retries: 5
 
 env_vars:
-  HASURA_VERSION:
-    default: v2.49.5
-    description: Hasura GraphQL Engine version
+  HASURA_IMAGE:
+    default: hasura/graphql-engine:v2.49.5@sha256:a9f427a9078b75c5f43ea40abd4ba4e426f45777f862eff7265f411a5ac96086
+    description: Complete Hasura GraphQL Engine image reference
   HASURA_PORT:
     default: 8082
     description: Hasura console and API port

--- a/packages/phlo-postgres/src/phlo_postgres/volume_setup.yaml
+++ b/packages/phlo-postgres/src/phlo_postgres/volume_setup.yaml
@@ -3,7 +3,7 @@ description: Initialize PostgreSQL data volume permissions
 category: core
 default: false
 
-image: alpine:3.24.1
+image: alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 compose:
   restart: "no"

--- a/packages/phlo-rustfs/src/phlo_rustfs/rustfs-setup.yaml
+++ b/packages/phlo-rustfs/src/phlo_rustfs/rustfs-setup.yaml
@@ -4,7 +4,7 @@ description: Initialize RustFS buckets for data lake
 category: core
 default: false
 
-image: amazon/aws-cli:2.36.8
+image: amazon/aws-cli:2.36.8@sha256:7e1b11a3c93bc5af81f496de0662f666b2352a4a6666e8ebae904fe102b131b6
 
 depends_on:
   - rustfs

--- a/packages/phlo-rustfs/src/phlo_rustfs/rustfs-volume-setup.yaml
+++ b/packages/phlo-rustfs/src/phlo_rustfs/rustfs-volume-setup.yaml
@@ -4,7 +4,7 @@ description: Initialize RustFS data volume permissions
 category: core
 default: false
 
-image: alpine:3.24.1
+image: alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 compose:
   restart: "no"

--- a/packages/phlo-rustfs/src/phlo_rustfs/service.yaml
+++ b/packages/phlo-rustfs/src/phlo_rustfs/service.yaml
@@ -6,7 +6,7 @@ default: false
 depends_on:
   - rustfs-volume-setup
 
-image: rustfs/rustfs:1.0.0-beta.11
+image: rustfs/rustfs:1.0.0-beta.11@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c
 
 compose:
   restart: unless-stopped

--- a/packages/phlo-traefik/src/phlo_traefik/service.yaml
+++ b/packages/phlo-traefik/src/phlo_traefik/service.yaml
@@ -4,7 +4,7 @@ category: networking
 default: false
 profile: proxy
 
-image: traefik:v3.7.9
+image: traefik:v3.7.9@sha256:652929a140a32d7cafafb13c6cdfab5376cfeff800f51397b87b524501ed02a8
 
 compose:
   restart: unless-stopped

--- a/registry/support/v1.json
+++ b/registry/support/v1.json
@@ -29,7 +29,7 @@
       {"name": "dagster", "image_reference": "ghcr.io/phlohouse/phlo-dagster:0.6.0"},
       {"name": "dagster-daemon", "image_reference": "ghcr.io/phlohouse/phlo-dagster:0.6.0"},
       {"name": "postgres", "image_reference": "postgres:18.4-alpine3.24@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15"},
-      {"name": "postgres-volume-setup", "image_reference": "alpine:3.24.1"},
+      {"name": "postgres-volume-setup", "image_reference": "alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b"},
       {"name": "minio", "image_reference": "quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"},
       {"name": "minio-setup", "image_reference": "quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"},
       {"name": "nessie", "image_reference": "ghcr.io/projectnessie/nessie:0.108.3@sha256:219709df809fcfac7abe0491b2070c8d56178ed29828fb30968a4365b62bcc8a"},

--- a/scripts/container_security.py
+++ b/scripts/container_security.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import re
 import subprocess
 import sys
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -29,6 +30,22 @@ REQUIRED_WAIVER_FIELDS = {
     "remediation_issue",
 }
 BLOCKING_SEVERITIES = {"CRITICAL", "HIGH"}
+PUBLISHED_SERVICE_REPOSITORIES = {
+    "phlo-api": "ghcr.io/phlohouse/phlo-api:",
+    "dagster": "ghcr.io/phlohouse/phlo-dagster:",
+    "dagster-daemon": "ghcr.io/phlohouse/phlo-dagster:",
+    "observatory": "ghcr.io/phlohouse/phlo-observatory:",
+}
+BROAD_IMAGE_PATHS = {
+    ".github/workflows/build-core-services.yml",
+    ".github/workflows/container-rescan.yml",
+    ".github/workflows/container-security.yml",
+    "pyproject.toml",
+    "scripts/container_security.py",
+    "scripts/generated_image_matrix.py",
+    "uv.lock",
+}
+DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
 
 
 def _date(value: Any, field: str) -> dt.date:
@@ -166,9 +183,7 @@ def affected_images(changed: Iterable[str], root: Path) -> dict[str, list[dict[s
     paths = set(changed)
     service_files = sorted((root / "packages").glob("*/src/*/service.yaml"))
     targets: list[dict[str, str]] = []
-    broad_change = any(
-        path in {"pyproject.toml", "uv.lock", "scripts/generated_image_matrix.py"} for path in paths
-    )
+    broad_change = any(path in BROAD_IMAGE_PATHS or path.startswith("security/") for path in paths)
     for service_file in service_files:
         service = yaml.safe_load(service_file.read_text(encoding="utf-8"))
         if not isinstance(service, dict) or not isinstance(service.get("build"), dict):
@@ -199,6 +214,103 @@ def affected_images(changed: Iterable[str], root: Path) -> dict[str, list[dict[s
             }
         )
     return {"include": targets}
+
+
+def published_fleet(root: Path) -> list[dict[str, Any]]:
+    """Derive and validate the complete unique published fleet from service source."""
+    by_service: dict[str, str] = {}
+    for service_file in sorted((root / "packages").glob("*/src/*/*.yaml")):
+        service = yaml.safe_load(service_file.read_text(encoding="utf-8"))
+        if not isinstance(service, dict) or not isinstance(service.get("build"), dict):
+            continue
+        service_name = service.get("name")
+        image = service.get("image")
+        if not isinstance(service_name, str) or not isinstance(image, str):
+            raise ValueError(f"built service in {service_file} has invalid name or image")
+        image = _image_default(image).split("@", 1)[0]
+        if service_name in by_service:
+            raise ValueError(f"duplicate published service {service_name!r}")
+        by_service[service_name] = image
+
+    expected_services = set(PUBLISHED_SERVICE_REPOSITORIES)
+    actual_services = set(by_service)
+    if actual_services != expected_services:
+        missing = sorted(expected_services - actual_services)
+        unexpected = sorted(actual_services - expected_services)
+        raise ValueError(
+            f"published service fleet mismatch; missing={missing!r}, unexpected={unexpected!r}"
+        )
+    for service_name, repository in PUBLISHED_SERVICE_REPOSITORIES.items():
+        if not by_service[service_name].startswith(repository):
+            raise ValueError(
+                f"published service {service_name!r} must use a versioned {repository!r} image"
+            )
+    if by_service["dagster"] != by_service["dagster-daemon"]:
+        raise ValueError("dagster and dagster-daemon must share one published image")
+
+    grouped: dict[str, list[str]] = {}
+    for service_name, image in by_service.items():
+        grouped.setdefault(image, []).append(service_name)
+    if len(grouped) != 3:
+        raise ValueError(
+            f"published fleet must contain exactly three unique images, found {len(grouped)}"
+        )
+    return [
+        {"image": image, "services": sorted(services)}
+        for image, services in sorted(grouped.items())
+    ]
+
+
+def assemble_rescan_manifest(records: Any, root: Path) -> list[dict[str, Any]]:
+    """Validate resolved registry records against source and return a stable manifest."""
+    if not isinstance(records, list):
+        raise ValueError("resolved registry records must be a list")
+    expected = {entry["image"]: entry["services"] for entry in published_fleet(root)}
+    resolved: dict[str, dict[str, Any]] = {}
+    seen_services: set[str] = set()
+    for index, raw_record in enumerate(records, start=1):
+        if not isinstance(raw_record, dict) or set(raw_record) != {"image", "digest", "services"}:
+            raise ValueError(f"resolved registry record {index} is malformed")
+        record = cast(dict[str, Any], raw_record)
+        image = record["image"]
+        digest = record["digest"]
+        services = record["services"]
+        if (
+            not isinstance(image, str)
+            or not isinstance(digest, str)
+            or DIGEST_PATTERN.fullmatch(digest) is None
+            or not isinstance(services, list)
+            or not services
+            or not all(isinstance(service, str) and service for service in services)
+            or len(services) != len(set(services))
+        ):
+            raise ValueError(f"resolved registry record {index} is malformed")
+        if image in resolved:
+            raise ValueError(f"duplicate resolved registry image {image!r}")
+        normalized_services = sorted(services)
+        conflicting = seen_services.intersection(normalized_services)
+        if conflicting:
+            raise ValueError(f"services mapped to multiple images: {sorted(conflicting)!r}")
+        seen_services.update(normalized_services)
+        resolved[image] = {
+            "image": image,
+            "digest": digest,
+            "services": normalized_services,
+        }
+
+    if set(resolved) != set(expected):
+        missing = sorted(set(expected) - set(resolved))
+        unexpected = sorted(set(resolved) - set(expected))
+        raise ValueError(
+            f"resolved image fleet mismatch; missing={missing!r}, unexpected={unexpected!r}"
+        )
+    for image, services in expected.items():
+        if resolved[image]["services"] != services:
+            raise ValueError(
+                f"resolved image {image!r} has services {resolved[image]['services']!r}; "
+                f"expected {services!r}"
+            )
+    return [resolved[image] for image in sorted(resolved)]
 
 
 def _waived(waivers: list[dict[str, Any]], image: str, vulnerability_id: str) -> bool:
@@ -251,11 +363,28 @@ def main() -> int:
         help="Return every generated service image for the nightly validation lane.",
     )
     affected.add_argument("--head", default="HEAD")
+    fleet = sub.add_parser("published-fleet")
+    fleet.add_argument("--root", type=Path, default=Path.cwd())
+    assemble = sub.add_parser("assemble-rescan-manifest")
+    assemble.add_argument("--records", type=Path, required=True)
+    assemble.add_argument("--output", type=Path, required=True)
+    assemble.add_argument("--root", type=Path, default=Path.cwd())
     policy = sub.add_parser("apply-policy")
     policy.add_argument("--register", type=Path, default=Path("security/container-waivers.yml"))
     policy.add_argument("--image", required=True)
     policy.add_argument("--report", type=Path, required=True)
     args = parser.parse_args()
+    if args.command == "published-fleet":
+        print(json.dumps(published_fleet(args.root), separators=(",", ":")))
+        return 0
+    if args.command == "assemble-rescan-manifest":
+        manifest = assemble_rescan_manifest(
+            json.loads(args.records.read_text(encoding="utf-8")), args.root
+        )
+        args.output.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return 0
     if args.command == "affected-images":
         if args.all:
             changed = ["pyproject.toml"]

--- a/tests/scripts/test_container_security.py
+++ b/tests/scripts/test_container_security.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -84,3 +85,111 @@ def test_affected_images_ignores_docs_and_selects_changed_service() -> None:
             "dockerfile": "src/phlo_api/Dockerfile",
         }
     ]
+
+
+def test_affected_images_selects_exact_unique_fleet_for_all_and_broad_changes() -> None:
+    expected = {
+        ("phlo-api", "ghcr.io/phlohouse/phlo-api:0.7.0"),
+        ("dagster", "ghcr.io/phlohouse/phlo-dagster:0.6.0"),
+        ("observatory", "ghcr.io/phlohouse/phlo-observatory:0.7.0"),
+    }
+    all_targets = container_security.affected_images(["pyproject.toml"], REPO_ROOT)["include"]
+    security_targets = container_security.affected_images(
+        ["scripts/container_security.py"], REPO_ROOT
+    )["include"]
+
+    assert {(target["service"], target["image"]) for target in all_targets} == expected
+    assert security_targets == all_targets
+
+
+def test_published_fleet_is_derived_from_source_with_required_shared_mapping() -> None:
+    assert container_security.published_fleet(REPO_ROOT) == [
+        {
+            "image": "ghcr.io/phlohouse/phlo-api:0.7.0",
+            "services": ["phlo-api"],
+        },
+        {
+            "image": "ghcr.io/phlohouse/phlo-dagster:0.6.0",
+            "services": ["dagster", "dagster-daemon"],
+        },
+        {
+            "image": "ghcr.io/phlohouse/phlo-observatory:0.7.0",
+            "services": ["observatory"],
+        },
+    ]
+
+
+def test_rescan_manifest_assembly_sorts_and_validates_complete_fleet() -> None:
+    records = [
+        {
+            "image": "ghcr.io/phlohouse/phlo-observatory:0.7.0",
+            "digest": "sha256:" + "c" * 64,
+            "services": ["observatory"],
+        },
+        {
+            "image": "ghcr.io/phlohouse/phlo-api:0.7.0",
+            "digest": "sha256:" + "a" * 64,
+            "services": ["phlo-api"],
+        },
+        {
+            "image": "ghcr.io/phlohouse/phlo-dagster:0.6.0",
+            "digest": "sha256:" + "b" * 64,
+            "services": ["dagster-daemon", "dagster"],
+        },
+    ]
+
+    manifest = container_security.assemble_rescan_manifest(records, REPO_ROOT)
+
+    assert [entry["image"] for entry in manifest] == sorted(entry["image"] for entry in records)
+    assert manifest[1]["services"] == ["dagster", "dagster-daemon"]
+
+
+def test_rescan_manifest_rejects_incomplete_duplicate_unexpected_and_malformed_records() -> None:
+    valid = [
+        {
+            "image": "ghcr.io/phlohouse/phlo-api:0.7.0",
+            "digest": "sha256:" + "a" * 64,
+            "services": ["phlo-api"],
+        },
+        {
+            "image": "ghcr.io/phlohouse/phlo-dagster:0.6.0",
+            "digest": "sha256:" + "b" * 64,
+            "services": ["dagster", "dagster-daemon"],
+        },
+        {
+            "image": "ghcr.io/phlohouse/phlo-observatory:0.7.0",
+            "digest": "sha256:" + "c" * 64,
+            "services": ["observatory"],
+        },
+    ]
+    invalid_cases = {
+        "missing": valid[:-1],
+        "duplicate": [*valid, valid[0]],
+        "unexpected": [
+            *valid,
+            {
+                "image": "ghcr.io/phlohouse/phlo-extra:1.0.0",
+                "digest": "sha256:" + "d" * 64,
+                "services": ["extra"],
+            },
+        ],
+        "bad digest": [{**valid[0], "digest": "latest"}, *valid[1:]],
+        "wrong Dagster mapping": [
+            valid[0],
+            {**valid[1], "services": ["dagster"]},
+            valid[2],
+        ],
+        "conflicting service": [
+            valid[0],
+            valid[1],
+            {**valid[2], "services": ["phlo-api"]},
+        ],
+        "malformed": [json.loads('{"image": 1}'), *valid[1:]],
+    }
+
+    for label, records in invalid_cases.items():
+        try:
+            container_security.assemble_rescan_manifest(records, REPO_ROOT)
+        except ValueError:
+            continue
+        raise AssertionError(f"{label} records were accepted")

--- a/tests/tooling/test_container_security_workflows.py
+++ b/tests/tooling/test_container_security_workflows.py
@@ -9,17 +9,38 @@ def test_container_workflows_run_validation_nightly_with_pinned_tools_and_digest
     validation = (REPO_ROOT / ".github/workflows/container-security.yml").read_text()
     nightly = (REPO_ROOT / ".github/workflows/container-rescan.yml").read_text()
     assert "schedule:" in validation
-    assert "pull_request:" not in validation
+    assert "pull_request:" in validation
+    assert "branches: [main]" in validation
     assert "hadolint/hadolint@sha256:" in validation
+    assert "github.event.pull_request.base.sha" in validation
+    assert "github.event.pull_request.head.sha" in validation
+    assert 'affected-images --base "$BASE_SHA" --head "$HEAD_SHA"' in validation
     assert "affected-images --all" in validation
     assert "container-waivers.md" in validation
     assert "docker build" not in validation
     assert "aquasec/trivy" not in validation
-    assert "generated-service-images" in nightly
+    assert "published-fleet" in nightly
+    assert "assemble-rescan-manifest" in nightly
+    assert "docker buildx imagetools inspect" in nightly
+    assert "generated-service-images.json" in nightly
     assert '"$image@$digest"' in nightly
-    assert "--limit 100" in nightly
-    assert "No successful image publication run with a digest manifest was found." in nightly
-    assert "docker build" not in nightly
+    assert "gh run download" not in nightly
+    assert "docker build --" not in nightly
+
+
+def test_container_security_pr_paths_cover_image_contract_inputs() -> None:
+    validation = (REPO_ROOT / ".github/workflows/container-security.yml").read_text()
+
+    for path in (
+        '"packages/**"',
+        '"scripts/container_security.py"',
+        '"scripts/generated_image_matrix.py"',
+        '"security/**"',
+        '"pyproject.toml"',
+        '"uv.lock"',
+    ):
+        assert path in validation
+    assert "if: always()" in validation
 
 
 def test_workflow_security_audit_is_nightly_not_a_pr_ci_gate() -> None:

--- a/tests/tooling/test_generated_image_publication.py
+++ b/tests/tooling/test_generated_image_publication.py
@@ -153,6 +153,52 @@ def test_remaining_vendor_services_use_upstream_images_and_are_not_published(
     assert published_services == {"phlo-api", "dagster", "observatory"}
 
 
+def test_every_vendor_runtime_default_is_pinned_to_an_immutable_digest() -> None:
+    tag_only: list[str] = []
+    for service_file in sorted((REPO_ROOT / "packages").glob("*/src/*/*.yaml")):
+        service = yaml.safe_load(service_file.read_text(encoding="utf-8"))
+        if not isinstance(service, dict) or not isinstance(service.get("image"), str):
+            continue
+        image = _published_image(service["image"])
+        if image.startswith("ghcr.io/phlohouse/phlo-") and service.get("build"):
+            continue
+        if "@sha256:" not in image:
+            tag_only.append(f"{service_file.relative_to(REPO_ROOT)}: {image}")
+
+    assert tag_only == []
+
+
+def test_hasura_and_clickhouse_accept_safe_full_image_overrides() -> None:
+    hasura = yaml.safe_load(
+        (REPO_ROOT / "packages/phlo-hasura/src/phlo_hasura/service.yaml").read_text()
+    )
+    clickhouse = yaml.safe_load(
+        (REPO_ROOT / "packages/phlo-clickhouse/src/phlo_clickhouse/service.yaml").read_text()
+    )
+    clickhouse_setup = yaml.safe_load(
+        (
+            REPO_ROOT / "packages/phlo-clickhouse/src/phlo_clickhouse/clickhouse-setup.yaml"
+        ).read_text()
+    )
+
+    assert hasura["image"] == (
+        "${HASURA_IMAGE:-hasura/graphql-engine:v2.49.5@"
+        "sha256:a9f427a9078b75c5f43ea40abd4ba4e426f45777f862eff7265f411a5ac96086}"
+    )
+    clickhouse_image = (
+        "${CLICKHOUSE_IMAGE:-clickhouse/clickhouse-server:26.5.6.64-alpine@"
+        "sha256:446c9d82443b926a5aacb952448dd632672606acc691ce1b3c2292b68a1197c2}"
+    )
+    assert clickhouse["image"] == clickhouse_image
+    assert clickhouse_setup["image"] == clickhouse_image
+    assert "HASURA_VERSION" not in hasura["env_vars"]
+    assert hasura["env_vars"]["HASURA_IMAGE"]["default"] == _published_image(hasura["image"])
+    assert "CLICKHOUSE_VERSION" not in clickhouse["env_vars"]
+    assert clickhouse["env_vars"]["CLICKHOUSE_IMAGE"]["default"] == _published_image(
+        clickhouse["image"]
+    )
+
+
 def test_publication_workflow_publishes_attested_images_after_digest_scans() -> None:
     workflow = (REPO_ROOT / ".github/workflows/build-core-services.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Outcome

Container governance now matches Phlo's reduced ownership boundary: vendor runtime defaults are immutable, pull requests validate affected first-party images, and nightly rescans derive and scan the complete current three-image fleet instead of trusting the newest partial publication artifact.

## Changes

- pin Hasura, ClickHouse, Alpine helpers, AWS CLI, RustFS, and Traefik to verified multi-architecture manifest digests
- replace unsafe HASURA_VERSION and CLICKHOUSE_VERSION interpolation with full HASURA_IMAGE and CLICKHOUSE_IMAGE overrides
- run Container Security on relevant pull requests using exact base/head selection; retain all-image schedule/manual validation
- derive the expected phlo-api, shared phlo-dagster, and phlo-observatory fleet from source
- resolve every current GHCR tag to an immutable digest during nightly rescan
- strictly reject missing, duplicate, conflicting, unexpected, malformed, or incorrect shared-service fleet records
- upload the deterministic full manifest alongside nightly scan reports
- update image/configuration/security documentation and regression contracts

## Validation

- full make check: all eight lanes passed
- focused governance tests: 24 passed
- broader relevant package/tooling tests: 182 passed, 31 deselected
- independent final rerun: 54 passed, 14 deselected
- support validator, Ruff, ty, actionlint, diff check, changed-file pre-commit and commit hooks: passed
- live GHCR resolution produced exactly the three expected current images with valid digests and Dagster shared-service mapping

## OrbStack arm64 acceptance

Generated Compose contained all eight new immutable defaults with no tag-only vendor runtime refs. Runtime smokes passed for Alpine ownership, PostgreSQL, ClickHouse server/setup, Hasura backed by PostgreSQL, RustFS plus AWS CLI setup, and Traefik version/configuration; running image digests matched the pins. Temporary resources were removed.

ClickHouse setup used the existing supported nonempty CLICKHOUSE_PASSWORD override because the upstream image does not accept remote setup connections with its current blank-password default. This behavior predates and is unchanged by the digest pin. Traefik was tested with a safe no-socket configuration rather than granting Docker socket access.

## Non-goals

No first-party Dockerfile implementation, vulnerability severity/waiver policy, publication pre-publish scan, Delta fixture, or unrelated CI behavior is changed.