### PR TITLE
feat(security): automate upstream image governance

### DIFF
--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -1,0 +1,35 @@
+name: Renovate Config
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "renovate.json"
+      - ".github/workflows/renovate-config.yml"
+      - "tests/tooling/test_renovate_container_images.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        with:
+          node-version: 24
+
+      - name: Validate Renovate configuration
+        # zizmor: ignore[adhoc-packages] -- the validator version is explicit and
+        # independently checked; this repository does not ship a Node tool lockfile.
+        run: |
+          npm install --global renovate@44.20.1
+          renovate-config-validator --no-global renovate.json

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -32,4 +32,4 @@ jobs:
         # independently checked; this repository does not ship a Node tool lockfile.
         run: |
           npm install --global renovate@44.20.1
-          renovate-config-validator --no-global renovate.json
+          renovate-config-validator renovate.json

--- a/.github/workflows/upstream-image-visibility.yml
+++ b/.github/workflows/upstream-image-visibility.yml
@@ -1,0 +1,71 @@
+name: Upstream Image Visibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs after the blocking first-party rescan (04:25 UTC). Scanning 24 large
+    # vendor images sequentially is intentionally thorough and may approach an hour.
+    - cron: "20 5 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: scan vendor runtime images
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          version: "0.12.1"
+          enable-cache: true
+
+      - name: Derive immutable upstream inventory
+        run: |
+          set -euo pipefail
+          uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py \
+            write-upstream-inventory \
+            --output upstream-inventory.json
+          mkdir -p upstream-reports upstream-trivy-cache
+
+      - name: Scan every upstream runtime image
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r reference report; do
+            echo "Scanning $reference"
+            docker run --rm \
+              -v "$PWD:/work" \
+              -v "$PWD/upstream-trivy-cache:/cache" \
+              -w /work \
+              aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
+              image --cache-dir /cache --timeout 10m --scanners vuln --format json \
+              --output "/work/upstream-reports/$report" "$reference" < /dev/null
+          done < <(jq -r '.images[] | [.reference, .report] | @tsv' upstream-inventory.json)
+
+      - name: Validate reports and publish summary
+        run: |
+          set -euo pipefail
+          uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py \
+            summarize-upstream-reports \
+            --inventory upstream-inventory.json \
+            --reports upstream-reports \
+            --output upstream-summary.md
+          cat upstream-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload inventory, summary, and raw reports
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: upstream-image-visibility
+          path: |
+            upstream-inventory.json
+            upstream-summary.md
+            upstream-reports/*.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/guides/developer-workflow.md
+++ b/docs/guides/developer-workflow.md
@@ -69,3 +69,11 @@ uv run ty check
 - platform topology and surfaces: [Platform Topology](../reference/platform-topology.md)
 - setup of optional external systems: [Setup](../setup/index.md)
 - production operation: [Operations](../operations/index.md)
+
+## Reviewing vendor image updates
+
+Renovate opens review-required pull requests for digest-pinned vendor images in
+package source YAML. These updates change the tag and digest together and are
+never automerged. Confirm the service contract and generated Compose behavior;
+the scheduled non-blocking vulnerability view and its raw Trivy artifacts are
+described in [Container image security operations](../operations/container-image-security.md).

--- a/docs/operations/container-image-security.md
+++ b/docs/operations/container-image-security.md
@@ -23,11 +23,33 @@ This repository has no safely configured issue token or issue-routing
 convention, so nightly failures are intentionally surfaced through workflow
 summaries and retained artifacts rather than creating issues automatically.
 
+Vendor runtime images have a separate, non-blocking visibility lane. The
+scheduled **Upstream Image Visibility** workflow derives every unique vendor
+image from root `image` fields under `packages/*/src/**/*.yaml`, requires an
+immutable tag and digest, and scans the exact references sequentially. HIGH and
+CRITICAL findings are reported rather than waived or treated as Phlo build
+failures: upstream vendors own those images. Inventory mistakes, registry or
+scanner failures, missing reports, and malformed results still fail the run so
+a green run means the visibility report is complete.
+
+The workflow summary shows aggregate and per-image severity and fixability,
+along with every package-source location and environment override. Its retained
+artifact contains the deterministic inventory, rendered Markdown summary, and
+raw Trivy JSON. Maintainers can run it on demand from **Actions > Upstream Image
+Visibility > Run workflow**. It scans 24 current images sequentially with a
+shared cache, so a complete run is intentionally relatively expensive and may
+take close to an hour.
+
 ## Base-image refresh
 
-Renovate is configured for dependency updates. Review digest updates as normal
-pull requests, including the container security workflow. For an upstream that
-Renovate cannot update, a maintainer should resolve the upstream digest, update
-the relevant `FROM` line in a branch, run `python scripts/container_security.py
-affected-images --base main --head HEAD`, and open a pull request. Do not update
-base images directly on the default branch.
+Renovate's Docker regex manager discovers immutable vendor runtime defaults in
+package source YAML, including strict `${NAME:-image}` defaults. It updates the
+tag and digest together and opens review-required pull requests; automerge is
+disabled. Phlo-owned `ghcr.io/phlohouse/phlo-*` images are explicitly disabled
+for this manager because the first-party publication pipeline owns them.
+
+Review each update as a normal dependency pull request and check the container
+security contracts. For an upstream that Renovate cannot update, resolve the
+new tag and digest in a branch, run `python scripts/container_security.py
+upstream-runtime-images`, and open a pull request. Never update image defaults
+directly on the default branch.

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,20 @@
   "prHourlyLimit": 2,
   "prConcurrentLimit": 4,
   "labels": ["dependencies"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update immutable package runtime image defaults.",
+      "managerFilePatterns": ["^packages/[^/]+/src/[^/]+/.+\\.ya?ml$"],
+      "matchStrings": [
+        "(?m)^(?<indent>[ \\t]*)image:(?<spacing>[ \\t]+)(?<depName>[a-z0-9][a-z0-9._/-]*):(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[0-9a-f]{64})[ \\t]*$",
+        "(?m)^(?<indent>[ \\t]*)image:(?<spacing>[ \\t]+)(?<wrapperPrefix>\\$\\{(?<envName>[A-Z][A-Z0-9_]*)\\:-)(?<depName>[a-z0-9][a-z0-9._/-]*):(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[0-9a-f]{64})(?<wrapperSuffix>\\})[ \\t]*$"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker",
+      "autoReplaceStringTemplate": "{{{indent}}}image:{{{spacing}}}{{{wrapperPrefix}}}{{{depName}}}:{{{newValue}}}@{{{newDigest}}}{{{wrapperSuffix}}}"
+    }
+  ],
   "vulnerabilityAlerts": {
     "enabled": true,
     "addLabels": ["security"],
@@ -13,6 +27,18 @@
     "vulnerabilityFixStrategy": "lowest"
   },
   "packageRules": [
+    {
+      "description": "Keep upstream runtime image digest updates review-required.",
+      "matchManagers": ["custom.regex"],
+      "matchDatasources": ["docker"],
+      "automerge": false
+    },
+    {
+      "description": "Do not update Phlo-owned published images as upstream dependencies.",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["ghcr.io/phlohouse/phlo-*"],
+      "enabled": false
+    },
     {
       "description": "Group GitHub Actions updates.",
       "matchManagers": ["github-actions"],

--- a/renovate.json
+++ b/renovate.json
@@ -11,12 +11,12 @@
       "description": "Update immutable package runtime image defaults.",
       "managerFilePatterns": ["^packages/[^/]+/src/[^/]+/.+\\.ya?ml$"],
       "matchStrings": [
-        "(?m)^(?<indent>[ \\t]*)image:(?<spacing>[ \\t]+)(?<depName>[a-z0-9][a-z0-9._/-]*):(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[0-9a-f]{64})[ \\t]*$",
-        "(?m)^(?<indent>[ \\t]*)image:(?<spacing>[ \\t]+)(?<wrapperPrefix>\\$\\{(?<envName>[A-Z][A-Z0-9_]*)\\:-)(?<depName>[a-z0-9][a-z0-9._/-]*):(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[0-9a-f]{64})(?<wrapperSuffix>\\})[ \\t]*$"
+        "(?m)^image:(?<spacing>[ \\t]+)(?<depName>[a-z0-9][a-z0-9._/-]*):(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[0-9a-f]{64})[ \\t]*$",
+        "(?m)^image:(?<spacing>[ \\t]+)(?<wrapperPrefix>\\$\\{(?<envName>[A-Z][A-Z0-9_]*)\\:-)(?<depName>[a-z0-9][a-z0-9._/-]*):(?<currentValue>[^@\\s}]+)@(?<currentDigest>sha256:[0-9a-f]{64})(?<wrapperSuffix>\\})[ \\t]*$"
       ],
       "datasourceTemplate": "docker",
       "versioningTemplate": "docker",
-      "autoReplaceStringTemplate": "{{{indent}}}image:{{{spacing}}}{{{wrapperPrefix}}}{{{depName}}}:{{{newValue}}}@{{{newDigest}}}{{{wrapperSuffix}}}"
+      "autoReplaceStringTemplate": "image:{{{spacing}}}{{{wrapperPrefix}}}{{{depName}}}:{{{newValue}}}@{{{newDigest}}}{{{wrapperSuffix}}}"
     }
   ],
   "vulnerabilityAlerts": {

--- a/scripts/container_security.py
+++ b/scripts/container_security.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""Validate container vulnerability waivers and apply Phlo's scan policy."""
+"""Derive container inventories, validate reports, and apply Phlo scan policy."""
 
 from __future__ import annotations
 
 import argparse
 import datetime as dt
+import hashlib
 import json
 import re
 import subprocess
@@ -46,6 +47,12 @@ BROAD_IMAGE_PATHS = {
     "uv.lock",
 }
 DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+IMMUTABLE_IMAGE_PATTERN = re.compile(
+    r"(?P<repository>[a-z0-9][a-z0-9._/-]*(?::[0-9]+)?):"
+    r"(?P<tag>[^:@\s{}]+)@(?P<digest>sha256:[0-9a-f]{64})"
+)
+ENV_IMAGE_PATTERN = re.compile(r"\$\{(?P<env>[A-Z][A-Z0-9_]*)\:-(?P<reference>[^{}]+)\}")
+UPSTREAM_SEVERITIES = ("CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN")
 
 
 def _date(value: Any, field: str) -> dt.date:
@@ -313,6 +320,203 @@ def assemble_rescan_manifest(records: Any, root: Path) -> list[dict[str, Any]]:
     return [resolved[image] for image in sorted(resolved)]
 
 
+def _upstream_image_default(value: str, path: Path) -> tuple[str, str | None]:
+    """Strictly unwrap one shell-style environment default."""
+    if value.startswith("${"):
+        match = ENV_IMAGE_PATTERN.fullmatch(value)
+        if match is None:
+            raise ValueError(f"{path}: image has malformed environment default")
+        return match.group("reference"), match.group("env")
+    return value, None
+
+
+def upstream_runtime_inventory(root: Path) -> dict[str, Any]:
+    """Derive immutable vendor runtime images and their package-source provenance."""
+    by_reference: dict[str, list[dict[str, str]]] = {}
+    for service_file in sorted((root / "packages").glob("*/src/**/*.yaml")):
+        try:
+            document = yaml.safe_load(service_file.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            raise ValueError(f"cannot parse package service {service_file}: {exc}") from exc
+        if not isinstance(document, dict) or "image" not in document:
+            continue
+        if isinstance(document.get("build"), dict):
+            continue
+        image = document["image"]
+        if not isinstance(image, str):
+            raise ValueError(f"{service_file}: runtime image must be a string")
+        reference, env = _upstream_image_default(image, service_file)
+        if reference.startswith("ghcr.io/phlohouse/phlo-"):
+            continue
+        if IMMUTABLE_IMAGE_PATTERN.fullmatch(reference) is None:
+            raise ValueError(
+                f"{service_file}: vendor runtime image must contain an immutable tag and digest"
+            )
+        service = document.get("name")
+        if not isinstance(service, str) or not service:
+            raise ValueError(f"{service_file}: vendor runtime service must have a name")
+        source = {
+            "path": service_file.relative_to(root).as_posix(),
+            "service": service,
+        }
+        if env is not None:
+            source["env"] = env
+        by_reference.setdefault(reference, []).append(source)
+
+    images = []
+    for reference, sources in sorted(by_reference.items()):
+        images.append(
+            {
+                "reference": reference,
+                "report": hashlib.sha256(reference.encode()).hexdigest() + ".json",
+                "sources": sorted(
+                    sources,
+                    key=lambda source: (source["path"], source["service"]),
+                ),
+            }
+        )
+    return {"version": 1, "images": images}
+
+
+def _validate_upstream_inventory(inventory: Any) -> list[dict[str, Any]]:
+    if not isinstance(inventory, dict) or set(inventory) != {"version", "images"}:
+        raise ValueError("upstream inventory is malformed")
+    if inventory["version"] != 1 or not isinstance(inventory["images"], list):
+        raise ValueError("upstream inventory is malformed")
+    images: list[dict[str, Any]] = []
+    references: set[str] = set()
+    reports: set[str] = set()
+    for index, raw_image in enumerate(inventory["images"], start=1):
+        if not isinstance(raw_image, dict) or set(raw_image) != {
+            "reference",
+            "report",
+            "sources",
+        }:
+            raise ValueError(f"upstream inventory image {index} is malformed")
+        image = cast(dict[str, Any], raw_image)
+        reference = image["reference"]
+        report = image["report"]
+        sources = image["sources"]
+        if (
+            not isinstance(reference, str)
+            or IMMUTABLE_IMAGE_PATTERN.fullmatch(reference) is None
+            or reference.startswith("ghcr.io/phlohouse/phlo-")
+            or not isinstance(report, str)
+            or re.fullmatch(r"[0-9a-f]{64}\.json", report) is None
+            or report != hashlib.sha256(reference.encode()).hexdigest() + ".json"
+            or not isinstance(sources, list)
+            or not sources
+        ):
+            raise ValueError(f"upstream inventory image {index} is malformed")
+        if reference in references or report in reports:
+            raise ValueError(f"upstream inventory image {index} is duplicate")
+        references.add(reference)
+        reports.add(report)
+        for source in sources:
+            if (
+                not isinstance(source, dict)
+                or not set(source).issubset({"path", "service", "env"})
+                or not {"path", "service"}.issubset(source)
+                or not all(isinstance(value, str) and value for value in source.values())
+            ):
+                raise ValueError(f"upstream inventory image {index} source is malformed")
+        images.append(image)
+    if images != sorted(images, key=lambda image: image["reference"]):
+        raise ValueError("upstream inventory images are not sorted")
+    return images
+
+
+def _report_findings(report: Any, report_name: str) -> list[dict[str, Any]]:
+    if not isinstance(report, dict) or not isinstance(report.get("SchemaVersion"), int):
+        raise ValueError(f"malformed Trivy report {report_name}")
+    results = report.get("Results") or []
+    if not isinstance(results, list):
+        raise ValueError(f"malformed Trivy report {report_name}")
+    findings: list[dict[str, Any]] = []
+    for result in results:
+        if not isinstance(result, dict):
+            raise ValueError(f"malformed Trivy report {report_name}")
+        vulnerabilities = result.get("Vulnerabilities") or []
+        if not isinstance(vulnerabilities, list):
+            raise ValueError(f"malformed Trivy report {report_name}")
+        for finding in vulnerabilities:
+            if (
+                not isinstance(finding, dict)
+                or not isinstance(finding.get("VulnerabilityID"), str)
+                or str(finding.get("Severity", "")).upper() not in UPSTREAM_SEVERITIES
+                or not isinstance(finding.get("FixedVersion", ""), str)
+            ):
+                raise ValueError(f"malformed Trivy report {report_name}")
+            findings.append(finding)
+    return findings
+
+
+def summarize_upstream_reports(inventory: Any, reports_dir: Path) -> str:
+    """Validate a complete Trivy report set and render non-blocking visibility."""
+    images = _validate_upstream_inventory(inventory)
+    expected = {image["report"] for image in images}
+    actual = {path.name for path in reports_dir.iterdir() if path.is_file()}
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing:
+        raise ValueError(f"missing upstream Trivy reports: {missing!r}")
+    if unexpected:
+        raise ValueError(f"unexpected upstream Trivy reports: {unexpected!r}")
+
+    aggregate = {severity: {"total": 0, "fixable": 0} for severity in UPSTREAM_SEVERITIES}
+    per_image: list[tuple[dict[str, Any], dict[str, dict[str, int]]]] = []
+    for image in images:
+        report_path = reports_dir / image["report"]
+        try:
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"malformed Trivy report {image['report']}: {exc}") from exc
+        counts = {severity: {"total": 0, "fixable": 0} for severity in UPSTREAM_SEVERITIES}
+        for finding in _report_findings(report, image["report"]):
+            severity = str(finding["Severity"]).upper()
+            counts[severity]["total"] += 1
+            aggregate[severity]["total"] += 1
+            if finding.get("FixedVersion"):
+                counts[severity]["fixable"] += 1
+                aggregate[severity]["fixable"] += 1
+        per_image.append((image, counts))
+
+    lines = [
+        "# Upstream runtime image vulnerability visibility",
+        "",
+        "> Generated non-blocking visibility. Findings do not apply Phlo's first-party",
+        "> waiver policy and do not fail this workflow; malformed or incomplete scans do.",
+        "",
+        "## Aggregate findings",
+        "",
+        "| Severity | Total | Fixable | Unfixed |",
+        "|---|---:|---:|---:|",
+    ]
+    for severity in UPSTREAM_SEVERITIES:
+        counts = aggregate[severity]
+        lines.append(
+            f"| {severity} | {counts['total']} | {counts['fixable']} | "
+            f"{counts['total'] - counts['fixable']} |"
+        )
+    lines.extend(("", "## Inventory and per-image findings", ""))
+    for image, counts in per_image:
+        lines.extend((f"### `{image['reference']}`", "", "Sources:"))
+        for source in image["sources"]:
+            provenance = f"{source['path']} ({source['service']})"
+            if source.get("env"):
+                provenance += f" via ${{{source['env']}}}"
+            lines.append(f"- `{provenance}`")
+        lines.extend(("", "| Severity | Total | Fixable | Unfixed |", "|---|---:|---:|---:|"))
+        for severity in UPSTREAM_SEVERITIES:
+            severity_counts = counts[severity]
+            lines.append(
+                f"| {severity} | {severity_counts['total']} | {severity_counts['fixable']} | "
+                f"{severity_counts['total'] - severity_counts['fixable']} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
 def _waived(waivers: list[dict[str, Any]], image: str, vulnerability_id: str) -> bool:
     image_name = image.split("@", 1)[0]
     for waiver in waivers:
@@ -369,6 +573,15 @@ def main() -> int:
     assemble.add_argument("--records", type=Path, required=True)
     assemble.add_argument("--output", type=Path, required=True)
     assemble.add_argument("--root", type=Path, default=Path.cwd())
+    upstream = sub.add_parser("upstream-runtime-images")
+    upstream.add_argument("--root", type=Path, default=Path.cwd())
+    write_upstream = sub.add_parser("write-upstream-inventory")
+    write_upstream.add_argument("--root", type=Path, default=Path.cwd())
+    write_upstream.add_argument("--output", type=Path, required=True)
+    summarize_upstream = sub.add_parser("summarize-upstream-reports")
+    summarize_upstream.add_argument("--inventory", type=Path, required=True)
+    summarize_upstream.add_argument("--reports", type=Path, required=True)
+    summarize_upstream.add_argument("--output", type=Path, required=True)
     policy = sub.add_parser("apply-policy")
     policy.add_argument("--register", type=Path, default=Path("security/container-waivers.yml"))
     policy.add_argument("--image", required=True)
@@ -384,6 +597,20 @@ def main() -> int:
         args.output.write_text(
             json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
         )
+        return 0
+    if args.command in {"upstream-runtime-images", "write-upstream-inventory"}:
+        inventory = upstream_runtime_inventory(args.root)
+        rendered = json.dumps(inventory, indent=2, sort_keys=True) + "\n"
+        if args.command == "upstream-runtime-images":
+            print(rendered, end="")
+        else:
+            args.output.write_text(rendered, encoding="utf-8")
+        return 0
+    if args.command == "summarize-upstream-reports":
+        summary = summarize_upstream_reports(
+            json.loads(args.inventory.read_text(encoding="utf-8")), args.reports
+        )
+        args.output.write_text(summary, encoding="utf-8")
         return 0
     if args.command == "affected-images":
         if args.all:

--- a/tests/scripts/test_container_security.py
+++ b/tests/scripts/test_container_security.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import importlib.util
 import json
+import re
 import sys
 from pathlib import Path
+
+import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 _spec = importlib.util.spec_from_file_location(
@@ -193,3 +198,134 @@ def test_rescan_manifest_rejects_incomplete_duplicate_unexpected_and_malformed_r
         except ValueError:
             continue
         raise AssertionError(f"{label} records were accepted")
+
+
+def test_upstream_runtime_inventory_is_complete_deduplicated_and_provenanced() -> None:
+    inventory = container_security.upstream_runtime_inventory(REPO_ROOT)
+    root_image_documents = []
+    for path in sorted((REPO_ROOT / "packages").glob("*/src/**/*.yaml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if isinstance(document, dict) and "image" in document:
+            root_image_documents.append(document)
+
+    assert inventory["version"] == 1
+    assert len(root_image_documents) == 31
+    assert sum(isinstance(document.get("build"), dict) for document in root_image_documents) == 4
+    assert len(inventory["images"]) == 24
+    assert sum(len(image["sources"]) for image in inventory["images"]) == 27
+    assert inventory["images"] == sorted(inventory["images"], key=lambda item: item["reference"])
+    for image in inventory["images"]:
+        assert re.fullmatch(r".+:[^@]+@sha256:[0-9a-f]{64}", image["reference"])
+        assert not image["reference"].startswith("ghcr.io/phlohouse/phlo-")
+        assert re.fullmatch(r"[0-9a-f]{64}\.json", image["report"])
+        assert image["sources"] == sorted(
+            image["sources"], key=lambda source: (source["path"], source["service"])
+        )
+
+    clickhouse = next(
+        image for image in inventory["images"] if image["reference"].startswith("clickhouse/")
+    )
+    assert len(clickhouse["sources"]) == 2
+    assert {source["env"] for source in clickhouse["sources"]} == {"CLICKHOUSE_IMAGE"}
+
+
+@pytest.mark.parametrize(
+    "image,build,error",
+    [
+        ("alpine:3.24", None, "immutable tag and digest"),
+        ("alpine@sha256:" + "a" * 64, None, "immutable tag and digest"),
+        ("alpine:3.24@sha256:ABC", None, "immutable tag and digest"),
+        ("${IMAGE-alpine:3.24@sha256:" + "a" * 64 + "}", None, "environment default"),
+        (123, None, "image must be a string"),
+        ("alpine:3.24", {"context": "."}, ""),
+    ],
+)
+def test_upstream_runtime_inventory_rejects_malformed_runtime_images(
+    tmp_path: Path, image: object, build: object, error: str
+) -> None:
+    service_dir = tmp_path / "packages/example/src/example"
+    service_dir.mkdir(parents=True)
+    document: dict[str, object] = {"name": "example", "image": image}
+    if build is not None:
+        document["build"] = build
+    (service_dir / "service.yaml").write_text(yaml.safe_dump(document), encoding="utf-8")
+
+    if build is not None:
+        assert container_security.upstream_runtime_inventory(tmp_path) == {
+            "version": 1,
+            "images": [],
+        }
+    else:
+        with pytest.raises(ValueError, match=error):
+            container_security.upstream_runtime_inventory(tmp_path)
+
+
+def _trivy_report(*findings: dict[str, object]) -> dict[str, object]:
+    return {"SchemaVersion": 2, "Results": [{"Target": "fixture", "Vulnerabilities": findings}]}
+
+
+def test_upstream_report_summary_counts_findings_without_blocking_on_severity(
+    tmp_path: Path,
+) -> None:
+    reference = "alpine:3.24@sha256:" + "a" * 64
+    report_name = hashlib.sha256(reference.encode()).hexdigest() + ".json"
+    inventory = {
+        "version": 1,
+        "images": [
+            {
+                "reference": reference,
+                "report": report_name,
+                "sources": [{"path": "packages/a/src/a/service.yaml", "service": "a"}],
+            }
+        ],
+    }
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / report_name).write_text(
+        json.dumps(
+            _trivy_report(
+                {"VulnerabilityID": "CVE-1", "Severity": "CRITICAL", "FixedVersion": "2"},
+                {"VulnerabilityID": "CVE-2", "Severity": "HIGH", "FixedVersion": ""},
+                {"VulnerabilityID": "CVE-3", "Severity": "LOW", "FixedVersion": "3"},
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    summary = container_security.summarize_upstream_reports(inventory, reports)
+
+    assert "non-blocking visibility" in summary.lower()
+    assert "| CRITICAL | 1 | 1 | 0 |" in summary
+    assert "| HIGH | 1 | 0 | 1 |" in summary
+    assert "| LOW | 1 | 1 | 0 |" in summary
+    assert "packages/a/src/a/service.yaml (a)" in summary
+
+
+@pytest.mark.parametrize("failure", ["missing", "unexpected", "malformed"])
+def test_upstream_report_summary_rejects_incomplete_or_invalid_report_sets(
+    tmp_path: Path, failure: str
+) -> None:
+    reference = "alpine:3.24@sha256:" + "a" * 64
+    report_name = hashlib.sha256(reference.encode()).hexdigest() + ".json"
+    inventory = {
+        "version": 1,
+        "images": [
+            {
+                "reference": reference,
+                "report": report_name,
+                "sources": [{"path": "packages/a/src/a/service.yaml", "service": "a"}],
+            }
+        ],
+    }
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    if failure != "missing":
+        (reports / report_name).write_text(
+            "not json" if failure == "malformed" else json.dumps(_trivy_report()),
+            encoding="utf-8",
+        )
+    if failure == "unexpected":
+        (reports / ("b" * 64 + ".json")).write_text(json.dumps(_trivy_report()), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=failure):
+        container_security.summarize_upstream_reports(inventory, reports)

--- a/tests/tooling/test_container_security_workflows.py
+++ b/tests/tooling/test_container_security_workflows.py
@@ -82,5 +82,6 @@ def test_renovate_config_validation_uses_pinned_node_and_renovate() -> None:
     assert '"renovate.json"' in workflow
     assert "actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238" in workflow
     assert "npm install --global renovate@44.20.1" in workflow
-    assert "renovate-config-validator --no-global renovate.json" in workflow
+    assert "renovate-config-validator renovate.json" in workflow
+    assert "--no-global" not in workflow
     assert "contents: read" in workflow

--- a/tests/tooling/test_container_security_workflows.py
+++ b/tests/tooling/test_container_security_workflows.py
@@ -50,3 +50,37 @@ def test_workflow_security_audit_is_nightly_not_a_pr_ci_gate() -> None:
     assert "make zizmor" not in ci
     assert "security / workflow hardening" in security
     assert "make zizmor" in security
+
+
+def test_upstream_visibility_is_scheduled_manual_non_blocking_and_strictly_reported() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/upstream-image-visibility.yml").read_text()
+
+    for contract in (
+        "workflow_dispatch:",
+        "schedule:",
+        "permissions:",
+        "contents: read",
+        "timeout-minutes: 90",
+        "write-upstream-inventory",
+        "summarize-upstream-reports",
+        "aquasec/trivy@sha256:",
+        "$GITHUB_STEP_SUMMARY",
+        "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
+        "if: always()",
+        "if-no-files-found: error",
+        '"$reference" < /dev/null',
+    ):
+        assert contract in workflow
+    for forbidden in ("apply-policy", "container-waivers", "continue-on-error", "--exit-code 1"):
+        assert forbidden not in workflow
+
+
+def test_renovate_config_validation_uses_pinned_node_and_renovate() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/renovate-config.yml").read_text()
+
+    assert "pull_request:" in workflow
+    assert '"renovate.json"' in workflow
+    assert "actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238" in workflow
+    assert "npm install --global renovate@44.20.1" in workflow
+    assert "renovate-config-validator --no-global renovate.json" in workflow
+    assert "contents: read" in workflow

--- a/tests/tooling/test_renovate_container_images.py
+++ b/tests/tooling/test_renovate_container_images.py
@@ -1,0 +1,147 @@
+"""Semantic contracts for Renovate-managed package runtime images."""
+
+from __future__ import annotations
+
+import json
+import re
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPO_ROOT / "renovate.json"
+
+
+def _manager() -> dict[str, Any]:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    managers = [
+        manager
+        for manager in config["customManagers"]
+        if manager.get("customType") == "regex" and manager.get("datasourceTemplate") == "docker"
+    ]
+    assert len(managers) == 1
+    return cast(dict[str, Any], managers[0])
+
+
+def _python_regex(pattern: str) -> re.Pattern[str]:
+    # Renovate uses RE2's JavaScript named-group spelling; Python uses ?P<name>.
+    return re.compile(pattern.replace("(?<", "(?P<"))
+
+
+def _image_patterns(manager: dict[str, Any]) -> list[re.Pattern[str]]:
+    return [_python_regex(pattern) for pattern in manager["matchStrings"]]
+
+
+def _image_match(manager: dict[str, Any], source: str) -> re.Match[str] | None:
+    matches = [match for pattern in _image_patterns(manager) if (match := pattern.search(source))]
+    assert len(matches) <= 1
+    return matches[0] if matches else None
+
+
+def test_runtime_image_manager_covers_only_recursive_package_source_yaml() -> None:
+    manager = _manager()
+    file_patterns = [_python_regex(pattern) for pattern in manager["managerFilePatterns"]]
+
+    assert any(
+        pattern.fullmatch("packages/phlo-postgres/src/phlo_postgres/service.yaml")
+        for pattern in file_patterns
+    )
+    assert any(
+        pattern.fullmatch("packages/phlo-openmetadata/src/phlo_openmetadata/setup/service.yml")
+        for pattern in file_patterns
+    )
+    assert not any(
+        pattern.fullmatch("packages/phlo-delta/tests/fixtures/delta_versions.yaml")
+        for pattern in file_patterns
+    )
+
+
+def test_runtime_image_manager_extracts_every_real_immutable_root_image() -> None:
+    manager = _manager()
+    matched: set[Path] = set()
+    eligible: set[Path] = set()
+
+    for path in sorted((REPO_ROOT / "packages").glob("*/src/**/*.yaml")):
+        document = yaml.safe_load(path.read_text(encoding="utf-8"))
+        if not isinstance(document, dict) or not isinstance(document.get("image"), str):
+            continue
+        relative = path.relative_to(REPO_ROOT)
+        if "@sha256:" in document["image"]:
+            eligible.add(relative)
+        match = _image_match(manager, path.read_text(encoding="utf-8"))
+        if match:
+            matched.add(relative)
+            assert match.group("depName")
+            assert match.group("currentValue")
+            assert re.fullmatch(r"sha256:[0-9a-f]{64}", match.group("currentDigest"))
+
+    assert matched == eligible
+
+
+def test_runtime_image_replacement_updates_tag_and_digest_without_damaging_wrapper() -> None:
+    manager = _manager()
+    replacement = manager["autoReplaceStringTemplate"]
+
+    def replace(source: str) -> str:
+        match = _image_match(manager, source)
+        assert match
+        values = {"wrapperPrefix": "", "wrapperSuffix": ""}
+        values.update({key: value or "" for key, value in match.groupdict().items()})
+        values.update(newValue="v9.9.9", newDigest="sha256:" + "f" * 64)
+        rendered = replacement
+        for key, value in values.items():
+            rendered = rendered.replace("{{{" + key + "}}}", value)
+        return source[: match.start()] + rendered + source[match.end() :]
+
+    assert replace("image: grafana/alloy:v1.0.0@sha256:" + "a" * 64) == (
+        "image: grafana/alloy:v9.9.9@sha256:" + "f" * 64
+    )
+    assert replace("image: ${ALLOY_IMAGE:-grafana/alloy:v1.0.0@sha256:" + "a" * 64 + "}") == (
+        "image: ${ALLOY_IMAGE:-grafana/alloy:v9.9.9@sha256:" + "f" * 64 + "}"
+    )
+    assert (
+        _image_match(
+            manager,
+            "image: ${ALLOY_IMAGE-grafana/alloy:v1.0.0@sha256:" + "a" * 64 + "}",
+        )
+        is None
+    )
+
+
+def test_phlo_owned_images_are_explicitly_disabled_and_never_automerged() -> None:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    manager = _manager()
+    rules = config["packageRules"]
+    disabled = [
+        rule
+        for rule in rules
+        if rule.get("matchManagers") == ["custom.regex"]
+        and rule.get("matchPackageNames") == ["ghcr.io/phlohouse/phlo-*"]
+    ]
+    review_required = [
+        rule
+        for rule in rules
+        if rule.get("matchManagers") == ["custom.regex"] and rule.get("enabled") is not False
+    ]
+    assert disabled == [
+        {
+            "description": "Do not update Phlo-owned published images as upstream dependencies.",
+            "matchManagers": ["custom.regex"],
+            "matchPackageNames": ["ghcr.io/phlohouse/phlo-*"],
+            "enabled": False,
+        }
+    ]
+    assert review_required and all(rule.get("automerge") is False for rule in review_required)
+    assert fnmatchcase("ghcr.io/phlohouse/phlo-api", disabled[0]["matchPackageNames"][0])
+    internal_files = sorted((REPO_ROOT / "packages").glob("*/src/**/*.yaml"))
+    internal_files = [
+        path
+        for path in internal_files
+        if "ghcr.io/phlohouse/phlo-" in path.read_text(encoding="utf-8")
+    ]
+    assert len(internal_files) == 4
+    assert all(
+        _image_match(manager, path.read_text(encoding="utf-8")) is None for path in internal_files
+    )

--- a/tests/tooling/test_renovate_container_images.py
+++ b/tests/tooling/test_renovate_container_images.py
@@ -40,6 +40,20 @@ def _image_match(manager: dict[str, Any], source: str) -> re.Match[str] | None:
     return matches[0] if matches else None
 
 
+def _render_update(manager: dict[str, Any], source: str, *, new_value: str, new_digest: str) -> str:
+    """Faithfully simulate Renovate's configured mustache replacement template."""
+    match = _image_match(manager, source)
+    assert match
+    values = {"wrapperPrefix": "", "wrapperSuffix": ""}
+    values.update({key: value or "" for key, value in match.groupdict().items()})
+    values.update(newValue=new_value, newDigest=new_digest)
+    rendered = manager["autoReplaceStringTemplate"]
+    for key, value in values.items():
+        rendered = rendered.replace("{{{" + key + "}}}", value)
+    assert "{{{" not in rendered
+    return source[: match.start()] + rendered + source[match.end() :]
+
+
 def test_runtime_image_manager_covers_only_recursive_package_source_yaml() -> None:
     manager = _manager()
     file_patterns = [_python_regex(pattern) for pattern in manager["managerFilePatterns"]]
@@ -52,10 +66,18 @@ def test_runtime_image_manager_covers_only_recursive_package_source_yaml() -> No
         pattern.fullmatch("packages/phlo-openmetadata/src/phlo_openmetadata/setup/service.yml")
         for pattern in file_patterns
     )
-    assert not any(
-        pattern.fullmatch("packages/phlo-delta/tests/fixtures/delta_versions.yaml")
-        for pattern in file_patterns
+    delta_path = REPO_ROOT / "packages/phlo-delta/tests/compose/docker-compose.yml"
+    delta_relative = delta_path.relative_to(REPO_ROOT).as_posix()
+    delta_source = delta_path.read_text(encoding="utf-8")
+    assert "    image: trinodb/trino:477" in delta_source
+    assert not any(pattern.fullmatch(delta_relative) for pattern in file_patterns)
+    assert _image_match(manager, delta_source) is None
+    nested_immutable = delta_source.replace(
+        "    image: trinodb/trino:477",
+        "    image: trinodb/trino:483@sha256:" + "a" * 64,
+        1,
     )
+    assert _image_match(manager, nested_immutable) is None
 
 
 def test_runtime_image_manager_extracts_every_real_immutable_root_image() -> None:
@@ -80,27 +102,40 @@ def test_runtime_image_manager_extracts_every_real_immutable_root_image() -> Non
     assert matched == eligible
 
 
-def test_runtime_image_replacement_updates_tag_and_digest_without_damaging_wrapper() -> None:
+def test_runtime_image_replacement_updates_real_plain_and_env_defaults_exactly() -> None:
     manager = _manager()
-    replacement = manager["autoReplaceStringTemplate"]
-
-    def replace(source: str) -> str:
-        match = _image_match(manager, source)
-        assert match
-        values = {"wrapperPrefix": "", "wrapperSuffix": ""}
-        values.update({key: value or "" for key, value in match.groupdict().items()})
-        values.update(newValue="v9.9.9", newDigest="sha256:" + "f" * 64)
-        rendered = replacement
-        for key, value in values.items():
-            rendered = rendered.replace("{{{" + key + "}}}", value)
-        return source[: match.start()] + rendered + source[match.end() :]
-
-    assert replace("image: grafana/alloy:v1.0.0@sha256:" + "a" * 64) == (
-        "image: grafana/alloy:v9.9.9@sha256:" + "f" * 64
+    new_digest = "sha256:" + "f" * 64
+    examples = (
+        (
+            REPO_ROOT / "packages/phlo-alloy/src/phlo_alloy/service.yaml",
+            "grafana/alloy:v1.18.0@sha256:491b0578c04983fd54fe99b587b6fab4404dc46d0dc16677bd6b00cc1140b308",
+            "grafana/alloy:v9.9.9@" + new_digest,
+            "image: grafana/alloy:v9.9.9@" + new_digest,
+        ),
+        (
+            REPO_ROOT / "packages/phlo-hasura/src/phlo_hasura/service.yaml",
+            "hasura/graphql-engine:v2.49.5@sha256:a9f427a9078b75c5f43ea40abd4ba4e426f45777f862eff7265f411a5ac96086",
+            "hasura/graphql-engine:v9.9.9@" + new_digest,
+            "image: ${HASURA_IMAGE:-hasura/graphql-engine:v9.9.9@" + new_digest + "}",
+        ),
     )
-    assert replace("image: ${ALLOY_IMAGE:-grafana/alloy:v1.0.0@sha256:" + "a" * 64 + "}") == (
-        "image: ${ALLOY_IMAGE:-grafana/alloy:v9.9.9@sha256:" + "f" * 64 + "}"
-    )
+
+    for path, old_reference, new_reference, expected_line in examples:
+        source = path.read_text(encoding="utf-8")
+        updated = _render_update(
+            manager,
+            source,
+            new_value="v9.9.9",
+            new_digest=new_digest,
+        )
+        assert updated == source.replace(old_reference, new_reference, 1)
+        assert expected_line in updated.splitlines()
+        assert updated.endswith("\n") == source.endswith("\n")
+        assert updated.count("\n") == source.count("\n")
+
+
+def test_runtime_image_manager_rejects_malformed_env_defaults() -> None:
+    manager = _manager()
     assert (
         _image_match(
             manager,


### PR DESCRIPTION
## Outcome

- teach Renovate to update immutable upstream runtime image tags and digests together in package service YAML
- inventory the complete upstream runtime fleet from source: 24 unique immutable images across 27 service references
- add a scheduled/manual, non-blocking Trivy visibility workflow with strict operational failure handling, deterministic Markdown summaries, and raw report artifacts
- keep the existing blocking first-party publication/rescan policy unchanged

## Why

Phlo now delegates vendor-image security maintenance upstream. We still need timely digest updates and visibility into upstream vulnerabilities without treating vendor findings as waivable failures in Phlo's three-image publication gate.

## Validation

- full `make check` passed
- focused governance/Renovate contracts passed: 28 tests
- pinned Renovate 44.20.1 config validator passed using the exact CI command
- Ruff, format, ty, actionlint, zizmor, changed-file hooks, and `git diff --check` passed
- source inventory produced exactly 24 unique upstream refs / 27 occurrences
- representative OrbStack scans covered Alpine, env-default Hasura, and OAuth2 Proxy; summary generation succeeded with HIGH findings present, proving findings are informational rather than job-failing
- actual Alloy and Hasura YAML replacement tests prove tag+digest updates preserve wrappers and file contents; the real Delta Compose fixture is excluded

## Operational proof on `main`

- Container Security run 31409366469 passed all jobs
- Container Rescan run 31409369492 passed and emitted exactly three published images: phlo-api, shared phlo-dagster/dagster-daemon, and phlo-observatory, each with a resolved registry digest and report

## Post-merge acceptance

The new Upstream Image Visibility workflow only becomes dispatchable after merge. Manually dispatch it then confirm the artifact contains the 24-image inventory, one Trivy JSON report per image, and the deterministic summary. Vulnerability counts must not change the successful conclusion; inventory, scan, or report errors must fail it.
