### PR TITLE
feat(security): compare Renovate image candidates

### DIFF
--- a/.github/workflows/upstream-image-visibility.yml
+++ b/.github/workflows/upstream-image-visibility.yml
@@ -1,6 +1,11 @@
 name: Upstream Image Visibility
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled]
+    paths:
+      - "packages/**"
+      - "scripts/container_security.py"
   workflow_dispatch:
   schedule:
     # Runs after the blocking first-party rescan (04:25 UTC). Scanning 24 large
@@ -11,8 +16,142 @@ permissions:
   contents: read
 
 jobs:
+  discover-candidates:
+    name: discover upstream image candidates
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.type == 'Bot' &&
+      startsWith(github.head_ref, 'renovate/') &&
+      contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      count: ${{ steps.manifest.outputs.count }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          version: "0.12.1"
+          enable-cache: true
+
+      - name: Derive exact base and candidate image references
+        id: manifest
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py \
+            write-upstream-candidates \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --output upstream-candidates.json
+          echo "count=$(jq '.images | length' upstream-candidates.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload candidate manifest
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: upstream-image-candidates
+          path: upstream-candidates.json
+          if-no-files-found: error
+          retention-days: 30
+
+  compare-candidates:
+    name: compare upstream image candidate security
+    needs: discover-candidates
+    if: needs.discover-candidates.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098
+        with:
+          version: "0.12.1"
+          enable-cache: true
+
+      - name: Derive exact base and candidate image references
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py \
+            write-upstream-candidates \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --output upstream-candidates.json
+          mkdir -p base-reports candidate-reports upstream-trivy-cache
+
+      - name: Download one pinned Trivy database snapshot
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "$PWD/upstream-trivy-cache:/cache" \
+            aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
+            image --cache-dir /cache --download-db-only < /dev/null
+
+      - name: Scan exact base and candidate references with the same database snapshot
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r base candidate base_report candidate_report; do
+            echo "Scanning base $base"
+            docker run --rm \
+              -v "$PWD:/work" \
+              -v "$PWD/upstream-trivy-cache:/cache" \
+              -w /work \
+              aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
+              image --cache-dir /cache --skip-db-update --timeout 10m --scanners vuln --format json \
+              --output "/work/base-reports/$base_report" "$base" < /dev/null
+            echo "Scanning candidate $candidate"
+            docker run --rm \
+              -v "$PWD:/work" \
+              -v "$PWD/upstream-trivy-cache:/cache" \
+              -w /work \
+              aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
+              image --cache-dir /cache --skip-db-update --timeout 10m --scanners vuln --format json \
+              --output "/work/candidate-reports/$candidate_report" "$candidate" < /dev/null
+          done < <(jq -r '.images[] | [.base, .candidate, .base_report, .candidate_report] | @tsv' upstream-candidates.json)
+
+      - name: Compare candidate security
+        run: |
+          set -euo pipefail
+          uv run --no-project --with pyyaml==6.0.3 python scripts/container_security.py \
+            compare-upstream-candidates \
+            --manifest upstream-candidates.json \
+            --base-reports base-reports \
+            --candidate-reports candidate-reports \
+            --output upstream-candidate-summary.md
+
+      - name: Publish candidate comparison
+        if: always()
+        run: cat upstream-candidate-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload candidate comparison evidence
+        if: always()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: upstream-image-candidate-comparison
+          path: |
+            upstream-candidates.json
+            upstream-candidate-summary.md
+            base-reports/*.json
+            candidate-reports/*.json
+          if-no-files-found: error
+          retention-days: 30
+
   scan:
     name: scan vendor runtime images
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/.github/workflows/upstream-image-visibility.yml
+++ b/.github/workflows/upstream-image-visibility.yml
@@ -152,7 +152,10 @@ jobs:
   publish-candidate-comparison:
     name: publish upstream image candidate comparison
     needs: [discover-candidates, compare-candidates]
-    if: always() && needs.discover-candidates.outputs.count != '0'
+    if: >-
+      always() &&
+      needs.discover-candidates.result == 'success' &&
+      fromJSON(needs.discover-candidates.outputs.count) > 0
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/upstream-image-visibility.yml
+++ b/.github/workflows/upstream-image-visibility.yml
@@ -149,6 +149,57 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  publish-candidate-comparison:
+    name: publish upstream image candidate comparison
+    needs: [discover-candidates, compare-candidates]
+    if: always() && needs.discover-candidates.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Download candidate comparison summary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          name: upstream-image-candidate-comparison
+          path: comparison
+
+      - name: Create or update one candidate comparison comment
+        env:
+          COMPARISON_RESULT: ${{ needs.compare-candidates.result }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          marker='<!-- phlo-upstream-image-candidate-comparison -->'
+          if [ "$COMPARISON_RESULT" = success ]; then
+            result='PASS: candidate strictly improves CRITICAL/HIGH findings.'
+          else
+            result='FAIL: candidate does not meet the CRITICAL/HIGH improvement gate.'
+          fi
+          {
+            printf '%s\n\n' "$marker"
+            printf '> **Upstream image candidate comparison: %s**\n\n' "$result"
+            cat comparison/upstream-candidate-summary.md
+          } > comment.md
+          jq --rawfile body comment.md '{body: $body}' > comment-payload.json
+          mapfile -t comment_ids < <(
+            gh api --paginate "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" |
+              jq -r --arg marker "$marker" \
+                '.[] | select(.user.login == "github-actions[bot]" and (.body | contains($marker))) | .id'
+          )
+          if [ "${#comment_ids[@]}" -eq 0 ]; then
+            gh api --method POST "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+              --input comment-payload.json
+          else
+            gh api --method PATCH "repos/$GITHUB_REPOSITORY/issues/comments/${comment_ids[0]}" \
+              --input comment-payload.json
+            for comment_id in "${comment_ids[@]:1}"; do
+              gh api --method DELETE "repos/$GITHUB_REPOSITORY/issues/comments/$comment_id"
+            done
+          fi
+
   scan:
     name: scan vendor runtime images
     if: github.event_name != 'pull_request'

--- a/docs/guides/developer-workflow.md
+++ b/docs/guides/developer-workflow.md
@@ -74,6 +74,9 @@ uv run ty check
 
 Renovate opens review-required pull requests for digest-pinned vendor images in
 package source YAML. These updates change the tag and digest together and are
-never automerged. Confirm the service contract and generated Compose behavior;
-the scheduled non-blocking vulnerability view and its raw Trivy artifacts are
-described in [Container image security operations](../operations/container-image-security.md).
+never automerged. Each changed reference is compared with its exact base using
+the same pinned Trivy database snapshot; CRITICAL and HIGH raw occurrence counts
+must not increase and at least one must decrease. Review the comparison, then
+confirm the service contract and generated Compose behavior. The scheduled
+non-blocking vulnerability view and raw Trivy artifacts are described in
+[Container image security operations](../operations/container-image-security.md).

--- a/docs/operations/container-image-security.md
+++ b/docs/operations/container-image-security.md
@@ -44,7 +44,9 @@ not increase raw CRITICAL or HIGH occurrences and must strictly decrease at
 least one. The report retains raw occurrence counts, unique vulnerability IDs,
 fixable and unfixed counts, and added, removed, and unchanged IDs for each
 deduplicated image pair. A passing comparison does not replace the affected
-package's runtime acceptance checks or human review.
+package's runtime acceptance checks or human review. The workflow updates one
+sticky pull-request comment with the exact comparison Markdown and an explicit
+pass/fail result, including when the comparison gate fails.
 
 The workflow summary shows aggregate and per-image severity and fixability,
 along with every package-source location and environment override. Its retained

--- a/docs/operations/container-image-security.md
+++ b/docs/operations/container-image-security.md
@@ -1,10 +1,12 @@
 # Container image security operations
 
-Pull requests run only cheap checks: waiver/report validation, Hadolint for
-affected Dockerfiles, and generated Compose/Dockerfile validation. They do not
-build or scan images; documentation-only changes do not trigger container work.
-Build, exact-digest vulnerability scanning, SBOM/provenance, and publication
-run only after a merge to `main`.
+Ordinary pull requests run only cheap checks: waiver/report validation, Hadolint
+for affected Dockerfiles, and generated Compose/Dockerfile validation. They do
+not build or scan images; documentation-only changes do not trigger container
+work. The narrow Renovate upstream-image exception performs paired exact-image
+scans before merge, as described below. Build, first-party exact-digest
+vulnerability scanning, SBOM/provenance, and publication run only after a merge
+to `main`.
 
 Publication runs collect the digests changed by that run as workflow artifacts.
 Those artifacts are publication evidence and may intentionally describe only a

--- a/docs/operations/container-image-security.md
+++ b/docs/operations/container-image-security.md
@@ -32,6 +32,18 @@ failures: upstream vendors own those images. Inventory mistakes, registry or
 scanner failures, missing reports, and malformed results still fail the run so
 a green run means the visibility report is complete.
 
+For Renovate-created vendor-image pull requests, the same workflow adds a
+blocking candidate comparison. Its trigger requires a GitHub bot account, the
+`renovate/` branch convention, and the `dependencies` label; this avoids
+granting secrets or write permissions to pull-request code. It derives exact
+base and head references from Git source, downloads one pinned Trivy database
+snapshot, and scans both references against that snapshot. The candidate must
+not increase raw CRITICAL or HIGH occurrences and must strictly decrease at
+least one. The report retains raw occurrence counts, unique vulnerability IDs,
+fixable and unfixed counts, and added, removed, and unchanged IDs for each
+deduplicated image pair. A passing comparison does not replace the affected
+package's runtime acceptance checks or human review.
+
 The workflow summary shows aggregate and per-image severity and fixability,
 along with every package-source location and environment override. Its retained
 artifact contains the deterministic inventory, rendered Markdown summary, and
@@ -49,7 +61,8 @@ disabled. Phlo-owned `ghcr.io/phlohouse/phlo-*` images are explicitly disabled
 for this manager because the first-party publication pipeline owns them.
 
 Review each update as a normal dependency pull request and check the container
-security contracts. For an upstream that Renovate cannot update, resolve the
+security comparison and the affected package's runtime acceptance checks. For
+an upstream that Renovate cannot update, resolve the
 new tag and digest in a branch, run `python scripts/container_security.py
 upstream-runtime-images`, and open a pull request. Never update image defaults
 directly on the default branch.

--- a/scripts/container_security.py
+++ b/scripts/container_security.py
@@ -413,6 +413,13 @@ def _git_yaml(revision: str, path: str) -> Any:
         raise ValueError(f"cannot parse package service {path} at {revision}: {exc}") from exc
 
 
+def _immutable_repository(reference: str) -> str:
+    match = IMMUTABLE_IMAGE_PATTERN.fullmatch(reference)
+    if match is None:
+        raise ValueError(f"invalid immutable image reference {reference!r}")
+    return match.group("repository")
+
+
 def upstream_runtime_candidates(base: str, head: str) -> dict[str, Any]:
     """Derive changed immutable vendor image pairs from exact Git source revisions."""
     try:
@@ -437,6 +444,13 @@ def upstream_runtime_candidates(base: str, head: str) -> dict[str, Any]:
         candidate_reference, source = candidate_image
         if base_reference == candidate_reference:
             continue
+        base_repository = _immutable_repository(base_reference)
+        candidate_repository = _immutable_repository(candidate_reference)
+        if base_repository != candidate_repository:
+            raise ValueError(
+                f"{path}: candidate must retain upstream repository {base_repository}; "
+                f"got {candidate_repository}"
+            )
         grouped.setdefault((base_reference, candidate_reference), []).append(source)
     images = []
     for (base_reference, candidate_reference), sources in sorted(grouped.items()):

--- a/scripts/container_security.py
+++ b/scripts/container_security.py
@@ -378,6 +378,83 @@ def upstream_runtime_inventory(root: Path) -> dict[str, Any]:
     return {"version": 1, "images": images}
 
 
+def _runtime_reference_from_document(document: Any, path: str) -> tuple[str, dict[str, str]] | None:
+    if (
+        not isinstance(document, dict)
+        or "image" not in document
+        or isinstance(document.get("build"), dict)
+    ):
+        return None
+    image = document["image"]
+    if not isinstance(image, str):
+        raise ValueError(f"{path}: runtime image must be a string")
+    reference, env = _upstream_image_default(image, Path(path))
+    if reference.startswith("ghcr.io/phlohouse/phlo-"):
+        return None
+    if IMMUTABLE_IMAGE_PATTERN.fullmatch(reference) is None:
+        raise ValueError(f"{path}: vendor runtime image must contain an immutable tag and digest")
+    service = document.get("name")
+    if not isinstance(service, str) or not service:
+        raise ValueError(f"{path}: vendor runtime service must have a name")
+    source = {"path": path, "service": service}
+    if env is not None:
+        source["env"] = env
+    return reference, source
+
+
+def _git_yaml(revision: str, path: str) -> Any:
+    try:
+        contents = subprocess.check_output(["git", "show", f"{revision}:{path}"], text=True)
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"{path}: missing from {revision}") from exc
+    try:
+        return yaml.safe_load(contents)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"cannot parse package service {path} at {revision}: {exc}") from exc
+
+
+def upstream_runtime_candidates(base: str, head: str) -> dict[str, Any]:
+    """Derive changed immutable vendor image pairs from exact Git source revisions."""
+    try:
+        changed = subprocess.check_output(
+            ["git", "diff", "--name-only", f"{base}...{head}", "--", "packages"], text=True
+        ).splitlines()
+    except subprocess.CalledProcessError as exc:
+        raise ValueError(f"cannot compare upstream runtime images: {exc}") from exc
+    grouped: dict[tuple[str, str], list[dict[str, str]]] = {}
+    for path in sorted(
+        path for path in changed if re.fullmatch(r"packages/[^/]+/src/.+\.ya?ml", path)
+    ):
+        base_image = _runtime_reference_from_document(_git_yaml(base, path), path)
+        candidate_image = _runtime_reference_from_document(_git_yaml(head, path), path)
+        if base_image is None and candidate_image is None:
+            continue
+        if base_image is None or candidate_image is None:
+            raise ValueError(
+                f"{path}: upstream runtime image must exist in both base and candidate"
+            )
+        base_reference, _ = base_image
+        candidate_reference, source = candidate_image
+        if base_reference == candidate_reference:
+            continue
+        grouped.setdefault((base_reference, candidate_reference), []).append(source)
+    images = []
+    for (base_reference, candidate_reference), sources in sorted(grouped.items()):
+        if len({(source["path"], source["service"]) for source in sources}) != len(sources):
+            raise ValueError(f"duplicate upstream runtime source for {candidate_reference}")
+        images.append(
+            {
+                "base": base_reference,
+                "candidate": candidate_reference,
+                "base_report": hashlib.sha256(base_reference.encode()).hexdigest() + ".json",
+                "candidate_report": hashlib.sha256(candidate_reference.encode()).hexdigest()
+                + ".json",
+                "sources": sorted(sources, key=lambda source: (source["path"], source["service"])),
+            }
+        )
+    return {"version": 1, "images": images}
+
+
 def _validate_upstream_inventory(inventory: Any) -> list[dict[str, Any]]:
     if not isinstance(inventory, dict) or set(inventory) != {"version", "images"}:
         raise ValueError("upstream inventory is malformed")
@@ -517,6 +594,150 @@ def summarize_upstream_reports(inventory: Any, reports_dir: Path) -> str:
     return "\n".join(lines)
 
 
+def _validate_candidate_manifest(manifest: Any) -> list[dict[str, Any]]:
+    if not isinstance(manifest, dict) or set(manifest) != {"version", "images"}:
+        raise ValueError("upstream candidate manifest is malformed")
+    if manifest["version"] != 1 or not isinstance(manifest["images"], list):
+        raise ValueError("upstream candidate manifest is malformed")
+    images: list[dict[str, Any]] = []
+    pairs: set[tuple[str, str]] = set()
+    reports: set[str] = set()
+    for index, raw_image in enumerate(manifest["images"], start=1):
+        required = {"base", "candidate", "base_report", "candidate_report", "sources"}
+        if not isinstance(raw_image, dict) or set(raw_image) != required:
+            raise ValueError(f"upstream candidate image {index} is malformed")
+        image = cast(dict[str, Any], raw_image)
+        base, candidate = image["base"], image["candidate"]
+        base_report, candidate_report = image["base_report"], image["candidate_report"]
+        sources = image["sources"]
+        if (
+            not isinstance(base, str)
+            or not isinstance(candidate, str)
+            or base == candidate
+            or IMMUTABLE_IMAGE_PATTERN.fullmatch(base) is None
+            or IMMUTABLE_IMAGE_PATTERN.fullmatch(candidate) is None
+            or not isinstance(base_report, str)
+            or not isinstance(candidate_report, str)
+            or base_report != hashlib.sha256(base.encode()).hexdigest() + ".json"
+            or candidate_report != hashlib.sha256(candidate.encode()).hexdigest() + ".json"
+            or not isinstance(sources, list)
+            or not sources
+        ):
+            raise ValueError(f"upstream candidate image {index} is malformed")
+        if (base, candidate) in pairs or base_report in reports or candidate_report in reports:
+            raise ValueError(f"upstream candidate image {index} is duplicate")
+        pairs.add((base, candidate))
+        reports.update((base_report, candidate_report))
+        for source in sources:
+            if (
+                not isinstance(source, dict)
+                or not set(source).issubset({"path", "service", "env"})
+                or not {"path", "service"}.issubset(source)
+                or not all(isinstance(value, str) and value for value in source.values())
+            ):
+                raise ValueError(f"upstream candidate image {index} source is malformed")
+        if sources != sorted(sources, key=lambda source: (source["path"], source["service"])):
+            raise ValueError(f"upstream candidate image {index} sources are not sorted")
+        images.append(image)
+    if images != sorted(images, key=lambda image: (image["base"], image["candidate"])):
+        raise ValueError("upstream candidate images are not sorted")
+    return images
+
+
+def _read_expected_reports(
+    reports_dir: Path, expected: set[str]
+) -> dict[str, list[dict[str, Any]]]:
+    actual = {path.name for path in reports_dir.iterdir() if path.is_file()}
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing:
+        raise ValueError(f"missing upstream Trivy reports: {missing!r}")
+    if unexpected:
+        raise ValueError(f"unexpected upstream Trivy reports: {unexpected!r}")
+    parsed: dict[str, list[dict[str, Any]]] = {}
+    for report_name in expected:
+        try:
+            report = json.loads((reports_dir / report_name).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"malformed Trivy report {report_name}: {exc}") from exc
+        parsed[report_name] = _report_findings(report, report_name)
+    return parsed
+
+
+def compare_upstream_candidate_reports(
+    manifest: Any, base_reports_dir: Path, candidate_reports_dir: Path
+) -> tuple[str, list[str]]:
+    """Render an exact upstream-image comparison and return gate failures."""
+    images = _validate_candidate_manifest(manifest)
+    base_reports = _read_expected_reports(
+        base_reports_dir, {image["base_report"] for image in images}
+    )
+    candidate_reports = _read_expected_reports(
+        candidate_reports_dir, {image["candidate_report"] for image in images}
+    )
+    lines = [
+        "# Upstream runtime image candidate security comparison",
+        "",
+        "A candidate passes only when Critical and High raw occurrence counts do not increase,",
+        "and at least one decreases. Malformed or incomplete reports fail closed.",
+        "",
+    ]
+    errors: list[str] = []
+    for image in images:
+        base_findings = base_reports[image["base_report"]]
+        candidate_findings = candidate_reports[image["candidate_report"]]
+        lines.extend((f"## `{image['candidate']}`", "", f"Base: `{image['base']}`", "", "Sources:"))
+        for source in image["sources"]:
+            provenance = f"{source['path']} ({source['service']})"
+            if source.get("env"):
+                provenance += f" via ${{{source['env']}}}"
+            lines.append(f"- `{provenance}`")
+        lines.extend(
+            (
+                "",
+                "| Severity | Base occurrences | Candidate occurrences | Base unique IDs | Candidate unique IDs | Base fixable | Base unfixed | Candidate fixable | Candidate unfixed |",
+                "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+            )
+        )
+        counts: dict[str, tuple[int, int]] = {}
+        for severity in UPSTREAM_SEVERITIES:
+            base_selected = [item for item in base_findings if item["Severity"].upper() == severity]
+            candidate_selected = [
+                item for item in candidate_findings if item["Severity"].upper() == severity
+            ]
+            base_fixable = sum(bool(item["FixedVersion"]) for item in base_selected)
+            candidate_fixable = sum(bool(item["FixedVersion"]) for item in candidate_selected)
+            lines.append(
+                f"| {severity} | {len(base_selected)} | {len(candidate_selected)} | "
+                f"{len({item['VulnerabilityID'] for item in base_selected})} | "
+                f"{len({item['VulnerabilityID'] for item in candidate_selected})} | "
+                f"{base_fixable} | {len(base_selected) - base_fixable} | "
+                f"{candidate_fixable} | {len(candidate_selected) - candidate_fixable} |"
+            )
+            counts[severity] = (len(base_selected), len(candidate_selected))
+        base_ids = {str(item["VulnerabilityID"]) for item in base_findings}
+        candidate_ids = {str(item["VulnerabilityID"]) for item in candidate_findings}
+        for label, values in (
+            ("Added IDs", sorted(candidate_ids - base_ids)),
+            ("Removed IDs", sorted(base_ids - candidate_ids)),
+            ("Unchanged IDs", sorted(base_ids & candidate_ids)),
+        ):
+            rendered = ", ".join(f"`{value}`" for value in values) or "None"
+            lines.append(f"{label}: {rendered}")
+        critical_base, critical_candidate = counts["CRITICAL"]
+        high_base, high_candidate = counts["HIGH"]
+        if not (
+            critical_candidate <= critical_base
+            and high_candidate <= high_base
+            and (critical_candidate < critical_base or high_candidate < high_base)
+        ):
+            errors.append(
+                f"{image['candidate']}: candidate does not strictly improve CRITICAL/HIGH findings"
+            )
+        lines.append("")
+    return "\n".join(lines), errors
+
+
 def _waived(waivers: list[dict[str, Any]], image: str, vulnerability_id: str) -> bool:
     image_name = image.split("@", 1)[0]
     for waiver in waivers:
@@ -578,10 +799,19 @@ def main() -> int:
     write_upstream = sub.add_parser("write-upstream-inventory")
     write_upstream.add_argument("--root", type=Path, default=Path.cwd())
     write_upstream.add_argument("--output", type=Path, required=True)
+    write_candidates = sub.add_parser("write-upstream-candidates")
+    write_candidates.add_argument("--base", required=True)
+    write_candidates.add_argument("--head", required=True)
+    write_candidates.add_argument("--output", type=Path, required=True)
     summarize_upstream = sub.add_parser("summarize-upstream-reports")
     summarize_upstream.add_argument("--inventory", type=Path, required=True)
     summarize_upstream.add_argument("--reports", type=Path, required=True)
     summarize_upstream.add_argument("--output", type=Path, required=True)
+    compare_upstream = sub.add_parser("compare-upstream-candidates")
+    compare_upstream.add_argument("--manifest", type=Path, required=True)
+    compare_upstream.add_argument("--base-reports", type=Path, required=True)
+    compare_upstream.add_argument("--candidate-reports", type=Path, required=True)
+    compare_upstream.add_argument("--output", type=Path, required=True)
     policy = sub.add_parser("apply-policy")
     policy.add_argument("--register", type=Path, default=Path("security/container-waivers.yml"))
     policy.add_argument("--image", required=True)
@@ -606,11 +836,30 @@ def main() -> int:
         else:
             args.output.write_text(rendered, encoding="utf-8")
         return 0
+    if args.command == "write-upstream-candidates":
+        manifest = upstream_runtime_candidates(args.base, args.head)
+        args.output.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        return 0
     if args.command == "summarize-upstream-reports":
         summary = summarize_upstream_reports(
             json.loads(args.inventory.read_text(encoding="utf-8")), args.reports
         )
         args.output.write_text(summary, encoding="utf-8")
+        return 0
+    if args.command == "compare-upstream-candidates":
+        summary, errors = compare_upstream_candidate_reports(
+            json.loads(args.manifest.read_text(encoding="utf-8")),
+            args.base_reports,
+            args.candidate_reports,
+        )
+        args.output.write_text(summary, encoding="utf-8")
+        if errors:
+            print(
+                "Upstream image candidate comparison failed:", *errors, sep="\n- ", file=sys.stderr
+            )
+            return 1
         return 0
     if args.command == "affected-images":
         if args.all:

--- a/tests/scripts/test_container_security.py
+++ b/tests/scripts/test_container_security.py
@@ -438,3 +438,25 @@ def test_upstream_candidate_comparison_rejects_equal_or_worse_critical_high(
     )
 
     assert errors == [f"{candidate}: candidate does not strictly improve CRITICAL/HIGH findings"]
+
+
+def test_upstream_runtime_candidates_reject_cross_repository_replacements(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = "packages/example/src/example/service.yaml"
+    base = "alpine:3.23@sha256:" + "a" * 64
+    candidate = "busybox:1.37@sha256:" + "b" * 64
+
+    def check_output(command: list[str], *, text: bool) -> str:
+        if command[:3] == ["git", "diff", "--name-only"]:
+            return path + "\n"
+        if command == ["git", "show", f"base:{path}"]:
+            return f"name: example\nimage: ${{IMAGE:-{base}}}\n"
+        if command == ["git", "show", f"head:{path}"]:
+            return f"name: example\nimage: ${{IMAGE:-{candidate}}}\n"
+        raise AssertionError(f"unexpected command: {command!r}")
+
+    monkeypatch.setattr(container_security.subprocess, "check_output", check_output)
+
+    with pytest.raises(ValueError, match="must retain upstream repository alpine; got busybox"):
+        container_security.upstream_runtime_candidates("base", "head")

--- a/tests/scripts/test_container_security.py
+++ b/tests/scripts/test_container_security.py
@@ -329,3 +329,112 @@ def test_upstream_report_summary_rejects_incomplete_or_invalid_report_sets(
 
     with pytest.raises(ValueError, match=failure):
         container_security.summarize_upstream_reports(inventory, reports)
+
+
+def test_upstream_candidate_comparison_requires_pareto_improvement_and_reports_id_deltas(
+    tmp_path: Path,
+) -> None:
+    base = "alpine:3.23@sha256:" + "a" * 64
+    candidate = "alpine:3.24@sha256:" + "b" * 64
+    manifest = {
+        "version": 1,
+        "images": [
+            {
+                "base": base,
+                "candidate": candidate,
+                "base_report": hashlib.sha256(base.encode()).hexdigest() + ".json",
+                "candidate_report": hashlib.sha256(candidate.encode()).hexdigest() + ".json",
+                "sources": [
+                    {"path": "packages/a/src/a/service.yaml", "service": "a"},
+                    {"path": "packages/b/src/b/service.yaml", "service": "b"},
+                ],
+            }
+        ],
+    }
+    base_reports = tmp_path / "base"
+    candidate_reports = tmp_path / "candidate"
+    base_reports.mkdir()
+    candidate_reports.mkdir()
+    (base_reports / manifest["images"][0]["base_report"]).write_text(
+        json.dumps(
+            _trivy_report(
+                {"VulnerabilityID": "CVE-1", "Severity": "CRITICAL", "FixedVersion": ""},
+                {"VulnerabilityID": "CVE-2", "Severity": "HIGH", "FixedVersion": "2"},
+                {"VulnerabilityID": "CVE-3", "Severity": "HIGH", "FixedVersion": ""},
+            )
+        ),
+        encoding="utf-8",
+    )
+    (candidate_reports / manifest["images"][0]["candidate_report"]).write_text(
+        json.dumps(
+            _trivy_report(
+                {"VulnerabilityID": "CVE-2", "Severity": "HIGH", "FixedVersion": "2"},
+                {"VulnerabilityID": "CVE-4", "Severity": "LOW", "FixedVersion": "3"},
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    summary, errors = container_security.compare_upstream_candidate_reports(
+        manifest, base_reports, candidate_reports
+    )
+
+    assert errors == []
+    assert "| CRITICAL | 1 | 0 | 1 | 0 |" in summary
+    assert "| HIGH | 2 | 1 | 2 | 1 |" in summary
+    assert "Added IDs: `CVE-4`" in summary
+    assert "Removed IDs: `CVE-1`, `CVE-3`" in summary
+    assert "Unchanged IDs: `CVE-2`" in summary
+
+
+@pytest.mark.parametrize(
+    ("base_findings", "candidate_findings"),
+    [
+        (
+            [{"VulnerabilityID": "CVE-1", "Severity": "CRITICAL", "FixedVersion": ""}],
+            [{"VulnerabilityID": "CVE-2", "Severity": "CRITICAL", "FixedVersion": ""}],
+        ),
+        (
+            [{"VulnerabilityID": "CVE-1", "Severity": "HIGH", "FixedVersion": ""}],
+            [
+                {"VulnerabilityID": "CVE-1", "Severity": "HIGH", "FixedVersion": ""},
+                {"VulnerabilityID": "CVE-2", "Severity": "HIGH", "FixedVersion": ""},
+            ],
+        ),
+    ],
+)
+def test_upstream_candidate_comparison_rejects_equal_or_worse_critical_high(
+    tmp_path: Path,
+    base_findings: list[dict[str, object]],
+    candidate_findings: list[dict[str, object]],
+) -> None:
+    base = "alpine:3.23@sha256:" + "a" * 64
+    candidate = "alpine:3.24@sha256:" + "b" * 64
+    manifest = {
+        "version": 1,
+        "images": [
+            {
+                "base": base,
+                "candidate": candidate,
+                "base_report": hashlib.sha256(base.encode()).hexdigest() + ".json",
+                "candidate_report": hashlib.sha256(candidate.encode()).hexdigest() + ".json",
+                "sources": [{"path": "packages/a/src/a/service.yaml", "service": "a"}],
+            }
+        ],
+    }
+    base_reports = tmp_path / "base"
+    candidate_reports = tmp_path / "candidate"
+    base_reports.mkdir()
+    candidate_reports.mkdir()
+    (base_reports / manifest["images"][0]["base_report"]).write_text(
+        json.dumps(_trivy_report(*base_findings)), encoding="utf-8"
+    )
+    (candidate_reports / manifest["images"][0]["candidate_report"]).write_text(
+        json.dumps(_trivy_report(*candidate_findings)), encoding="utf-8"
+    )
+
+    _, errors = container_security.compare_upstream_candidate_reports(
+        manifest, base_reports, candidate_reports
+    )
+
+    assert errors == [f"{candidate}: candidate does not strictly improve CRITICAL/HIGH findings"]

--- a/tests/tooling/test_container_security_workflows.py
+++ b/tests/tooling/test_container_security_workflows.py
@@ -96,8 +96,25 @@ def test_renovate_image_prs_compare_exact_changed_base_and_candidate_refs() -> N
         "candidate-reports/*.json",
     ):
         assert contract in workflow
-    assert "contents: read" in workflow
-    assert "pull-requests: write" not in workflow
+    for publisher_contract in (
+        "publish-candidate-comparison",
+        "needs: [discover-candidates, compare-candidates]",
+        "if: always() && needs.discover-candidates.outputs.count != '0'",
+        "actions: read",
+        "pull-requests: write",
+        "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
+        "name: upstream-image-candidate-comparison",
+        "<!-- phlo-upstream-image-candidate-comparison -->",
+        "gh api --paginate",
+        "--method PATCH",
+        "--method POST",
+        "--method DELETE",
+        "--input comment-payload.json",
+    ):
+        assert publisher_contract in workflow
+    publisher = workflow.split("  publish-candidate-comparison:", 1)[1].split("\n  scan:", 1)[0]
+    assert "permissions:\n      actions: read\n      pull-requests: write" in publisher
+    assert "actions/checkout" not in publisher
 
 
 def test_renovate_config_validation_uses_pinned_node_and_renovate() -> None:

--- a/tests/tooling/test_container_security_workflows.py
+++ b/tests/tooling/test_container_security_workflows.py
@@ -75,6 +75,31 @@ def test_upstream_visibility_is_scheduled_manual_non_blocking_and_strictly_repor
         assert forbidden not in workflow
 
 
+def test_renovate_image_prs_compare_exact_changed_base_and_candidate_refs() -> None:
+    workflow = (REPO_ROOT / ".github/workflows/upstream-image-visibility.yml").read_text()
+
+    for contract in (
+        "pull_request:",
+        "types: [opened, reopened, synchronize, labeled]",
+        "discover-candidates",
+        "compare-candidates",
+        "github.event.pull_request.user.type == 'Bot'",
+        "startsWith(github.head_ref, 'renovate/')",
+        "contains(github.event.pull_request.labels.*.name, 'dependencies')",
+        "github.event.pull_request.base.sha",
+        "github.event.pull_request.head.sha",
+        "write-upstream-candidates",
+        "--download-db-only",
+        "--skip-db-update",
+        "compare-upstream-candidates",
+        "base-reports/*.json",
+        "candidate-reports/*.json",
+    ):
+        assert contract in workflow
+    assert "contents: read" in workflow
+    assert "pull-requests: write" not in workflow
+
+
 def test_renovate_config_validation_uses_pinned_node_and_renovate() -> None:
     workflow = (REPO_ROOT / ".github/workflows/renovate-config.yml").read_text()
 

--- a/tests/tooling/test_container_security_workflows.py
+++ b/tests/tooling/test_container_security_workflows.py
@@ -5,6 +5,17 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _publisher_should_run(discovery_result: str, count: str) -> bool:
+    return discovery_result == "success" and count.isdecimal() and int(count) > 0
+
+
+def test_candidate_comment_publisher_requires_successful_nonempty_discovery() -> None:
+    assert not _publisher_should_run("skipped", "")
+    assert not _publisher_should_run("success", "")
+    assert not _publisher_should_run("success", "0")
+    assert _publisher_should_run("success", "1")
+
+
 def test_container_workflows_run_validation_nightly_with_pinned_tools_and_digest_rescans() -> None:
     validation = (REPO_ROOT / ".github/workflows/container-security.yml").read_text()
     nightly = (REPO_ROOT / ".github/workflows/container-rescan.yml").read_text()
@@ -99,7 +110,8 @@ def test_renovate_image_prs_compare_exact_changed_base_and_candidate_refs() -> N
     for publisher_contract in (
         "publish-candidate-comparison",
         "needs: [discover-candidates, compare-candidates]",
-        "if: always() && needs.discover-candidates.outputs.count != '0'",
+        "needs.discover-candidates.result == 'success'",
+        "fromJSON(needs.discover-candidates.outputs.count) > 0",
         "actions: read",
         "pull-requests: write",
         "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",


### PR DESCRIPTION
## Outcome

- compare exact current and candidate upstream image digests only on Renovate-created upstream-image PRs
- scan each pair with the same pinned Trivy version and one downloaded vulnerability database snapshot
- pass only a strict Pareto improvement: Critical and High occurrences cannot increase, and at least one must decrease
- report raw occurrences, unique vulnerability IDs, fixable/unfixed counts, and added/removed/unchanged IDs per image
- preserve the independent scheduled/manual 24-image visibility scan and review-required Renovate policy

## Safety boundaries

- automatic comparison requires a bot-authored PR, `renovate/` head branch, `dependencies` label, and relevant package changes
- workflow permissions remain `contents: read`; checkout credentials are not persisted and no secrets are provided
- malformed, incomplete, unexpected, equal, or worse comparisons fail closed
- candidate references must retain the same upstream repository, preventing a cleaner-scanning product replacement from passing
- no VEX, waivers, custom images, product replacement, auto-merge, or first-party policy changes

## Validation

- full `make check` passed on the implementation commit
- focused container-security/workflow suite passed: 28 tests after the review fix
- Ruff check/format, targeted `ty`, Actionlint, commit hooks including zizmor, and `git diff --check` passed
- bounded Standards and Spec reviews completed; both blocking findings were fixed separately

## Live comparison proof

Using exact multi-architecture digests and the same pinned Trivy 0.72.0 database snapshot:

- base: `alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375`
- candidate: `alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b`
- Critical occurrences: 2 → 0
- High occurrences: 17 → 0
- comparator exited successfully and rendered exact CVE removal evidence

## Known trigger boundary

The repository has no historical Renovate image PR from which to pin a verified login. The safe trigger therefore uses GitHub's bot account type together with Renovate's branch convention and dependency label. If the installed Renovate integration uses a different branch or label convention, its first image PR will show a skipped comparison and the guard will need a narrow configuration adjustment.
